### PR TITLE
feat(finance): REST migration slice 4 — imports pipeline (F1, AI stubbed)

### DIFF
--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -771,6 +771,4508 @@
         "tags": ["budgets"]
       }
     },
+    "/imports/apply-changeset-reevaluate": {
+      "post": {
+        "operationId": "imports.applyChangeSetAndReevaluate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "default": [],
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "minConfidence": {
+                    "default": 0.7,
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "sessionId": {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionId", "changeSet", "minConfidence"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "affectedCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "result": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "aiUsage": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "apiCalls": {
+                              "type": "number"
+                            },
+                            "avgCostPerCall": {
+                              "type": "number"
+                            },
+                            "cacheHits": {
+                              "type": "number"
+                            },
+                            "totalCostUsd": {
+                              "type": "number"
+                            },
+                            "totalInputTokens": {
+                              "type": "number"
+                            },
+                            "totalOutputTokens": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "apiCalls",
+                            "cacheHits",
+                            "totalInputTokens",
+                            "totalOutputTokens",
+                            "totalCostUsd",
+                            "avgCostPerCall"
+                          ],
+                          "type": "object"
+                        },
+                        "failed": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "matched": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "skipped": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "uncertain": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "warnings": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "affectedCount": {
+                                "type": "number"
+                              },
+                              "details": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": ["AI_CATEGORIZATION_UNAVAILABLE", "AI_API_ERROR"],
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type", "message"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["matched", "uncertain", "failed", "skipped"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["result", "affectedCount"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "412"
+          }
+        },
+        "summary": "Apply a correction ChangeSet atomically, then re-evaluate the import session",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/commit": {
+      "post": {
+        "operationId": "imports.commitImport",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSets": {
+                    "default": [],
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ops": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "default": "exact",
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "default": [],
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["descriptionPattern", "matchType", "tags"],
+                                    "type": "object"
+                                  },
+                                  "op": {
+                                    "enum": ["add"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["edit"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["disable"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["remove"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ops"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "entities": {
+                    "default": [],
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tempId": {
+                          "pattern": "^temp:entity:[0-9a-f-]{36}$",
+                          "type": "string"
+                        },
+                        "type": {
+                          "default": "company",
+                          "enum": [
+                            "company",
+                            "person",
+                            "government",
+                            "bank",
+                            "place",
+                            "brand",
+                            "organisation"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["tempId", "name", "type"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "tagRuleChangeSets": {
+                    "default": [],
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ops": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "matchType": {
+                                        "default": "exact",
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": ["descriptionPattern", "matchType", "tags"],
+                                    "type": "object"
+                                  },
+                                  "op": {
+                                    "enum": ["add"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["edit"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["disable"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["remove"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ops"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "account": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "number"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                          "type": "string"
+                        },
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "rawRow": {
+                          "type": "string"
+                        },
+                        "suggestedTags": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "isNew": {
+                                "type": "boolean"
+                              },
+                              "pattern": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "enum": ["ai", "rule", "entity"],
+                                "type": "string"
+                              },
+                              "tag": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["tag", "source"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "tags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "transactionType": {
+                          "enum": ["purchase", "transfer", "income"],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "date",
+                        "description",
+                        "amount",
+                        "account",
+                        "rawRow",
+                        "checksum"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["entities", "changeSets", "tagRuleChangeSets", "transactions"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "entitiesCreated": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "failedDetails": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "checksum": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "error": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["checksum", "error"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "retroactiveReclassifications": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "rulesApplied": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "add": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "disable": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "edit": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "remove": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": ["add", "edit", "disable", "remove"],
+                          "type": "object"
+                        },
+                        "tagRulesApplied": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "transactionsFailed": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "transactionsImported": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "entitiesCreated",
+                        "rulesApplied",
+                        "tagRulesApplied",
+                        "transactionsImported",
+                        "transactionsFailed",
+                        "failedDetails",
+                        "retroactiveReclassifications"
+                      ],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Atomically create entities, apply changeSets + tag-rule changeSets, write transactions",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/entities": {
+      "post": {
+        "operationId": "imports.createEntity",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "maxLength": 200,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["name"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "entityId": {
+                      "type": "string"
+                    },
+                    "entityName": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["entityId", "entityName"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create a new entity during an import session",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/execute": {
+      "post": {
+        "operationId": "imports.executeImport",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "account": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "number"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                          "type": "string"
+                        },
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "rawRow": {
+                          "type": "string"
+                        },
+                        "suggestedTags": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "isNew": {
+                                "type": "boolean"
+                              },
+                              "pattern": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "enum": ["ai", "rule", "entity"],
+                                "type": "string"
+                              },
+                              "tag": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["tag", "source"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "tags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "transactionType": {
+                          "enum": ["purchase", "transfer", "income"],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "date",
+                        "description",
+                        "amount",
+                        "account",
+                        "rawRow",
+                        "checksum"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["transactions"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "sessionId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["sessionId"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Write confirmed transactions to SQLite; returns a session id to poll",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/process": {
+      "post": {
+        "operationId": "imports.processImport",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "account": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "account": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "number"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                          "type": "string"
+                        },
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "rawRow": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "date",
+                        "description",
+                        "amount",
+                        "account",
+                        "rawRow",
+                        "checksum"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["transactions", "account"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "sessionId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["sessionId"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Start an import process (dedup + entity matching); returns a session id to poll",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/progress": {
+      "get": {
+        "operationId": "imports.getImportProgress",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sessionId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "nullable": true,
+                  "properties": {
+                    "currentBatch": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["processing", "success", "failed"],
+                            "type": "string"
+                          }
+                        },
+                        "required": ["description", "status"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "currentStep": {
+                      "enum": ["deduplicating", "matching", "writing"],
+                      "type": "string"
+                    },
+                    "errors": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["description", "error"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "processedCount": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "aiUsage": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "apiCalls": {
+                                  "type": "number"
+                                },
+                                "avgCostPerCall": {
+                                  "type": "number"
+                                },
+                                "cacheHits": {
+                                  "type": "number"
+                                },
+                                "totalCostUsd": {
+                                  "type": "number"
+                                },
+                                "totalInputTokens": {
+                                  "type": "number"
+                                },
+                                "totalOutputTokens": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "apiCalls",
+                                "cacheHits",
+                                "totalInputTokens",
+                                "totalOutputTokens",
+                                "totalCostUsd",
+                                "avgCostPerCall"
+                              ],
+                              "type": "object"
+                            },
+                            "failed": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "account": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "checksum": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "entity": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": [
+                                          "alias",
+                                          "exact",
+                                          "prefix",
+                                          "contains",
+                                          "ai",
+                                          "learned",
+                                          "manual",
+                                          "none"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["matchType"],
+                                    "type": "object"
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "type": "string"
+                                  },
+                                  "matchedRules": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "confidence": {
+                                          "maximum": 1,
+                                          "minimum": 0,
+                                          "type": "number"
+                                        },
+                                        "entityId": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "entityName": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "matchType": {
+                                          "enum": ["exact", "contains", "regex"],
+                                          "type": "string"
+                                        },
+                                        "pattern": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "priority": {
+                                          "type": "number"
+                                        },
+                                        "ruleId": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "ruleId",
+                                        "pattern",
+                                        "matchType",
+                                        "confidence",
+                                        "priority"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "rawRow": {
+                                    "type": "string"
+                                  },
+                                  "ruleProvenance": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "pattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "ruleId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "enum": ["correction"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "source",
+                                      "ruleId",
+                                      "pattern",
+                                      "matchType",
+                                      "confidence"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "skipReason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "enum": ["matched", "uncertain", "failed", "skipped"],
+                                    "type": "string"
+                                  },
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["ai", "rule", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "date",
+                                  "description",
+                                  "amount",
+                                  "account",
+                                  "rawRow",
+                                  "checksum",
+                                  "entity",
+                                  "status"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "matched": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "account": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "checksum": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "entity": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": [
+                                          "alias",
+                                          "exact",
+                                          "prefix",
+                                          "contains",
+                                          "ai",
+                                          "learned",
+                                          "manual",
+                                          "none"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["matchType"],
+                                    "type": "object"
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "type": "string"
+                                  },
+                                  "matchedRules": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "confidence": {
+                                          "maximum": 1,
+                                          "minimum": 0,
+                                          "type": "number"
+                                        },
+                                        "entityId": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "entityName": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "matchType": {
+                                          "enum": ["exact", "contains", "regex"],
+                                          "type": "string"
+                                        },
+                                        "pattern": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "priority": {
+                                          "type": "number"
+                                        },
+                                        "ruleId": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "ruleId",
+                                        "pattern",
+                                        "matchType",
+                                        "confidence",
+                                        "priority"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "rawRow": {
+                                    "type": "string"
+                                  },
+                                  "ruleProvenance": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "pattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "ruleId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "enum": ["correction"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "source",
+                                      "ruleId",
+                                      "pattern",
+                                      "matchType",
+                                      "confidence"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "skipReason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "enum": ["matched", "uncertain", "failed", "skipped"],
+                                    "type": "string"
+                                  },
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["ai", "rule", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "date",
+                                  "description",
+                                  "amount",
+                                  "account",
+                                  "rawRow",
+                                  "checksum",
+                                  "entity",
+                                  "status"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "skipped": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "account": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "checksum": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "entity": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": [
+                                          "alias",
+                                          "exact",
+                                          "prefix",
+                                          "contains",
+                                          "ai",
+                                          "learned",
+                                          "manual",
+                                          "none"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["matchType"],
+                                    "type": "object"
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "type": "string"
+                                  },
+                                  "matchedRules": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "confidence": {
+                                          "maximum": 1,
+                                          "minimum": 0,
+                                          "type": "number"
+                                        },
+                                        "entityId": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "entityName": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "matchType": {
+                                          "enum": ["exact", "contains", "regex"],
+                                          "type": "string"
+                                        },
+                                        "pattern": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "priority": {
+                                          "type": "number"
+                                        },
+                                        "ruleId": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "ruleId",
+                                        "pattern",
+                                        "matchType",
+                                        "confidence",
+                                        "priority"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "rawRow": {
+                                    "type": "string"
+                                  },
+                                  "ruleProvenance": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "pattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "ruleId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "enum": ["correction"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "source",
+                                      "ruleId",
+                                      "pattern",
+                                      "matchType",
+                                      "confidence"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "skipReason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "enum": ["matched", "uncertain", "failed", "skipped"],
+                                    "type": "string"
+                                  },
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["ai", "rule", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "date",
+                                  "description",
+                                  "amount",
+                                  "account",
+                                  "rawRow",
+                                  "checksum",
+                                  "entity",
+                                  "status"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "uncertain": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "account": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "checksum": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "entity": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": [
+                                          "alias",
+                                          "exact",
+                                          "prefix",
+                                          "contains",
+                                          "ai",
+                                          "learned",
+                                          "manual",
+                                          "none"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["matchType"],
+                                    "type": "object"
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "type": "string"
+                                  },
+                                  "matchedRules": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "confidence": {
+                                          "maximum": 1,
+                                          "minimum": 0,
+                                          "type": "number"
+                                        },
+                                        "entityId": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "entityName": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "matchType": {
+                                          "enum": ["exact", "contains", "regex"],
+                                          "type": "string"
+                                        },
+                                        "pattern": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "priority": {
+                                          "type": "number"
+                                        },
+                                        "ruleId": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "ruleId",
+                                        "pattern",
+                                        "matchType",
+                                        "confidence",
+                                        "priority"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "rawRow": {
+                                    "type": "string"
+                                  },
+                                  "ruleProvenance": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "pattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "ruleId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "enum": ["correction"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "source",
+                                      "ruleId",
+                                      "pattern",
+                                      "matchType",
+                                      "confidence"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "skipReason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "enum": ["matched", "uncertain", "failed", "skipped"],
+                                    "type": "string"
+                                  },
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["ai", "rule", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "date",
+                                  "description",
+                                  "amount",
+                                  "account",
+                                  "rawRow",
+                                  "checksum",
+                                  "entity",
+                                  "status"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "warnings": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "affectedCount": {
+                                    "type": "number"
+                                  },
+                                  "details": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "enum": ["AI_CATEGORIZATION_UNAVAILABLE", "AI_API_ERROR"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["type", "message"],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": ["matched", "uncertain", "failed", "skipped"],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "failed": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "pageId": {
+                                    "type": "string"
+                                  },
+                                  "success": {
+                                    "type": "boolean"
+                                  },
+                                  "transaction": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "account": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "number"
+                                      },
+                                      "checksum": {
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "type": "string"
+                                      },
+                                      "rawRow": {
+                                        "type": "string"
+                                      },
+                                      "suggestedTags": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "isNew": {
+                                              "type": "boolean"
+                                            },
+                                            "pattern": {
+                                              "type": "string"
+                                            },
+                                            "source": {
+                                              "enum": ["ai", "rule", "entity"],
+                                              "type": "string"
+                                            },
+                                            "tag": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["tag", "source"],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "date",
+                                      "description",
+                                      "amount",
+                                      "account",
+                                      "rawRow",
+                                      "checksum"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": ["transaction", "success"],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "imported": {
+                              "type": "number"
+                            },
+                            "skipped": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["imported", "failed", "skipped"],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "sessionId": {
+                      "type": "string"
+                    },
+                    "startedAt": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": ["processing", "completed", "failed"],
+                      "type": "string"
+                    },
+                    "totalTransactions": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "sessionId",
+                    "status",
+                    "currentStep",
+                    "totalTransactions",
+                    "processedCount",
+                    "currentBatch",
+                    "errors",
+                    "startedAt"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Poll an import session for progress (null when the session is unknown/expired)",
+        "tags": ["imports"]
+      }
+    },
+    "/imports/reevaluate-pending": {
+      "post": {
+        "operationId": "imports.reevaluateWithPendingRules",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "minConfidence": {
+                    "default": 0.7,
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "pendingChangeSets": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "changeSet": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "ops": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "default": "exact",
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "default": [],
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["descriptionPattern", "matchType", "tags"],
+                                        "type": "object"
+                                      },
+                                      "op": {
+                                        "enum": ["add"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["edit"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["disable"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["remove"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ops"],
+                          "type": "object"
+                        }
+                      },
+                      "required": ["changeSet"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "sessionId": {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionId", "minConfidence", "pendingChangeSets"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "affectedCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "result": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "aiUsage": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "apiCalls": {
+                              "type": "number"
+                            },
+                            "avgCostPerCall": {
+                              "type": "number"
+                            },
+                            "cacheHits": {
+                              "type": "number"
+                            },
+                            "totalCostUsd": {
+                              "type": "number"
+                            },
+                            "totalInputTokens": {
+                              "type": "number"
+                            },
+                            "totalOutputTokens": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "apiCalls",
+                            "cacheHits",
+                            "totalInputTokens",
+                            "totalOutputTokens",
+                            "totalCostUsd",
+                            "avgCostPerCall"
+                          ],
+                          "type": "object"
+                        },
+                        "failed": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "matched": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "skipped": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "uncertain": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "account": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "checksum": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "type": "string"
+                              },
+                              "description": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "entity": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "entityId": {
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "type": "string"
+                                  },
+                                  "matchType": {
+                                    "enum": [
+                                      "alias",
+                                      "exact",
+                                      "prefix",
+                                      "contains",
+                                      "ai",
+                                      "learned",
+                                      "manual",
+                                      "none"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["matchType"],
+                                "type": "object"
+                              },
+                              "error": {
+                                "type": "string"
+                              },
+                              "location": {
+                                "type": "string"
+                              },
+                              "matchedRules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "pattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "type": "number"
+                                    },
+                                    "ruleId": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ruleId",
+                                    "pattern",
+                                    "matchType",
+                                    "confidence",
+                                    "priority"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "rawRow": {
+                                "type": "string"
+                              },
+                              "ruleProvenance": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "confidence": {
+                                    "maximum": 1,
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "matchType": {
+                                    "enum": ["exact", "contains", "regex"],
+                                    "type": "string"
+                                  },
+                                  "pattern": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "enum": ["correction"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "ruleId",
+                                  "pattern",
+                                  "matchType",
+                                  "confidence"
+                                ],
+                                "type": "object"
+                              },
+                              "skipReason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain", "failed", "skipped"],
+                                "type": "string"
+                              },
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["ai", "rule", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "transactionType": {
+                                "enum": ["purchase", "transfer", "income"],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "description",
+                              "amount",
+                              "account",
+                              "rawRow",
+                              "checksum",
+                              "entity",
+                              "status"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "warnings": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "affectedCount": {
+                                "type": "number"
+                              },
+                              "details": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": ["AI_CATEGORIZATION_UNAVAILABLE", "AI_API_ERROR"],
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type", "message"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["matched", "uncertain", "failed", "skipped"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["result", "affectedCount"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "412"
+          }
+        },
+        "summary": "Re-evaluate the import session against merged (DB + pending) rules; no DB writes",
+        "tags": ["imports"]
+      }
+    },
     "/tag-rules/apply": {
       "post": {
         "operationId": "tagRules.apply",

--- a/pillars/finance/src/api/__tests__/imports.test.ts
+++ b/pillars/finance/src/api/__tests__/imports.test.ts
@@ -1,0 +1,813 @@
+/**
+ * Integration tests for the `imports.*` REST surface against the real Express
+ * app: the async session-poll pattern (processImport → poll → assert), dedup,
+ * executeImport writes, createEntity, the synchronous re-evaluation endpoints
+ * (applyChangeSetAndReevaluate / reevaluateWithPendingRules) with their 404/412
+ * error mapping, and the atomic commitImport (temp-id resolution, changeset +
+ * tag-rule changeset application, rollback, retroactive reclassification).
+ *
+ * The AI categorizer is stubbed off in F1, so unmatched rows land in `uncertain`
+ * with the reason `'No entity match found'` and the AI counters stay zero —
+ * asserted explicitly. Entities are seeded through the drizzle handle (the REST
+ * createEntity only sets a name); writes are verified through the transactions
+ * REST surface and the raw handle.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { entities, openFinanceDb, type OpenedFinanceDb } from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+import { clearProgress } from '../modules/imports/index.js';
+import { makeClient, waitForImportCompletion } from './test-utils.js';
+
+import type { ExecuteImportOutput, ProcessImportOutput } from '../modules/imports/types.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-imports-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+  clearProgress();
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createFinanceApiApp({ financeDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3004' })
+  );
+}
+
+function seedEntity(input: {
+  name: string;
+  id?: string;
+  aliases?: string;
+  defaultTags?: string;
+}): string {
+  const id = input.id ?? crypto.randomUUID();
+  financeDb.db
+    .insert(entities)
+    .values({
+      id,
+      name: input.name,
+      aliases: input.aliases ?? null,
+      defaultTags: input.defaultTags ?? null,
+      lastEditedTime: new Date().toISOString(),
+    })
+    .run();
+  return id;
+}
+
+function processResultOf(progress: { result?: unknown } | null): ProcessImportOutput {
+  if (!progress?.result) throw new Error('Expected a completed process-import session result');
+  return progress.result as ProcessImportOutput;
+}
+
+function parsed(overrides: Record<string, unknown> = {}) {
+  return {
+    date: '2026-02-13',
+    description: 'TEST MERCHANT',
+    amount: -100,
+    account: 'Amex',
+    rawRow: '{}',
+    checksum: `chk-${Math.random().toString(36).slice(2, 12)}`,
+    ...overrides,
+  };
+}
+
+function confirmed(overrides: Record<string, unknown> = {}) {
+  return {
+    date: '2026-02-13',
+    description: 'CONFIRMED MERCHANT',
+    amount: -42.5,
+    account: 'Amex',
+    rawRow: '{"line":"x"}',
+    checksum: `chk-${Math.random().toString(36).slice(2, 12)}`,
+    ...overrides,
+  };
+}
+
+describe('imports.processImport — session poll + matching', () => {
+  it('matches a seeded entity and returns it via the polled result', async () => {
+    const c = client();
+    seedEntity({ name: 'Woolworths', id: 'woolworths-id' });
+
+    const { sessionId } = await c.imports.processImport({
+      transactions: [parsed({ description: 'WOOLWORTHS 1234', checksum: 'match-1' })],
+      account: 'Amex',
+    });
+
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0]?.entity.entityName).toBe('Woolworths');
+    // "WOOLWORTHS 1234" starts with the entity name → prefix stage (3) wins.
+    expect(result.matched[0]?.entity.matchType).toBe('prefix');
+  });
+
+  it('with AI disabled, an unmatched row is uncertain with reason "No entity match found" and zero AI counters', async () => {
+    const c = client();
+    const { sessionId } = await c.imports.processImport({
+      transactions: [parsed({ description: 'ZZZ UNKNOWN VENDOR 9', checksum: 'nomatch-1' })],
+      account: 'Amex',
+    });
+
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.matched).toHaveLength(0);
+    expect(result.uncertain).toHaveLength(1);
+    expect(result.uncertain[0]?.error).toBe('No entity match found');
+    expect(result.uncertain[0]?.entity.matchType).toBe('none');
+    // AI off → no usage stats, no AI warnings.
+    expect(result.aiUsage).toBeUndefined();
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('skips checksums that already exist in the transactions table (dedup)', async () => {
+    const c = client();
+    // Seed an existing transaction with a known checksum via executeImport.
+    const { sessionId: execSession } = await c.imports.executeImport({
+      transactions: [confirmed({ description: 'PRIOR ROW', checksum: 'dup-checksum' })],
+    });
+    await waitForImportCompletion<ExecuteImportOutput>(c, execSession);
+
+    const { sessionId } = await c.imports.processImport({
+      transactions: [
+        parsed({ description: 'DUPLICATE', checksum: 'dup-checksum' }),
+        parsed({ description: 'FRESH ROW', checksum: 'fresh-checksum' }),
+      ],
+      account: 'Amex',
+    });
+
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.checksum).toBe('dup-checksum');
+    expect(result.skipped[0]?.skipReason).toContain('Duplicate');
+    // The fresh row is still processed.
+    const total =
+      result.matched.length +
+      result.uncertain.length +
+      result.failed.length +
+      result.skipped.length;
+    expect(total).toBe(2);
+  });
+
+  it('auto-classifies a negative transfer-keyword row as a transfer (no entity)', async () => {
+    const c = client();
+    const { sessionId } = await c.imports.processImport({
+      transactions: [
+        parsed({ description: 'PayID Payment Received', amount: -2300, checksum: 'xfer-1' }),
+      ],
+      account: 'Amex',
+    });
+
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0]?.transactionType).toBe('transfer');
+    expect(result.matched[0]?.entity.matchType).toBe('none');
+  });
+
+  it('returns an empty bucketed result for an empty batch', async () => {
+    const c = client();
+    const { sessionId } = await c.imports.processImport({ transactions: [], account: 'Amex' });
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.matched).toEqual([]);
+    expect(result.uncertain).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('rejects a malformed payload (bad date format) with 400', async () => {
+    const c = client();
+    await expect(
+      c.imports.processImport({
+        transactions: [parsed({ date: '13/02/2026' })],
+        account: 'Amex',
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('imports.executeImport — writes', () => {
+  it('writes confirmed transactions verifiable through the transactions REST surface', async () => {
+    const c = client();
+    const entityId = seedEntity({ name: 'Entity Co', id: 'entity-co-id' });
+
+    const { sessionId } = await c.imports.executeImport({
+      transactions: [
+        confirmed({
+          description: 'WRITTEN TXN',
+          amount: -125.5,
+          checksum: 'written-1',
+          entityId,
+          entityName: 'Entity Co',
+        }),
+      ],
+    });
+
+    const result = await waitForImportCompletion<ExecuteImportOutput>(c, sessionId);
+    expect(result.imported).toBe(1);
+    expect(result.failed).toEqual([]);
+
+    const list = await c.transactions.list({ search: 'WRITTEN TXN' });
+    expect(list.data).toHaveLength(1);
+    expect(list.data[0]?.amount).toBe(-125.5);
+    expect(list.data[0]?.entityName).toBe('Entity Co');
+    expect(list.data[0]?.type).toBe('Expense');
+  });
+
+  it('maps transactionType to the stored type column', async () => {
+    const c = client();
+    const { sessionId } = await c.imports.executeImport({
+      transactions: [
+        confirmed({ description: 'A TRANSFER', checksum: 'xfer-w', transactionType: 'transfer' }),
+        confirmed({ description: 'SOME INCOME', checksum: 'income-w', transactionType: 'income' }),
+      ],
+    });
+    const result = await waitForImportCompletion<ExecuteImportOutput>(c, sessionId);
+    expect(result.imported).toBe(2);
+
+    const transfer = await c.transactions.list({ search: 'A TRANSFER' });
+    expect(transfer.data[0]?.type).toBe('Transfer');
+    const income = await c.transactions.list({ search: 'SOME INCOME' });
+    expect(income.data[0]?.type).toBe('Income');
+  });
+});
+
+describe('imports.getImportProgress', () => {
+  it('returns null for an unknown session', async () => {
+    const c = client();
+    const progress = await c.imports.getImportProgress('00000000-0000-0000-0000-000000000000');
+    expect(progress).toBeNull();
+  });
+});
+
+describe('imports.createEntity', () => {
+  it('creates an entity and returns its id + name', async () => {
+    const c = client();
+    const res = await c.imports.createEntity({ name: 'New Merchant' });
+    expect(res.entityId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(res.entityName).toBe('New Merchant');
+
+    const row = financeDb.raw
+      .prepare('SELECT name FROM entities WHERE id = ?')
+      .get(res.entityId) as { name: string } | undefined;
+    expect(row?.name).toBe('New Merchant');
+  });
+
+  it('preserves special characters in the entity name', async () => {
+    const c = client();
+    const res = await c.imports.createEntity({ name: "McDonald's Cafe & Grill" });
+    expect(res.entityName).toBe("McDonald's Cafe & Grill");
+  });
+
+  it('rejects an empty name with 400', async () => {
+    const c = client();
+    await expect(c.imports.createEntity({ name: '' })).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('imports.applyChangeSetAndReevaluate', () => {
+  async function uncertainSession(c: ReturnType<typeof client>, checksum: string) {
+    const { sessionId } = await c.imports.processImport({
+      transactions: [parsed({ description: 'ACME SUPPLIES 1234', checksum })],
+      account: 'Amex',
+    });
+    const before = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(before.uncertain).toHaveLength(1);
+    return sessionId;
+  }
+
+  it('applies a ChangeSet and re-buckets the matching transaction, mutating the session', async () => {
+    const c = client();
+    seedEntity({ name: 'Woolworths', id: 'woolworths-id' });
+    const sessionId = await uncertainSession(c, 'acme-apply-1');
+
+    const res = await c.imports.applyChangeSetAndReevaluate({
+      sessionId,
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: {
+              descriptionPattern: 'ACME SUPPLIES',
+              matchType: 'contains',
+              entityId: 'woolworths-id',
+              entityName: 'Woolworths',
+              tags: [],
+              confidence: 0.95,
+            },
+          },
+        ],
+      },
+      minConfidence: 0.7,
+    });
+
+    expect(res.affectedCount).toBeGreaterThan(0);
+    expect(res.result.matched.some((t) => t.checksum === 'acme-apply-1')).toBe(true);
+    expect(res.result.uncertain.some((t) => t.checksum === 'acme-apply-1')).toBe(false);
+
+    // Session result was persisted with the new buckets.
+    const after = await c.imports.getImportProgress(sessionId);
+    expect(processResultOf(after).matched.some((t) => t.checksum === 'acme-apply-1')).toBe(true);
+  });
+
+  it('returns affectedCount=0 when the applied rule matches nothing remaining', async () => {
+    const c = client();
+    seedEntity({ name: 'Woolworths', id: 'woolworths-id' });
+    const sessionId = await uncertainSession(c, 'acme-apply-0');
+
+    const res = await c.imports.applyChangeSetAndReevaluate({
+      sessionId,
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: {
+              descriptionPattern: 'DOES NOT MATCH',
+              matchType: 'contains',
+              entityId: 'woolworths-id',
+              entityName: 'Woolworths',
+              tags: [],
+              confidence: 0.95,
+            },
+          },
+        ],
+      },
+      minConfidence: 0.7,
+    });
+    expect(res.affectedCount).toBe(0);
+    expect(res.result.uncertain.some((t) => t.checksum === 'acme-apply-0')).toBe(true);
+  });
+
+  it('404s an unknown session', async () => {
+    const c = client();
+    await expect(
+      c.imports.applyChangeSetAndReevaluate({
+        sessionId: '00000000-0000-0000-0000-000000000000',
+        changeSet: {
+          ops: [
+            {
+              op: 'add',
+              data: { descriptionPattern: 'X', matchType: 'exact', tags: [], confidence: 0.9 },
+            },
+          ],
+        },
+        minConfidence: 0.7,
+      })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('does NOT mutate the session when the ChangeSet apply fails (unknown rule id → 404)', async () => {
+    const c = client();
+    const sessionId = await uncertainSession(c, 'acme-apply-fail');
+
+    await expect(
+      c.imports.applyChangeSetAndReevaluate({
+        sessionId,
+        changeSet: { ops: [{ op: 'edit', id: 'does-not-exist', data: { confidence: 0.9 } }] },
+        minConfidence: 0.7,
+      })
+    ).rejects.toMatchObject({ status: 404 });
+
+    const after = await c.imports.getImportProgress(sessionId);
+    expect(after?.status).toBe('completed');
+    expect(processResultOf(after).uncertain.some((t) => t.checksum === 'acme-apply-fail')).toBe(
+      true
+    );
+  });
+});
+
+describe('imports.reevaluateWithPendingRules', () => {
+  async function uncertainSession(c: ReturnType<typeof client>, checksum: string) {
+    const { sessionId } = await c.imports.processImport({
+      transactions: [parsed({ description: 'ACME SUPPLIES 1234', checksum })],
+      account: 'Amex',
+    });
+    await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    return sessionId;
+  }
+
+  it('re-evaluates using merged (DB + pending) rules without writing the rule to the DB', async () => {
+    const c = client();
+    seedEntity({ name: 'Woolworths', id: 'woolworths-id' });
+    const sessionId = await uncertainSession(c, 'reeval-merged');
+
+    const res = await c.imports.reevaluateWithPendingRules({
+      sessionId,
+      minConfidence: 0.7,
+      pendingChangeSets: [
+        {
+          changeSet: {
+            ops: [
+              {
+                op: 'add',
+                data: {
+                  descriptionPattern: 'ACME SUPPLIES',
+                  matchType: 'contains',
+                  entityId: 'woolworths-id',
+                  entityName: 'Woolworths',
+                  tags: [],
+                  confidence: 0.95,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(res.affectedCount).toBeGreaterThan(0);
+    expect(res.result.matched.some((t) => t.checksum === 'reeval-merged')).toBe(true);
+
+    // The pending rule was NOT persisted: a fresh process of the same description stays uncertain.
+    const probe = await c.imports.processImport({
+      transactions: [parsed({ description: 'ACME SUPPLIES 9999', checksum: 'reeval-probe' })],
+      account: 'Amex',
+    });
+    const probeResult = await waitForImportCompletion<ProcessImportOutput>(c, probe.sessionId);
+    expect(probeResult.uncertain.some((t) => t.checksum === 'reeval-probe')).toBe(true);
+  });
+
+  it('accepts an empty pendingChangeSets array (re-evaluates against DB rules only)', async () => {
+    const c = client();
+    const sessionId = await uncertainSession(c, 'reeval-empty');
+    const res = await c.imports.reevaluateWithPendingRules({
+      sessionId,
+      minConfidence: 0.7,
+      pendingChangeSets: [],
+    });
+    expect(res.result).toBeDefined();
+    expect(res.affectedCount).toBe(0);
+  });
+
+  it('404s an unknown session', async () => {
+    const c = client();
+    await expect(
+      c.imports.reevaluateWithPendingRules({
+        sessionId: '00000000-0000-0000-0000-000000000000',
+        minConfidence: 0.7,
+        pendingChangeSets: [],
+      })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('imports.commitImport', () => {
+  it('commits transactions only', async () => {
+    const c = client();
+    const res = await c.imports.commitImport({
+      transactions: [confirmed({ description: 'COLES SUPERMARKET', checksum: 'commit-1' })],
+    });
+    expect(res.data.entitiesCreated).toBe(0);
+    expect(res.data.transactionsImported).toBe(1);
+    expect(res.data.transactionsFailed).toBe(0);
+    expect(res.data.rulesApplied).toEqual({ add: 0, edit: 0, disable: 0, remove: 0 });
+    expect(res.data.tagRulesApplied).toBe(0);
+    expect(res.message).toBe('Import committed');
+
+    const list = await c.transactions.list({ search: 'COLES SUPERMARKET' });
+    expect(list.data).toHaveLength(1);
+  });
+
+  it('creates pending entities and resolves temp ids in transactions', async () => {
+    const c = client();
+    const tempId = 'temp:entity:00000000-0000-0000-0000-000000000001';
+    const res = await c.imports.commitImport({
+      entities: [{ tempId, name: 'Woolworths', type: 'company' }],
+      transactions: [
+        confirmed({
+          description: 'WOOLWORTHS 1234',
+          checksum: 'commit-temp',
+          entityId: tempId,
+          entityName: 'Woolworths',
+        }),
+      ],
+    });
+    expect(res.data.entitiesCreated).toBe(1);
+
+    const entity = financeDb.raw
+      .prepare('SELECT id FROM entities WHERE name = ?')
+      .get('Woolworths') as { id: string };
+    const txn = financeDb.raw
+      .prepare('SELECT entity_id FROM transactions WHERE description = ?')
+      .get('WOOLWORTHS 1234') as { entity_id: string };
+    expect(txn.entity_id).toBe(entity.id);
+    expect(txn.entity_id).not.toBe(tempId);
+  });
+
+  it('creates an entity with a non-default type', async () => {
+    const c = client();
+    const tempId = 'temp:entity:00000000-0000-0000-0000-000000000002';
+    await c.imports.commitImport({
+      entities: [{ tempId, name: 'ATO', type: 'government' }],
+      transactions: [confirmed({ checksum: 'commit-gov' })],
+    });
+    const entity = financeDb.raw.prepare('SELECT type FROM entities WHERE name = ?').get('ATO') as {
+      type: string;
+    };
+    expect(entity.type).toBe('government');
+  });
+
+  it('resolves temp ids inside correction ChangeSet add ops', async () => {
+    const c = client();
+    const tempId = 'temp:entity:00000000-0000-0000-0000-000000000003';
+    const res = await c.imports.commitImport({
+      entities: [{ tempId, name: 'TestCorp' }],
+      changeSets: [
+        {
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'TESTCORP',
+                matchType: 'exact',
+                entityId: tempId,
+                entityName: 'TestCorp',
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [confirmed({ checksum: 'commit-cs' })],
+    });
+    expect(res.data.rulesApplied).toEqual({ add: 1, edit: 0, disable: 0, remove: 0 });
+
+    const entity = financeDb.raw
+      .prepare('SELECT id FROM entities WHERE name = ?')
+      .get('TestCorp') as { id: string };
+    const rule = financeDb.raw
+      .prepare('SELECT entity_id FROM transaction_corrections WHERE description_pattern = ?')
+      .get('TESTCORP') as { entity_id: string };
+    expect(rule.entity_id).toBe(entity.id);
+  });
+
+  it('applies pending tag-rule ChangeSets during commit', async () => {
+    const c = client();
+    const res = await c.imports.commitImport({
+      tagRuleChangeSets: [
+        {
+          source: 'unit-test',
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'TAG_RULE_TEST',
+                matchType: 'contains',
+                tags: ['UnitTestTag'],
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [
+        confirmed({
+          description: 'TAG_RULE_TEST 1',
+          checksum: 'commit-tagrule',
+          tags: ['UnitTestTag'],
+        }),
+      ],
+    });
+    expect(res.data.tagRulesApplied).toBe(1);
+
+    const rule = financeDb.raw
+      .prepare(
+        'SELECT description_pattern FROM transaction_tag_rules WHERE description_pattern = ?'
+      )
+      .get('TAG_RULE_TEST') as { description_pattern: string } | undefined;
+    expect(rule?.description_pattern).toBe('TAG_RULE_TEST');
+  });
+
+  it('rejects an unknown temp id with 400', async () => {
+    const c = client();
+    await expect(
+      c.imports.commitImport({
+        transactions: [
+          confirmed({
+            checksum: 'commit-bad-temp',
+            entityId: 'temp:entity:00000000-0000-0000-0000-999999999999',
+          }),
+        ],
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects duplicate temp ids with 400', async () => {
+    const c = client();
+    const tempId = 'temp:entity:00000000-0000-0000-0000-000000000004';
+    await expect(
+      c.imports.commitImport({
+        entities: [
+          { tempId, name: 'Entity A' },
+          { tempId, name: 'Entity B' },
+        ],
+        transactions: [confirmed({ checksum: 'dup-temp' })],
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a malformed temp id format with 400', async () => {
+    const c = client();
+    await expect(
+      c.imports.commitImport({
+        entities: [{ tempId: 'bad-format', name: 'Test' }],
+        transactions: [confirmed({ checksum: 'bad-format-temp' })],
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rolls back ALL writes if a ChangeSet op references an unknown rule id', async () => {
+    const c = client();
+    const tempId = 'temp:entity:00000000-0000-0000-0000-000000000007';
+    const entitiesBefore = financeDb.raw.prepare('SELECT count(*) as c FROM entities').get() as {
+      c: number;
+    };
+    const txnsBefore = financeDb.raw.prepare('SELECT count(*) as c FROM transactions').get() as {
+      c: number;
+    };
+
+    await expect(
+      c.imports.commitImport({
+        entities: [{ tempId, name: 'RollbackTest' }],
+        changeSets: [
+          { ops: [{ op: 'edit', id: 'non-existent-rule-id', data: { confidence: 0.9 } }] },
+        ],
+        transactions: [
+          confirmed({ checksum: 'rollback-1', entityId: tempId, entityName: 'RollbackTest' }),
+        ],
+      })
+    ).rejects.toMatchObject({ status: 404 });
+
+    const entitiesAfter = financeDb.raw.prepare('SELECT count(*) as c FROM entities').get() as {
+      c: number;
+    };
+    const txnsAfter = financeDb.raw.prepare('SELECT count(*) as c FROM transactions').get() as {
+      c: number;
+    };
+    expect(entitiesAfter.c).toBe(entitiesBefore.c);
+    expect(txnsAfter.c).toBe(txnsBefore.c);
+  });
+
+  it('handles multiple entities and transactions in one commit', async () => {
+    const c = client();
+    const tempId1 = 'temp:entity:00000000-0000-0000-0000-000000000008';
+    const tempId2 = 'temp:entity:00000000-0000-0000-0000-000000000009';
+    const res = await c.imports.commitImport({
+      entities: [
+        { tempId: tempId1, name: 'Woolworths' },
+        { tempId: tempId2, name: 'Coles', type: 'company' },
+      ],
+      transactions: [
+        confirmed({
+          description: 'WOOLWORTHS 1',
+          checksum: 'multi-1',
+          entityId: tempId1,
+          entityName: 'Woolworths',
+        }),
+        confirmed({
+          description: 'COLES 1',
+          checksum: 'multi-2',
+          entityId: tempId2,
+          entityName: 'Coles',
+        }),
+        confirmed({ description: 'TRANSFER', checksum: 'multi-3', transactionType: 'transfer' }),
+      ],
+    });
+    expect(res.data.entitiesCreated).toBe(2);
+    expect(res.data.transactionsImported).toBe(3);
+  });
+});
+
+describe('imports.commitImport — retroactive reclassification', () => {
+  it('reclassifies existing transactions a new rule now matches', async () => {
+    const c = client();
+    const entityId = seedEntity({ name: 'Woolworths' });
+    // Seed a pre-existing transaction with no entity link.
+    await c.imports
+      .executeImport({
+        transactions: [
+          confirmed({ description: 'WOOLWORTHS 9999', checksum: 'pre-existing-chk-1' }),
+        ],
+      })
+      .then((r) => waitForImportCompletion<ExecuteImportOutput>(c, r.sessionId));
+
+    const res = await c.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'WOOLWORTHS',
+                matchType: 'contains',
+                entityId,
+                entityName: 'Woolworths',
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [confirmed({ description: 'NEW IMPORT TXN', checksum: 'reclass-new' })],
+    });
+
+    expect(res.data.retroactiveReclassifications).toBe(1);
+    const txn = financeDb.raw
+      .prepare('SELECT entity_id, entity_name FROM transactions WHERE checksum = ?')
+      .get('pre-existing-chk-1') as { entity_id: string | null; entity_name: string | null };
+    expect(txn.entity_id).toBe(entityId);
+    expect(txn.entity_name).toBe('Woolworths');
+  });
+
+  it('excludes the current import batch from reclassification', async () => {
+    const c = client();
+    const entityId = seedEntity({ name: 'Coles' });
+    const res = await c.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'COLES',
+                matchType: 'contains',
+                entityId,
+                entityName: 'Coles',
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [
+        confirmed({ description: 'COLES SUPERMARKET', checksum: 'import-batch-chk-1' }),
+      ],
+    });
+    expect(res.data.retroactiveReclassifications).toBe(0);
+  });
+
+  it('reclassifies type and location when the rule specifies them', async () => {
+    const c = client();
+    const entityId = seedEntity({ name: 'Rent Corp' });
+    await c.imports
+      .executeImport({
+        transactions: [
+          confirmed({
+            description: 'RENT CORP PAYMENT',
+            checksum: 'type-loc-chk',
+            entityId,
+            entityName: 'Rent Corp',
+          }),
+        ],
+      })
+      .then((r) => waitForImportCompletion<ExecuteImportOutput>(c, r.sessionId));
+
+    const res = await c.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'RENT CORP',
+                matchType: 'contains',
+                entityId,
+                entityName: 'Rent Corp',
+                transactionType: 'transfer',
+                location: 'Melbourne',
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [confirmed({ description: 'UNRELATED', checksum: 'reclass-tl' })],
+    });
+    expect(res.data.retroactiveReclassifications).toBe(1);
+
+    const txn = financeDb.raw
+      .prepare('SELECT type, location FROM transactions WHERE checksum = ?')
+      .get('type-loc-chk') as { type: string; location: string | null };
+    expect(txn.type).toBe('Transfer');
+    expect(txn.location).toBe('Melbourne');
+  });
+});
+
+describe('imports — AI seam', () => {
+  it('keeps the categorizer disabled by default (no entity suggestion, zero counters)', async () => {
+    const c = client();
+    const { sessionId } = await c.imports.processImport({
+      transactions: [parsed({ description: 'COMPLETELY UNSEEN VENDOR', checksum: 'ai-seam-1' })],
+      account: 'Amex',
+    });
+    const result = await waitForImportCompletion<ProcessImportOutput>(c, sessionId);
+    expect(result.uncertain[0]?.entity.matchType).toBe('none');
+    expect(result.uncertain[0]?.error).toBe('No entity match found');
+    expect(result.aiUsage).toBeUndefined();
+  });
+});

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -11,6 +11,12 @@ import supertest from 'supertest';
 import type { Express } from 'express';
 
 import type { Budget } from '../modules/budgets-types.js';
+import type { ImportProgress } from '../modules/imports/index.js';
+import type {
+  CommitResult,
+  CreateEntityOutput,
+  ProcessImportOutput,
+} from '../modules/imports/types.js';
 import type { Transaction } from '../modules/transactions-types.js';
 import type { WishListItem } from '../modules/wishlist-types.js';
 
@@ -186,5 +192,50 @@ export function makeClient(app: Express) {
           r.post('/tag-rules/reject').send(body)
         ),
     },
+    imports: {
+      processImport: (body: Record<string, unknown>) =>
+        send<{ sessionId: string }>(r.post('/imports/process').send(body)),
+      executeImport: (body: Record<string, unknown>) =>
+        send<{ sessionId: string }>(r.post('/imports/execute').send(body)),
+      getImportProgress: (sessionId: string) =>
+        send<ImportProgress | null>(r.get('/imports/progress').query({ sessionId })),
+      createEntity: (body: { name: string }) =>
+        send<CreateEntityOutput>(r.post('/imports/entities').send(body)),
+      applyChangeSetAndReevaluate: (body: Record<string, unknown>) =>
+        send<{ result: ProcessImportOutput; affectedCount: number }>(
+          r.post('/imports/apply-changeset-reevaluate').send(body)
+        ),
+      commitImport: (body: Record<string, unknown>) =>
+        send<{ data: CommitResult; message: string }>(r.post('/imports/commit').send(body)),
+      reevaluateWithPendingRules: (body: Record<string, unknown>) =>
+        send<{ result: ProcessImportOutput; affectedCount: number }>(
+          r.post('/imports/reevaluate-pending').send(body)
+        ),
+    },
   };
+}
+
+/**
+ * Poll an import session until it reports `completed`, returning the result.
+ * The single pillar process completes small batches near-instantly, but the
+ * processImport handler does its work on a detached promise so we still poll.
+ */
+export async function waitForImportCompletion<T>(
+  client: ReturnType<typeof makeClient>,
+  sessionId: string,
+  maxAttempts = 50
+): Promise<T> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const progress = await client.imports.getImportProgress(sessionId);
+    if (!progress) throw new Error('Progress not found');
+    if (progress.status === 'completed') {
+      if (!progress.result) throw new Error('Import completed but result is missing');
+      return progress.result as T;
+    }
+    if (progress.status === 'failed') {
+      throw new Error(`Import failed: ${progress.errors.map((e) => e.error).join(', ')}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('Timeout waiting for import to complete');
 }

--- a/pillars/finance/src/api/modules/corrections/index.ts
+++ b/pillars/finance/src/api/modules/corrections/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Correction-rule domain logic consumed by the imports pipeline.
+ *
+ * No REST routes of its own (see `contract/rest-corrections.ts` for the shared
+ * schemas). Exposes the DB-injected `applyChangeSet` plus the pure in-memory
+ * matchers and classification helpers.
+ */
+export { applyChangeSet } from './service.js';
+export {
+  applyChangeSetToRules,
+  findAllMatchingCorrectionFromRules,
+  findMatchingCorrectionFromRules,
+  ruleMatchesDescription,
+} from './pure.js';
+export {
+  classifyCorrectionMatch,
+  parseCorrectionTags,
+  HIGH_CONFIDENCE_THRESHOLD,
+  type CorrectionMatchResult,
+  type CorrectionMatchStatus,
+  type CorrectionRow,
+} from './types.js';

--- a/pillars/finance/src/api/modules/corrections/pure.ts
+++ b/pillars/finance/src/api/modules/corrections/pure.ts
@@ -1,0 +1,172 @@
+/**
+ * Pure, in-memory correction-rule matchers + ChangeSet application.
+ *
+ * Copied (per the severance rules) from the monolith
+ * `core/corrections/{pure-service,apply-changeset-rules}.ts`. These never touch
+ * the database — they operate on caller-supplied rule arrays so the import
+ * re-evaluation paths can merge pending (un-persisted) ChangeSets with the DB
+ * rule set and re-run matching deterministically.
+ *
+ * `normalizeDescription` comes from the pillar's own
+ * `transactionCorrectionsService` so the normalisation is identical to the
+ * DB-side matcher.
+ */
+import { transactionCorrectionsService } from '../../../db/index.js';
+import { NotFoundError } from '../../shared/errors.js';
+import { classifyCorrectionMatch } from './types.js';
+
+import type { ChangeSet, ChangeSetOp } from '../../../contract/rest-corrections.js';
+import type { CorrectionMatchResult, CorrectionRow } from './types.js';
+
+const { normalizeDescription } = transactionCorrectionsService;
+
+/** Test whether a single rule's pattern matches a normalized description. */
+export function ruleMatchesDescription(rule: CorrectionRow, normalized: string): boolean {
+  const pattern = rule.descriptionPattern;
+  switch (rule.matchType) {
+    case 'exact':
+      return pattern.toUpperCase() === normalized;
+    case 'contains':
+      return pattern.length > 0 && normalized.includes(pattern.toUpperCase());
+    case 'regex':
+      if (pattern.length === 0) return false;
+      try {
+        return new RegExp(pattern, 'i').test(normalized);
+      } catch {
+        return false;
+      }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Return ALL matching correction rules in priority order (priority ASC, id ASC).
+ * The first entry is the winner; subsequent entries are overridden alternatives.
+ * Inactive rules and rules below `minConfidence` are filtered out first.
+ */
+export function findAllMatchingCorrectionFromRules(
+  description: string,
+  rules: CorrectionRow[],
+  minConfidence: number = 0.7
+): CorrectionRow[] {
+  const normalized = normalizeDescription(description);
+  const eligible = rules
+    .filter((r) => r.isActive && r.confidence >= minConfidence)
+    .toSorted((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      if (a.id < b.id) return -1;
+      if (a.id > b.id) return 1;
+      return 0;
+    });
+
+  return eligible.filter((rule) => ruleMatchesDescription(rule, normalized));
+}
+
+/** First matching rule in priority order, classified — or null when none match. */
+export function findMatchingCorrectionFromRules(
+  description: string,
+  rules: CorrectionRow[],
+  minConfidence: number = 0.7
+): CorrectionMatchResult | null {
+  const first = findAllMatchingCorrectionFromRules(description, rules, minConfidence)[0];
+  return first ? classifyCorrectionMatch(first) : null;
+}
+
+function makeAddedRow(op: Extract<ChangeSetOp, { op: 'add' }>, tempId: string): CorrectionRow {
+  return {
+    id: tempId,
+    descriptionPattern: normalizeDescription(op.data.descriptionPattern),
+    matchType: op.data.matchType,
+    entityId: op.data.entityId ?? null,
+    entityName: op.data.entityName ?? null,
+    location: op.data.location ?? null,
+    tags: JSON.stringify(op.data.tags ?? []),
+    transactionType: op.data.transactionType ?? null,
+    isActive: op.data.isActive ?? true,
+    confidence: op.data.confidence ?? 0.5,
+    priority: op.data.priority ?? 0,
+    timesApplied: 0,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: null,
+  };
+}
+
+function withDefined<T>(provided: T | undefined, fallback: T): T {
+  return provided ?? fallback;
+}
+
+function applyEditOpInMemory(
+  existing: CorrectionRow,
+  op: Extract<ChangeSetOp, { op: 'edit' }>
+): CorrectionRow {
+  return {
+    ...existing,
+    entityId: withDefined(op.data.entityId, existing.entityId),
+    entityName: withDefined(op.data.entityName, existing.entityName),
+    location: withDefined(op.data.location, existing.location),
+    tags: op.data.tags !== undefined ? JSON.stringify(op.data.tags) : existing.tags,
+    transactionType: withDefined(op.data.transactionType, existing.transactionType),
+    isActive:
+      op.data.isActive !== undefined ? Boolean(op.data.isActive) : Boolean(existing.isActive),
+    confidence: withDefined(op.data.confidence, existing.confidence),
+  };
+}
+
+function replaceRow(
+  next: CorrectionRow[],
+  byId: Map<string, CorrectionRow>,
+  updated: CorrectionRow
+): void {
+  const idx = next.findIndex((r) => r.id === updated.id);
+  if (idx !== -1) next[idx] = updated;
+  byId.set(updated.id, updated);
+}
+
+function applyMutatingInMemory(
+  next: CorrectionRow[],
+  byId: Map<string, CorrectionRow>,
+  op: Exclude<ChangeSetOp, { op: 'add' }>
+): void {
+  const existing = byId.get(op.id);
+  if (!existing) throw new NotFoundError('Correction', op.id);
+
+  if (op.op === 'edit') {
+    replaceRow(next, byId, applyEditOpInMemory(existing, op));
+    return;
+  }
+  if (op.op === 'disable') {
+    replaceRow(next, byId, { ...existing, isActive: false });
+    return;
+  }
+  const idx = next.findIndex((r) => r.id === existing.id);
+  if (idx !== -1) next.splice(idx, 1);
+  byId.delete(existing.id);
+}
+
+/**
+ * Apply a ChangeSet to an in-memory rule array (no DB). Ops are applied in a
+ * fixed order (add → edit → disable → remove) so previews are deterministic.
+ */
+export function applyChangeSetToRules(
+  rules: CorrectionRow[],
+  changeSet: ChangeSet
+): CorrectionRow[] {
+  const byId = new Map(rules.map((r) => [r.id, r]));
+  const next: CorrectionRow[] = [...rules];
+
+  let tempCounter = 0;
+  const order: Record<ChangeSetOp['op'], number> = { add: 1, edit: 2, disable: 3, remove: 4 };
+  const ops = [...changeSet.ops].toSorted((a, b) => order[a.op] - order[b.op]);
+
+  for (const op of ops) {
+    if (op.op === 'add') {
+      tempCounter += 1;
+      next.push(makeAddedRow(op, `temp:${tempCounter}`));
+    } else {
+      applyMutatingInMemory(next, byId, op);
+    }
+  }
+
+  return next;
+}

--- a/pillars/finance/src/api/modules/corrections/service.ts
+++ b/pillars/finance/src/api/modules/corrections/service.ts
@@ -1,0 +1,102 @@
+/**
+ * DB-injected correction-rule ChangeSet application.
+ *
+ * Ported from the monolith `core/corrections/handlers/apply-corrections.ts`,
+ * rewritten to take a `FinanceDb` handle as its first argument and to wrap the
+ * whole ChangeSet in a single `db.transaction` so a partial set never lands.
+ *
+ * `TransactionTagRuleNotFoundError`-style behaviour is preserved: an
+ * edit/disable/remove op targeting an unknown id throws `NotFoundError` (→ 404),
+ * which inside `db.transaction` rolls the whole set back.
+ */
+import { desc, eq } from 'drizzle-orm';
+
+import {
+  type FinanceDb,
+  transactionCorrections,
+  transactionCorrectionsService,
+} from '../../../db/index.js';
+import { NotFoundError } from '../../shared/errors.js';
+
+import type { ChangeSet, ChangeSetOp } from '../../../contract/rest-corrections.js';
+import type { CorrectionRow } from './types.js';
+
+const { normalizeDescription } = transactionCorrectionsService;
+
+function applyAddOp(tx: FinanceDb, op: Extract<ChangeSetOp, { op: 'add' }>): void {
+  tx.insert(transactionCorrections)
+    .values({
+      descriptionPattern: normalizeDescription(op.data.descriptionPattern),
+      matchType: op.data.matchType,
+      entityId: op.data.entityId ?? null,
+      entityName: op.data.entityName ?? null,
+      location: op.data.location ?? null,
+      tags: JSON.stringify(op.data.tags ?? []),
+      transactionType: op.data.transactionType ?? null,
+      isActive: op.data.isActive ?? true,
+      confidence: op.data.confidence ?? 0.5,
+    })
+    .run();
+}
+
+function buildEditUpdates(
+  op: Extract<ChangeSetOp, { op: 'edit' }>
+): Partial<typeof transactionCorrections.$inferInsert> {
+  const updates: Partial<typeof transactionCorrections.$inferInsert> = {};
+  if (op.data.entityId !== undefined) updates.entityId = op.data.entityId;
+  if (op.data.entityName !== undefined) updates.entityName = op.data.entityName;
+  if (op.data.location !== undefined) updates.location = op.data.location;
+  if (op.data.tags !== undefined) updates.tags = JSON.stringify(op.data.tags);
+  if (op.data.transactionType !== undefined) updates.transactionType = op.data.transactionType;
+  if (op.data.isActive !== undefined) updates.isActive = op.data.isActive;
+  if (op.data.confidence !== undefined) updates.confidence = op.data.confidence;
+  return updates;
+}
+
+function applyMutatingOp(tx: FinanceDb, op: Exclude<ChangeSetOp, { op: 'add' }>): void {
+  const existing = tx
+    .select()
+    .from(transactionCorrections)
+    .where(eq(transactionCorrections.id, op.id))
+    .get();
+  if (!existing) throw new NotFoundError('Correction', op.id);
+
+  if (op.op === 'edit') {
+    tx.update(transactionCorrections)
+      .set(buildEditUpdates(op))
+      .where(eq(transactionCorrections.id, op.id))
+      .run();
+    return;
+  }
+  if (op.op === 'disable') {
+    tx.update(transactionCorrections)
+      .set({ isActive: false })
+      .where(eq(transactionCorrections.id, op.id))
+      .run();
+    return;
+  }
+  tx.delete(transactionCorrections).where(eq(transactionCorrections.id, op.id)).run();
+}
+
+/**
+ * Apply a ChangeSet atomically and return the full rule set ordered by
+ * `confidence DESC, timesApplied DESC`. Ops run in a fixed order
+ * (add → edit → disable → remove).
+ */
+export function applyChangeSet(db: FinanceDb, changeSet: ChangeSet): CorrectionRow[] {
+  return db.transaction((tx) => {
+    const order: Record<ChangeSetOp['op'], number> = { add: 1, edit: 2, disable: 3, remove: 4 };
+    const ops = [...changeSet.ops].toSorted((a, b) => order[a.op] - order[b.op]);
+
+    for (const op of ops) {
+      if (op.op === 'add') applyAddOp(tx, op);
+      else applyMutatingOp(tx, op);
+    }
+
+    return tx
+      .select()
+      .from(transactionCorrections)
+      .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
+      .all();
+  });
+}

--- a/pillars/finance/src/api/modules/corrections/types.ts
+++ b/pillars/finance/src/api/modules/corrections/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Correction-match classification helpers for the imports pipeline.
+ *
+ * Copied (per the severance rules) from the monolith
+ * `core/corrections/types-base.ts`. `CorrectionRow` aliases the pillar db's
+ * `TransactionCorrectionRow` rather than re-deriving the column shape.
+ */
+import { type TransactionCorrectionRow } from '../../../db/index.js';
+
+export type CorrectionRow = TransactionCorrectionRow;
+
+/** Confidence at/above which a learned correction is treated as a confident match. */
+export const HIGH_CONFIDENCE_THRESHOLD = 0.9;
+
+export type CorrectionMatchStatus = 'matched' | 'uncertain';
+
+export interface CorrectionMatchResult {
+  correction: CorrectionRow;
+  status: CorrectionMatchStatus;
+}
+
+/**
+ * Classify a matched correction as a confident (`matched`) or tentative
+ * (`uncertain`) outcome by its confidence relative to
+ * {@link HIGH_CONFIDENCE_THRESHOLD}.
+ */
+export function classifyCorrectionMatch(correction: CorrectionRow): CorrectionMatchResult {
+  return {
+    correction,
+    status: correction.confidence >= HIGH_CONFIDENCE_THRESHOLD ? 'matched' : 'uncertain',
+  };
+}
+
+/** Parse a JSON-encoded tags string from the corrections table into a string array. */
+export function parseCorrectionTags(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/pillars/finance/src/api/modules/imports/__tests__/ai-stub.test.ts
+++ b/pillars/finance/src/api/modules/imports/__tests__/ai-stub.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the F1 AI categorizer seam. The categorizer is stubbed off:
+ * `categorizeWithAi` must honour the return contract (`{ result, usage? }`) and
+ * yield `{ result: null }` regardless of the flag in F1 — the flag only gates
+ * the (not-yet-wired) F2 implementation, so flipping it on must NOT start
+ * suggesting entities or recording usage.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { categorizeWithAi, isAiCategorizerEnabled } from '../ai-stub.js';
+
+const FLAG = 'FINANCE_AI_CATEGORIZER_ENABLED';
+
+afterEach(() => {
+  delete process.env[FLAG];
+});
+
+describe('ai-stub seam', () => {
+  it('is disabled by default', () => {
+    delete process.env[FLAG];
+    expect(isAiCategorizerEnabled()).toBe(false);
+  });
+
+  it('reads the enable flag from the environment', () => {
+    process.env[FLAG] = 'true';
+    expect(isAiCategorizerEnabled()).toBe(true);
+    process.env[FLAG] = 'false';
+    expect(isAiCategorizerEnabled()).toBe(false);
+  });
+
+  it('returns { result: null } with no usage when disabled', async () => {
+    delete process.env[FLAG];
+    const out = await categorizeWithAi('SOME RAW ROW', 'batch-1', ['groceries']);
+    expect(out.result).toBeNull();
+    expect(out.usage).toBeUndefined();
+  });
+
+  it('returns { result: null } even when enabled (F1: no real wiring yet)', async () => {
+    process.env[FLAG] = 'true';
+    const out = await categorizeWithAi('SOME RAW ROW');
+    expect(out.result).toBeNull();
+    expect(out.usage).toBeUndefined();
+  });
+});

--- a/pillars/finance/src/api/modules/imports/ai-stub.ts
+++ b/pillars/finance/src/api/modules/imports/ai-stub.ts
@@ -1,0 +1,61 @@
+/**
+ * AI categorizer seam — STUBBED for the F1 slice.
+ *
+ * The monolith routes unmatched transactions to Claude Haiku to suggest an
+ * entity + tags. That wiring (Anthropic SDK, disk cache, retry/inference
+ * middleware, API-key resolution) is deliberately NOT ported here: F2 owns it.
+ *
+ * This stub preserves the exact return contract the pipeline expects —
+ * `{ result: AiCacheEntry | null; usage?: AiUsageStats }` — and is gated behind
+ * `FINANCE_AI_CATEGORIZER_ENABLED`. With the categorizer disabled (the F1
+ * default) every call returns `{ result: null }`: no entity is suggested, no
+ * usage is recorded, and the pipeline falls through to the no-match path.
+ *
+ * F2 replaces the body of {@link categorizeWithAi} with the real Anthropic
+ * call; the call sites and the counters plumbing in `process-transaction.ts`
+ * stay untouched.
+ */
+
+/** Cached/derived AI categorization for one transaction description. */
+export interface AiCacheEntry {
+  entityName: string;
+  /** Preferred multi-tag result. */
+  tags?: string[];
+  /** Legacy single-category fallback (validated against the known-tags vocabulary). */
+  category?: string | null;
+}
+
+/** Per-call token/cost accounting surfaced to the batch counters. */
+export interface AiCallUsage {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+export interface AiCallResult {
+  result: AiCacheEntry | null;
+  usage?: AiCallUsage;
+}
+
+/** True only when the categorizer is explicitly enabled via env. Default: disabled. */
+export function isAiCategorizerEnabled(): boolean {
+  return process.env.FINANCE_AI_CATEGORIZER_ENABLED === 'true';
+}
+
+/**
+ * Categorize an unknown transaction description.
+ *
+ * F1: always resolves to `{ result: null }` (categorizer disabled). The
+ * arguments are kept on the signature so the F2 wiring is a body-only change.
+ */
+export async function categorizeWithAi(
+  _rawRow: string,
+  _importBatchId?: string,
+  _knownTags: string[] = []
+): Promise<AiCallResult> {
+  if (!isAiCategorizerEnabled()) return { result: null };
+
+  // F2: wire the real Anthropic categorizer here. Until then, an "enabled"
+  // flag with no implementation behaves identically to disabled.
+  return { result: null };
+}

--- a/pillars/finance/src/api/modules/imports/apply-learned-correction.ts
+++ b/pillars/finance/src/api/modules/imports/apply-learned-correction.ts
@@ -1,0 +1,174 @@
+/**
+ * Apply the highest-priority learned correction rule to a transaction.
+ *
+ * Ported from the monolith `lib/apply-learned-correction.ts`, db-injected:
+ * - DB matching → `transactionCorrectionsService.findAllMatchingTransactionCorrectionsFromDb`
+ * - In-memory matching (merged/pending rules) → corrections module `findAllMatchingCorrectionFromRules`
+ * - classification + tag parsing → corrections module helpers
+ */
+import { type FinanceDb, transactionCorrectionsService } from '../../../db/index.js';
+import {
+  classifyCorrectionMatch,
+  type CorrectionRow,
+  findAllMatchingCorrectionFromRules,
+  parseCorrectionTags,
+} from '../corrections/index.js';
+import { buildSuggestedTags } from './tag-management.js';
+
+import type { MatchedRule, ParsedTransaction, ProcessedTransaction } from './types.js';
+
+export interface ApplyLearnedCorrectionArgs {
+  transaction: ParsedTransaction;
+  minConfidence: number;
+  knownTags: string[];
+  rules?: CorrectionRow[];
+}
+
+export interface ApplyLearnedCorrectionResult {
+  processed: ProcessedTransaction;
+  bucket: 'matched' | 'uncertain';
+}
+
+function toMatchedRules(rules: CorrectionRow[]): MatchedRule[] {
+  return rules.map((rule) => ({
+    ruleId: rule.id,
+    pattern: rule.descriptionPattern,
+    matchType: rule.matchType,
+    confidence: rule.confidence,
+    priority: rule.priority,
+    entityId: rule.entityId ?? null,
+    entityName: rule.entityName ?? null,
+  }));
+}
+
+interface TypeOnlyMatchArgs {
+  db: FinanceDb;
+  transaction: ParsedTransaction;
+  correction: CorrectionRow;
+  matchedRules: MatchedRule[];
+  knownTags: string[];
+}
+
+function buildTypeOnlyMatch(args: TypeOnlyMatchArgs): ProcessedTransaction {
+  const { db, transaction, correction, matchedRules, knownTags } = args;
+  return {
+    ...transaction,
+    location: correction.location ?? transaction.location,
+    transactionType: correction.transactionType ?? undefined,
+    entity: { matchType: 'learned', confidence: correction.confidence },
+    ruleProvenance: {
+      source: 'correction',
+      ruleId: correction.id,
+      pattern: correction.descriptionPattern,
+      matchType: correction.matchType,
+      confidence: correction.confidence,
+    },
+    matchedRules,
+    status: 'matched',
+    suggestedTags: buildSuggestedTags(db, {
+      description: transaction.description,
+      entityId: null,
+      correctionTags: parseCorrectionTags(correction.tags),
+      aiCategory: null,
+      knownTags,
+      correctionPattern: correction.descriptionPattern,
+    }),
+  };
+}
+
+interface EntityMatchArgs {
+  db: FinanceDb;
+  transaction: ParsedTransaction;
+  correction: CorrectionRow;
+  matchedRules: MatchedRule[];
+  status: 'matched' | 'uncertain';
+  entityId: string;
+  knownTags: string[];
+}
+
+function buildEntityMatch(args: EntityMatchArgs): ProcessedTransaction {
+  const { db, transaction, correction, matchedRules, status, entityId, knownTags } = args;
+  return {
+    ...transaction,
+    location: correction.location ?? transaction.location,
+    entity: {
+      entityId,
+      entityName: correction.entityName ?? 'Unknown',
+      matchType: 'learned',
+      confidence: correction.confidence,
+    },
+    ruleProvenance: {
+      source: 'correction',
+      ruleId: correction.id,
+      pattern: correction.descriptionPattern,
+      matchType: correction.matchType,
+      confidence: correction.confidence,
+    },
+    matchedRules,
+    status,
+    suggestedTags: buildSuggestedTags(db, {
+      description: transaction.description,
+      entityId,
+      correctionTags: parseCorrectionTags(correction.tags),
+      aiCategory: null,
+      knownTags,
+      correctionPattern: correction.descriptionPattern,
+    }),
+  };
+}
+
+function handleNoEntityCorrection(
+  db: FinanceDb,
+  args: ApplyLearnedCorrectionArgs,
+  correction: CorrectionRow,
+  matchedRules: MatchedRule[]
+): ApplyLearnedCorrectionResult | null {
+  if (!correction.transactionType) return null;
+  return {
+    processed: buildTypeOnlyMatch({
+      db,
+      transaction: args.transaction,
+      correction,
+      matchedRules,
+      knownTags: args.knownTags,
+    }),
+    bucket: 'matched',
+  };
+}
+
+export function applyLearnedCorrection(
+  db: FinanceDb,
+  args: ApplyLearnedCorrectionArgs
+): ApplyLearnedCorrectionResult | null {
+  const { transaction, minConfidence, knownTags, rules } = args;
+
+  const allMatchingRules = rules
+    ? findAllMatchingCorrectionFromRules(transaction.description, rules, minConfidence)
+    : transactionCorrectionsService.findAllMatchingTransactionCorrectionsFromDb(
+        db,
+        transaction.description,
+        minConfidence
+      );
+
+  const correction = allMatchingRules[0];
+  if (!correction) return null;
+
+  const { status } = classifyCorrectionMatch(correction);
+  const entityId = correction.entityId;
+  const matchedRules = toMatchedRules(allMatchingRules);
+
+  if (!entityId) return handleNoEntityCorrection(db, args, correction, matchedRules);
+
+  return {
+    processed: buildEntityMatch({
+      db,
+      transaction,
+      correction,
+      matchedRules,
+      status,
+      entityId,
+      knownTags,
+    }),
+    bucket: status === 'matched' ? 'matched' : 'uncertain',
+  };
+}

--- a/pillars/finance/src/api/modules/imports/commit-temp-resolver.ts
+++ b/pillars/finance/src/api/modules/imports/commit-temp-resolver.ts
@@ -1,0 +1,52 @@
+/**
+ * Resolve `temp:entity:{uuid}` placeholders in ChangeSet/tag-rule ops to the
+ * real entity ids minted during the commit's entity-creation phase.
+ *
+ * Ported from the monolith `lib/commit-temp-resolver.ts`.
+ */
+import { COMMIT_TEMP_ENTITY_PREFIX } from './commit-validation.js';
+
+import type { TagRuleChangeSet } from '../../../contract/rest-tag-rules.js';
+import type { CommitPayload } from './types.js';
+
+function resolveOpEntityId<TOp extends { op: string; data?: { entityId?: string | null } }>(
+  op: TOp,
+  tempIdMap: Map<string, string>
+): TOp {
+  if (
+    (op.op === 'add' || op.op === 'edit') &&
+    op.data?.entityId?.startsWith(COMMIT_TEMP_ENTITY_PREFIX)
+  ) {
+    const realId = tempIdMap.get(op.data.entityId);
+    return { ...op, data: { ...op.data, entityId: realId ?? op.data.entityId } };
+  }
+  return op;
+}
+
+export function resolveChangeSetTempIds(
+  cs: CommitPayload['changeSets'][number],
+  tempIdMap: Map<string, string>
+): CommitPayload['changeSets'][number] {
+  return { ...cs, ops: cs.ops.map((op) => resolveOpEntityId(op, tempIdMap)) };
+}
+
+export function resolveTagRuleChangeSetTempIds(
+  cs: TagRuleChangeSet,
+  tempIdMap: Map<string, string>
+): TagRuleChangeSet {
+  return { ...cs, ops: cs.ops.map((op) => resolveOpEntityId(op, tempIdMap)) };
+}
+
+function collectTagsFromOp(op: TagRuleChangeSet['ops'][number], tags: Set<string>): void {
+  if (op.op !== 'add' || !op.data.tags) return;
+  for (const t of op.data.tags) {
+    const s = t.trim();
+    if (s) tags.add(s);
+  }
+}
+
+export function collectTagsFromTagRuleChangeSet(cs: TagRuleChangeSet): string[] {
+  const tags = new Set<string>();
+  for (const op of cs.ops) collectTagsFromOp(op, tags);
+  return [...tags];
+}

--- a/pillars/finance/src/api/modules/imports/commit-validation.ts
+++ b/pillars/finance/src/api/modules/imports/commit-validation.ts
@@ -1,0 +1,58 @@
+/**
+ * Pre-flight validation for a commit payload.
+ *
+ * Ported from the monolith `lib/commit-validation.ts`. Rejects duplicate temp
+ * ids, duplicate entity names, and dangling temp-id references (a ChangeSet op
+ * or transaction pointing at a temp id with no matching pending entity).
+ *
+ * `ValidationError` maps to a 400 through the shared `HttpError` path.
+ */
+import { ValidationError } from '../../shared/errors.js';
+
+import type { CommitPayload } from './types.js';
+
+const TEMP_ENTITY_PREFIX = 'temp:entity:';
+
+export const COMMIT_TEMP_ENTITY_PREFIX = TEMP_ENTITY_PREFIX;
+
+function collectTempIdsFromOps(
+  ops: { op: string; data?: { entityId?: string | null } }[],
+  out: Set<string>
+): void {
+  for (const op of ops) {
+    if (
+      (op.op === 'add' || op.op === 'edit') &&
+      op.data?.entityId?.startsWith(TEMP_ENTITY_PREFIX)
+    ) {
+      out.add(op.data.entityId);
+    }
+  }
+}
+
+function assertNoDuplicateNames(payload: CommitPayload): void {
+  const names = new Set<string>();
+  for (const entity of payload.entities) {
+    const lower = entity.name.toLowerCase();
+    if (names.has(lower)) throw new ValidationError(`Duplicate entity name: '${entity.name}'`);
+    names.add(lower);
+  }
+}
+
+export function validateCommitPayload(payload: CommitPayload): void {
+  const tempIds = new Set(payload.entities.map((e) => e.tempId));
+  if (tempIds.size !== payload.entities.length) {
+    throw new ValidationError('Duplicate temp IDs in entities array');
+  }
+  assertNoDuplicateNames(payload);
+
+  const referencedTempIds = new Set<string>();
+  for (const cs of payload.changeSets) collectTempIdsFromOps(cs.ops, referencedTempIds);
+  for (const cs of payload.tagRuleChangeSets) collectTempIdsFromOps(cs.ops, referencedTempIds);
+  for (const txn of payload.transactions) {
+    if (txn.entityId?.startsWith(TEMP_ENTITY_PREFIX)) referencedTempIds.add(txn.entityId);
+  }
+
+  for (const ref of referencedTempIds) {
+    if (!tempIds.has(ref)) throw new ValidationError(`Unknown temp ID referenced: '${ref}'`);
+  }
+}

--- a/pillars/finance/src/api/modules/imports/commit.ts
+++ b/pillars/finance/src/api/modules/imports/commit.ts
@@ -1,0 +1,172 @@
+/**
+ * Atomic import commit: create pending entities, apply correction + tag-rule
+ * ChangeSets, write transactions, and retroactively re-classify existing rows —
+ * all inside one SQLite transaction so a failure anywhere rolls the lot back.
+ *
+ * Ported from the monolith `lib/transaction-persistence.ts` (the commit half).
+ * Db-injected: the outer `db.transaction` handle (`tx`) is threaded into every
+ * inner service so the correction/tag-rule ChangeSet applies nest as savepoints
+ * rather than opening independent transactions.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  type FinanceDb,
+  entities,
+  importsService,
+  tagVocabularyService,
+} from '../../../db/index.js';
+import { applyChangeSet } from '../corrections/index.js';
+import { applyTagRuleChangeSet } from '../tag-rules/service.js';
+import {
+  collectTagsFromTagRuleChangeSet,
+  resolveChangeSetTempIds,
+  resolveTagRuleChangeSetTempIds,
+} from './commit-temp-resolver.js';
+import { COMMIT_TEMP_ENTITY_PREFIX, validateCommitPayload } from './commit-validation.js';
+import { reclassifyExistingTransactions } from './reclassify-existing.js';
+
+import type { CommitPayload, CommitResult, FailedTransactionDetail } from './types.js';
+
+interface RuleApplyCounts {
+  add: number;
+  edit: number;
+  disable: number;
+  remove: number;
+}
+
+function createEntitiesPhase(
+  tx: FinanceDb,
+  payload: CommitPayload
+): { tempIdMap: Map<string, string>; entitiesCreated: number } {
+  const tempIdMap = new Map<string, string>();
+  let entitiesCreated = 0;
+  for (const pending of payload.entities) {
+    const { entityId } = importsService.createImportEntity(tx, pending.name);
+    tempIdMap.set(pending.tempId, entityId);
+    entitiesCreated++;
+    if (pending.type !== 'company') {
+      tx.update(entities).set({ type: pending.type }).where(eq(entities.id, entityId)).run();
+    }
+  }
+  return { tempIdMap, entitiesCreated };
+}
+
+function applyChangeSetsPhase(
+  tx: FinanceDb,
+  payload: CommitPayload,
+  tempIdMap: Map<string, string>
+): RuleApplyCounts {
+  const counts: RuleApplyCounts = { add: 0, edit: 0, disable: 0, remove: 0 };
+  for (const cs of payload.changeSets) {
+    const resolved = resolveChangeSetTempIds(cs, tempIdMap);
+    applyChangeSet(tx, resolved);
+    for (const op of resolved.ops) counts[op.op]++;
+  }
+  return counts;
+}
+
+function applyTagRuleChangeSetsPhase(
+  tx: FinanceDb,
+  payload: CommitPayload,
+  tempIdMap: Map<string, string>
+): number {
+  let tagRulesApplied = 0;
+  for (const cs of payload.tagRuleChangeSets) {
+    const resolved = resolveTagRuleChangeSetTempIds(cs, tempIdMap);
+    for (const tag of collectTagsFromTagRuleChangeSet(resolved)) {
+      tagVocabularyService.upsertVocabularyTag(tx, tag, 'user');
+    }
+    applyTagRuleChangeSet(tx, resolved);
+    tagRulesApplied += resolved.ops.length;
+  }
+  return tagRulesApplied;
+}
+
+function deriveTransactionType(
+  txnType: string | null | undefined
+): 'Transfer' | 'Income' | 'Expense' {
+  if (txnType === 'transfer') return 'Transfer';
+  if (txnType === 'income') return 'Income';
+  return 'Expense';
+}
+
+interface WriteTxnsResult {
+  imported: number;
+  failed: number;
+  failedDetails: FailedTransactionDetail[];
+}
+
+function resolveTxnEntityId(
+  entityId: string | undefined,
+  tempIdMap: Map<string, string>
+): string | undefined {
+  if (entityId?.startsWith(COMMIT_TEMP_ENTITY_PREFIX)) {
+    return tempIdMap.get(entityId) ?? entityId;
+  }
+  return entityId;
+}
+
+function writeTransactionsPhase(
+  tx: FinanceDb,
+  payload: CommitPayload,
+  tempIdMap: Map<string, string>
+): WriteTxnsResult {
+  let imported = 0;
+  let failed = 0;
+  const failedDetails: FailedTransactionDetail[] = [];
+
+  for (const txn of payload.transactions) {
+    const entityId = resolveTxnEntityId(txn.entityId, tempIdMap);
+    try {
+      importsService.insertImportTransaction(tx, {
+        description: txn.description,
+        account: txn.account,
+        amount: txn.amount,
+        date: txn.date,
+        type: deriveTransactionType(txn.transactionType),
+        tags: txn.tags ?? [],
+        entityId: entityId ?? null,
+        entityName: txn.entityName ?? null,
+        location: txn.location ?? null,
+        rawRow: txn.rawRow,
+        checksum: txn.checksum,
+      });
+      imported++;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[CommitImport] Transaction write failed: ${errorMessage}`);
+      failed++;
+      failedDetails.push({ checksum: txn.checksum ?? null, error: errorMessage });
+    }
+  }
+
+  return { imported, failed, failedDetails };
+}
+
+/** Atomically commit an import inside a single SQLite transaction. */
+export function commitImport(db: FinanceDb, payload: CommitPayload): CommitResult {
+  validateCommitPayload(payload);
+
+  return db.transaction((tx) => {
+    const { tempIdMap, entitiesCreated } = createEntitiesPhase(tx, payload);
+    const rulesApplied = applyChangeSetsPhase(tx, payload, tempIdMap);
+    const tagRulesApplied = applyTagRuleChangeSetsPhase(tx, payload, tempIdMap);
+    const writeResult = writeTransactionsPhase(tx, payload, tempIdMap);
+
+    const retroactiveReclassifications = reclassifyExistingTransactions(
+      tx,
+      payload.transactions.map((t) => t.checksum).filter((c): c is string => c != null)
+    );
+
+    return {
+      entitiesCreated,
+      rulesApplied,
+      tagRulesApplied,
+      transactionsImported: writeResult.imported,
+      transactionsFailed: writeResult.failed,
+      failedDetails: writeResult.failedDetails,
+      retroactiveReclassifications,
+    };
+  });
+}

--- a/pillars/finance/src/api/modules/imports/entity-matcher.ts
+++ b/pillars/finance/src/api/modules/imports/entity-matcher.ts
@@ -1,0 +1,112 @@
+/**
+ * 5-stage entity matching pipeline (pure, no DB).
+ *
+ *   1. Manual aliases — alias substring → entity name
+ *   2. Exact match — case-insensitive against the entity lookup
+ *   3. Prefix match — description starts with entity name (longest wins)
+ *   4. Contains match — entity name anywhere in description (min 4 chars, longest wins)
+ *   5. Punctuation stripping — drop apostrophes, retry stages 2-4
+ *
+ * The AI fallback (stage 6) is handled by the caller. Copied verbatim from the
+ * monolith `lib/entity-matcher.ts`.
+ */
+import type { EntityLookupEntry } from '../../../db/index.js';
+
+export type EntityLookupMap = Map<string, EntityLookupEntry>;
+export type AliasMap = Map<string, string>;
+
+export interface EntityMatch {
+  entityName: string;
+  entityId: string;
+  matchType: 'alias' | 'exact' | 'prefix' | 'contains';
+}
+
+function normalizeKey(key: string, stripPunctuation: boolean): string {
+  const stripped = stripPunctuation ? key.replaceAll(/[''`]/g, '') : key;
+  return stripped.toUpperCase();
+}
+
+function findExactMatch(
+  normalized: string,
+  entries: [string, EntityLookupEntry][],
+  stripPunctuation: boolean
+): EntityMatch | null {
+  for (const [key, entry] of entries) {
+    if (normalized === normalizeKey(key, stripPunctuation)) {
+      return { entityName: entry.name, entityId: entry.id, matchType: 'exact' };
+    }
+  }
+  return null;
+}
+
+function findPrefixMatch(
+  normalized: string,
+  entries: [string, EntityLookupEntry][],
+  stripPunctuation: boolean
+): EntityMatch | null {
+  let best: EntityMatch | null = null;
+  for (const [key, entry] of entries) {
+    const upper = normalizeKey(key, stripPunctuation);
+    if (!normalized.startsWith(upper)) continue;
+    if (!best || entry.name.length > best.entityName.length) {
+      best = { entityName: entry.name, entityId: entry.id, matchType: 'prefix' };
+    }
+  }
+  return best;
+}
+
+function findContainsMatch(
+  normalized: string,
+  entries: [string, EntityLookupEntry][],
+  stripPunctuation: boolean
+): EntityMatch | null {
+  let best: EntityMatch | null = null;
+  for (const [key, entry] of entries) {
+    if (key.length < 4) continue;
+    const upper = normalizeKey(key, stripPunctuation);
+    if (!normalized.includes(upper)) continue;
+    if (!best || entry.name.length > best.entityName.length) {
+      best = { entityName: entry.name, entityId: entry.id, matchType: 'contains' };
+    }
+  }
+  return best;
+}
+
+function tryMatch(
+  normalized: string,
+  entityLookup: EntityLookupMap,
+  stripPunctuation = false
+): EntityMatch | null {
+  const entries = [...entityLookup.entries()];
+  return (
+    findExactMatch(normalized, entries, stripPunctuation) ??
+    findPrefixMatch(normalized, entries, stripPunctuation) ??
+    findContainsMatch(normalized, entries, stripPunctuation)
+  );
+}
+
+function findByName(entityName: string, lookup: EntityLookupMap): EntityLookupEntry | undefined {
+  return lookup.get(entityName.toLowerCase());
+}
+
+/** Match a transaction description to an entity, or null if no stage hits. */
+export function matchEntity(
+  description: string,
+  entityLookup: EntityLookupMap,
+  aliases: AliasMap
+): EntityMatch | null {
+  const normalized = description.toUpperCase().trim();
+
+  for (const [key, entityName] of aliases) {
+    if (normalized.includes(key.toUpperCase())) {
+      const entry = findByName(entityName, entityLookup);
+      if (entry) return { entityName: entry.name, entityId: entry.id, matchType: 'alias' };
+    }
+  }
+
+  const result = tryMatch(normalized, entityLookup);
+  if (result) return result;
+
+  const stripped = normalized.replaceAll(/[''`]/g, '');
+  return tryMatch(stripped, entityLookup, true);
+}

--- a/pillars/finance/src/api/modules/imports/execute-service.ts
+++ b/pillars/finance/src/api/modules/imports/execute-service.ts
@@ -1,0 +1,126 @@
+/**
+ * Import execution core — write confirmed transactions to SQLite.
+ *
+ * Ported from the monolith `execute-service.ts`, db-injected: writes route
+ * through the pillar's `importsService.insertImportTransaction`.
+ */
+import { type FinanceDb, importsService } from '../../../db/index.js';
+import { formatImportError } from './format-error.js';
+import { appendBatchItem, type ProgressBatchItem } from './processing-helpers.js';
+
+import type { updateProgress } from './progress-store.js';
+import type {
+  ConfirmedTransaction,
+  ErrorEntry,
+  ExecuteImportOutput,
+  ImportResult,
+} from './types.js';
+
+type ImportProgressUpdate = Parameters<typeof updateProgress>[1];
+type ImportProgressCallback = (update: ImportProgressUpdate) => void;
+
+export interface ExecuteCoreInput {
+  db: FinanceDb;
+  transactions: ConfirmedTransaction[];
+  onProgress?: ImportProgressCallback;
+}
+
+export interface ExecuteCoreOutput {
+  output: ExecuteImportOutput;
+  errors: ErrorEntry[];
+  processedCount: number;
+}
+
+function resolveTransactionType(t: ConfirmedTransaction): string {
+  if (t.transactionType === 'transfer') return 'Transfer';
+  if (t.transactionType === 'income') return 'Income';
+  return 'Expense';
+}
+
+function writeConfirmedTransaction(db: FinanceDb, transaction: ConfirmedTransaction): ImportResult {
+  const row = importsService.insertImportTransaction(db, {
+    description: transaction.description,
+    account: transaction.account,
+    amount: transaction.amount,
+    date: transaction.date,
+    type: resolveTransactionType(transaction),
+    tags: transaction.tags ?? [],
+    entityId: transaction.entityId ?? null,
+    entityName: transaction.entityName ?? null,
+    location: transaction.location ?? null,
+    rawRow: transaction.rawRow,
+    checksum: transaction.checksum,
+  });
+  return { transaction, success: true, pageId: row.id };
+}
+
+interface WriteAttempt {
+  result: ImportResult;
+  ok: boolean;
+  message?: string;
+  error?: unknown;
+}
+
+function tryWriteTransaction(db: FinanceDb, transaction: ConfirmedTransaction): WriteAttempt {
+  try {
+    return { result: writeConfirmedTransaction(db, transaction), ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return { result: { transaction, success: false, error: message }, ok: false, message, error };
+  }
+}
+
+function recordExecuteError(
+  transaction: ConfirmedTransaction,
+  attempt: WriteAttempt,
+  errors: ErrorEntry[]
+): void {
+  const formatted = formatImportError(attempt.error ?? new Error(attempt.message), {
+    transaction: transaction.description,
+  });
+  errors.push({
+    description: transaction.description.slice(0, 50),
+    error: formatted.message + (formatted.suggestion ? ` - ${formatted.suggestion}` : ''),
+  });
+}
+
+export function executeImportCore(args: ExecuteCoreInput): ExecuteCoreOutput {
+  const { db, transactions, onProgress } = args;
+  const results: ImportResult[] = [];
+  let imported = 0;
+  const skipped = 0;
+
+  const currentBatch: ProgressBatchItem[] = [];
+  const errors: ErrorEntry[] = [];
+
+  for (let i = 0; i < transactions.length; i++) {
+    const transaction = transactions[i];
+    if (!transaction) continue;
+
+    const batchItem: ProgressBatchItem = {
+      description: transaction.description.slice(0, 50),
+      status: 'processing',
+    };
+    if (onProgress) {
+      appendBatchItem(currentBatch, batchItem);
+      onProgress({ processedCount: i + 1, currentBatch: [...currentBatch] });
+    }
+
+    const attempt = tryWriteTransaction(db, transaction);
+    results.push(attempt.result);
+
+    if (attempt.ok) {
+      imported++;
+      batchItem.status = 'success';
+    } else {
+      batchItem.status = 'failed';
+      batchItem.error = attempt.message;
+      if (onProgress) recordExecuteError(transaction, attempt, errors);
+    }
+
+    if (onProgress) onProgress({ currentBatch: [...currentBatch] });
+  }
+
+  const failed = results.filter((r) => !r.success);
+  return { output: { imported, failed, skipped }, errors, processedCount: transactions.length };
+}

--- a/pillars/finance/src/api/modules/imports/format-error.ts
+++ b/pillars/finance/src/api/modules/imports/format-error.ts
@@ -1,0 +1,56 @@
+/**
+ * User-facing error formatting for the import pipeline.
+ *
+ * Copied (per the severance rules) from the monolith `lib/errors.ts`, minus the
+ * `AiCategorizationError` branch — that error type belongs to the AI categorizer
+ * which is stubbed out in F1. F2 reintroduces the AI-specific formatting
+ * alongside the real categorizer.
+ */
+export interface FormattedError {
+  message: string;
+  suggestion?: string;
+  details?: string;
+}
+
+export interface ErrorContext {
+  transaction?: string;
+}
+
+function formatNetworkError(error: Error): FormattedError | null {
+  if (error.message.includes('ECONNREFUSED')) {
+    return {
+      message: 'Connection refused',
+      suggestion: 'Check your internet connection and try again',
+      details: error.message,
+    };
+  }
+  if (error.message.includes('ETIMEDOUT')) {
+    return {
+      message: 'Request timed out',
+      suggestion: 'Check your internet connection and try again',
+      details: error.message,
+    };
+  }
+  return null;
+}
+
+/** Format an import-pipeline error into a user-friendly message + optional suggestion. */
+export function formatImportError(error: unknown, context: ErrorContext = {}): FormattedError {
+  if (error instanceof SyntaxError && error.message.includes('JSON')) {
+    return {
+      message: 'Invalid AI response format',
+      suggestion: 'This is a temporary API issue. Try again or manually categorize.',
+      details: error.message,
+    };
+  }
+
+  if (error instanceof Error) {
+    const network = formatNetworkError(error);
+    if (network) return network;
+  }
+
+  return {
+    message: error instanceof Error ? error.message : 'Unknown error occurred',
+    details: context.transaction,
+  };
+}

--- a/pillars/finance/src/api/modules/imports/index.ts
+++ b/pillars/finance/src/api/modules/imports/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Statement-import pipeline for the finance pillar (db-injected).
+ *
+ * The CSV/PDF transformers are out of scope (the wire receives already-parsed
+ * transactions) and the AI categorizer is stubbed behind a flag (see
+ * `ai-stub.ts`). Everything else — dedup, the deterministic matching stages,
+ * learned-correction application, session re-evaluation, atomic commit, and the
+ * in-memory progress store — is here.
+ */
+export {
+  createEntity,
+  commitImport,
+  executeImportWithProgress,
+  processImportWithProgress,
+  reevaluateImportSessionResult,
+  reevaluateImportSessionWithRules,
+} from './service.js';
+
+export {
+  clearProgress,
+  getProgress,
+  setProgress,
+  updateProgress,
+  type ImportProgress,
+} from './progress-store.js';

--- a/pillars/finance/src/api/modules/imports/process-service.ts
+++ b/pillars/finance/src/api/modules/imports/process-service.ts
@@ -1,0 +1,156 @@
+/**
+ * Import processing core — dedup + entity matching (pure read flow, no writes).
+ *
+ * Ported from the monolith `process-service.ts`, db-injected. Dedup +
+ * entity-map loading route through the pillar's `importsService`; per-row
+ * classification through `process-transaction.ts`.
+ */
+import { type FinanceDb, importsService } from '../../../db/index.js';
+import { processTransactionSafely } from './process-transaction.js';
+import {
+  appendBatchItem,
+  buildAiUsage,
+  buildAiWarnings,
+  makeBuckets,
+  type ProcessBuckets,
+  type ProgressBatchItem,
+} from './processing-helpers.js';
+import { loadKnownTags } from './tag-management.js';
+import { createAiCounters } from './types.js';
+
+import type { updateProgress } from './progress-store.js';
+import type {
+  AiCounters,
+  ErrorEntry,
+  ParsedTransaction,
+  ProcessContext,
+  ProcessedTransaction,
+  ProcessImportOutput,
+} from './types.js';
+
+type ImportProgressUpdate = Parameters<typeof updateProgress>[1];
+type ImportProgressCallback = (update: ImportProgressUpdate) => void;
+
+export interface ProcessCoreInput {
+  db: FinanceDb;
+  transactions: ParsedTransaction[];
+  account: string;
+  importBatchId: string;
+  onProgress?: ImportProgressCallback;
+}
+
+export interface ProcessCoreOutput {
+  output: ProcessImportOutput;
+  errors: ErrorEntry[];
+  processedNewCount: number;
+}
+
+function partitionByChecksum(
+  db: FinanceDb,
+  transactions: ParsedTransaction[]
+): { newTransactions: ParsedTransaction[]; duplicates: ParsedTransaction[] } {
+  const existing = importsService.findExistingChecksums(
+    db,
+    transactions.map((t) => t.checksum)
+  );
+  return {
+    newTransactions: transactions.filter((t) => !existing.has(t.checksum)),
+    duplicates: transactions.filter((t) => existing.has(t.checksum)),
+  };
+}
+
+function buildSkippedBucket(duplicates: ParsedTransaction[]): ProcessedTransaction[] {
+  return duplicates.map((t) => ({
+    ...t,
+    entity: { matchType: 'none' as const },
+    status: 'skipped' as const,
+    skipReason: 'Duplicate transaction (checksum match)',
+  }));
+}
+
+function pushClassified(
+  buckets: ProcessBuckets,
+  result: Awaited<ReturnType<typeof processTransactionSafely>>
+): void {
+  if (result.matched) buckets.matched.push(result.matched);
+  if (result.uncertain) buckets.uncertain.push(result.uncertain);
+  if (result.failed) buckets.failed.push(result.failed);
+}
+
+interface ProcessLoopArgs {
+  db: FinanceDb;
+  newTransactions: ParsedTransaction[];
+  context: ProcessContext;
+  counters: AiCounters;
+  buckets: ProcessBuckets;
+  onProgress?: ImportProgressCallback;
+}
+
+async function runProcessLoop(args: ProcessLoopArgs): Promise<{ errors: ErrorEntry[] }> {
+  const { db, newTransactions, context, counters, buckets, onProgress } = args;
+  const currentBatch: ProgressBatchItem[] = [];
+  const errors: ErrorEntry[] = [];
+
+  for (let i = 0; i < newTransactions.length; i++) {
+    const transaction = newTransactions[i];
+    if (!transaction) continue;
+
+    const batchItem: ProgressBatchItem = {
+      description: transaction.description.slice(0, 50),
+      status: 'processing',
+    };
+    if (onProgress) {
+      appendBatchItem(currentBatch, batchItem);
+      onProgress({ processedCount: i + 1, currentBatch: [...currentBatch] });
+    }
+
+    const result = await processTransactionSafely({ db, transaction, context, counters });
+    pushClassified(buckets, result);
+    batchItem.status = result.batchStatus;
+    if (result.errorEntry) {
+      batchItem.error = result.errorEntry.error;
+      if (onProgress) errors.push(result.errorEntry);
+    }
+
+    if (onProgress) onProgress({ currentBatch: [...currentBatch] });
+  }
+
+  return { errors };
+}
+
+export async function processImportCore(args: ProcessCoreInput): Promise<ProcessCoreOutput> {
+  const { db, transactions, importBatchId, onProgress } = args;
+
+  onProgress?.({ currentStep: 'deduplicating', processedCount: 0 });
+  const { newTransactions, duplicates } = partitionByChecksum(db, transactions);
+
+  onProgress?.({ currentStep: 'matching', processedCount: 0 });
+  const { entityLookup, aliasMap: aliases } = importsService.loadEntityMaps(db);
+  const knownTags = loadKnownTags(db);
+
+  const buckets = makeBuckets();
+  buckets.skipped = buildSkippedBucket(duplicates);
+
+  const counters = createAiCounters();
+  const context: ProcessContext = { entityLookup, aliases, knownTags, importBatchId };
+
+  const { errors } = await runProcessLoop({
+    db,
+    newTransactions,
+    context,
+    counters,
+    buckets,
+    onProgress,
+  });
+
+  const warnings = buildAiWarnings(counters);
+  return {
+    output: {
+      ...buckets,
+      warnings: warnings.length > 0 ? warnings : undefined,
+      aiUsage: buildAiUsage(counters),
+    },
+    errors,
+    processedNewCount: newTransactions.length,
+  };
+}

--- a/pillars/finance/src/api/modules/imports/process-transaction-helpers.ts
+++ b/pillars/finance/src/api/modules/imports/process-transaction-helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * ProcessedTransaction builders for each classification outcome.
+ *
+ * Ported from the monolith `lib/process-transaction-helpers.ts`, db-injected:
+ * every builder takes a `FinanceDb` handle so it can resolve suggested tags
+ * through the pillar's tag-suggester.
+ */
+import { type FinanceDb } from '../../../db/index.js';
+import { formatImportError } from './format-error.js';
+import { buildSuggestedTags } from './tag-management.js';
+
+import type { EntityLookupEntry } from '../../../db/index.js';
+import type { ErrorEntry, ParsedTransaction, ProcessedTransaction } from './types.js';
+
+export interface AiCategorizationResult {
+  entityName: string;
+  aiTags: string[];
+  aiCategory: string | null;
+}
+
+export interface MatchedFromEntityArgs {
+  transaction: ParsedTransaction;
+  entry: EntityLookupEntry;
+  matchType: 'alias' | 'exact' | 'prefix' | 'contains' | 'ai';
+  aiTags?: string[];
+  category?: string | null;
+  knownTags: string[];
+}
+
+export function buildMatchedFromEntity(
+  db: FinanceDb,
+  args: MatchedFromEntityArgs
+): ProcessedTransaction {
+  return {
+    ...args.transaction,
+    entity: { entityId: args.entry.id, entityName: args.entry.name, matchType: args.matchType },
+    status: 'matched',
+    suggestedTags: buildSuggestedTags(db, {
+      description: args.transaction.description,
+      entityId: args.entry.id,
+      correctionTags: [],
+      aiTags: args.aiTags,
+      aiCategory: args.category ?? null,
+      knownTags: args.knownTags,
+    }),
+  };
+}
+
+/** Build a `matched` transfer row — no entity (transfers are inter-account moves). */
+export function buildMatchedTransfer(
+  db: FinanceDb,
+  transaction: ParsedTransaction,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'matched',
+    transactionType: 'transfer',
+    suggestedTags: buildSuggestedTags(db, {
+      description: transaction.description,
+      entityId: null,
+      correctionTags: [],
+      aiCategory: null,
+      knownTags,
+    }),
+  };
+}
+
+export interface UncertainFromAiArgs {
+  transaction: ParsedTransaction;
+  entityName: string;
+  aiTags: string[];
+  aiCategory: string | null;
+  knownTags: string[];
+}
+
+export function buildUncertainFromAi(
+  db: FinanceDb,
+  args: UncertainFromAiArgs
+): ProcessedTransaction {
+  return {
+    ...args.transaction,
+    entity: { entityName: args.entityName, matchType: 'ai', confidence: 0.7 },
+    status: 'uncertain',
+    suggestedTags: buildSuggestedTags(db, {
+      description: args.transaction.description,
+      entityId: null,
+      correctionTags: [],
+      aiTags: args.aiTags,
+      aiCategory: args.aiCategory,
+      knownTags: args.knownTags,
+    }),
+  };
+}
+
+export function buildUncertainNoMatch(
+  db: FinanceDb,
+  transaction: ParsedTransaction,
+  reason: string,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'uncertain',
+    error: reason,
+    suggestedTags: buildSuggestedTags(db, {
+      description: transaction.description,
+      entityId: null,
+      correctionTags: [],
+      aiCategory: null,
+      knownTags,
+    }),
+  };
+}
+
+export function buildFailure(
+  transaction: ParsedTransaction,
+  error: unknown
+): { failed: ProcessedTransaction; message: string; errorEntry: ErrorEntry } {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const failed: ProcessedTransaction = {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'failed',
+    error: message,
+  };
+  const formatted = formatImportError(error, { transaction: transaction.description });
+  return {
+    failed,
+    message,
+    errorEntry: {
+      description: transaction.description.slice(0, 50),
+      error: formatted.message + (formatted.suggestion ? ` - ${formatted.suggestion}` : ''),
+    },
+  };
+}

--- a/pillars/finance/src/api/modules/imports/process-transaction.ts
+++ b/pillars/finance/src/api/modules/imports/process-transaction.ts
@@ -1,0 +1,165 @@
+/**
+ * Single-transaction classification: correction rules → transfer heuristic →
+ * entity matcher → AI fallback (stubbed in F1) → no-match.
+ *
+ * Ported from the monolith `lib/process-transaction.ts`, db-injected. The AI
+ * stage calls the `ai-stub` categorizer, which returns `{ result: null }` while
+ * the categorizer is disabled — so with AI off the no-match reason is always
+ * `'No entity match found'` and the AI counters stay zero.
+ */
+import { type FinanceDb } from '../../../db/index.js';
+import { categorizeWithAi } from './ai-stub.js';
+import { applyLearnedCorrection } from './apply-learned-correction.js';
+import { matchEntity } from './entity-matcher.js';
+import {
+  type AiCategorizationResult,
+  buildFailure,
+  buildMatchedFromEntity,
+  buildMatchedTransfer,
+  buildUncertainFromAi,
+  buildUncertainNoMatch,
+} from './process-transaction-helpers.js';
+import { isTransferOrIncomeRow } from './transfer-classifier.js';
+
+import type {
+  AiCounters,
+  ParsedTransaction,
+  ProcessContext,
+  ProcessedTransaction,
+} from './types.js';
+
+export interface TransactionProcessResult {
+  matched?: ProcessedTransaction;
+  uncertain?: ProcessedTransaction;
+  failed?: ProcessedTransaction;
+  batchStatus: 'success' | 'failed';
+  errorEntry?: { description: string; error: string };
+}
+
+export interface ProcessTransactionArgs {
+  db: FinanceDb;
+  transaction: ParsedTransaction;
+  context: ProcessContext;
+  counters: AiCounters;
+}
+
+function tryEntityMatch(
+  db: FinanceDb,
+  transaction: ParsedTransaction,
+  context: ProcessContext
+): ProcessedTransaction | null {
+  const match = matchEntity(transaction.description, context.entityLookup, context.aliases);
+  if (!match) return null;
+  const entry = context.entityLookup.get(match.entityName.toLowerCase());
+  if (!entry) throw new Error(`Entity lookup failed for matched entity: ${match.entityName}`);
+  return buildMatchedFromEntity(db, {
+    transaction,
+    entry,
+    matchType: match.matchType,
+    knownTags: context.knownTags,
+  });
+}
+
+async function tryAiCategorization(
+  transaction: ParsedTransaction,
+  context: ProcessContext,
+  counters: AiCounters
+): Promise<AiCategorizationResult | null> {
+  const { result, usage } = await categorizeWithAi(
+    transaction.rawRow,
+    context.importBatchId,
+    context.knownTags
+  );
+  if (usage) {
+    counters.aiApiCalls++;
+    counters.totalInputTokens += usage.inputTokens;
+    counters.totalOutputTokens += usage.outputTokens;
+    counters.totalCostUsd += usage.costUsd;
+  } else if (result) {
+    counters.aiCacheHits++;
+  }
+  if (!result?.entityName) return null;
+  return {
+    entityName: result.entityName,
+    aiTags: result.tags ?? [],
+    aiCategory: result.tags?.length ? null : (result.category ?? null),
+  };
+}
+
+function resolveAiResult(
+  db: FinanceDb,
+  transaction: ParsedTransaction,
+  ai: AiCategorizationResult,
+  context: ProcessContext
+): ProcessedTransaction {
+  const entry = context.entityLookup.get(ai.entityName.toLowerCase());
+  if (entry) {
+    return buildMatchedFromEntity(db, {
+      transaction,
+      entry,
+      matchType: 'ai',
+      aiTags: ai.aiTags,
+      category: ai.aiCategory,
+      knownTags: context.knownTags,
+    });
+  }
+  return buildUncertainFromAi(db, {
+    transaction,
+    entityName: ai.entityName,
+    aiTags: ai.aiTags,
+    aiCategory: ai.aiCategory,
+    knownTags: context.knownTags,
+  });
+}
+
+async function classifyTransaction(
+  args: ProcessTransactionArgs
+): Promise<TransactionProcessResult> {
+  const { db, transaction, context, counters } = args;
+
+  const correctionApplied = applyLearnedCorrection(db, {
+    transaction,
+    minConfidence: 0.7,
+    knownTags: context.knownTags,
+  });
+  if (correctionApplied) {
+    return {
+      [correctionApplied.bucket]: correctionApplied.processed,
+      batchStatus: 'success',
+    } as TransactionProcessResult;
+  }
+
+  if (isTransferOrIncomeRow(transaction)) {
+    return {
+      matched: buildMatchedTransfer(db, transaction, context.knownTags),
+      batchStatus: 'success',
+    };
+  }
+
+  const entityMatched = tryEntityMatch(db, transaction, context);
+  if (entityMatched) return { matched: entityMatched, batchStatus: 'success' };
+
+  const aiResult = await tryAiCategorization(transaction, context, counters);
+  if (aiResult?.entityName) {
+    const processed = resolveAiResult(db, transaction, aiResult, context);
+    const bucket = processed.status === 'matched' ? 'matched' : 'uncertain';
+    return { [bucket]: processed, batchStatus: 'success' } as TransactionProcessResult;
+  }
+
+  const reason = counters.aiError ? 'AI categorization unavailable' : 'No entity match found';
+  return {
+    uncertain: buildUncertainNoMatch(db, transaction, reason, context.knownTags),
+    batchStatus: 'success',
+  };
+}
+
+export async function processTransactionSafely(
+  args: ProcessTransactionArgs
+): Promise<TransactionProcessResult> {
+  try {
+    return await classifyTransaction(args);
+  } catch (error) {
+    const { failed, errorEntry } = buildFailure(args.transaction, error);
+    return { failed, batchStatus: 'failed', errorEntry };
+  }
+}

--- a/pillars/finance/src/api/modules/imports/processing-helpers.ts
+++ b/pillars/finance/src/api/modules/imports/processing-helpers.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-batch state helpers — bucket scaffolding, AI usage rollup, warnings.
+ *
+ * Ported from the monolith `lib/processing-helpers.ts`. The AI warning shape is
+ * preserved on the wire (`ImportWarning`); with the categorizer stubbed off the
+ * counters stay zero so no warnings are emitted in F1.
+ */
+import type { AiCounters, AiUsageStats, ImportWarning, ProcessedTransaction } from './types.js';
+
+export interface ProgressBatchItem {
+  description: string;
+  status: 'processing' | 'success' | 'failed';
+  error?: string;
+}
+
+export function appendBatchItem(currentBatch: ProgressBatchItem[], item: ProgressBatchItem): void {
+  currentBatch.push(item);
+  if (currentBatch.length > 5) currentBatch.shift();
+}
+
+export function buildAiUsage(counters: AiCounters): AiUsageStats | undefined {
+  const { aiApiCalls, aiCacheHits, totalInputTokens, totalOutputTokens, totalCostUsd } = counters;
+  if (aiApiCalls === 0 && aiCacheHits === 0) return undefined;
+  return {
+    apiCalls: aiApiCalls,
+    cacheHits: aiCacheHits,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCostUsd,
+    avgCostPerCall: aiApiCalls > 0 ? totalCostUsd / aiApiCalls : 0,
+  };
+}
+
+export function buildAiWarnings(counters: AiCounters): ImportWarning[] {
+  if (!counters.aiError || counters.aiFailureCount === 0) return [];
+  return [
+    {
+      type: 'AI_API_ERROR',
+      message: 'AI categorization unavailable',
+      affectedCount: counters.aiFailureCount,
+    },
+  ];
+}
+
+export interface ProcessBuckets {
+  matched: ProcessedTransaction[];
+  uncertain: ProcessedTransaction[];
+  failed: ProcessedTransaction[];
+  skipped: ProcessedTransaction[];
+}
+
+export function makeBuckets(): ProcessBuckets {
+  return { matched: [], uncertain: [], failed: [], skipped: [] };
+}

--- a/pillars/finance/src/api/modules/imports/progress-store.ts
+++ b/pillars/finance/src/api/modules/imports/progress-store.ts
@@ -1,0 +1,51 @@
+/**
+ * In-memory progress tracking for import sessions.
+ *
+ * Process-local state polled by the FE via `getImportProgress`. Entries
+ * auto-expire after 5 minutes to bound memory. Ported verbatim from the
+ * monolith `progress-store.ts` — the single pillar process makes the
+ * process-local store correct (no cross-instance sharing needed).
+ */
+import type { ExecuteImportOutput, ProcessImportOutput } from './types.js';
+
+export interface ImportProgress {
+  sessionId: string;
+  status: 'processing' | 'completed' | 'failed';
+  currentStep: 'deduplicating' | 'matching' | 'writing';
+  totalTransactions: number;
+  processedCount: number;
+  currentBatch: Array<{
+    description: string;
+    status: 'processing' | 'success' | 'failed';
+    error?: string;
+  }>;
+  errors: Array<{ description: string; error: string }>;
+  startedAt: string;
+  result?: ProcessImportOutput | ExecuteImportOutput;
+}
+
+const progressStore = new Map<string, ImportProgress>();
+
+const CLEANUP_DELAY_MS = 5 * 60 * 1000;
+
+/** Store progress for a session; auto-cleans after 5 minutes. */
+export function setProgress(sessionId: string, progress: ImportProgress): void {
+  progressStore.set(sessionId, progress);
+  setTimeout(() => progressStore.delete(sessionId), CLEANUP_DELAY_MS).unref?.();
+}
+
+/** Get progress for a session. Returns null if unknown or expired. */
+export function getProgress(sessionId: string): ImportProgress | null {
+  return progressStore.get(sessionId) ?? null;
+}
+
+/** Merge partial updates into an existing session. No-op if the session is gone. */
+export function updateProgress(sessionId: string, updates: Partial<ImportProgress>): void {
+  const current = progressStore.get(sessionId);
+  if (current) progressStore.set(sessionId, { ...current, ...updates });
+}
+
+/** Clear all progress entries (used by tests). */
+export function clearProgress(): void {
+  progressStore.clear();
+}

--- a/pillars/finance/src/api/modules/imports/reclassify-existing.ts
+++ b/pillars/finance/src/api/modules/imports/reclassify-existing.ts
@@ -1,0 +1,119 @@
+/**
+ * Retroactively re-classify pre-existing transactions against the updated rule
+ * set after a commit (US-04). Excludes the just-imported batch by checksum.
+ *
+ * Ported from the monolith `lib/reclassify-existing.ts`, db-injected. Matching
+ * reuses the corrections module's pure `findMatchingCorrectionFromRules`.
+ */
+import { asc, eq, notInArray } from 'drizzle-orm';
+
+import { type FinanceDb, transactionCorrections, transactions } from '../../../db/index.js';
+import { type CorrectionRow, findMatchingCorrectionFromRules } from '../corrections/index.js';
+
+const RECLASSIFY_BATCH_SIZE = 500;
+
+interface BatchTxn {
+  id: string;
+  description: string;
+  entityId: string | null;
+  type: string;
+  location: string | null;
+}
+
+function deriveNewType(ruleType: string | null): 'Transfer' | 'Income' | 'Expense' | null {
+  if (!ruleType) return null;
+  if (ruleType === 'transfer') return 'Transfer';
+  if (ruleType === 'income') return 'Income';
+  return 'Expense';
+}
+
+interface RuleDerivedState {
+  newEntityId: string | null;
+  newType: 'Transfer' | 'Income' | 'Expense' | null;
+  newLocation: string | null;
+}
+
+function deriveRuleState(rule: CorrectionRow): RuleDerivedState {
+  return {
+    newEntityId: rule.entityId ?? null,
+    newType: deriveNewType(rule.transactionType),
+    newLocation: rule.location ?? null,
+  };
+}
+
+function buildReclassifyUpdates(
+  txn: BatchTxn,
+  rule: CorrectionRow
+): Record<string, unknown> | null {
+  const state = deriveRuleState(rule);
+  const entityChanged = state.newEntityId !== (txn.entityId ?? null);
+  const typeChanged = state.newType !== null && state.newType !== txn.type;
+  const locationChanged =
+    state.newLocation !== null && state.newLocation !== (txn.location ?? null);
+
+  if (!entityChanged && !typeChanged && !locationChanged) return null;
+
+  const updates: Record<string, unknown> = { lastEditedTime: new Date().toISOString() };
+  if (entityChanged) {
+    updates.entityId = state.newEntityId;
+    updates.entityName = rule.entityName ?? null;
+  }
+  if (typeChanged) updates.type = state.newType;
+  if (locationChanged) updates.location = state.newLocation;
+  return updates;
+}
+
+function fetchBatch(db: FinanceDb, importedChecksums: string[], offset: number): BatchTxn[] {
+  let batchQuery = db
+    .select({
+      id: transactions.id,
+      description: transactions.description,
+      entityId: transactions.entityId,
+      type: transactions.type,
+      location: transactions.location,
+    })
+    .from(transactions)
+    .$dynamic();
+
+  if (importedChecksums.length > 0) {
+    batchQuery = batchQuery.where(notInArray(transactions.checksum, importedChecksums));
+  }
+
+  return batchQuery.orderBy(asc(transactions.id)).limit(RECLASSIFY_BATCH_SIZE).offset(offset).all();
+}
+
+/**
+ * Re-evaluate every existing transaction (excluding the current import batch)
+ * against the current rule set; apply and count the ones whose classification
+ * changed.
+ */
+export function reclassifyExistingTransactions(db: FinanceDb, importedChecksums: string[]): number {
+  const allRules = db
+    .select()
+    .from(transactionCorrections)
+    .orderBy(asc(transactionCorrections.priority), asc(transactionCorrections.id))
+    .all();
+
+  if (allRules.length === 0) return 0;
+
+  let reclassified = 0;
+  let offset = 0;
+
+  while (true) {
+    const batch = fetchBatch(db, importedChecksums, offset);
+    if (batch.length === 0) break;
+
+    for (const txn of batch) {
+      const match = findMatchingCorrectionFromRules(txn.description, allRules);
+      if (!match) continue;
+      const updates = buildReclassifyUpdates(txn, match.correction);
+      if (!updates) continue;
+      db.update(transactions).set(updates).where(eq(transactions.id, txn.id)).run();
+      reclassified++;
+    }
+
+    offset += RECLASSIFY_BATCH_SIZE;
+  }
+
+  return reclassified;
+}

--- a/pillars/finance/src/api/modules/imports/reevaluate-diff.ts
+++ b/pillars/finance/src/api/modules/imports/reevaluate-diff.ts
@@ -1,0 +1,22 @@
+/**
+ * Detects whether re-evaluation changed a transaction's classification.
+ *
+ * Copied verbatim from the monolith `lib/correction-helpers.ts`. A change is
+ * any bucket move, status flip, type/entity change, or match-type change —
+ * this drives the `affectedCount` returned to the FE.
+ */
+import type { ProcessedTransaction } from './types.js';
+
+export function transactionChanged(
+  prev: ProcessedTransaction,
+  next: ProcessedTransaction,
+  prevBucket?: 'matched' | 'uncertain' | 'failed',
+  nextBucket?: 'matched' | 'uncertain' | 'failed'
+): boolean {
+  if (prevBucket && nextBucket && prevBucket !== nextBucket) return true;
+  if (prev.status !== next.status) return true;
+  if (prev.transactionType !== next.transactionType) return true;
+  if (prev.entity.entityId !== next.entity.entityId) return true;
+  if (prev.entity.entityName !== next.entity.entityName) return true;
+  return prev.entity.matchType !== next.entity.matchType;
+}

--- a/pillars/finance/src/api/modules/imports/reevaluate.ts
+++ b/pillars/finance/src/api/modules/imports/reevaluate.ts
@@ -1,0 +1,201 @@
+/**
+ * Synchronous re-evaluation of an import session's remaining (uncertain/failed)
+ * transactions against the current rule set, with no AI.
+ *
+ * Ported from the monolith `lib/correction-application.ts`, db-injected. Used by
+ * applyChangeSetAndReevaluate (DB rules) and reevaluateWithPendingRules
+ * (DB rules merged with un-persisted pending ChangeSets).
+ */
+import {
+  type FinanceDb,
+  importsService,
+  transactionCorrectionsService,
+} from '../../../db/index.js';
+import { applyChangeSetToRules, type CorrectionRow } from '../corrections/index.js';
+import { applyLearnedCorrection } from './apply-learned-correction.js';
+import { matchEntity } from './entity-matcher.js';
+import { transactionChanged } from './reevaluate-diff.js';
+import { buildSuggestedTags, loadKnownTags } from './tag-management.js';
+
+import type { ChangeSet } from '../../../contract/rest-corrections.js';
+import type { EntityMaps } from '../../../db/index.js';
+import type { ProcessedTransaction, ProcessImportOutput } from './types.js';
+
+interface ReevaluateContext {
+  db: FinanceDb;
+  rules?: CorrectionRow[];
+  minConfidence: number;
+  knownTags: string[];
+  entityLookup: EntityMaps['entityLookup'];
+  aliases: EntityMaps['aliasMap'];
+}
+
+interface RemainingItem {
+  tx: ProcessedTransaction;
+  bucket: 'uncertain' | 'failed';
+}
+
+interface BucketAccumulator {
+  matched: ProcessedTransaction[];
+  uncertain: ProcessedTransaction[];
+  failed: ProcessedTransaction[];
+}
+
+interface StageResult {
+  handled: boolean;
+  changed: boolean;
+}
+
+function tryApplyCorrectionStage(
+  item: RemainingItem,
+  ctx: ReevaluateContext,
+  buckets: BucketAccumulator
+): StageResult {
+  const correctionApplied = applyLearnedCorrection(ctx.db, {
+    transaction: item.tx,
+    minConfidence: ctx.minConfidence,
+    knownTags: ctx.knownTags,
+    rules: ctx.rules,
+  });
+  if (!correctionApplied) return { handled: false, changed: false };
+
+  const nextTx = correctionApplied.processed;
+  const nextBucket = correctionApplied.bucket;
+  if (nextBucket === 'matched') buckets.matched.push(nextTx);
+  else buckets.uncertain.push(nextTx);
+
+  return { handled: true, changed: transactionChanged(item.tx, nextTx, item.bucket, nextBucket) };
+}
+
+function tryEntityMatchStage(
+  item: RemainingItem,
+  ctx: ReevaluateContext,
+  buckets: BucketAccumulator,
+  alwaysAffected: boolean
+): StageResult {
+  const match = matchEntity(item.tx.description, ctx.entityLookup, ctx.aliases);
+  if (!match) return { handled: false, changed: false };
+
+  const entityEntry = ctx.entityLookup.get(match.entityName.toLowerCase());
+  if (!entityEntry) {
+    if (item.bucket === 'failed') buckets.failed.push(item.tx);
+    else buckets.uncertain.push(item.tx);
+    return { handled: true, changed: false };
+  }
+
+  const nextTx: ProcessedTransaction = {
+    ...item.tx,
+    entity: { entityId: entityEntry.id, entityName: entityEntry.name, matchType: match.matchType },
+    status: 'matched',
+    error: undefined,
+    suggestedTags: buildSuggestedTags(ctx.db, {
+      description: item.tx.description,
+      entityId: entityEntry.id,
+      correctionTags: [],
+      aiCategory: null,
+      knownTags: ctx.knownTags,
+    }),
+  };
+
+  buckets.matched.push(nextTx);
+  return { handled: true, changed: alwaysAffected || transactionChanged(item.tx, nextTx) };
+}
+
+function processRemainingItem(
+  item: RemainingItem,
+  ctx: ReevaluateContext,
+  buckets: BucketAccumulator,
+  alwaysAffectedOnEntityMatch: boolean
+): boolean {
+  const corrStage = tryApplyCorrectionStage(item, ctx, buckets);
+  if (corrStage.handled) return corrStage.changed;
+
+  const entityStage = tryEntityMatchStage(item, ctx, buckets, alwaysAffectedOnEntityMatch);
+  if (entityStage.handled) return entityStage.changed;
+
+  if (item.bucket === 'failed') buckets.failed.push(item.tx);
+  else buckets.uncertain.push(item.tx);
+  return false;
+}
+
+function runReevaluate(
+  result: ProcessImportOutput,
+  ctx: ReevaluateContext,
+  alwaysAffectedOnEntityMatch: boolean
+): { nextResult: ProcessImportOutput; affectedCount: number } {
+  const buckets: BucketAccumulator = { matched: [...result.matched], uncertain: [], failed: [] };
+
+  const remaining: RemainingItem[] = [
+    ...result.uncertain.map((tx) => ({ tx, bucket: 'uncertain' as const })),
+    ...result.failed.map((tx) => ({ tx, bucket: 'failed' as const })),
+  ];
+
+  let affectedCount = 0;
+  for (const item of remaining) {
+    if (processRemainingItem(item, ctx, buckets, alwaysAffectedOnEntityMatch)) affectedCount += 1;
+  }
+
+  return {
+    nextResult: {
+      ...result,
+      matched: buckets.matched,
+      uncertain: buckets.uncertain,
+      failed: buckets.failed,
+    },
+    affectedCount,
+  };
+}
+
+/** Re-evaluate against the persisted DB rule set (post-apply). */
+export function reevaluateImportSessionResult(args: {
+  db: FinanceDb;
+  result: ProcessImportOutput;
+  minConfidence: number;
+}): { nextResult: ProcessImportOutput; affectedCount: number } {
+  const { entityLookup, aliasMap: aliases } = importsService.loadEntityMaps(args.db);
+  return runReevaluate(
+    args.result,
+    {
+      db: args.db,
+      minConfidence: args.minConfidence,
+      knownTags: loadKnownTags(args.db),
+      entityLookup,
+      aliases,
+    },
+    false
+  );
+}
+
+/** Re-evaluate against merged rules (DB rules + un-persisted pending ChangeSets). */
+export function reevaluateImportSessionWithRules(args: {
+  db: FinanceDb;
+  result: ProcessImportOutput;
+  minConfidence: number;
+  pendingChangeSets: { changeSet: ChangeSet }[];
+}): { nextResult: ProcessImportOutput; affectedCount: number } {
+  const dbRules = transactionCorrectionsService.listTransactionCorrections(args.db, {
+    limit: 50_000,
+    offset: 0,
+  }).rows;
+  const mergedRules =
+    args.pendingChangeSets.length > 0
+      ? args.pendingChangeSets.reduce(
+          (acc, pcs) => applyChangeSetToRules(acc, pcs.changeSet),
+          dbRules
+        )
+      : dbRules;
+
+  const { entityLookup, aliasMap: aliases } = importsService.loadEntityMaps(args.db);
+  return runReevaluate(
+    args.result,
+    {
+      db: args.db,
+      rules: mergedRules,
+      minConfidence: args.minConfidence,
+      knownTags: loadKnownTags(args.db),
+      entityLookup,
+      aliases,
+    },
+    true
+  );
+}

--- a/pillars/finance/src/api/modules/imports/service.ts
+++ b/pillars/finance/src/api/modules/imports/service.ts
@@ -1,0 +1,102 @@
+/**
+ * Import service orchestration — background process/execute with progress
+ * streaming into the in-memory progress store, plus the thin `createEntity`
+ * shim.
+ *
+ * Ported from the monolith `service.ts`, db-injected. The handler kicks these
+ * off (returning a session id immediately) and the FE polls `getImportProgress`.
+ */
+import { type FinanceDb, importsService } from '../../../db/index.js';
+import { executeImportCore } from './execute-service.js';
+import { formatImportError } from './format-error.js';
+import { processImportCore } from './process-service.js';
+import { updateProgress } from './progress-store.js';
+
+import type { ConfirmedTransaction, CreateEntityOutput, ParsedTransaction } from './types.js';
+
+export { commitImport } from './commit.js';
+export { reevaluateImportSessionResult, reevaluateImportSessionWithRules } from './reevaluate.js';
+
+/** Create a new entity during an import session. */
+export function createEntity(db: FinanceDb, name: string): CreateEntityOutput {
+  return importsService.createImportEntity(db, name);
+}
+
+function newImportBatchId(): string {
+  return `import-${Date.now()}-${Math.random().toString(36).slice(7)}`;
+}
+
+function reportBackgroundFailure(sessionId: string, error: unknown): void {
+  const formatted = formatImportError(error);
+  updateProgress(sessionId, {
+    status: 'failed',
+    errors: [
+      {
+        description: 'System',
+        error: formatted.message + (formatted.suggestion ? ` - ${formatted.suggestion}` : ''),
+      },
+    ],
+  });
+}
+
+/** Run a process import with progress updates, then mark the session completed/failed. */
+export async function processImportWithProgress(
+  db: FinanceDb,
+  sessionId: string,
+  transactions: ParsedTransaction[],
+  account: string
+): Promise<void> {
+  try {
+    const {
+      output: result,
+      errors,
+      processedNewCount,
+    } = await processImportCore({
+      db,
+      transactions,
+      account,
+      importBatchId: newImportBatchId(),
+      onProgress: (update) => updateProgress(sessionId, update),
+    });
+
+    updateProgress(sessionId, {
+      status: 'completed',
+      processedCount: processedNewCount,
+      result,
+      errors,
+    });
+  } catch (error) {
+    reportBackgroundFailure(sessionId, error);
+  }
+}
+
+/** Run an execute import with progress updates, then mark the session completed/failed. */
+export function executeImportWithProgress(
+  db: FinanceDb,
+  sessionId: string,
+  transactions: ConfirmedTransaction[]
+): void {
+  try {
+    updateProgress(sessionId, {
+      currentStep: 'writing',
+      totalTransactions: transactions.length,
+      processedCount: 0,
+      currentBatch: [],
+      errors: [],
+    });
+
+    const {
+      output: result,
+      errors,
+      processedCount,
+    } = executeImportCore({
+      db,
+      transactions,
+      onProgress: (update) => updateProgress(sessionId, update),
+    });
+
+    updateProgress(sessionId, { status: 'completed', processedCount, result, errors });
+  } catch (error) {
+    reportBackgroundFailure(sessionId, error);
+  }
+}

--- a/pillars/finance/src/api/modules/imports/tag-management.ts
+++ b/pillars/finance/src/api/modules/imports/tag-management.ts
@@ -1,0 +1,80 @@
+/**
+ * Tag-loading + suggestion glue for the import pipeline.
+ *
+ * Ported from the monolith `lib/tag-management.ts`, db-injected: `loadKnownTags`
+ * takes a `FinanceDb` handle and `buildSuggestedTags` forwards to the pillar's
+ * own `suggestTags` (which also takes the handle).
+ */
+import { and, eq, isNotNull, ne } from 'drizzle-orm';
+
+import { type FinanceDb, tagVocabulary, transactions } from '../../../db/index.js';
+import { suggestTags, type SuggestedTag } from '../tag-suggester/index.js';
+
+function addTagsToSet(target: Set<string>, raw: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  for (const t of parsed) {
+    if (typeof t === 'string') target.add(t);
+  }
+}
+
+/**
+ * Load the flat list of every tag currently in use — the active tag vocabulary
+ * plus every distinct tag on a stored transaction. Called once per import batch
+ * and threaded into `buildSuggestedTags` so AI/category validation has the full
+ * vocabulary without re-querying per transaction.
+ */
+export function loadKnownTags(db: FinanceDb): string[] {
+  const seen = new Set<string>();
+
+  const vocab = db
+    .select({ tag: tagVocabulary.tag })
+    .from(tagVocabulary)
+    .where(eq(tagVocabulary.isActive, true))
+    .all();
+  for (const row of vocab) {
+    if (row.tag) seen.add(row.tag);
+  }
+
+  const rows = db
+    .select({ tags: transactions.tags })
+    .from(transactions)
+    .where(and(isNotNull(transactions.tags), ne(transactions.tags, '[]')))
+    .all();
+  for (const row of rows) {
+    if (row.tags) addTagsToSet(seen, row.tags);
+  }
+
+  return Array.from(seen);
+}
+
+export interface BuildSuggestedTagsOptions {
+  description: string;
+  entityId: string | null;
+  correctionTags: string[];
+  aiTags?: string[];
+  aiCategory: string | null;
+  knownTags: string[];
+  correctionPattern?: string;
+}
+
+/**
+ * Build the suggested tags for a single transaction with source attribution
+ * (rule > ai > entity). Thin pass-through to the pillar's `suggestTags`.
+ */
+export function buildSuggestedTags(db: FinanceDb, opts: BuildSuggestedTagsOptions): SuggestedTag[] {
+  return suggestTags(db, {
+    description: opts.description,
+    entityId: opts.entityId,
+    aiTags: opts.aiTags,
+    aiCategory: opts.aiCategory,
+    knownTags: opts.knownTags,
+    correctionTags: opts.correctionTags,
+    correctionPattern: opts.correctionPattern,
+  });
+}

--- a/pillars/finance/src/api/modules/imports/transfer-classifier.ts
+++ b/pillars/finance/src/api/modules/imports/transfer-classifier.ts
@@ -1,0 +1,17 @@
+/**
+ * Pre-AI classifier that auto-tags inbound transfer / income rows so they skip
+ * the entity matcher and AI categorizer entirely (#2448).
+ *
+ * Rule: a negative-amount row whose description contains a transfer/income
+ * keyword is an inter-account movement, not a merchant purchase. Copied verbatim
+ * from the monolith `lib/transfer-classifier.ts`.
+ */
+import type { ParsedTransaction } from './types.js';
+
+const TRANSFER_KEYWORD_PATTERN = /\b(payment|transfer|refund|payid|salary|reimbursement)\b/i;
+
+/** True when the row should be auto-classified as a transfer (bypassing matching/AI). */
+export function isTransferOrIncomeRow(transaction: ParsedTransaction): boolean {
+  if (transaction.amount >= 0) return false;
+  return TRANSFER_KEYWORD_PATTERN.test(transaction.description);
+}

--- a/pillars/finance/src/api/modules/imports/types.ts
+++ b/pillars/finance/src/api/modules/imports/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Internal TS shapes for the imports domain logic.
+ *
+ * The wire schemas + their inferred types live in the contract
+ * (`contract/rest-imports-schemas.ts`); this file re-exports those inferred
+ * types for the pipeline plus the internal-only coordination types that never
+ * cross the wire (progress batch items, AI counters, the per-batch context).
+ */
+import type { EntityMaps } from '../../../db/index.js';
+
+export type {
+  AiUsageStats,
+  CommitPayload,
+  CommitResult,
+  ConfirmedTransaction,
+  CreateEntityOutput,
+  EntityMatch,
+  ExecuteImportOutput,
+  FailedTransactionDetail,
+  ImportResult,
+  ImportWarning,
+  MatchedRule,
+  ParsedTransaction,
+  ProcessedTransaction,
+  ProcessImportOutput,
+  RuleProvenance,
+  SuggestedTag,
+  TransactionType,
+} from '../../../contract/rest-imports-schemas.js';
+
+export interface ProgressBatchItem {
+  description: string;
+  status: 'processing' | 'success' | 'failed';
+  error?: string;
+}
+
+export interface ErrorEntry {
+  description: string;
+  error: string;
+}
+
+export interface AiCounters {
+  /** True once any AI call has failed in this batch (gates the no-match reason). */
+  aiError: boolean;
+  aiFailureCount: number;
+  aiApiCalls: number;
+  aiCacheHits: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+}
+
+export interface ProcessContext {
+  entityLookup: EntityMaps['entityLookup'];
+  aliases: EntityMaps['aliasMap'];
+  knownTags: string[];
+  importBatchId: string;
+}
+
+export function createAiCounters(): AiCounters {
+  return {
+    aiError: false,
+    aiFailureCount: 0,
+    aiApiCalls: 0,
+    aiCacheHits: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCostUsd: 0,
+  };
+}

--- a/pillars/finance/src/api/rest/error-mapping.ts
+++ b/pillars/finance/src/api/rest/error-mapping.ts
@@ -19,7 +19,7 @@ export interface ErrorBody {
   messageKey?: string;
 }
 
-export type ErrorStatus = 400 | 404 | 409;
+export type ErrorStatus = 400 | 404 | 409 | 412;
 
 export interface MappedHttpError {
   status: ErrorStatus;
@@ -27,7 +27,7 @@ export interface MappedHttpError {
 }
 
 function isMappedStatus(status: number): status is ErrorStatus {
-  return status === 400 || status === 404 || status === 409;
+  return status === 400 || status === 404 || status === 409 || status === 412;
 }
 
 export function mapHttpError(err: unknown): MappedHttpError | null {

--- a/pillars/finance/src/api/rest/handlers.ts
+++ b/pillars/finance/src/api/rest/handlers.ts
@@ -10,6 +10,7 @@ import { initServer } from '@ts-rest/express';
 import { financeContract } from '../../contract/rest.js';
 import { type OpenedFinanceDb } from '../../db/index.js';
 import { makeBudgetsHandlers } from './budgets-handlers.js';
+import { makeImportsHandlers } from './imports-handlers.js';
 import { makeTagRulesHandlers } from './tag-rules-handlers.js';
 import { makeTransactionsHandlers } from './transactions-handlers.js';
 import { makeWishlistHandlers } from './wishlist-handlers.js';
@@ -25,5 +26,6 @@ export function makeFinanceRestHandlers(deps: {
     budgets: makeBudgetsHandlers(db),
     transactions: makeTransactionsHandlers(db),
     tagRules: makeTagRulesHandlers(db),
+    imports: makeImportsHandlers(db),
   });
 }

--- a/pillars/finance/src/api/rest/imports-handlers.ts
+++ b/pillars/finance/src/api/rest/imports-handlers.ts
@@ -1,0 +1,153 @@
+/**
+ * Handlers for the `imports.*` sub-router.
+ *
+ * processImport / executeImport mint a session id, seed the in-memory progress
+ * store, kick off the work (process in the background; execute synchronously),
+ * and return `{ sessionId }` immediately — the FE then polls getImportProgress.
+ *
+ * Error translation (preserving the monolith's tRPC error codes):
+ *   - unknown session                       → 404 (finance.import.sessionNotFound)
+ *   - session not completed / no result     → 412 (finance.import.sessionNotReady)
+ *   - completed but wrong result type       → 412 (finance.import.sessionNotProcessResult)
+ *   - correction/tag-rule NotFoundError      → 404 (propagated from the ChangeSet apply)
+ *   - ValidationError (commit payload)       → 400 (propagated)
+ */
+import { randomUUID } from 'node:crypto';
+
+import { type FinanceDb } from '../../db/index.js';
+import { applyChangeSet } from '../modules/corrections/index.js';
+import {
+  commitImport,
+  createEntity,
+  executeImportWithProgress,
+  getProgress,
+  processImportWithProgress,
+  reevaluateImportSessionResult,
+  reevaluateImportSessionWithRules,
+  setProgress,
+  updateProgress,
+} from '../modules/imports/index.js';
+import { NotFoundError, PreconditionError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { financeImportsContract } from '../../contract/rest-imports.js';
+import type { ImportProgress } from '../modules/imports/index.js';
+import type { ProcessImportOutput } from '../modules/imports/types.js';
+
+type Req = ServerInferRequest<typeof financeImportsContract>;
+
+function isProcessImportOutput(result: unknown): result is ProcessImportOutput {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'matched' in result &&
+    'uncertain' in result &&
+    'failed' in result &&
+    'skipped' in result
+  );
+}
+
+/**
+ * Resolve a completed processImport session or throw the matching HttpError.
+ * Shared by applyChangeSetAndReevaluate + reevaluateWithPendingRules.
+ */
+function requireProcessSession(sessionId: string): {
+  progress: ImportProgress;
+  result: ProcessImportOutput;
+} {
+  const progress = getProgress(sessionId);
+  if (!progress) {
+    throw new NotFoundError('Import session', sessionId);
+  }
+  if (progress.status !== 'completed' || !progress.result) {
+    throw new PreconditionError('Import session not ready', 'finance.import.sessionNotReady');
+  }
+  const result = progress.result;
+  if (!isProcessImportOutput(result)) {
+    throw new PreconditionError(
+      'Import session result is not a process result',
+      'finance.import.sessionNotProcessResult'
+    );
+  }
+  return { progress, result };
+}
+
+export function makeImportsHandlers(db: FinanceDb) {
+  return {
+    processImport: ({ body }: Req['processImport']) =>
+      runHttp(() => {
+        const sessionId = randomUUID();
+        setProgress(sessionId, {
+          sessionId,
+          status: 'processing',
+          currentStep: 'deduplicating',
+          totalTransactions: body.transactions.length,
+          processedCount: 0,
+          currentBatch: [],
+          errors: [],
+          startedAt: new Date().toISOString(),
+        });
+        processImportWithProgress(db, sessionId, body.transactions, body.account).catch((error) => {
+          console.error(`[Import] Background processing failed: ${String(error)}`);
+        });
+        return { status: 200 as const, body: { sessionId } };
+      }),
+
+    executeImport: ({ body }: Req['executeImport']) =>
+      runHttp(() => {
+        const sessionId = randomUUID();
+        setProgress(sessionId, {
+          sessionId,
+          status: 'processing',
+          currentStep: 'writing',
+          totalTransactions: body.transactions.length,
+          processedCount: 0,
+          currentBatch: [],
+          errors: [],
+          startedAt: new Date().toISOString(),
+        });
+        executeImportWithProgress(db, sessionId, body.transactions);
+        return { status: 200 as const, body: { sessionId } };
+      }),
+
+    getImportProgress: ({ query }: Req['getImportProgress']) =>
+      runHttp(() => ({ status: 200 as const, body: getProgress(query.sessionId) })),
+
+    createEntity: ({ body }: Req['createEntity']) =>
+      runHttp(() => ({ status: 200 as const, body: createEntity(db, body.name) })),
+
+    applyChangeSetAndReevaluate: ({ body }: Req['applyChangeSetAndReevaluate']) =>
+      runHttp(() => {
+        const { result } = requireProcessSession(body.sessionId);
+        applyChangeSet(db, body.changeSet);
+        const { nextResult, affectedCount } = reevaluateImportSessionResult({
+          db,
+          result,
+          minConfidence: body.minConfidence,
+        });
+        updateProgress(body.sessionId, { result: nextResult });
+        return { status: 200 as const, body: { result: nextResult, affectedCount } };
+      }),
+
+    commitImport: ({ body }: Req['commitImport']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: commitImport(db, body), message: 'Import committed' },
+      })),
+
+    reevaluateWithPendingRules: ({ body }: Req['reevaluateWithPendingRules']) =>
+      runHttp(() => {
+        const { result } = requireProcessSession(body.sessionId);
+        const { nextResult, affectedCount } = reevaluateImportSessionWithRules({
+          db,
+          result,
+          minConfidence: body.minConfidence,
+          pendingChangeSets: body.pendingChangeSets,
+        });
+        updateProgress(body.sessionId, { result: nextResult });
+        return { status: 200 as const, body: { result: nextResult, affectedCount } };
+      }),
+  };
+}

--- a/pillars/finance/src/api/shared/errors.ts
+++ b/pillars/finance/src/api/shared/errors.ts
@@ -44,3 +44,16 @@ export class ConflictError extends HttpError {
     this.name = 'ConflictError';
   }
 }
+
+/**
+ * 412 Precondition Failed — the targeted import session exists but is not in a
+ * state the requested operation can act on (still processing, no result, or
+ * the wrong result type). Carries an optional `messageKey` so the FE keeps the
+ * i18n behaviour the tRPC layer had.
+ */
+export class PreconditionError extends HttpError {
+  constructor(message: string, messageKey?: string) {
+    super(412, message, undefined, messageKey);
+    this.name = 'PreconditionError';
+  }
+}

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -40,6 +40,125 @@ export interface paths {
     patch: operations['budgets.update'];
     trace?: never;
   };
+  '/imports/apply-changeset-reevaluate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Apply a correction ChangeSet atomically, then re-evaluate the import session */
+    post: operations['imports.applyChangeSetAndReevaluate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/commit': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Atomically create entities, apply changeSets + tag-rule changeSets, write transactions */
+    post: operations['imports.commitImport'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/entities': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a new entity during an import session */
+    post: operations['imports.createEntity'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/execute': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Write confirmed transactions to SQLite; returns a session id to poll */
+    post: operations['imports.executeImport'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/process': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Start an import process (dedup + entity matching); returns a session id to poll */
+    post: operations['imports.processImport'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/progress': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Poll an import session for progress (null when the session is unknown/expired) */
+    get: operations['imports.getImportProgress'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/imports/reevaluate-pending': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Re-evaluate the import session against merged (DB + pending) rules; no DB writes */
+    post: operations['imports.reevaluateWithPendingRules'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/tag-rules/apply': {
     parameters: {
       query?: never;
@@ -622,6 +741,1577 @@ export interface operations {
       };
       /** @description 409 */
       409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.applyChangeSetAndReevaluate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          /** @default 0.7 */
+          minConfidence: number;
+          /** Format: uuid */
+          sessionId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            affectedCount: number;
+            result: {
+              aiUsage?: {
+                apiCalls: number;
+                avgCostPerCall: number;
+                cacheHits: number;
+                totalCostUsd: number;
+                totalInputTokens: number;
+                totalOutputTokens: number;
+              };
+              failed: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              matched: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              skipped: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              uncertain: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              warnings?: {
+                affectedCount?: number;
+                details?: string;
+                message: string;
+                /** @enum {string} */
+                type: 'AI_CATEGORIZATION_UNAVAILABLE' | 'AI_API_ERROR';
+              }[];
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 412 */
+      412: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.commitImport': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @default [] */
+          changeSets: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          }[];
+          /** @default [] */
+          entities: {
+            name: string;
+            tempId: string;
+            /**
+             * @default company
+             * @enum {string}
+             */
+            type: 'company' | 'person' | 'government' | 'bank' | 'place' | 'brand' | 'organisation';
+          }[];
+          /** @default [] */
+          tagRuleChangeSets: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags: string[];
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    priority?: number;
+                    tags?: string[];
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          }[];
+          transactions: {
+            account: string;
+            amount: number;
+            checksum: string;
+            date: string;
+            description: string;
+            entityId?: string;
+            entityName?: string;
+            location?: string;
+            rawRow: string;
+            suggestedTags?: {
+              isNew?: boolean;
+              pattern?: string;
+              /** @enum {string} */
+              source: 'ai' | 'rule' | 'entity';
+              tag: string;
+            }[];
+            tags?: string[];
+            /** @enum {string} */
+            transactionType?: 'purchase' | 'transfer' | 'income';
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              entitiesCreated: number;
+              failedDetails: {
+                checksum: string | null;
+                error: string;
+              }[];
+              retroactiveReclassifications: number;
+              rulesApplied: {
+                add: number;
+                disable: number;
+                edit: number;
+                remove: number;
+              };
+              tagRulesApplied: number;
+              transactionsFailed: number;
+              transactionsImported: number;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.createEntity': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          name: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            entityId: string;
+            entityName: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.executeImport': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          transactions: {
+            account: string;
+            amount: number;
+            checksum: string;
+            date: string;
+            description: string;
+            entityId?: string;
+            entityName?: string;
+            location?: string;
+            rawRow: string;
+            suggestedTags?: {
+              isNew?: boolean;
+              pattern?: string;
+              /** @enum {string} */
+              source: 'ai' | 'rule' | 'entity';
+              tag: string;
+            }[];
+            tags?: string[];
+            /** @enum {string} */
+            transactionType?: 'purchase' | 'transfer' | 'income';
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            sessionId: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.processImport': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          account: string;
+          transactions: {
+            account: string;
+            amount: number;
+            checksum: string;
+            date: string;
+            description: string;
+            location?: string;
+            rawRow: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            sessionId: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.getImportProgress': {
+    parameters: {
+      query: {
+        sessionId: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            currentBatch: {
+              description: string;
+              error?: string;
+              /** @enum {string} */
+              status: 'processing' | 'success' | 'failed';
+            }[];
+            /** @enum {string} */
+            currentStep: 'deduplicating' | 'matching' | 'writing';
+            errors: {
+              description: string;
+              error: string;
+            }[];
+            processedCount: number;
+            result?:
+              | {
+                  aiUsage?: {
+                    apiCalls: number;
+                    avgCostPerCall: number;
+                    cacheHits: number;
+                    totalCostUsd: number;
+                    totalInputTokens: number;
+                    totalOutputTokens: number;
+                  };
+                  failed: {
+                    account: string;
+                    amount: number;
+                    checksum: string;
+                    date: string;
+                    description: string;
+                    entity: {
+                      confidence?: number;
+                      entityId?: string;
+                      entityName?: string;
+                      /** @enum {string} */
+                      matchType:
+                        | 'alias'
+                        | 'exact'
+                        | 'prefix'
+                        | 'contains'
+                        | 'ai'
+                        | 'learned'
+                        | 'manual'
+                        | 'none';
+                    };
+                    error?: string;
+                    location?: string;
+                    matchedRules?: {
+                      confidence: number;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      priority: number;
+                      ruleId: string;
+                    }[];
+                    rawRow: string;
+                    ruleProvenance?: {
+                      confidence: number;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      ruleId: string;
+                      /** @enum {string} */
+                      source: 'correction';
+                    };
+                    skipReason?: string;
+                    /** @enum {string} */
+                    status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                    suggestedTags?: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'ai' | 'rule' | 'entity';
+                      tag: string;
+                    }[];
+                    /** @enum {string} */
+                    transactionType?: 'purchase' | 'transfer' | 'income';
+                  }[];
+                  matched: {
+                    account: string;
+                    amount: number;
+                    checksum: string;
+                    date: string;
+                    description: string;
+                    entity: {
+                      confidence?: number;
+                      entityId?: string;
+                      entityName?: string;
+                      /** @enum {string} */
+                      matchType:
+                        | 'alias'
+                        | 'exact'
+                        | 'prefix'
+                        | 'contains'
+                        | 'ai'
+                        | 'learned'
+                        | 'manual'
+                        | 'none';
+                    };
+                    error?: string;
+                    location?: string;
+                    matchedRules?: {
+                      confidence: number;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      priority: number;
+                      ruleId: string;
+                    }[];
+                    rawRow: string;
+                    ruleProvenance?: {
+                      confidence: number;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      ruleId: string;
+                      /** @enum {string} */
+                      source: 'correction';
+                    };
+                    skipReason?: string;
+                    /** @enum {string} */
+                    status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                    suggestedTags?: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'ai' | 'rule' | 'entity';
+                      tag: string;
+                    }[];
+                    /** @enum {string} */
+                    transactionType?: 'purchase' | 'transfer' | 'income';
+                  }[];
+                  skipped: {
+                    account: string;
+                    amount: number;
+                    checksum: string;
+                    date: string;
+                    description: string;
+                    entity: {
+                      confidence?: number;
+                      entityId?: string;
+                      entityName?: string;
+                      /** @enum {string} */
+                      matchType:
+                        | 'alias'
+                        | 'exact'
+                        | 'prefix'
+                        | 'contains'
+                        | 'ai'
+                        | 'learned'
+                        | 'manual'
+                        | 'none';
+                    };
+                    error?: string;
+                    location?: string;
+                    matchedRules?: {
+                      confidence: number;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      priority: number;
+                      ruleId: string;
+                    }[];
+                    rawRow: string;
+                    ruleProvenance?: {
+                      confidence: number;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      ruleId: string;
+                      /** @enum {string} */
+                      source: 'correction';
+                    };
+                    skipReason?: string;
+                    /** @enum {string} */
+                    status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                    suggestedTags?: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'ai' | 'rule' | 'entity';
+                      tag: string;
+                    }[];
+                    /** @enum {string} */
+                    transactionType?: 'purchase' | 'transfer' | 'income';
+                  }[];
+                  uncertain: {
+                    account: string;
+                    amount: number;
+                    checksum: string;
+                    date: string;
+                    description: string;
+                    entity: {
+                      confidence?: number;
+                      entityId?: string;
+                      entityName?: string;
+                      /** @enum {string} */
+                      matchType:
+                        | 'alias'
+                        | 'exact'
+                        | 'prefix'
+                        | 'contains'
+                        | 'ai'
+                        | 'learned'
+                        | 'manual'
+                        | 'none';
+                    };
+                    error?: string;
+                    location?: string;
+                    matchedRules?: {
+                      confidence: number;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      priority: number;
+                      ruleId: string;
+                    }[];
+                    rawRow: string;
+                    ruleProvenance?: {
+                      confidence: number;
+                      /** @enum {string} */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      pattern: string;
+                      ruleId: string;
+                      /** @enum {string} */
+                      source: 'correction';
+                    };
+                    skipReason?: string;
+                    /** @enum {string} */
+                    status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                    suggestedTags?: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'ai' | 'rule' | 'entity';
+                      tag: string;
+                    }[];
+                    /** @enum {string} */
+                    transactionType?: 'purchase' | 'transfer' | 'income';
+                  }[];
+                  warnings?: {
+                    affectedCount?: number;
+                    details?: string;
+                    message: string;
+                    /** @enum {string} */
+                    type: 'AI_CATEGORIZATION_UNAVAILABLE' | 'AI_API_ERROR';
+                  }[];
+                }
+              | {
+                  failed: {
+                    error?: string;
+                    pageId?: string;
+                    success: boolean;
+                    transaction: {
+                      account: string;
+                      amount: number;
+                      checksum: string;
+                      date: string;
+                      description: string;
+                      entityId?: string;
+                      entityName?: string;
+                      location?: string;
+                      rawRow: string;
+                      suggestedTags?: {
+                        isNew?: boolean;
+                        pattern?: string;
+                        /** @enum {string} */
+                        source: 'ai' | 'rule' | 'entity';
+                        tag: string;
+                      }[];
+                      tags?: string[];
+                      /** @enum {string} */
+                      transactionType?: 'purchase' | 'transfer' | 'income';
+                    };
+                  }[];
+                  imported: number;
+                  skipped: number;
+                };
+            sessionId: string;
+            startedAt: string;
+            /** @enum {string} */
+            status: 'processing' | 'completed' | 'failed';
+            totalTransactions: number;
+          } | null;
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'imports.reevaluateWithPendingRules': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @default 0.7 */
+          minConfidence: number;
+          pendingChangeSets: {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      /** @default [] */
+                      tags: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern?: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /** @enum {string} */
+                      matchType?: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags?: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+          }[];
+          /** Format: uuid */
+          sessionId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            affectedCount: number;
+            result: {
+              aiUsage?: {
+                apiCalls: number;
+                avgCostPerCall: number;
+                cacheHits: number;
+                totalCostUsd: number;
+                totalInputTokens: number;
+                totalOutputTokens: number;
+              };
+              failed: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              matched: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              skipped: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              uncertain: {
+                account: string;
+                amount: number;
+                checksum: string;
+                date: string;
+                description: string;
+                entity: {
+                  confidence?: number;
+                  entityId?: string;
+                  entityName?: string;
+                  /** @enum {string} */
+                  matchType:
+                    | 'alias'
+                    | 'exact'
+                    | 'prefix'
+                    | 'contains'
+                    | 'ai'
+                    | 'learned'
+                    | 'manual'
+                    | 'none';
+                };
+                error?: string;
+                location?: string;
+                matchedRules?: {
+                  confidence: number;
+                  entityId?: string | null;
+                  entityName?: string | null;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  priority: number;
+                  ruleId: string;
+                }[];
+                rawRow: string;
+                ruleProvenance?: {
+                  confidence: number;
+                  /** @enum {string} */
+                  matchType: 'exact' | 'contains' | 'regex';
+                  pattern: string;
+                  ruleId: string;
+                  /** @enum {string} */
+                  source: 'correction';
+                };
+                skipReason?: string;
+                /** @enum {string} */
+                status: 'matched' | 'uncertain' | 'failed' | 'skipped';
+                suggestedTags?: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'ai' | 'rule' | 'entity';
+                  tag: string;
+                }[];
+                /** @enum {string} */
+                transactionType?: 'purchase' | 'transfer' | 'income';
+              }[];
+              warnings?: {
+                affectedCount?: number;
+                details?: string;
+                message: string;
+                /** @enum {string} */
+                type: 'AI_CATEGORIZATION_UNAVAILABLE' | 'AI_API_ERROR';
+              }[];
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 412 */
+      412: {
         headers: {
           [name: string]: unknown;
         };

--- a/pillars/finance/src/contract/rest-corrections.ts
+++ b/pillars/finance/src/contract/rest-corrections.ts
@@ -1,0 +1,64 @@
+/**
+ * Correction-rule ChangeSet zod schemas for the finance pillar.
+ *
+ * Mirrors the monolith `core/corrections/{correction-schemas,changeset-types}.ts`.
+ * The corrections domain has no finance-owned REST routes of its own yet — the
+ * imports pipeline is the only consumer, and it needs the ChangeSet shape both
+ * on the wire (commit / applyChangeSetAndReevaluate / reevaluateWithPendingRules
+ * payloads) and internally (the ported `applyChangeSet` + reevaluation logic).
+ *
+ * Authored standalone (not imported from the monolith barrel) per the severance
+ * rules. Only the schemas + inferred types are exported; if a real corrections
+ * route surfaces later it composes these.
+ */
+import { z } from 'zod';
+
+const MatchTypeSchema = z.enum(['exact', 'contains', 'regex']);
+const TransactionTypeSchema = z.enum(['purchase', 'transfer', 'income']);
+
+/** Body of a correction `add` op (create-shape + ChangeSet-only confidence/isActive). */
+export const CreateCorrectionSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema.default('exact'),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional().default([]),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+/** Body of a correction `edit` op (all fields optional patch). */
+export const UpdateCorrectionSchema = z.object({
+  descriptionPattern: z.string().min(1).optional(),
+  matchType: MatchTypeSchema.optional(),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+  isActive: z.boolean().optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+const CorrectionRuleDataSchema = CreateCorrectionSchema.extend({
+  confidence: z.number().min(0).max(1).optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const ChangeSetOpSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('add'), data: CorrectionRuleDataSchema }),
+  z.object({ op: z.literal('edit'), id: z.string().min(1), data: UpdateCorrectionSchema }),
+  z.object({ op: z.literal('disable'), id: z.string().min(1) }),
+  z.object({ op: z.literal('remove'), id: z.string().min(1) }),
+]);
+
+export const ChangeSetSchema = z.object({
+  source: z.string().optional(),
+  reason: z.string().optional(),
+  ops: z.array(ChangeSetOpSchema).min(1),
+});
+
+export type ChangeSetOp = z.infer<typeof ChangeSetOpSchema>;
+export type ChangeSet = z.infer<typeof ChangeSetSchema>;

--- a/pillars/finance/src/contract/rest-imports-schemas.ts
+++ b/pillars/finance/src/contract/rest-imports-schemas.ts
@@ -1,0 +1,221 @@
+/**
+ * Zod schemas + inferred types for the `imports.*` sub-router.
+ *
+ * Split from `rest-imports.ts` so the route map there stays under the per-file
+ * line cap. These are the single source of truth for the import wire shapes;
+ * the CSV/PDF transformers are out of scope (the wire receives already-parsed
+ * transactions via {@link ParsedTransactionSchema}).
+ */
+import { z } from 'zod';
+
+import { ENTITY_TYPES } from '../db/index.js';
+import { ChangeSetSchema } from './rest-corrections.js';
+import { TagRuleChangeSetSchema } from './rest-tag-rules.js';
+
+/** Transaction as parsed upstream (client-side or a transformer), with audit + dedup fields. */
+export const ParsedTransactionSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format'),
+  description: z.string().min(1),
+  amount: z.number(),
+  account: z.string().min(1),
+  location: z.string().optional(),
+  rawRow: z.string(),
+  checksum: z.string(),
+});
+
+export const EntityMatchSchema = z.object({
+  entityId: z.string().optional(),
+  entityName: z.string().optional(),
+  matchType: z.enum(['alias', 'exact', 'prefix', 'contains', 'ai', 'learned', 'manual', 'none']),
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+export const TransactionTypeSchema = z.enum(['purchase', 'transfer', 'income']);
+
+export const SuggestedTagSchema = z.object({
+  tag: z.string(),
+  source: z.enum(['ai', 'rule', 'entity']),
+  pattern: z.string().optional(),
+  isNew: z.boolean().optional(),
+});
+
+export const RuleProvenanceSchema = z.object({
+  source: z.literal('correction'),
+  ruleId: z.string().min(1),
+  pattern: z.string().min(1),
+  matchType: z.enum(['exact', 'contains', 'regex']),
+  confidence: z.number().min(0).max(1),
+});
+
+export const MatchedRuleSchema = z.object({
+  ruleId: z.string().min(1),
+  pattern: z.string().min(1),
+  matchType: z.enum(['exact', 'contains', 'regex']),
+  confidence: z.number().min(0).max(1),
+  priority: z.number(),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+});
+
+export const ProcessedTransactionSchema = ParsedTransactionSchema.extend({
+  entity: EntityMatchSchema,
+  status: z.enum(['matched', 'uncertain', 'failed', 'skipped']),
+  skipReason: z.string().optional(),
+  error: z.string().optional(),
+  transactionType: TransactionTypeSchema.optional(),
+  suggestedTags: z.array(SuggestedTagSchema).optional(),
+  ruleProvenance: RuleProvenanceSchema.optional(),
+  matchedRules: z.array(MatchedRuleSchema).optional(),
+});
+
+export const ConfirmedTransactionSchema = ParsedTransactionSchema.extend({
+  transactionType: TransactionTypeSchema.optional(),
+  entityId: z.string().optional(),
+  entityName: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  suggestedTags: z.array(SuggestedTagSchema).optional(),
+});
+
+export const ImportWarningSchema = z.object({
+  type: z.enum(['AI_CATEGORIZATION_UNAVAILABLE', 'AI_API_ERROR']),
+  message: z.string(),
+  affectedCount: z.number().optional(),
+  details: z.string().optional(),
+});
+
+export const AiUsageStatsSchema = z.object({
+  apiCalls: z.number(),
+  cacheHits: z.number(),
+  totalInputTokens: z.number(),
+  totalOutputTokens: z.number(),
+  totalCostUsd: z.number(),
+  avgCostPerCall: z.number(),
+});
+
+export const ProcessImportOutputSchema = z.object({
+  matched: z.array(ProcessedTransactionSchema),
+  uncertain: z.array(ProcessedTransactionSchema),
+  failed: z.array(ProcessedTransactionSchema),
+  skipped: z.array(ProcessedTransactionSchema),
+  warnings: z.array(ImportWarningSchema).optional(),
+  aiUsage: AiUsageStatsSchema.optional(),
+});
+
+export const ImportResultSchema = z.object({
+  transaction: ConfirmedTransactionSchema,
+  success: z.boolean(),
+  error: z.string().optional(),
+  pageId: z.string().optional(),
+});
+
+export const ExecuteImportOutputSchema = z.object({
+  imported: z.number(),
+  failed: z.array(ImportResultSchema),
+  skipped: z.number(),
+});
+
+export const ProcessImportInputSchema = z.object({
+  transactions: z.array(ParsedTransactionSchema),
+  account: z.string().min(1),
+});
+
+export const ExecuteImportInputSchema = z.object({
+  transactions: z.array(ConfirmedTransactionSchema),
+});
+
+export const CreateEntityInputSchema = z.object({ name: z.string().min(1).max(200) });
+export const CreateEntityOutputSchema = z.object({
+  entityId: z.string(),
+  entityName: z.string(),
+});
+
+export const ApplyChangeSetAndReevaluateInputSchema = z.object({
+  sessionId: z.string().uuid(),
+  changeSet: ChangeSetSchema,
+  minConfidence: z.number().min(0).max(1).default(0.7),
+});
+
+export const ApplyChangeSetAndReevaluateOutputSchema = z.object({
+  result: ProcessImportOutputSchema,
+  affectedCount: z.number().int().nonnegative(),
+});
+
+export const PendingEntitySchema = z.object({
+  tempId: z.string().regex(/^temp:entity:[0-9a-f-]{36}$/, 'Temp ID must match temp:entity:{uuid}'),
+  name: z.string().min(1),
+  type: z.enum(ENTITY_TYPES).default('company'),
+});
+
+export const CommitPayloadSchema = z.object({
+  entities: z.array(PendingEntitySchema).default([]),
+  changeSets: z.array(ChangeSetSchema).default([]),
+  tagRuleChangeSets: z.array(TagRuleChangeSetSchema).default([]),
+  transactions: z.array(ConfirmedTransactionSchema),
+});
+
+export const RulesAppliedSchema = z.object({
+  add: z.number().int().nonnegative(),
+  edit: z.number().int().nonnegative(),
+  disable: z.number().int().nonnegative(),
+  remove: z.number().int().nonnegative(),
+});
+
+export const FailedTransactionDetailSchema = z.object({
+  checksum: z.string().nullable(),
+  error: z.string(),
+});
+
+export const CommitResultSchema = z.object({
+  entitiesCreated: z.number().int().nonnegative(),
+  rulesApplied: RulesAppliedSchema,
+  tagRulesApplied: z.number().int().nonnegative(),
+  transactionsImported: z.number().int().nonnegative(),
+  transactionsFailed: z.number().int().nonnegative(),
+  failedDetails: z.array(FailedTransactionDetailSchema),
+  retroactiveReclassifications: z.number().int().nonnegative(),
+});
+
+export const ReevaluateWithPendingRulesInputSchema = z.object({
+  sessionId: z.string().uuid(),
+  minConfidence: z.number().min(0).max(1).default(0.7),
+  pendingChangeSets: z.array(z.object({ changeSet: ChangeSetSchema })),
+});
+
+export const SessionIdSchema = z.object({ sessionId: z.string() });
+
+const ProgressBatchItemSchema = z.object({
+  description: z.string(),
+  status: z.enum(['processing', 'success', 'failed']),
+  error: z.string().optional(),
+});
+
+export const ImportProgressSchema = z.object({
+  sessionId: z.string(),
+  status: z.enum(['processing', 'completed', 'failed']),
+  currentStep: z.enum(['deduplicating', 'matching', 'writing']),
+  totalTransactions: z.number(),
+  processedCount: z.number(),
+  currentBatch: z.array(ProgressBatchItemSchema),
+  errors: z.array(z.object({ description: z.string(), error: z.string() })),
+  startedAt: z.string(),
+  result: z.union([ProcessImportOutputSchema, ExecuteImportOutputSchema]).optional(),
+});
+
+export type ParsedTransaction = z.infer<typeof ParsedTransactionSchema>;
+export type EntityMatch = z.infer<typeof EntityMatchSchema>;
+export type TransactionType = z.infer<typeof TransactionTypeSchema>;
+export type SuggestedTag = z.infer<typeof SuggestedTagSchema>;
+export type RuleProvenance = z.infer<typeof RuleProvenanceSchema>;
+export type MatchedRule = z.infer<typeof MatchedRuleSchema>;
+export type ProcessedTransaction = z.infer<typeof ProcessedTransactionSchema>;
+export type ConfirmedTransaction = z.infer<typeof ConfirmedTransactionSchema>;
+export type ImportWarning = z.infer<typeof ImportWarningSchema>;
+export type AiUsageStats = z.infer<typeof AiUsageStatsSchema>;
+export type ProcessImportOutput = z.infer<typeof ProcessImportOutputSchema>;
+export type ImportResult = z.infer<typeof ImportResultSchema>;
+export type ExecuteImportOutput = z.infer<typeof ExecuteImportOutputSchema>;
+export type CreateEntityOutput = z.infer<typeof CreateEntityOutputSchema>;
+export type PendingEntity = z.infer<typeof PendingEntitySchema>;
+export type CommitPayload = z.infer<typeof CommitPayloadSchema>;
+export type CommitResult = z.infer<typeof CommitResultSchema>;
+export type FailedTransactionDetail = z.infer<typeof FailedTransactionDetailSchema>;

--- a/pillars/finance/src/contract/rest-imports.ts
+++ b/pillars/finance/src/contract/rest-imports.ts
@@ -1,0 +1,90 @@
+/**
+ * `imports.*` sub-router — the statement-import pipeline.
+ *
+ * Finance-owned (transactions / entities / corrections / tag-rules all live in
+ * the finance db). The CSV/PDF transformers are out of scope for this slice:
+ * the wire receives already-parsed transactions (`ParsedTransactionSchema`).
+ *
+ * processImport / executeImport kick off background work and return a
+ * `{ sessionId }` immediately; the FE polls `getImportProgress` until the
+ * session reports `completed`. The progress store is process-local in-memory
+ * state — fine for the single pillar process.
+ *
+ * The wire shapes live in `rest-imports-schemas.ts`; this file is only the
+ * route map + the public type re-exports.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  ApplyChangeSetAndReevaluateInputSchema,
+  ApplyChangeSetAndReevaluateOutputSchema,
+  CommitPayloadSchema,
+  CommitResultSchema,
+  CreateEntityInputSchema,
+  CreateEntityOutputSchema,
+  ExecuteImportInputSchema,
+  ImportProgressSchema,
+  ProcessImportInputSchema,
+  ReevaluateWithPendingRulesInputSchema,
+  SessionIdSchema,
+} from './rest-imports-schemas.js';
+import { ERR_RESPONSES, ERR_RESPONSES_WITH_412 } from './rest-schemas.js';
+
+const c = initContract();
+
+export const financeImportsContract = c.router({
+  processImport: {
+    method: 'POST',
+    path: '/imports/process',
+    body: ProcessImportInputSchema,
+    responses: { 200: SessionIdSchema, ...ERR_RESPONSES },
+    summary: 'Start an import process (dedup + entity matching); returns a session id to poll',
+  },
+  executeImport: {
+    method: 'POST',
+    path: '/imports/execute',
+    body: ExecuteImportInputSchema,
+    responses: { 200: SessionIdSchema, ...ERR_RESPONSES },
+    summary: 'Write confirmed transactions to SQLite; returns a session id to poll',
+  },
+  getImportProgress: {
+    method: 'GET',
+    path: '/imports/progress',
+    query: z.object({ sessionId: z.string().uuid() }),
+    responses: { 200: ImportProgressSchema.nullable(), ...ERR_RESPONSES },
+    summary: 'Poll an import session for progress (null when the session is unknown/expired)',
+  },
+  createEntity: {
+    method: 'POST',
+    path: '/imports/entities',
+    body: CreateEntityInputSchema,
+    responses: { 200: CreateEntityOutputSchema, ...ERR_RESPONSES },
+    summary: 'Create a new entity during an import session',
+  },
+  applyChangeSetAndReevaluate: {
+    method: 'POST',
+    path: '/imports/apply-changeset-reevaluate',
+    body: ApplyChangeSetAndReevaluateInputSchema,
+    responses: { 200: ApplyChangeSetAndReevaluateOutputSchema, ...ERR_RESPONSES_WITH_412 },
+    summary: 'Apply a correction ChangeSet atomically, then re-evaluate the import session',
+  },
+  commitImport: {
+    method: 'POST',
+    path: '/imports/commit',
+    body: CommitPayloadSchema,
+    responses: {
+      200: z.object({ data: CommitResultSchema, message: z.string() }),
+      ...ERR_RESPONSES,
+    },
+    summary:
+      'Atomically create entities, apply changeSets + tag-rule changeSets, write transactions',
+  },
+  reevaluateWithPendingRules: {
+    method: 'POST',
+    path: '/imports/reevaluate-pending',
+    body: ReevaluateWithPendingRulesInputSchema,
+    responses: { 200: ApplyChangeSetAndReevaluateOutputSchema, ...ERR_RESPONSES_WITH_412 },
+    summary: 'Re-evaluate the import session against merged (DB + pending) rules; no DB writes',
+  },
+});

--- a/pillars/finance/src/contract/rest-schemas.ts
+++ b/pillars/finance/src/contract/rest-schemas.ts
@@ -57,3 +57,13 @@ export const ERR_RESPONSES = {
   404: ErrorBodySchema,
   409: ErrorBodySchema,
 } as const;
+
+/**
+ * Error responses for routes that can additionally fail with 412 Precondition
+ * Failed (the import session-targeted endpoints). Spread alongside or instead
+ * of {@link ERR_RESPONSES} where a `PreconditionError` is reachable.
+ */
+export const ERR_RESPONSES_WITH_412 = {
+  ...ERR_RESPONSES,
+  412: ErrorBodySchema,
+} as const;

--- a/pillars/finance/src/contract/rest.ts
+++ b/pillars/finance/src/contract/rest.ts
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 
 import { financeBudgetsContract } from './rest-budgets.js';
+import { financeImportsContract } from './rest-imports.js';
 import { financeTagRulesContract } from './rest-tag-rules.js';
 import { financeTransactionsContract } from './rest-transactions.js';
 import { financeWishlistContract } from './rest-wishlist.js';
@@ -25,6 +26,7 @@ export const financeContract = c.router(
     budgets: financeBudgetsContract,
     transactions: financeTransactionsContract,
     tagRules: financeTagRulesContract,
+    imports: financeImportsContract,
   },
   {
     pathPrefix: '',

--- a/pillars/finance/src/db/schema.ts
+++ b/pillars/finance/src/db/schema.ts
@@ -11,6 +11,7 @@
  * because db-types still owned `entities`; that shadow is now deleted.
  */
 export { entities } from '@pops/core-db';
+export { ENTITY_TYPES } from '@pops/core-db';
 
 export { budgets } from './schema/budgets.js';
 export { transactionCorrections } from './schema/corrections.js';


### PR DESCRIPTION
## Finance REST migration — slice 4 (imports F1)

Ports the **imports** domain — the last runbook BE domain — into `pillars/finance` (builds on #3344/#3345/#3348). This is the **F1** sub-slice: the full deterministic pipeline with the AI categorizer stubbed; **F2** wires real Anthropic as a body-only change at the seam.

### Endpoints
`POST /imports/process` · `POST /imports/execute` · `GET /imports/progress?sessionId` · `POST /imports/entities` · `POST /imports/apply-changeset-reevaluate` · `POST /imports/commit` · `POST /imports/reevaluate-pending`

### Severance (no genuine cross-pillar coupling)
- every `getFinanceDrizzle()` → injected `FinanceDb`
- corrections match/list/normalize reuse `@pops/finance`'s `transactionCorrectionsService`; the corrections-apply path + pure changeset helpers ported into a new `api/modules/corrections`
- tag-rule apply reuses the migrated pillar service; `entities` + `ENTITY_TYPES` from the finance-db schema re-export
- transformers stay client-side (wire takes already-parsed transactions)
- AI categorizer stubbed behind `FINANCE_AI_CATEGORIZER_ENABLED`
- new 412 `PreconditionError` for the session-state guards; `commit` threads one `db.transaction` (atomic rollback)

### Tests
37 new (33 supertest integration: session-poll, dedup, transfer classify, executeImport writes, commit atomicity + temp-id resolution + full rollback, retroactive reclassification, 400/404/412 mapping; 4 AI-seam unit). **278 total green.** No `as any`/suppressions. Pure addition to `pillars/finance`.