### PR TITLE
feat(food): REST migration slice 4c — send-to-list rewire (closes slice 4 + lists Phase E)

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -6704,6 +6704,348 @@
         "tags": ["recipes"]
       }
     },
+    "/recipes/versions/{versionId}/send-to-list": {
+      "post": {
+        "operationId": "sendToList.send",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "scaleFactor": {
+                    "type": "number"
+                  },
+                  "target": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": ["existing"],
+                            "type": "string"
+                          },
+                          "listId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": ["kind", "listId"],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": ["new"],
+                            "type": "string"
+                          },
+                          "name": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": ["kind", "name"],
+                        "type": "object"
+                      }
+                    ]
+                  }
+                },
+                "required": ["target"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "addedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "listId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "mergedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok", "listId", "addedCount", "mergedCount"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "RecipeNotFound",
+                            "NoIngredients",
+                            "TargetListNotFound",
+                            "TargetListArchived",
+                            "TargetListNotShopping",
+                            "NameRequiredForNew",
+                            "CompileNotReady"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Send a recipe version’s ingredients to a shopping list",
+        "tags": ["sendToList"]
+      }
+    },
+    "/recipes/versions/{versionId}/send-to-list/preview": {
+      "get": {
+        "operationId": "sendToList.prepare",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scaleFactor",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "alreadySentToListIds": {
+                      "items": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "canonicalItems": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "ingredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "prepStateLabel": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qty": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "sourceLineIds": {
+                            "items": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          },
+                          "unit": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "qty",
+                          "unit",
+                          "ingredientId",
+                          "variantId",
+                          "prepStateLabel",
+                          "sourceLineIds"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "recipeTitle": {
+                      "type": "string"
+                    },
+                    "scaleFactor": {
+                      "type": "number"
+                    },
+                    "unconvertedItems": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "ingredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "prepStateLabel": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qty": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "sourceLineIds": {
+                            "items": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          },
+                          "unit": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "qty",
+                          "unit",
+                          "ingredientId",
+                          "variantId",
+                          "prepStateLabel",
+                          "sourceLineIds"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "recipeTitle",
+                    "scaleFactor",
+                    "canonicalItems",
+                    "unconvertedItems",
+                    "alreadySentToListIds"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Preview the items a recipe version would add to a shopping list",
+        "tags": ["sendToList"]
+      }
+    },
     "/recipes/{recipeId}/hero-image": {
       "delete": {
         "operationId": "heroImage.remove",

--- a/pillars/food/src/api/__tests__/send-to-list.test.ts
+++ b/pillars/food/src/api/__tests__/send-to-list.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration tests for the send-to-list REST surface (PRD-142), rewired
+ * onto the lists pillar over HTTP. A stub `ListsClient` is injected via
+ * `deps.listsClient`, recording the cross-pillar calls so the flow is
+ * exercised end-to-end without a live lists-api. Aggregation maths live in
+ * the db-layer tests; here we assert the wire envelopes + target handling.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import {
+  type ListHeader,
+  type ListsClient,
+  type UpsertByRefBody,
+} from '../modules/recipes/send-to-list/lists-client.js';
+import { makeClient } from './test-utils.js';
+
+const DSL = `@recipe(slug="grilled-cheese", title="Grilled Cheese", servings=1)
+@yield(bread, 1:count)
+@ingredient(1, bread, 2:count)
+@ingredient(2, butter, 10:g)
+@ingredient(3, cheddar, 60:g)
+@step("Assemble @1 @2 @3 and grill.")
+`;
+
+interface StubState {
+  created: { name: string }[];
+  upserts: { listId: number; body: UpsertByRefBody }[];
+  lists: Map<number, ListHeader>;
+}
+
+function makeStubClient(state: StubState): ListsClient {
+  let nextId = 100;
+  return {
+    getList: (id) => Promise.resolve(state.lists.get(id) ?? null),
+    createShoppingList: (name) => {
+      state.created.push({ name });
+      const id = (nextId += 1);
+      state.lists.set(id, { id, kind: 'shopping', ownerApp: 'food', archivedAt: null });
+      return Promise.resolve(id);
+    },
+    upsertByRef: (listId, body) => {
+      state.upserts.push({ listId, body });
+      return Promise.resolve({ outcome: 'inserted' as const, itemId: state.upserts.length });
+    },
+    addItem: () => Promise.resolve(),
+    searchShoppingListIdsByNotes: () => Promise.resolve([]),
+  };
+}
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let state: StubState;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({
+      foodDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3005',
+      listsClient: makeStubClient(state),
+    })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-send-to-list-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  state = { created: [], upserts: [], lists: new Map() };
+  createIngredient(foodDb.db, { name: 'Bread', slug: 'bread', defaultUnit: 'count' });
+  createIngredient(foodDb.db, { name: 'Butter', slug: 'butter', defaultUnit: 'g' });
+  createIngredient(foodDb.db, { name: 'Cheddar', slug: 'cheddar', defaultUnit: 'g' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('send-to-list REST', () => {
+  it('previews a compiled version and sends to a new shopping list via REST', async () => {
+    const api = client();
+    const created = await api.recipes.create(DSL);
+
+    const preview = await api.sendToList.prepare(created.versionId);
+    expect(preview.recipeTitle).toBe('Grilled Cheese');
+    expect(preview.canonicalItems.length).toBeGreaterThan(0);
+
+    const res = await api.sendToList.send(created.versionId, { kind: 'new', name: 'Groceries' });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.addedCount).toBeGreaterThan(0);
+      expect(state.created).toEqual([{ name: 'Groceries' }]);
+      expect(state.upserts.length).toBe(res.addedCount);
+      expect(state.upserts[0]?.body.onConflict).toBe('merge-additive');
+    }
+  });
+
+  it('rejects a non-shopping existing target', async () => {
+    state.lists.set(7, { id: 7, kind: 'todo', ownerApp: 'x', archivedAt: null });
+    const api = client();
+    const created = await api.recipes.create(DSL);
+    const res = await api.sendToList.send(created.versionId, { kind: 'existing', listId: 7 });
+    expect(res).toEqual({ ok: false, reason: 'TargetListNotShopping' });
+  });
+
+  it('404s prepare for an unknown version', async () => {
+    await expect(client().sendToList.prepare(999999)).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -179,6 +179,18 @@ interface UploadHeroResult {
   height: number;
 }
 
+interface SendPreview {
+  recipeTitle: string;
+  scaleFactor: number;
+  canonicalItems: unknown[];
+  unconvertedItems: unknown[];
+  alreadySentToListIds: number[];
+}
+type SendTarget = { kind: 'existing'; listId: number } | { kind: 'new'; name: string };
+type SendToListResult =
+  | { ok: true; listId: number; addedCount: number; mergedCount: number }
+  | { ok: false; reason: string };
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -428,6 +440,18 @@ export function makeClient(app: Express) {
         ),
       remove: (recipeId: number) =>
         send<{ ok: true; message: string }>(r.delete(`/recipes/${recipeId}/hero-image`)),
+    },
+    sendToList: {
+      prepare: (versionId: number, scaleFactor?: number) =>
+        send<SendPreview>(
+          r
+            .get(`/recipes/versions/${versionId}/send-to-list/preview`)
+            .query(scaleFactor === undefined ? {} : { scaleFactor })
+        ),
+      send: (versionId: number, target: SendTarget, scaleFactor?: number) =>
+        send<SendToListResult>(
+          r.post(`/recipes/versions/${versionId}/send-to-list`).send({ target, scaleFactor })
+        ),
     },
   };
 }

--- a/pillars/food/src/api/handlers.ts
+++ b/pillars/food/src/api/handlers.ts
@@ -11,6 +11,7 @@ import { getPillarRegistry } from './pillars/registry.js';
 import type { PillarRegistryEntry } from '@pops/types';
 
 import type { OpenedFoodDb } from '../db/index.js';
+import type { ListsClient } from './modules/recipes/send-to-list/lists-client.js';
 
 export interface FoodApiDeps {
   /** Open handle to the food pillar's SQLite. */
@@ -23,6 +24,12 @@ export interface FoodApiDeps {
    * special-case the host pillar.
    */
   selfBaseUrl: string;
+  /**
+   * Cross-pillar lists client used by send-to-list. Optional — production
+   * resolves the real HTTP client lazily from `POPS_PILLARS`; tests inject
+   * a stub so the flow runs without a live lists-api.
+   */
+  listsClient?: ListsClient;
 }
 
 export interface HealthResponse {

--- a/pillars/food/src/api/modules/recipes/send-to-list/aggregate.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/aggregate.ts
@@ -1,0 +1,152 @@
+/**
+ * Recipe-line aggregation for PRD-142's send-to-list flow.
+ *
+ * Reads compiled `recipe_lines` for a version, splits into canonical
+ * (`qty_g | qty_ml | qty_count` non-null) vs unconverted (all three null),
+ * groups canonical rows by `(ingredient_id, variant_id, canonical_unit)`,
+ * sums the matching qty field × `scaleFactor`, and collects distinct prep
+ * slugs per group. PRD-142 §`prepareSendToList` server-side flow steps 4–6.
+ */
+import { asc, eq } from 'drizzle-orm';
+
+import {
+  type FoodDb,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeLines,
+} from '../../../../db/index.js';
+import { type AggregatedCanonical } from './types.js';
+
+export interface UnconvertedAggregate {
+  lineId: number;
+  ingredientId: number;
+  variantId: number | null;
+  ingredientName: string;
+  variantName: string | null;
+  prepStateName: string | null;
+  originalQty: number;
+  originalUnit: string;
+}
+
+export interface AggregateResult {
+  canonical: AggregatedCanonical[];
+  unconverted: UnconvertedAggregate[];
+}
+
+interface JoinedLine {
+  id: number;
+  ingredientId: number;
+  variantId: number | null;
+  prepStateId: number | null;
+  originalQty: number;
+  originalUnit: string;
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+  ingredientName: string | null;
+  variantName: string | null;
+  prepStateSlug: string | null;
+  prepStateName: string | null;
+}
+
+export function aggregateLinesForSend(
+  db: FoodDb,
+  versionId: number,
+  scaleFactor: number
+): AggregateResult {
+  const rows = loadJoinedLines(db, versionId);
+  const canonicalMap = new Map<string, AggregatedCanonical>();
+  const unconverted: UnconvertedAggregate[] = [];
+  for (const row of rows) {
+    const qty = pickCanonicalQty(row);
+    if (qty === null) {
+      unconverted.push(rowToUnconverted(row));
+      continue;
+    }
+    accumulate(canonicalMap, row, qty * scaleFactor);
+  }
+  return {
+    canonical: [...canonicalMap.values()],
+    unconverted,
+  };
+}
+
+function loadJoinedLines(db: FoodDb, versionId: number): readonly JoinedLine[] {
+  return db
+    .select({
+      id: recipeLines.id,
+      ingredientId: recipeLines.ingredientId,
+      variantId: recipeLines.variantId,
+      prepStateId: recipeLines.prepStateId,
+      originalQty: recipeLines.originalQty,
+      originalUnit: recipeLines.originalUnit,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+      ingredientName: ingredients.name,
+      variantName: ingredientVariants.name,
+      prepStateSlug: prepStates.slug,
+      prepStateName: prepStates.name,
+    })
+    .from(recipeLines)
+    .leftJoin(ingredients, eq(ingredients.id, recipeLines.ingredientId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .leftJoin(prepStates, eq(prepStates.id, recipeLines.prepStateId))
+    .where(eq(recipeLines.recipeVersionId, versionId))
+    .orderBy(asc(recipeLines.position))
+    .all() as readonly JoinedLine[];
+}
+
+function pickCanonicalQty(row: JoinedLine): number | null {
+  switch (row.canonicalUnit) {
+    case 'g':
+      return row.qtyG;
+    case 'ml':
+      return row.qtyMl;
+    case 'count':
+      return row.qtyCount;
+    default:
+      return null;
+  }
+}
+
+function accumulate(
+  map: Map<string, AggregatedCanonical>,
+  row: JoinedLine,
+  scaledQty: number
+): void {
+  const key = `${row.ingredientId}|${row.variantId ?? 'null'}|${row.canonicalUnit}`;
+  const existing = map.get(key);
+  if (existing === undefined) {
+    map.set(key, {
+      ingredientId: row.ingredientId,
+      variantId: row.variantId,
+      canonicalUnit: row.canonicalUnit,
+      qtySum: scaledQty,
+      ingredientName: row.ingredientName ?? '',
+      variantName: row.variantName,
+      prepSlugs: new Set(row.prepStateSlug === null ? [] : [row.prepStateSlug]),
+      sourceLineIds: [row.id],
+    });
+    return;
+  }
+  existing.qtySum += scaledQty;
+  existing.sourceLineIds.push(row.id);
+  if (row.prepStateSlug !== null) existing.prepSlugs.add(row.prepStateSlug);
+}
+
+function rowToUnconverted(row: JoinedLine): UnconvertedAggregate {
+  return {
+    lineId: row.id,
+    ingredientId: row.ingredientId,
+    variantId: row.variantId,
+    ingredientName: row.ingredientName ?? '',
+    variantName: row.variantName,
+    prepStateName: row.prepStateName,
+    originalQty: row.originalQty,
+    originalUnit: row.originalUnit,
+  };
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/already-sent.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/already-sent.ts
@@ -1,0 +1,17 @@
+/**
+ * "Already sent" detection for PRD-142.
+ *
+ * Returns the ids of non-archived shopping lists whose item notes mention
+ * the recipe title. The substring search + shopping/non-archived filter run
+ * in the lists pillar (`GET /items?kind=shopping&notesContains=...`); this
+ * just dedupes the list ids. Soft warning only — never blocks the send.
+ */
+import { type ListsClient } from './lists-client.js';
+
+export async function findListsAlreadyMentioning(
+  client: ListsClient,
+  recipeTitle: string
+): Promise<number[]> {
+  if (recipeTitle.length === 0) return [];
+  return client.searchShoppingListIdsByNotes(recipeTitle);
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/compose-label.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/compose-label.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared label composer for PRD-142 — used by the preview builder and the
+ * merge-time relabel step. Format pinned by PRD-142 §`prepareSendToList`
+ * server-side flow step 6:
+ *
+ *   "<qty> <unit> <ingredient_name>[ <variant_name>][ (<prep_label>)]"
+ */
+export interface ComposeArgs {
+  qty: string;
+  unit: string;
+  ingredientName: string;
+  variantName: string | null;
+  prepLabel: string | null;
+}
+
+export function composeLabel({
+  qty,
+  unit,
+  ingredientName,
+  variantName,
+  prepLabel,
+}: ComposeArgs): string {
+  const base = `${qty} ${unit} ${ingredientName}`.trim();
+  const withVariant = variantName === null || variantName === '' ? base : `${base} ${variantName}`;
+  return prepLabel === null || prepLabel === '' ? withVariant : `${withVariant} (${prepLabel})`;
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/label.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/label.ts
@@ -1,0 +1,66 @@
+import { composeLabel } from './compose-label.js';
+
+/**
+ * Label-builder helpers for PRD-142's preview items.
+ *
+ * Canonical format: `"<qty> <unit> <ingredient_name>[ <variant_name>][ (<prep_states joined with ', '>)]"`
+ * Unconverted format: `"<original_qty> <original_unit> <ingredient_name>[ <variant_name>][ (<prep_state>)]"`.
+ *
+ * Numbers render compact: integers stay as integers, fractionals round to
+ * two decimal places (matches the way the recipe renderer displays qty).
+ */
+import type { UnconvertedAggregate } from './aggregate.js';
+import type { AggregatedCanonical, PreviewItem } from './types.js';
+
+const DECIMALS = 2;
+
+export function formatQty(qty: number): string {
+  if (Number.isInteger(qty)) return String(qty);
+  const rounded = Math.round(qty * 10 ** DECIMALS) / 10 ** DECIMALS;
+  // Trim trailing zeros from the rounded fixed representation.
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toString();
+}
+
+export function buildCanonicalItem(agg: AggregatedCanonical): PreviewItem {
+  const prepLabel = prepStatesLabel([...agg.prepSlugs].toSorted());
+  const label = composeLabel({
+    qty: formatQty(agg.qtySum),
+    unit: agg.canonicalUnit,
+    ingredientName: agg.ingredientName,
+    variantName: agg.variantName,
+    prepLabel,
+  });
+  return {
+    label,
+    qty: agg.qtySum,
+    unit: agg.canonicalUnit,
+    ingredientId: agg.ingredientId,
+    variantId: agg.variantId,
+    prepStateLabel: prepLabel,
+    sourceLineIds: [...agg.sourceLineIds],
+  };
+}
+
+export function buildUnconvertedItem(row: UnconvertedAggregate): PreviewItem {
+  const label = composeLabel({
+    qty: formatQty(row.originalQty),
+    unit: row.originalUnit,
+    ingredientName: row.ingredientName,
+    variantName: row.variantName,
+    prepLabel: row.prepStateName,
+  });
+  return {
+    label,
+    qty: row.originalQty,
+    unit: row.originalUnit,
+    ingredientId: row.ingredientId,
+    variantId: row.variantId,
+    prepStateLabel: row.prepStateName,
+    sourceLineIds: [row.lineId],
+  };
+}
+
+function prepStatesLabel(slugs: readonly string[]): string | null {
+  if (slugs.length === 0) return null;
+  return slugs.join(', ');
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/lists-client.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/lists-client.ts
@@ -1,0 +1,141 @@
+/**
+ * Cross-pillar HTTP client for the lists pillar — used by send-to-list to
+ * write shopping-list items over REST instead of reaching into the lists
+ * DB. Pillars trust the docker network (the dispatcher authenticates), so
+ * no per-request auth header is sent. The base URL is resolved from the
+ * `POPS_PILLARS` registry.
+ *
+ * Each call is its own atomic operation on the lists side; the single
+ * cross-pillar transaction the old `@pops/app-lists-db` path had is gone by
+ * design (PRD: lists owns its own consistency now). `upsertByRef` makes the
+ * merge-or-insert atomic per item so retries are idempotent.
+ */
+import { parsePillarsEnv } from '../../../pillars/env.js';
+
+export interface ListHeader {
+  id: number;
+  kind: string;
+  ownerApp: string;
+  archivedAt: string | null;
+}
+
+export type UpsertRefKind = 'ingredient' | 'variant' | 'recipe' | 'custom';
+export type UpsertConflictMode = 'merge-additive' | 'replace' | 'skip';
+
+export interface UpsertByRefBody {
+  refKind: UpsertRefKind;
+  refId: number;
+  label: string;
+  qty?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+  onConflict?: UpsertConflictMode;
+}
+
+export interface UpsertByRefResult {
+  outcome: 'inserted' | 'merged' | 'skipped';
+  itemId: number;
+}
+
+export interface AddItemBody {
+  label: string;
+  qty?: number | null;
+  unit?: string | null;
+  refKind?: string;
+  refId?: number | null;
+  notes?: string | null;
+}
+
+export interface ListsClient {
+  getList(id: number): Promise<ListHeader | null>;
+  createShoppingList(name: string): Promise<number>;
+  upsertByRef(listId: number, body: UpsertByRefBody): Promise<UpsertByRefResult>;
+  addItem(listId: number, body: AddItemBody): Promise<void>;
+  /** Distinct shopping-list ids whose item notes contain `notesContains`. */
+  searchShoppingListIdsByNotes(notesContains: string): Promise<number[]>;
+}
+
+/** Resolve the lists pillar's base URL from `POPS_PILLARS`. */
+export function resolveListsBaseUrl(): string {
+  const entry = parsePillarsEnv(process.env['POPS_PILLARS']).find((p) => p.id === 'lists');
+  if (entry === undefined) {
+    throw new Error('lists pillar not present in POPS_PILLARS — cannot send to list');
+  }
+  return entry.baseUrl;
+}
+
+type FetchImpl = typeof globalThis.fetch;
+
+async function readJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  return text.length === 0 ? null : (JSON.parse(text) as unknown);
+}
+
+function asMessage(body: unknown): string {
+  return body !== null && typeof body === 'object' && 'message' in body
+    ? String((body as { message: unknown }).message)
+    : '';
+}
+
+/**
+ * Bare-`fetch` implementation. `fetchImpl` is injectable so the send-to-list
+ * tests can drive the flow without a live lists-api.
+ */
+export function createListsHttpClient(
+  baseUrl: string,
+  fetchImpl: FetchImpl = globalThis.fetch
+): ListsClient {
+  const root = baseUrl.replace(/\/$/, '');
+
+  async function call(method: string, path: string, body?: unknown): Promise<Response> {
+    return fetchImpl(`${root}${path}`, {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  }
+
+  return {
+    async getList(id) {
+      const res = await call('GET', `/lists/${id}`);
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`lists GET /lists/${id} → HTTP ${res.status}`);
+      const json = (await readJson(res)) as { list: ListHeader } | null;
+      return json?.list ?? null;
+    },
+
+    async createShoppingList(name) {
+      const res = await call('POST', '/lists', { name, kind: 'shopping', ownerApp: 'food' });
+      if (!res.ok)
+        throw new Error(
+          `lists POST /lists → HTTP ${res.status}: ${asMessage(await readJson(res))}`
+        );
+      const json = (await readJson(res)) as { id: number };
+      return json.id;
+    },
+
+    async upsertByRef(listId, body) {
+      const res = await call('POST', `/lists/${listId}/items/upsert-by-ref`, body);
+      if (!res.ok) {
+        throw new Error(
+          `lists upsert-by-ref → HTTP ${res.status}: ${asMessage(await readJson(res))}`
+        );
+      }
+      return (await readJson(res)) as UpsertByRefResult;
+    },
+
+    async addItem(listId, body) {
+      const res = await call('POST', `/lists/${listId}/items`, body);
+      if (!res.ok) throw new Error(`lists POST /lists/${listId}/items → HTTP ${res.status}`);
+    },
+
+    async searchShoppingListIdsByNotes(notesContains) {
+      const qs = new URLSearchParams({ kind: 'shopping', notesContains });
+      const res = await call('GET', `/items?${qs.toString()}`);
+      if (!res.ok) throw new Error(`lists GET /items → HTTP ${res.status}`);
+      const json = (await readJson(res)) as { items: { listId: number }[] };
+      const ids = new Set(json.items.map((i) => i.listId));
+      return [...ids].toSorted((a, b) => a - b);
+    },
+  };
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/merge.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/merge.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-item merge / insert for PRD-142's send loop, over the lists REST API.
+ *
+ * Mergeable (ingredient/variant) items go through `upsert-by-ref` with
+ * `onConflict='merge-additive'` — the lists pillar atomically sums qty +
+ * merges notes by `(refKind, refId)`. Unconverted ("free") lines always
+ * insert fresh (they have no ref to merge on).
+ */
+import { type ListsClient } from './lists-client.js';
+import { type SendItem } from './send-items.js';
+
+export interface MergeOutcome {
+  kind: 'merged' | 'inserted';
+}
+
+export async function processItem(
+  client: ListsClient,
+  listId: number,
+  item: SendItem,
+  recipeTitle: string
+): Promise<MergeOutcome> {
+  const notes = buildNoteFragment(recipeTitle, item.prepLabel);
+  if (item.mergeable && item.refId !== null && item.refKind !== 'free') {
+    const res = await client.upsertByRef(listId, {
+      refKind: item.refKind,
+      refId: item.refId,
+      label: item.preview.label,
+      qty: item.preview.qty,
+      unit: item.preview.unit,
+      notes,
+      onConflict: 'merge-additive',
+    });
+    return { kind: res.outcome === 'merged' ? 'merged' : 'inserted' };
+  }
+  await client.addItem(listId, {
+    label: item.preview.label,
+    qty: item.preview.qty,
+    unit: item.preview.unit,
+    refKind: 'free',
+    refId: null,
+    notes,
+  });
+  return { kind: 'inserted' };
+}
+
+/**
+ * `<recipe title>` or `<recipe title> (<prep>)` — short note fragment
+ * recorded against each list item so the "already sent" search can find it.
+ */
+function buildNoteFragment(recipeTitle: string, prepLabel: string | null): string {
+  if (prepLabel === null || prepLabel === '') return recipeTitle;
+  return `${recipeTitle} (${prepLabel})`;
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/prepare.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/prepare.ts
@@ -1,0 +1,46 @@
+/**
+ * `recipes.prepareSendToList` server logic — PRD-142.
+ *
+ * Returns the preview the modal renders. Throws `HttpError(404)` for unknown
+ * versions and `HttpError(400)` for uncompiled ones. The send-side procedure
+ * uses the same internal aggregation but maps errors onto the discriminated
+ * `SendToListError` union instead. The "already sent" lookup hits the lists
+ * REST API.
+ */
+import { type FoodDb } from '../../../../db/index.js';
+import { HttpError } from '../../../shared/errors.js';
+import { aggregateLinesForSend } from './aggregate.js';
+import { findListsAlreadyMentioning } from './already-sent.js';
+import { buildCanonicalItem, buildUnconvertedItem } from './label.js';
+import { type ListsClient } from './lists-client.js';
+import { type SendPreview } from './types.js';
+import { clampScaleFactor, loadVersionForSend } from './version-load.js';
+
+export async function prepareSendToList(
+  foodDb: FoodDb,
+  client: ListsClient,
+  versionId: number,
+  scaleFactorIn: number | undefined
+): Promise<SendPreview> {
+  const loaded = loadVersionForSend(foodDb, versionId);
+  if (!loaded.ok) {
+    if (loaded.reason === 'CompileNotReady') {
+      throw new HttpError(
+        400,
+        `Recipe version ${versionId} is not compiled`,
+        undefined,
+        'common.validationFailed'
+      );
+    }
+    throw new HttpError(404, `Recipe version ${versionId} not found`, undefined, 'common.notFound');
+  }
+  const scaleFactor = clampScaleFactor(scaleFactorIn);
+  const aggregate = aggregateLinesForSend(foodDb, versionId, scaleFactor);
+  return {
+    recipeTitle: loaded.version.title,
+    scaleFactor,
+    canonicalItems: aggregate.canonical.map(buildCanonicalItem),
+    unconvertedItems: aggregate.unconverted.map(buildUnconvertedItem),
+    alreadySentToListIds: await findListsAlreadyMentioning(client, loaded.version.title),
+  };
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/send-items.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/send-items.ts
@@ -1,0 +1,74 @@
+import { composeLabel } from './compose-label.js';
+import { buildCanonicalItem, buildUnconvertedItem, formatQty } from './label.js';
+
+/**
+ * Bridges PRD-142's aggregate output into the row-shaped `SendItem`
+ * structures the send loop iterates over. Carries the ingredient + variant
+ * names alongside the wire-shape `PreviewItem` so the merge step can
+ * regenerate the label after summing without re-querying.
+ */
+import type { AggregateResult, UnconvertedAggregate } from './aggregate.js';
+import type { AggregatedCanonical, PreviewItem } from './types.js';
+
+export type SendItemRefKind = 'ingredient' | 'variant' | 'free';
+
+export interface SendItem {
+  preview: PreviewItem;
+  refKind: SendItemRefKind;
+  /** Null when `refKind='free'`. */
+  refId: number | null;
+  /** Ingredient name for label regeneration after merge. */
+  ingredientName: string;
+  /** Variant name for label regeneration after merge. May be null. */
+  variantName: string | null;
+  /** Joined prep-state label (e.g. "diced, sliced") for label regeneration. */
+  prepLabel: string | null;
+  /** Canonical items can merge; unconverted lines always insert fresh. */
+  mergeable: boolean;
+}
+
+export function buildSendItems(agg: AggregateResult): SendItem[] {
+  return [...agg.canonical.map(canonicalToSendItem), ...agg.unconverted.map(unconvertedToSendItem)];
+}
+
+function canonicalToSendItem(agg: AggregatedCanonical): SendItem {
+  return {
+    preview: buildCanonicalItem(agg),
+    refKind: agg.variantId === null ? 'ingredient' : 'variant',
+    refId: agg.variantId ?? agg.ingredientId,
+    ingredientName: agg.ingredientName,
+    variantName: agg.variantName,
+    prepLabel: agg.prepSlugs.size === 0 ? null : [...agg.prepSlugs].toSorted().join(', '),
+    mergeable: true,
+  };
+}
+
+function unconvertedToSendItem(row: UnconvertedAggregate): SendItem {
+  return {
+    preview: buildUnconvertedItem(row),
+    // Unconverted lines never merge — keep refKind='free' so a later
+    // canonical send for the same ingredient (different unit) doesn't
+    // collide with the raw line.
+    refKind: 'free',
+    refId: null,
+    ingredientName: row.ingredientName,
+    variantName: row.variantName,
+    prepLabel: row.prepStateName,
+    mergeable: false,
+  };
+}
+
+/**
+ * Rebuild a list-item label after a merge bumps the qty. Mirrors
+ * `composeLabel` from `label.ts` but exposed here so the send loop
+ * doesn't have to import two helpers.
+ */
+export function relabelAfterMerge(item: SendItem, newQty: number): string {
+  return composeLabel({
+    qty: formatQty(newQty),
+    unit: item.preview.unit ?? '',
+    ingredientName: item.ingredientName,
+    variantName: item.variantName,
+    prepLabel: item.prepLabel,
+  });
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/send.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/send.ts
@@ -1,0 +1,52 @@
+/**
+ * `recipes.sendToList` server logic — PRD-142, rewired onto the lists REST
+ * API. Discriminated result so the handler surfaces validation failures
+ * inline. Each item is its own atomic `upsert-by-ref`/`add` call; there is
+ * no longer a single cross-pillar transaction (lists owns its consistency).
+ */
+import { type FoodDb } from '../../../../db/index.js';
+import { aggregateLinesForSend } from './aggregate.js';
+import { type ListsClient } from './lists-client.js';
+import { processItem } from './merge.js';
+import { buildSendItems, type SendItem } from './send-items.js';
+import { resolveTarget } from './target-resolve.js';
+import { type SendTarget, type SendToListResult } from './types.js';
+import { clampScaleFactor, loadVersionForSend } from './version-load.js';
+
+export interface SendToListInput {
+  versionId: number;
+  scaleFactor?: number;
+  target: SendTarget;
+}
+
+export async function sendToList(
+  foodDb: FoodDb,
+  client: ListsClient,
+  input: SendToListInput
+): Promise<SendToListResult> {
+  const loaded = loadVersionForSend(foodDb, input.versionId);
+  if (!loaded.ok) return { ok: false, reason: loaded.reason };
+  const scaleFactor = clampScaleFactor(input.scaleFactor);
+  const aggregate = aggregateLinesForSend(foodDb, input.versionId, scaleFactor);
+  const items = buildSendItems(aggregate);
+  if (items.length === 0) return { ok: false, reason: 'NoIngredients' };
+  return writeItems(client, items, input.target, loaded.version.title);
+}
+
+async function writeItems(
+  client: ListsClient,
+  items: readonly SendItem[],
+  target: SendTarget,
+  recipeTitle: string
+): Promise<SendToListResult> {
+  const resolved = await resolveTarget(client, target);
+  if (!resolved.ok) return { ok: false, reason: resolved.reason };
+  let added = 0;
+  let merged = 0;
+  for (const item of items) {
+    const outcome = await processItem(client, resolved.listId, item, recipeTitle);
+    if (outcome.kind === 'merged') merged += 1;
+    else added += 1;
+  }
+  return { ok: true, listId: resolved.listId, addedCount: added, mergedCount: merged };
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/target-resolve.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/target-resolve.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve the send target — either an existing shopping list or a new one,
+ * over the lists REST API. Existing: GET the list header and validate
+ * `kind='shopping'` + non-archived. New: trim + reject empty name, then
+ * POST a new `kind='shopping'`, `ownerApp='food'` list.
+ */
+import { type ListsClient } from './lists-client.js';
+import { type SendTarget, type SendToListError } from './types.js';
+
+export type ResolveTargetResult =
+  | { ok: true; listId: number; isNew: boolean }
+  | { ok: false; reason: SendToListError };
+
+export async function resolveTarget(
+  client: ListsClient,
+  target: SendTarget
+): Promise<ResolveTargetResult> {
+  if (target.kind === 'existing') return resolveExisting(client, target.listId);
+  return resolveNew(client, target.name);
+}
+
+async function resolveExisting(client: ListsClient, listId: number): Promise<ResolveTargetResult> {
+  const row = await client.getList(listId);
+  if (row === null) return { ok: false, reason: 'TargetListNotFound' };
+  if (row.archivedAt !== null) return { ok: false, reason: 'TargetListArchived' };
+  if (row.kind !== 'shopping') return { ok: false, reason: 'TargetListNotShopping' };
+  return { ok: true, listId, isNew: false };
+}
+
+async function resolveNew(client: ListsClient, rawName: string): Promise<ResolveTargetResult> {
+  const name = rawName.trim();
+  if (name.length === 0) return { ok: false, reason: 'NameRequiredForNew' };
+  const id = await client.createShoppingList(name);
+  return { ok: true, listId: id, isNew: true };
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/types.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Wire shapes for `food.recipes.prepareSendToList` + `food.recipes.sendToList`
+ * — PRD-142.
+ */
+export interface PreviewItem {
+  /** Human-readable label combining qty + unit + ingredient + variant + prep. */
+  label: string;
+  /** Canonical qty after aggregation + scale; null for unconverted rows. */
+  qty: number | null;
+  /** 'g' | 'ml' | 'count' for canonical rows; original unit for unconverted. */
+  unit: string | null;
+  ingredientId: number;
+  variantId: number | null;
+  /** Distinct prep slugs aggregated into this row (canonical) or this line (unconverted). */
+  prepStateLabel: string | null;
+  /** `recipe_lines.id` values that aggregated into this preview row. */
+  sourceLineIds: number[];
+}
+
+export interface SendPreview {
+  recipeTitle: string;
+  scaleFactor: number;
+  /** Grouped by `(ingredient_id, variant_id, canonical_unit)`, summed × scale. */
+  canonicalItems: PreviewItem[];
+  /** One row per recipe_line where `qty_g`/`qty_ml`/`qty_count` are all null. */
+  unconvertedItems: PreviewItem[];
+  /** Shopping-list IDs whose `notes` mention this recipe (soft warning only). */
+  alreadySentToListIds: number[];
+}
+
+export type SendToListError =
+  | 'RecipeNotFound'
+  | 'NoIngredients'
+  | 'TargetListNotFound'
+  | 'TargetListArchived'
+  | 'TargetListNotShopping'
+  | 'NameRequiredForNew'
+  | 'CompileNotReady';
+
+export type SendTarget = { kind: 'existing'; listId: number } | { kind: 'new'; name: string };
+
+export type SendToListResult =
+  | { ok: true; listId: number; addedCount: number; mergedCount: number }
+  | { ok: false; reason: SendToListError };
+
+/**
+ * Internal shape used inside the aggregator — keeps `prepState` distinct slugs
+ * as a Set so the merger can collect across multiple lines, then collapsed
+ * to a sorted joined string when the PreviewItem is finalised.
+ */
+export interface AggregatedCanonical {
+  ingredientId: number;
+  variantId: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+  qtySum: number;
+  ingredientName: string;
+  variantName: string | null;
+  prepSlugs: Set<string>;
+  sourceLineIds: number[];
+}

--- a/pillars/food/src/api/modules/recipes/send-to-list/version-load.ts
+++ b/pillars/food/src/api/modules/recipes/send-to-list/version-load.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared version-loading helper for PRD-142's prepare + send flows.
+ *
+ * Both procedures need the version row + parent recipe slug + a
+ * compile-status check. Returning a discriminated result lets the caller
+ * map to either `SendToListError` (send) or throw `TRPCError` (prepare).
+ */
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, recipes, recipeVersions } from '../../../../db/index.js';
+
+export interface LoadedVersion {
+  versionId: number;
+  recipeId: number;
+  title: string;
+  recipeSlug: string;
+}
+
+export type LoadVersionResult =
+  | { ok: true; version: LoadedVersion }
+  | { ok: false; reason: 'RecipeNotFound' | 'CompileNotReady' };
+
+export function loadVersionForSend(db: FoodDb, versionId: number): LoadVersionResult {
+  const v = db.select().from(recipeVersions).where(eq(recipeVersions.id, versionId)).all()[0];
+  if (v === undefined) return { ok: false, reason: 'RecipeNotFound' };
+  if (v.compileStatus !== 'compiled') return { ok: false, reason: 'CompileNotReady' };
+  const recipe = db.select().from(recipes).where(eq(recipes.id, v.recipeId)).all()[0];
+  if (recipe === undefined) return { ok: false, reason: 'RecipeNotFound' };
+  return {
+    ok: true,
+    version: {
+      versionId: v.id,
+      recipeId: v.recipeId,
+      title: v.title,
+      recipeSlug: recipe.slug,
+    },
+  };
+}
+
+/** Clamp scale factor per PRD §Business Rules: defaults to 1, 0/negative → 1. */
+export function clampScaleFactor(scale: number | undefined): number {
+  if (scale === undefined || scale <= 0 || !Number.isFinite(scale)) return 1;
+  return scale;
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -8,7 +8,12 @@
 import { initServer } from '@ts-rest/express';
 
 import { foodContract } from '../../contract/rest.js';
-import { type OpenedFoodDb } from '../../db/index.js';
+import { type FoodApiDeps } from '../handlers.js';
+import {
+  createListsHttpClient,
+  type ListsClient,
+  resolveListsBaseUrl,
+} from '../modules/recipes/send-to-list/lists-client.js';
 import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
@@ -19,6 +24,7 @@ import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
 import { makeRecipesHandlers } from './recipes-handlers.js';
+import { makeSendToListHandlers } from './send-to-list-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
 import { makeSolverHandlers } from './solver-handlers.js';
 import { makeSubstitutionsHandlers } from './substitutions-handlers.js';
@@ -26,10 +32,16 @@ import { makeVariantsHandlers } from './variants-handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
 
-export function makeFoodRestHandlers(deps: {
-  foodDb: OpenedFoodDb;
-}): ReturnType<typeof server.router<typeof foodContract>> {
+export function makeFoodRestHandlers(
+  deps: Pick<FoodApiDeps, 'foodDb' | 'listsClient'>
+): ReturnType<typeof server.router<typeof foodContract>> {
   const db = deps.foodDb.db;
+  // Lazy: only build the real HTTP lists client (which needs lists in
+  // POPS_PILLARS) when a send-to-list request actually arrives and no stub
+  // was injected.
+  let realClient: ListsClient | undefined;
+  const resolveListsClient = (): ListsClient =>
+    deps.listsClient ?? (realClient ??= createListsHttpClient(resolveListsBaseUrl()));
   return server.router(foodContract, {
     aliases: makeAliasesHandlers(db),
     batches: makeBatchesHandlers(db),
@@ -41,6 +53,7 @@ export function makeFoodRestHandlers(deps: {
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),
     recipes: makeRecipesHandlers(db),
+    sendToList: makeSendToListHandlers(db, resolveListsClient),
     slugs: makeSlugsHandlers(db),
     solver: makeSolverHandlers(db),
     substitutions: makeSubstitutionsHandlers(db),

--- a/pillars/food/src/api/rest/send-to-list-handlers.ts
+++ b/pillars/food/src/api/rest/send-to-list-handlers.ts
@@ -1,0 +1,36 @@
+/**
+ * Handlers for the `sendToList.*` sub-router. The lists client is resolved
+ * lazily (real HTTP client built from POPS_PILLARS, or an injected stub in
+ * tests) so non-send-to-list requests never touch the lists registry.
+ */
+import { type ListsClient } from '../modules/recipes/send-to-list/lists-client.js';
+import { prepareSendToList } from '../modules/recipes/send-to-list/prepare.js';
+import { sendToList } from '../modules/recipes/send-to-list/send.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodSendToListContract } from '../../contract/rest-send-to-list.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodSendToListContract>;
+
+export function makeSendToListHandlers(db: FoodDb, resolveClient: () => ListsClient) {
+  return {
+    prepare: ({ params, query }: Req['prepare']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await prepareSendToList(db, resolveClient(), params.versionId, query.scaleFactor),
+      })),
+
+    send: ({ params, body }: Req['send']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await sendToList(db, resolveClient(), {
+          versionId: params.versionId,
+          scaleFactor: body.scaleFactor,
+          target: body.target,
+        }),
+      })),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -779,6 +779,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/recipes/versions/{versionId}/send-to-list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Send a recipe version’s ingredients to a shopping list */
+    post: operations['sendToList.send'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}/send-to-list/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Preview the items a recipe version would add to a shopping list */
+    get: operations['sendToList.prepare'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/recipes/{recipeId}/hero-image': {
     parameters: {
       query?: never;
@@ -4144,6 +4178,136 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'sendToList.send': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          scaleFactor?: number;
+          target:
+            | {
+                /** @enum {string} */
+                kind: 'existing';
+                listId: number;
+              }
+            | {
+                /** @enum {string} */
+                kind: 'new';
+                name: string;
+              };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                addedCount: number;
+                listId: number;
+                mergedCount: number;
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'RecipeNotFound'
+                  | 'NoIngredients'
+                  | 'TargetListNotFound'
+                  | 'TargetListArchived'
+                  | 'TargetListNotShopping'
+                  | 'NameRequiredForNew'
+                  | 'CompileNotReady';
+              };
+        };
+      };
+    };
+  };
+  'sendToList.prepare': {
+    parameters: {
+      query?: {
+        scaleFactor?: number;
+      };
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            alreadySentToListIds: number[];
+            canonicalItems: {
+              ingredientId: number;
+              label: string;
+              prepStateLabel: string | null;
+              qty: number | null;
+              sourceLineIds: number[];
+              unit: string | null;
+              variantId: number | null;
+            }[];
+            recipeTitle: string;
+            scaleFactor: number;
+            unconvertedItems: {
+              ingredientId: number;
+              label: string;
+              prepStateLabel: string | null;
+              qty: number | null;
+              sourceLineIds: number[];
+              unit: string | null;
+              variantId: number | null;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
           };
         };
       };

--- a/pillars/food/src/contract/rest-send-to-list.ts
+++ b/pillars/food/src/contract/rest-send-to-list.ts
@@ -1,0 +1,79 @@
+/**
+ * `sendToList.*` sub-router — PRD-142. Aggregates a recipe version's lines
+ * into shopping-list items and writes them to the lists pillar over REST
+ * (no cross-pillar DB write). `prepare` returns the preview the modal
+ * renders; `send` performs the upserts and returns add/merge counts.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const PreviewItemSchema = z.object({
+  label: z.string(),
+  qty: z.number().nullable(),
+  unit: z.string().nullable(),
+  ingredientId: z.number().int(),
+  variantId: z.number().int().nullable(),
+  prepStateLabel: z.string().nullable(),
+  sourceLineIds: z.array(z.number().int()),
+});
+
+const SendPreviewSchema = z.object({
+  recipeTitle: z.string(),
+  scaleFactor: z.number(),
+  canonicalItems: z.array(PreviewItemSchema),
+  unconvertedItems: z.array(PreviewItemSchema),
+  alreadySentToListIds: z.array(z.number().int()),
+});
+
+const SendToListResultSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    listId: z.number().int(),
+    addedCount: z.number().int(),
+    mergedCount: z.number().int(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.enum([
+      'RecipeNotFound',
+      'NoIngredients',
+      'TargetListNotFound',
+      'TargetListArchived',
+      'TargetListNotShopping',
+      'NameRequiredForNew',
+      'CompileNotReady',
+    ]),
+  }),
+]);
+
+const SendTargetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('existing'), listId: z.number().int().positive() }),
+  z.object({ kind: z.literal('new'), name: z.string().min(1) }),
+]);
+
+export const foodSendToListContract = c.router({
+  prepare: {
+    method: 'GET',
+    path: '/recipes/versions/:versionId/send-to-list/preview',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    query: z.object({ scaleFactor: z.coerce.number().optional() }),
+    responses: {
+      200: SendPreviewSchema,
+      400: z.object({ message: z.string(), code: z.string().optional() }),
+      404: z.object({ message: z.string(), code: z.string().optional() }),
+    },
+    summary: 'Preview the items a recipe version would add to a shopping list',
+  },
+  send: {
+    method: 'POST',
+    path: '/recipes/versions/:versionId/send-to-list',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    body: z.object({ scaleFactor: z.number().optional(), target: SendTargetSchema }),
+    responses: { 200: SendToListResultSchema },
+    summary: 'Send a recipe version’s ingredients to a shopping list',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -24,6 +24,7 @@ import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
 import { foodRecipesContract } from './rest-recipes.js';
+import { foodSendToListContract } from './rest-send-to-list.js';
 import { foodSlugsContract } from './rest-slugs.js';
 import { foodSolverContract } from './rest-solver.js';
 import { foodSubstitutionsContract } from './rest-substitutions.js';
@@ -43,6 +44,7 @@ export const foodContract = c.router(
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,
     recipes: foodRecipesContract,
+    sendToList: foodSendToListContract,
     slugs: foodSlugsContract,
     solver: foodSolverContract,
     substitutions: foodSubstitutionsContract,


### PR DESCRIPTION
Final part of slice 4, after #3353/#3354. Moves **send-to-list** (PRD-142) into the pillar and **drops the cross-pillar `@pops/app-lists-db` DB write**, calling the lists pillar over HTTP instead. Closes lists Phase E.

## What changed
- Cross-pillar writes now go over REST via a bare-`fetch` `ListsClient`:
  - `POST /lists/:id/items/upsert-by-ref` (`onConflict: merge-additive`) for ingredient/variant items
  - `POST /lists/:id/items` for unconverted ("free") lines
  - `POST /lists` to create a new target; `GET /lists/:id` to validate an existing one (shopping + non-archived)
  - `GET /items?kind=shopping&notesContains=…` for "already sent" detection
- Base URL resolves from `POPS_PILLARS`; pillars trust the docker network (no per-request auth). The single cross-pillar transaction is gone by design — each upsert is atomic + idempotent on the lists side.
- Food-only helpers (aggregate/version-load/label/send-items) lifted over the pillar db; the lists-touching helpers became async HTTP. `ListsClient` is injectable via `FoodApiDeps.listsClient` so tests drive the flow with a recording stub.
- REST: `GET /recipes/versions/:versionId/send-to-list/preview` + `POST /recipes/versions/:versionId/send-to-list`.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **863 tests (71 files) green** incl. a full prepare→send round-trip through a stub lists client + target-validation + 404 paths. OpenAPI idempotent.

## Slice 4 complete
recipes CRUD + hero-image + send-to-list all ported. Remaining: plan/shopping (5) → ingest/ai (6) → Phase C/D/E.