### PR TITLE
feat(food): REST migration slice 5 — plan + shopping

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -5791,6 +5791,951 @@
         "tags": ["ingredients"]
       }
     },
+    "/plan/entries": {
+      "post": {
+        "operationId": "plan.addEntry",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "date": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  },
+                  "notes": {
+                    "maxLength": 1000,
+                    "type": "string"
+                  },
+                  "plannedServings": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeVersionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "slot": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                    "type": "string"
+                  }
+                },
+                "required": ["date", "slot", "recipeId", "plannedServings"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "position": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["ok", "id", "position"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotFound",
+                            "AlreadyCooked",
+                            "BadDate",
+                            "BadSlot",
+                            "RecipeArchived",
+                            "RecipeHasNoCurrentVersion"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Add a plan entry",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/entries/{id}": {
+      "delete": {
+        "operationId": "plan.deleteEntry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotFound",
+                            "AlreadyCooked",
+                            "BadDate",
+                            "BadSlot",
+                            "RecipeArchived",
+                            "RecipeHasNoCurrentVersion"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Delete a plan entry",
+        "tags": ["plan"]
+      },
+      "patch": {
+        "operationId": "plan.updateEntry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "notes": {
+                    "maxLength": 1000,
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "plannedServings": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeVersionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotFound",
+                            "AlreadyCooked",
+                            "BadDate",
+                            "BadSlot",
+                            "RecipeArchived",
+                            "RecipeHasNoCurrentVersion"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Update a plan entry",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/entries/{id}/move": {
+      "post": {
+        "operationId": "plan.moveEntry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "date": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  },
+                  "position": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "slot": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                    "type": "string"
+                  }
+                },
+                "required": ["date", "slot"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotFound",
+                            "AlreadyCooked",
+                            "BadDate",
+                            "BadSlot",
+                            "RecipeArchived",
+                            "RecipeHasNoCurrentVersion"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Move a plan entry to another date/slot",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/reorder": {
+      "post": {
+        "operationId": "plan.reorderSlot",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "date": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  },
+                  "orderedIds": {
+                    "items": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "slot": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                    "type": "string"
+                  }
+                },
+                "required": ["date", "slot", "orderedIds"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["BadIds", "EmptySlot"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Reorder entries within a date/slot cell",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/slots": {
+      "get": {
+        "operationId": "plan.listSlots",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "slots": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayOrder": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "isDefault": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["slug", "name", "displayOrder", "isDefault"],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    }
+                  },
+                  "required": ["slots"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List plan slots",
+        "tags": ["plan"]
+      },
+      "post": {
+        "operationId": "plan.addSlot",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "slug": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                    "type": "string"
+                  }
+                },
+                "required": ["slug", "name"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["SlugTaken", "SlugInvalid"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Add a plan slot",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/slots/{slug}": {
+      "delete": {
+        "operationId": "plan.deleteSlot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["SlotNotFound", "CannotDeleteDefault", "SlotInUse"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Delete a plan slot",
+        "tags": ["plan"]
+      },
+      "patch": {
+        "operationId": "plan.updateSlot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "displayOrder": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "name": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["SlotNotFound", "CannotEditDefault"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Update a plan slot",
+        "tags": ["plan"]
+      }
+    },
+    "/plan/week": {
+      "get": {
+        "operationId": "plan.weekView",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "weekStart",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "entries": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string"
+                          },
+                          "heroImagePath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "plannedServings": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "position": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "recipeId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "recipeRunCookedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "recipeRunId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "recipeTitle": {
+                            "type": "string"
+                          },
+                          "recipeType": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "recipeVersionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "slot": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "date",
+                          "slot",
+                          "position",
+                          "recipeId",
+                          "recipeSlug",
+                          "recipeTitle",
+                          "recipeType",
+                          "heroImagePath",
+                          "plannedServings",
+                          "recipeVersionId",
+                          "recipeRunId",
+                          "recipeRunCookedAt",
+                          "notes"
+                        ],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "slots": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayOrder": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "isDefault": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["slug", "name", "displayOrder", "isDefault"],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "weekEnd": {
+                      "type": "string"
+                    },
+                    "weekStart": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["weekStart", "weekEnd", "slots", "entries"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Denormalised meal-plan week view",
+        "tags": ["plan"]
+      }
+    },
     "/prep-states": {
       "get": {
         "operationId": "prepStates.list",
@@ -7813,6 +8758,287 @@
         },
         "summary": "Fork a new draft from a recipe’s current version",
         "tags": ["recipes"]
+      }
+    },
+    "/shopping/generate": {
+      "post": {
+        "operationId": "shopping.generate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "endDate": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  },
+                  "listName": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  }
+                },
+                "required": ["startDate", "endDate", "listName"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "listId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok", "listId", "itemCount"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "BadDateRange",
+                            "NoPlanEntries",
+                            "ListNameEmpty",
+                            "BulkAddFailed"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Generate a shopping list from a plan range (writes to lists)",
+        "tags": ["shopping"]
+      }
+    },
+    "/shopping/preview": {
+      "post": {
+        "operationId": "shopping.preview",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "endDate": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                  }
+                },
+                "required": ["startDate", "endDate"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "endDate": {
+                      "type": "string"
+                    },
+                    "planEntryCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "recipeTitles": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "sections": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "items": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "buyQty": {
+                                  "type": "number"
+                                },
+                                "canonicalUnit": {
+                                  "enum": ["g", "ml", "count"],
+                                  "type": "string"
+                                },
+                                "ingredientId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "ingredientName": {
+                                  "type": "string"
+                                },
+                                "isUnconverted": {
+                                  "type": "boolean"
+                                },
+                                "needQty": {
+                                  "type": "number"
+                                },
+                                "originalQty": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "originalUnit": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "pantryQty": {
+                                  "type": "number"
+                                },
+                                "sourceLineIds": {
+                                  "items": {
+                                    "maximum": 9007199254740991,
+                                    "minimum": -9007199254740991,
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "variantId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "variantName": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ingredientId",
+                                "ingredientName",
+                                "variantId",
+                                "variantName",
+                                "needQty",
+                                "pantryQty",
+                                "buyQty",
+                                "canonicalUnit",
+                                "isUnconverted",
+                                "originalQty",
+                                "originalUnit",
+                                "sourceLineIds"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "sectionLabel": {
+                            "type": "string"
+                          },
+                          "sectionTag": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": ["sectionTag", "sectionLabel", "items"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "skippedPlanEntryCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "startDate": {
+                      "type": "string"
+                    },
+                    "uncategorisedIngredientIds": {
+                      "items": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "startDate",
+                    "endDate",
+                    "planEntryCount",
+                    "skippedPlanEntryCount",
+                    "sections",
+                    "uncategorisedIngredientIds",
+                    "recipeTitles"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Preview the shopping list a plan range would generate",
+        "tags": ["shopping"]
       }
     },
     "/slugs/search": {

--- a/pillars/food/src/api/__tests__/plan.test.ts
+++ b/pillars/food/src/api/__tests__/plan.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration tests for the `plan.*` REST surface (PRD-143). Covers slot
+ * CRUD, the week view, and a promoted-recipe addEntry happy path plus the
+ * discriminated error results. Plan-service invariants live in the db tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+const OMELETTE = `@recipe(slug="omelette", title="Omelette", servings=1)
+@yield(egg, 1:count)
+@ingredient(1, egg, 2:count)
+@step("Beat @1 and cook.")
+`;
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-plan-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  createIngredient(foodDb.db, { name: 'Egg', slug: 'egg', defaultUnit: 'count' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('plan REST — slots', () => {
+  it('adds, lists, updates and reports duplicate/unknown slots', async () => {
+    const api = client();
+    expect(await api.plan.addSlot('dinner', 'Dinner')).toEqual({ ok: true });
+    expect((await api.plan.listSlots()).slots.map((s) => s.slug)).toContain('dinner');
+    expect(await api.plan.addSlot('dinner', 'Dinner 2')).toEqual({
+      ok: false,
+      reason: 'SlugTaken',
+    });
+    expect(await api.plan.updateSlot('ghost', { name: 'X' })).toEqual({
+      ok: false,
+      reason: 'SlotNotFound',
+    });
+    expect(await api.plan.deleteSlot('ghost')).toEqual({ ok: false, reason: 'SlotNotFound' });
+  });
+});
+
+describe('plan REST — entries', () => {
+  it('adds a planned entry for a promoted recipe and shows it in the week view', async () => {
+    const api = client();
+    await api.plan.addSlot('dinner', 'Dinner');
+    const created = await api.recipes.create(OMELETTE);
+    const promoted = await api.recipes.promote(created.versionId);
+    expect(promoted.ok).toBe(true);
+
+    const added = await api.plan.addEntry({
+      date: '2026-06-16',
+      slot: 'dinner',
+      recipeId: created.recipeId,
+      plannedServings: 2,
+    });
+    expect(added.ok).toBe(true);
+
+    const week = await api.plan.weekView('2026-06-15');
+    expect(week.entries.some((e) => e.recipeId === created.recipeId)).toBe(true);
+
+    if (added.ok) {
+      expect(await api.plan.deleteEntry(added.id)).toEqual({ ok: true });
+    }
+  });
+
+  it('reports NotFound adding an entry for an unknown recipe', async () => {
+    const api = client();
+    await api.plan.addSlot('dinner', 'Dinner');
+    const res = await api.plan.addEntry({
+      date: '2026-06-16',
+      slot: 'dinner',
+      recipeId: 999999,
+      plannedServings: 1,
+    });
+    expect(res).toEqual({ ok: false, reason: 'NotFound' });
+  });
+
+  it('reports BadSlot for an unknown slot', async () => {
+    const created = await client().recipes.create(OMELETTE);
+    await client().recipes.promote(created.versionId);
+    const res = await client().plan.addEntry({
+      date: '2026-06-16',
+      slot: 'nonexistent',
+      recipeId: created.recipeId,
+      plannedServings: 1,
+    });
+    expect(res).toEqual({ ok: false, reason: 'BadSlot' });
+  });
+
+  it('returns an empty week view envelope', async () => {
+    const week = await client().plan.weekView('2026-06-15');
+    expect(week.entries).toEqual([]);
+    expect(Array.isArray(week.slots)).toBe(true);
+  });
+});

--- a/pillars/food/src/api/__tests__/shopping.test.ts
+++ b/pillars/food/src/api/__tests__/shopping.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for the `shopping.*` REST surface (PRD-152). Builds a
+ * plan fixture via the recipes/plan REST, previews the buy-list, and
+ * generates it to a stub lists client. Aggregation/pantry maths live in the
+ * db tests; here we assert the wire envelopes + the cross-pillar write.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { type ListsClient } from '../modules/recipes/send-to-list/lists-client.js';
+import { makeClient } from './test-utils.js';
+
+const OMELETTE = `@recipe(slug="omelette", title="Omelette", servings=1)
+@yield(egg, 1:count)
+@ingredient(1, egg, 2:count)
+@step("Beat @1 and cook.")
+`;
+
+interface Stub {
+  created: string[];
+  items: number;
+}
+
+function stubClient(state: Stub): ListsClient {
+  return {
+    getList: () => Promise.resolve(null),
+    createShoppingList: (name) => {
+      state.created.push(name);
+      return Promise.resolve(42);
+    },
+    upsertByRef: () => Promise.resolve({ outcome: 'inserted' as const, itemId: 1 }),
+    addItem: () => {
+      state.items += 1;
+      return Promise.resolve();
+    },
+    searchShoppingListIdsByNotes: () => Promise.resolve([]),
+  };
+}
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let state: Stub;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({
+      foodDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3005',
+      listsClient: stubClient(state),
+    })
+  );
+}
+
+async function seedPlannedRecipe(api: ReturnType<typeof makeClient>): Promise<void> {
+  await api.plan.addSlot('dinner', 'Dinner');
+  const created = await api.recipes.create(OMELETTE);
+  await api.recipes.promote(created.versionId);
+  await api.plan.addEntry({
+    date: '2026-06-16',
+    slot: 'dinner',
+    recipeId: created.recipeId,
+    plannedServings: 2,
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-shopping-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  state = { created: [], items: 0 };
+  createIngredient(foodDb.db, { name: 'Egg', slug: 'egg', defaultUnit: 'count' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('shopping REST', () => {
+  it('previews a buy-list from a planned recipe', async () => {
+    const api = client();
+    await seedPlannedRecipe(api);
+
+    const preview = await api.shopping.preview('2026-06-15', '2026-06-21');
+    expect(preview.planEntryCount).toBe(1);
+    const allItems = preview.sections.flatMap((s) => s.items);
+    expect(allItems.length).toBeGreaterThan(0);
+    expect(preview.recipeTitles).toContain('Omelette');
+  });
+
+  it('generates a list to the lists pillar via the client', async () => {
+    const api = client();
+    await seedPlannedRecipe(api);
+
+    const res = await api.shopping.generate('2026-06-15', '2026-06-21', 'Week Groceries');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.listId).toBe(42);
+      expect(res.itemCount).toBeGreaterThan(0);
+      expect(state.created).toEqual(['Week Groceries']);
+      expect(state.items).toBe(res.itemCount);
+    }
+  });
+
+  it('rejects an empty list name and an empty plan range', async () => {
+    const api = client();
+    await seedPlannedRecipe(api);
+    expect(await api.shopping.generate('2026-06-15', '2026-06-21', '   ')).toEqual({
+      ok: false,
+      reason: 'ListNameEmpty',
+    });
+    // A range with no plan entries → nothing to buy.
+    expect(await api.shopping.generate('2025-01-06', '2025-01-12', 'Empty')).toEqual({
+      ok: false,
+      reason: 'NoPlanEntries',
+    });
+  });
+
+  it('400s an invalid date range', async () => {
+    await expect(client().shopping.preview('2026-06-21', '2026-06-15')).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -191,6 +191,27 @@ type SendToListResult =
   | { ok: true; listId: number; addedCount: number; mergedCount: number }
   | { ok: false; reason: string };
 
+interface WeekView {
+  weekStart: string;
+  weekEnd: string;
+  slots: { slug: string; name: string }[];
+  entries: { id: number; recipeId: number; slot: string }[];
+}
+type OkOr<R extends string> = { ok: true } | { ok: false; reason: R };
+type AddEntryResult = { ok: true; id: number; position: number } | { ok: false; reason: string };
+
+interface GeneratorPreview {
+  startDate: string;
+  endDate: string;
+  planEntryCount: number;
+  skippedPlanEntryCount: number;
+  sections: { sectionLabel: string; items: { ingredientId: number; buyQty: number }[] }[];
+  recipeTitles: string[];
+}
+type GenerateResult =
+  | { ok: true; listId: number; itemCount: number }
+  | { ok: false; reason: string };
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -452,6 +473,31 @@ export function makeClient(app: Express) {
         send<SendToListResult>(
           r.post(`/recipes/versions/${versionId}/send-to-list`).send({ target, scaleFactor })
         ),
+    },
+    plan: {
+      weekView: (weekStart: string) => send<WeekView>(r.get('/plan/week').query({ weekStart })),
+      listSlots: () => send<{ slots: { slug: string; name: string }[] }>(r.get('/plan/slots')),
+      addSlot: (slug: string, name: string) =>
+        send<OkOr<'SlugTaken' | 'SlugInvalid'>>(r.post('/plan/slots').send({ slug, name })),
+      updateSlot: (slug: string, body: { name?: string; displayOrder?: number }) =>
+        send<OkOr<'SlotNotFound' | 'CannotEditDefault'>>(r.patch(`/plan/slots/${slug}`).send(body)),
+      deleteSlot: (slug: string) =>
+        send<OkOr<'SlotNotFound' | 'CannotDeleteDefault' | 'SlotInUse'>>(
+          r.delete(`/plan/slots/${slug}`)
+        ),
+      addEntry: (body: { date: string; slot: string; recipeId: number; plannedServings: number }) =>
+        send<AddEntryResult>(r.post('/plan/entries').send(body)),
+      updateEntry: (id: number, body: { plannedServings?: number; notes?: string | null }) =>
+        send<OkOr<string>>(r.patch(`/plan/entries/${id}`).send(body)),
+      moveEntry: (id: number, date: string, slot: string) =>
+        send<OkOr<string>>(r.post(`/plan/entries/${id}/move`).send({ date, slot })),
+      deleteEntry: (id: number) => send<OkOr<string>>(r.delete(`/plan/entries/${id}`)),
+    },
+    shopping: {
+      preview: (startDate: string, endDate: string) =>
+        send<GeneratorPreview>(r.post('/shopping/preview').send({ startDate, endDate })),
+      generate: (startDate: string, endDate: string, listName: string) =>
+        send<GenerateResult>(r.post('/shopping/generate').send({ startDate, endDate, listName })),
     },
   };
 }

--- a/pillars/food/src/api/modules/plan/iso-week.ts
+++ b/pillars/food/src/api/modules/plan/iso-week.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure ISO-week date helpers — no external dep.
+ *
+ * `toIsoMonday` normalises any `YYYY-MM-DD` to the Monday of the
+ * containing ISO week. Invalid input throws — the router maps this to
+ * an INPUT validation error so the UI can fall back to "current week".
+ */
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export class BadIsoDateError extends Error {
+  readonly input: string;
+  constructor(input: string) {
+    super(`Invalid ISO date: "${input}"`);
+    this.name = 'BadIsoDateError';
+    this.input = input;
+  }
+}
+
+/**
+ * Parse a strict `YYYY-MM-DD` into a UTC date. We use UTC throughout to
+ * keep day arithmetic free of DST surprises — the wire format carries
+ * no time-of-day so timezone is irrelevant.
+ */
+export function isValidIsoDate(input: string): boolean {
+  try {
+    parseIsoDateUtc(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseIsoDateUtc(input: string): Date {
+  const match = ISO_DATE_RE.exec(input);
+  if (match === null) throw new BadIsoDateError(input);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const d = new Date(Date.UTC(year, month - 1, day));
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    throw new BadIsoDateError(input);
+  }
+  return d;
+}
+
+function formatIsoDateUtc(d: Date): string {
+  const y = d.getUTCFullYear().toString().padStart(4, '0');
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function toIsoMonday(input: string): string {
+  const d = parseIsoDateUtc(input);
+  // JS: getUTCDay() returns 0=Sun..6=Sat. ISO: 1=Mon..7=Sun.
+  const isoDow = d.getUTCDay() === 0 ? 7 : d.getUTCDay();
+  const offset = isoDow - 1;
+  d.setUTCDate(d.getUTCDate() - offset);
+  return formatIsoDateUtc(d);
+}
+
+export function isoDateAddDays(input: string, days: number): string {
+  const d = parseIsoDateUtc(input);
+  d.setUTCDate(d.getUTCDate() + days);
+  return formatIsoDateUtc(d);
+}

--- a/pillars/food/src/api/modules/plan/router-helpers.ts
+++ b/pillars/food/src/api/modules/plan/router-helpers.ts
@@ -1,0 +1,88 @@
+/**
+ * Helpers used by `food.plan.*` mutation procedures — separated so
+ * `router.ts` stays under the per-file line cap.
+ */
+import { and, eq, sql } from 'drizzle-orm';
+
+import { planEntries, recipes, recipeVersions, type FoodDb } from '../../../db/index.js';
+import { listWireSlots } from './week-view.js';
+
+import type { PlanEntryError, PlanEntryMutationResult } from '../../../domain/types/plan.js';
+
+type FailResult = { ok: false; reason: PlanEntryError };
+
+export function planEntryFail(reason: PlanEntryError): FailResult {
+  return { ok: false, reason };
+}
+
+export interface PlanEntryGuardRow {
+  id: number;
+  recipeId: number;
+  recipeVersionId: number | null;
+  recipeRunId: number | null;
+}
+
+export function planEntryById(db: FoodDb, id: number): PlanEntryGuardRow | null {
+  const rows = db
+    .select({
+      id: planEntries.id,
+      recipeId: planEntries.recipeId,
+      recipeVersionId: planEntries.recipeVersionId,
+      recipeRunId: planEntries.recipeRunId,
+    })
+    .from(planEntries)
+    .where(eq(planEntries.id, id))
+    .all();
+  return rows[0] ?? null;
+}
+
+export function slotExists(db: FoodDb, slug: string): boolean {
+  return listWireSlots(db).some((s) => s.slug === slug);
+}
+
+export function nextPositionForSlot(db: FoodDb, date: string, slot: string): number {
+  const rows = db
+    .select({ max: sql<number | null>`max(${planEntries.position})` })
+    .from(planEntries)
+    .where(and(eq(planEntries.date, date), eq(planEntries.slot, slot)))
+    .all();
+  const max = rows[0]?.max;
+  return max === null || max === undefined ? 0 : max + 1;
+}
+
+export function recipeGuard(
+  db: FoodDb,
+  recipeId: number,
+  pinnedVersionId: number | null
+): FailResult | null {
+  const rows = db
+    .select({
+      id: recipes.id,
+      archivedAt: recipes.archivedAt,
+      currentVersionId: recipes.currentVersionId,
+    })
+    .from(recipes)
+    .where(eq(recipes.id, recipeId))
+    .all();
+  const recipe = rows[0];
+  if (recipe === undefined) return planEntryFail('NotFound');
+  if (recipe.archivedAt !== null) return planEntryFail('RecipeArchived');
+  if (pinnedVersionId !== null) {
+    const versionRows = db
+      .select({ id: recipeVersions.id, recipeId: recipeVersions.recipeId })
+      .from(recipeVersions)
+      .where(eq(recipeVersions.id, pinnedVersionId))
+      .all();
+    const version = versionRows[0];
+    if (version === undefined || version.recipeId !== recipeId) return planEntryFail('NotFound');
+    return null;
+  }
+  if (recipe.currentVersionId === null) return planEntryFail('RecipeHasNoCurrentVersion');
+  return null;
+}
+
+export type PlanEntryFailHelpers = {
+  planEntryFail: (reason: PlanEntryError) => FailResult;
+};
+
+export type PlanEntryMutationOk = PlanEntryMutationResult & { ok: true };

--- a/pillars/food/src/api/modules/plan/slot-mutations.ts
+++ b/pillars/food/src/api/modules/plan/slot-mutations.ts
@@ -1,0 +1,62 @@
+/**
+ * Plan-slot mutation logic (add / update / delete) returning the
+ * discriminated `{ ok, ... }` results. Split from the handler to keep it
+ * under the per-file line cap (mirrors the pops-api `slot-procedures.ts`
+ * split). The handler wraps each result in a 200 envelope.
+ */
+import {
+  type FoodDb,
+  InvalidSlugError,
+  planService,
+  PlanSlotInUse,
+  PlanSlotIsDefault,
+  PlanSlotNotFound,
+  PlanSlotSlugAlreadyExists,
+} from '../../../db/index.js';
+import { listWireSlots } from './week-view.js';
+
+import type {
+  PlanSlotDeleteResult,
+  PlanSlotMutationResult,
+  PlanSlotUpdateResult,
+} from '../../../domain/types/plan.js';
+
+export function addSlotResult(db: FoodDb, slug: string, name: string): PlanSlotMutationResult {
+  try {
+    planService.addSlot(db, { slug, name });
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof PlanSlotSlugAlreadyExists) return { ok: false, reason: 'SlugTaken' };
+    if (err instanceof InvalidSlugError) return { ok: false, reason: 'SlugInvalid' };
+    throw err;
+  }
+}
+
+export function updateSlotResult(
+  db: FoodDb,
+  slug: string,
+  patch: { name?: string; displayOrder?: number }
+): PlanSlotUpdateResult {
+  const slot = listWireSlots(db).find((s) => s.slug === slug);
+  if (slot === undefined) return { ok: false, reason: 'SlotNotFound' };
+  if (slot.isDefault && patch.name !== undefined) return { ok: false, reason: 'CannotEditDefault' };
+  try {
+    planService.updateSlot(db, slug, { name: patch.name, displayOrder: patch.displayOrder });
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof PlanSlotNotFound) return { ok: false, reason: 'SlotNotFound' };
+    throw err;
+  }
+}
+
+export function deleteSlotResult(db: FoodDb, slug: string): PlanSlotDeleteResult {
+  try {
+    planService.deleteSlot(db, slug);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof PlanSlotNotFound) return { ok: false, reason: 'SlotNotFound' };
+    if (err instanceof PlanSlotIsDefault) return { ok: false, reason: 'CannotDeleteDefault' };
+    if (err instanceof PlanSlotInUse) return { ok: false, reason: 'SlotInUse' };
+    throw err;
+  }
+}

--- a/pillars/food/src/api/modules/plan/week-view.ts
+++ b/pillars/food/src/api/modules/plan/week-view.ts
@@ -1,0 +1,100 @@
+/**
+ * `food.plan.weekView` read projection.
+ *
+ * Normalises an arbitrary YYYY-MM-DD to the containing ISO Monday, then
+ * joins `plan_entries` with `recipes`, the resolved `recipe_versions`
+ * (pinned id falls back to `recipes.current_version_id`), and
+ * `recipe_runs.completed_at` to denormalise every cell-rendering field
+ * into the wire row. One round-trip per week.
+ */
+import { and, asc, between, eq, sql } from 'drizzle-orm';
+
+import {
+  planEntries,
+  planSlots,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '../../../db/index.js';
+import { toIsoMonday, isoDateAddDays } from './iso-week.js';
+
+import type { WeekView, PlanEntryRow, PlanSlotRow } from '../../../domain/types/plan.js';
+
+export function buildWeekView(db: FoodDb, weekStartInput: string): WeekView {
+  const weekStart = toIsoMonday(weekStartInput);
+  const weekEnd = isoDateAddDays(weekStart, 6);
+
+  const slots = listWireSlots(db);
+  const entries = listWireEntries(db, weekStart, weekEnd);
+
+  return { weekStart, weekEnd, slots, entries };
+}
+
+export function listWireSlots(db: FoodDb): readonly PlanSlotRow[] {
+  const rows = db
+    .select()
+    .from(planSlots)
+    .orderBy(asc(planSlots.displayOrder), asc(planSlots.slug))
+    .all();
+  return rows.map((r) => ({
+    slug: r.slug,
+    name: r.name,
+    displayOrder: r.displayOrder,
+    isDefault: r.isDefault === 1,
+  }));
+}
+
+function listWireEntries(db: FoodDb, weekStart: string, weekEnd: string): readonly PlanEntryRow[] {
+  const resolvedVersionId = sql<
+    number | null
+  >`coalesce(${planEntries.recipeVersionId}, ${recipes.currentVersionId})`;
+
+  const rows = db
+    .select({
+      id: planEntries.id,
+      date: planEntries.date,
+      slot: planEntries.slot,
+      position: planEntries.position,
+      recipeId: planEntries.recipeId,
+      recipeSlug: recipes.slug,
+      recipeTitle: sql<string>`coalesce(${recipeVersions.title}, ${recipes.slug})`,
+      recipeType: recipes.recipeType,
+      heroImagePath: recipes.heroImagePath,
+      plannedServings: planEntries.plannedServings,
+      pinnedVersionId: planEntries.recipeVersionId,
+      resolvedVersionId,
+      recipeRunId: planEntries.recipeRunId,
+      recipeRunCookedAt: recipeRuns.completedAt,
+      notes: planEntries.notes,
+    })
+    .from(planEntries)
+    .innerJoin(recipes, eq(recipes.id, planEntries.recipeId))
+    .leftJoin(recipeVersions, eq(recipeVersions.id, resolvedVersionId))
+    .leftJoin(recipeRuns, eq(recipeRuns.id, planEntries.recipeRunId))
+    .where(and(between(planEntries.date, weekStart, weekEnd)))
+    .orderBy(
+      asc(planEntries.date),
+      asc(planEntries.slot),
+      asc(planEntries.position),
+      asc(planEntries.id)
+    )
+    .all();
+
+  return rows.map((r) => ({
+    id: r.id,
+    date: r.date,
+    slot: r.slot,
+    position: r.position,
+    recipeId: r.recipeId,
+    recipeSlug: r.recipeSlug,
+    recipeTitle: r.recipeTitle,
+    recipeType: r.recipeType ?? null,
+    heroImagePath: r.heroImagePath,
+    plannedServings: r.plannedServings,
+    recipeVersionId: r.pinnedVersionId,
+    recipeRunId: r.recipeRunId,
+    recipeRunCookedAt: r.recipeRunCookedAt,
+    notes: r.notes,
+  }));
+}

--- a/pillars/food/src/api/modules/shopping/aggregate.ts
+++ b/pillars/food/src/api/modules/shopping/aggregate.ts
@@ -1,0 +1,205 @@
+/**
+ * Aggregator — walks every plan entry's recipe lines, scales by
+ * `planned_servings / recipe_versions.servings` (falling back to 1.0 when
+ * servings is null per PRD-152), groups by
+ * `(ingredient_id, variant_id, canonical_unit)`, and emits two collections:
+ *
+ *   - `canonical[]`: rows where the source line had a non-null canonical qty
+ *     (`qty_g | qty_ml | qty_count`).
+ *   - `unconverted[]`: rows where the source line had all three canonical qty
+ *     fields null — one row per source line (no merging, mirrors PRD-142).
+ *
+ * Optional lines (`recipe_lines.optional = 1`) are filtered out at the SQL
+ * boundary so they never enter the need set.
+ */
+import { and, asc, eq, inArray } from 'drizzle-orm';
+
+import { type FoodDb, ingredients, ingredientVariants, recipeLines } from '../../../db/index.js';
+import { type PlanEntryNeed } from './load-plan.js';
+import { type CanonicalUnit } from './types.js';
+
+export interface CanonicalNeed {
+  ingredientId: number;
+  ingredientName: string;
+  variantId: number | null;
+  variantName: string | null;
+  canonicalUnit: CanonicalUnit;
+  needQty: number;
+  sourceLineIds: number[];
+}
+
+export interface UnconvertedNeed {
+  ingredientId: number;
+  ingredientName: string;
+  variantId: number | null;
+  variantName: string | null;
+  /** Always derived from the line's canonical_unit (PRD-116 NOT NULL). */
+  canonicalUnit: CanonicalUnit;
+  originalQty: number;
+  originalUnit: string;
+  sourceLineId: number;
+}
+
+export interface AggregateResult {
+  canonical: CanonicalNeed[];
+  unconverted: UnconvertedNeed[];
+  /**
+   * Recipe titles encountered, in plan-date order (earliest plan entry that
+   * referenced the recipe first). Powers the default list-name + the
+   * `notes` provenance string per AC.
+   */
+  recipeTitles: string[];
+}
+
+interface JoinedLine {
+  lineId: number;
+  recipeVersionId: number;
+  ingredientId: number;
+  ingredientName: string;
+  variantId: number | null;
+  variantName: string | null;
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: CanonicalUnit;
+  originalQty: number;
+  originalUnit: string;
+}
+
+export function aggregatePlanNeeds(db: FoodDb, entries: readonly PlanEntryNeed[]): AggregateResult {
+  if (entries.length === 0) {
+    return { canonical: [], unconverted: [], recipeTitles: [] };
+  }
+  const versionIds = [...new Set(entries.map((e) => e.recipeVersionId))];
+  const linesByVersion = loadLinesGroupedByVersion(db, versionIds);
+
+  const canonicalMap = new Map<string, CanonicalNeed>();
+  const unconverted: UnconvertedNeed[] = [];
+  const recipeTitles = collectRecipeTitles(entries);
+
+  for (const entry of entries) {
+    const lines = linesByVersion.get(entry.recipeVersionId) ?? [];
+    const scale = computeScale(entry.plannedServings, entry.versionServings);
+    for (const line of lines) {
+      const qty = pickCanonicalQty(line);
+      if (qty === null) {
+        unconverted.push(toUnconverted(line));
+        continue;
+      }
+      accumulateCanonical(canonicalMap, line, qty * scale);
+    }
+  }
+  return { canonical: [...canonicalMap.values()], unconverted, recipeTitles };
+}
+
+function computeScale(plannedServings: number, versionServings: number | null): number {
+  if (versionServings === null || versionServings <= 0) return 1.0;
+  return plannedServings / versionServings;
+}
+
+function pickCanonicalQty(line: JoinedLine): number | null {
+  switch (line.canonicalUnit) {
+    case 'g':
+      return line.qtyG;
+    case 'ml':
+      return line.qtyMl;
+    case 'count':
+      return line.qtyCount;
+  }
+}
+
+function accumulateCanonical(
+  map: Map<string, CanonicalNeed>,
+  line: JoinedLine,
+  scaledQty: number
+): void {
+  const key = `${line.ingredientId}|${line.variantId ?? 'null'}|${line.canonicalUnit}`;
+  const existing = map.get(key);
+  if (existing === undefined) {
+    map.set(key, {
+      ingredientId: line.ingredientId,
+      ingredientName: line.ingredientName,
+      variantId: line.variantId,
+      variantName: line.variantName,
+      canonicalUnit: line.canonicalUnit,
+      needQty: scaledQty,
+      sourceLineIds: [line.lineId],
+    });
+    return;
+  }
+  existing.needQty += scaledQty;
+  existing.sourceLineIds.push(line.lineId);
+}
+
+function toUnconverted(line: JoinedLine): UnconvertedNeed {
+  return {
+    ingredientId: line.ingredientId,
+    ingredientName: line.ingredientName,
+    variantId: line.variantId,
+    variantName: line.variantName,
+    canonicalUnit: line.canonicalUnit,
+    originalQty: line.originalQty,
+    originalUnit: line.originalUnit,
+    sourceLineId: line.lineId,
+  };
+}
+
+function loadLinesGroupedByVersion(
+  db: FoodDb,
+  versionIds: readonly number[]
+): Map<number, JoinedLine[]> {
+  const rows = db
+    .select({
+      lineId: recipeLines.id,
+      recipeVersionId: recipeLines.recipeVersionId,
+      ingredientId: recipeLines.ingredientId,
+      ingredientName: ingredients.name,
+      variantId: recipeLines.variantId,
+      variantName: ingredientVariants.name,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+      originalQty: recipeLines.originalQty,
+      originalUnit: recipeLines.originalUnit,
+      optional: recipeLines.optional,
+    })
+    .from(recipeLines)
+    .innerJoin(ingredients, eq(ingredients.id, recipeLines.ingredientId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .where(and(inArray(recipeLines.recipeVersionId, [...versionIds]), eq(recipeLines.optional, 0)))
+    .orderBy(asc(recipeLines.recipeVersionId), asc(recipeLines.position))
+    .all();
+  const map = new Map<number, JoinedLine[]>();
+  for (const r of rows) {
+    const list = map.get(r.recipeVersionId);
+    const joined: JoinedLine = {
+      lineId: r.lineId,
+      recipeVersionId: r.recipeVersionId,
+      ingredientId: r.ingredientId,
+      ingredientName: r.ingredientName,
+      variantId: r.variantId,
+      variantName: r.variantName,
+      qtyG: r.qtyG,
+      qtyMl: r.qtyMl,
+      qtyCount: r.qtyCount,
+      canonicalUnit: r.canonicalUnit,
+      originalQty: r.originalQty,
+      originalUnit: r.originalUnit,
+    };
+    if (list === undefined) map.set(r.recipeVersionId, [joined]);
+    else list.push(joined);
+  }
+  return map;
+}
+
+function collectRecipeTitles(entries: readonly PlanEntryNeed[]): string[] {
+  const seen = new Set<string>();
+  const titles: string[] = [];
+  for (const e of entries) {
+    if (seen.has(e.recipeTitle)) continue;
+    seen.add(e.recipeTitle);
+    titles.push(e.recipeTitle);
+  }
+  return titles;
+}

--- a/pillars/food/src/api/modules/shopping/generate.ts
+++ b/pillars/food/src/api/modules/shopping/generate.ts
@@ -1,0 +1,111 @@
+/**
+ * `food.shopping.generateFromPlan` — PRD-152, rewired onto the lists REST
+ * API. Re-runs the preview server-side (single source of truth) then writes
+ * a new shopping list over HTTP: create the list, then add each item in
+ * section-then-name order (the lists pillar auto-assigns sequential
+ * positions, so insertion order = display order). No cross-pillar
+ * transaction — a failure mid-write leaves a partial list (lists owns its
+ * own consistency).
+ */
+import { type ListsClient } from '../recipes/send-to-list/lists-client.js';
+import { buildItemNotes } from './list-name.js';
+import { previewFromPlan } from './preview.js';
+import { type GenerateResult, type GeneratorItem } from './types.js';
+
+import type { FoodDb } from '../../../db/index.js';
+
+export interface GenerateInput {
+  startDate: string;
+  endDate: string;
+  listName: string;
+}
+
+interface PreparedItem {
+  label: string;
+  qty: number;
+  unit: string;
+  refKind: 'ingredient' | 'variant';
+  refId: number;
+  notes: string;
+}
+
+export async function generateFromPlan(
+  db: FoodDb,
+  client: ListsClient,
+  input: GenerateInput
+): Promise<GenerateResult> {
+  const name = input.listName.trim();
+  if (name.length === 0) return { ok: false, reason: 'ListNameEmpty' };
+
+  const previewResult = previewFromPlan(db, {
+    startDate: input.startDate,
+    endDate: input.endDate,
+  });
+  if (!previewResult.ok) return { ok: false, reason: previewResult.reason };
+  const { preview } = previewResult;
+
+  const writableItems = collectWritableItems(preview.sections.flatMap((s) => s.items));
+  if (writableItems.length === 0) return { ok: false, reason: 'NoPlanEntries' };
+
+  const notes = buildItemNotes(input.startDate, input.endDate, preview.recipeTitles);
+  const prepared = writableItems.map((item) => buildPreparedItem(item, notes));
+
+  return runWrite(client, name, prepared);
+}
+
+async function runWrite(
+  client: ListsClient,
+  listName: string,
+  prepared: readonly PreparedItem[]
+): Promise<GenerateResult> {
+  try {
+    const listId = await client.createShoppingList(listName);
+    for (const item of prepared) {
+      await client.addItem(listId, {
+        label: item.label,
+        qty: item.qty,
+        unit: item.unit,
+        refKind: item.refKind,
+        refId: item.refId,
+        notes: item.notes,
+      });
+    }
+    return { ok: true, listId, itemCount: prepared.length };
+  } catch {
+    return { ok: false, reason: 'BulkAddFailed' };
+  }
+}
+
+function collectWritableItems(items: readonly GeneratorItem[]): GeneratorItem[] {
+  return items.filter((i) => i.isUnconverted || i.buyQty > 0);
+}
+
+function buildPreparedItem(item: GeneratorItem, notes: string): PreparedItem {
+  const qty = item.isUnconverted ? (item.originalQty ?? 0) : item.buyQty;
+  const unit = item.isUnconverted ? (item.originalUnit ?? '') : item.canonicalUnit;
+  const refKind: 'ingredient' | 'variant' = item.variantId === null ? 'ingredient' : 'variant';
+  const refId = item.variantId ?? item.ingredientId;
+  return {
+    label: buildLabel(item, qty, unit),
+    qty,
+    unit,
+    refKind,
+    refId,
+    notes,
+  };
+}
+
+function buildLabel(item: GeneratorItem, qty: number, unit: string): string {
+  const variantSuffix = item.variantName === null ? '' : ` ${item.variantName}`;
+  const qtyStr = formatQty(qty);
+  return `${qtyStr} ${unit} ${item.ingredientName}${variantSuffix}`;
+}
+
+function formatQty(qty: number): string {
+  if (Number.isInteger(qty)) return String(qty);
+  // Mirror PRD-142's `formatQty` — trailing-zero strip, no thousands.
+  return Number(qty.toFixed(2))
+    .toString()
+    .replace(/(\.\d*?)0+$/, '$1')
+    .replace(/\.$/, '');
+}

--- a/pillars/food/src/api/modules/shopping/inputs.ts
+++ b/pillars/food/src/api/modules/shopping/inputs.ts
@@ -1,0 +1,24 @@
+/**
+ * Zod inputs for the `food.shopping.*` procedures (PRD-152).
+ */
+import { z } from 'zod';
+
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD');
+
+export const PreviewFromPlanInputSchema = z.object({
+  startDate: IsoDate,
+  endDate: IsoDate,
+});
+
+export type PreviewFromPlanInput = z.infer<typeof PreviewFromPlanInputSchema>;
+
+export const GenerateFromPlanInputSchema = z.object({
+  startDate: IsoDate,
+  endDate: IsoDate,
+  listName: z.string(),
+});
+
+export type GenerateFromPlanInput = z.infer<typeof GenerateFromPlanInputSchema>;
+
+/** Inclusive on both ends; > 90 days is `BadDateRange`. */
+export const MAX_RANGE_DAYS = 90;

--- a/pillars/food/src/api/modules/shopping/list-name.ts
+++ b/pillars/food/src/api/modules/shopping/list-name.ts
@@ -1,0 +1,83 @@
+/**
+ * Default list-name composer + provenance notes builder — PRD-152.
+ *
+ * Format: `"Shopping list — <d-MMM>"` for single-day ranges; otherwise
+ * `"Shopping list — <d>-<d> <Mmm>"` when start + end share a month;
+ * `"Shopping list — <d Mmm>-<d Mmm>"` when they span months. All in
+ * en-AU short-month names — i18n at the list-name level is overkill for v1
+ * since the user can rename freely before generate.
+ *
+ * `notes` per item: `"Plan <start>-<end> · <recipe titles joined by ', '>"`
+ * front-truncated to 500 chars with `"…"` per AC.
+ */
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+const NOTES_MAX = 500;
+const ELLIPSIS = '…';
+
+interface DateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export function defaultListName(startDate: string, endDate: string): string {
+  const start = parseIsoDate(startDate);
+  const end = parseIsoDate(endDate);
+  if (start === null || end === null) return 'Shopping list';
+  if (sameDay(start, end)) {
+    return `Shopping list — ${start.day} ${MONTHS_SHORT[start.month - 1]}`;
+  }
+  if (start.year === end.year && start.month === end.month) {
+    return `Shopping list — ${start.day}-${end.day} ${MONTHS_SHORT[start.month - 1]}`;
+  }
+  return `Shopping list — ${start.day} ${MONTHS_SHORT[start.month - 1]}-${end.day} ${MONTHS_SHORT[end.month - 1]}`;
+}
+
+export function buildItemNotes(
+  startDate: string,
+  endDate: string,
+  recipeTitles: readonly string[]
+): string {
+  const prefix = `Plan ${startDate}-${endDate} · `;
+  const titlesStr = recipeTitles.join(', ');
+  const full = `${prefix}${titlesStr}`;
+  if (full.length <= NOTES_MAX) return full;
+  // Front-truncate the titles portion so the `Plan <start>-<end> ·` prefix
+  // always survives — that's the provenance signal the UI relies on.
+  const availableForTitles = NOTES_MAX - prefix.length - ELLIPSIS.length;
+  if (availableForTitles <= 0) {
+    // Pathological — the prefix alone exceeds the cap. Drop the titles.
+    return full.slice(0, NOTES_MAX - ELLIPSIS.length) + ELLIPSIS;
+  }
+  const trimmedTitles = titlesStr.slice(titlesStr.length - availableForTitles);
+  return `${prefix}${ELLIPSIS}${trimmedTitles}`;
+}
+
+function parseIsoDate(iso: string): DateParts | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (match === null) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+  return { year, month, day };
+}
+
+function sameDay(a: DateParts, b: DateParts): boolean {
+  return a.year === b.year && a.month === b.month && a.day === b.day;
+}

--- a/pillars/food/src/api/modules/shopping/load-plan.ts
+++ b/pillars/food/src/api/modules/shopping/load-plan.ts
@@ -1,0 +1,112 @@
+/**
+ * Plan-entry loader for the shopping generator — PRD-152.
+ *
+ * Selects `plan_entries` in the given date range whose `recipe_run_id IS
+ * NULL` (already-cooked entries don't contribute — their batches are already
+ * in the fridge), resolves each entry's effective `recipe_version_id` via
+ * `COALESCE(pe.recipe_version_id, recipes.current_version_id)`, and skips
+ * entries whose recipe has no current version.
+ */
+import { and, asc, between, eq, inArray, isNull } from 'drizzle-orm';
+
+import { type FoodDb, planEntries, recipes, recipeVersions } from '../../../db/index.js';
+
+export interface PlanEntryNeed {
+  planEntryId: number;
+  planDate: string;
+  recipeId: number;
+  recipeVersionId: number;
+  recipeTitle: string;
+  plannedServings: number;
+  /** Null when the recipe version had no `servings` value — caller falls back to scale=1.0. */
+  versionServings: number | null;
+}
+
+export interface LoadPlanResult {
+  entries: PlanEntryNeed[];
+  /** Plan entries in range whose recipe has no current version + no pin. */
+  skippedCount: number;
+  /** Total rows seen (entries.length + skippedCount). */
+  rawCount: number;
+}
+
+export function loadPlanEntriesForRange(
+  db: FoodDb,
+  startDate: string,
+  endDate: string
+): LoadPlanResult {
+  const rows = db
+    .select({
+      planEntryId: planEntries.id,
+      planDate: planEntries.date,
+      recipeId: planEntries.recipeId,
+      pinnedVersionId: planEntries.recipeVersionId,
+      currentVersionId: recipes.currentVersionId,
+      plannedServings: planEntries.plannedServings,
+    })
+    .from(planEntries)
+    .innerJoin(recipes, eq(recipes.id, planEntries.recipeId))
+    .where(and(between(planEntries.date, startDate, endDate), isNull(planEntries.recipeRunId)))
+    .orderBy(asc(planEntries.date), asc(planEntries.position), asc(planEntries.id))
+    .all();
+
+  const versionIds = collectVersionIds(rows);
+  const versions = loadVersions(db, versionIds);
+
+  const entries: PlanEntryNeed[] = [];
+  let skipped = 0;
+  for (const r of rows) {
+    const versionId = r.pinnedVersionId ?? r.currentVersionId;
+    if (versionId === null) {
+      skipped += 1;
+      continue;
+    }
+    const v = versions.get(versionId);
+    if (v === undefined) {
+      skipped += 1;
+      continue;
+    }
+    entries.push({
+      planEntryId: r.planEntryId,
+      planDate: r.planDate,
+      recipeId: r.recipeId,
+      recipeVersionId: versionId,
+      recipeTitle: v.title,
+      plannedServings: r.plannedServings,
+      versionServings: v.servings,
+    });
+  }
+  return { entries, skippedCount: skipped, rawCount: rows.length };
+}
+
+function collectVersionIds(
+  rows: readonly { pinnedVersionId: number | null; currentVersionId: number | null }[]
+): number[] {
+  const set = new Set<number>();
+  for (const r of rows) {
+    const v = r.pinnedVersionId ?? r.currentVersionId;
+    if (v !== null) set.add(v);
+  }
+  return [...set];
+}
+
+function loadVersions(
+  db: FoodDb,
+  ids: readonly number[]
+): Map<number, { title: string; servings: number | null }> {
+  const map = new Map<number, { title: string; servings: number | null }>();
+  if (ids.length === 0) return map;
+  const rows = db
+    .select({
+      id: recipeVersions.id,
+      title: recipeVersions.title,
+      servings: recipeVersions.servings,
+    })
+    .from(recipeVersions)
+    .where(inArray(recipeVersions.id, [...ids]))
+    .all();
+  for (const r of rows) {
+    map.set(r.id, { title: r.title, servings: r.servings });
+  }
+  return map;
+}

--- a/pillars/food/src/api/modules/shopping/load-tags.ts
+++ b/pillars/food/src/api/modules/shopping/load-tags.ts
@@ -1,0 +1,31 @@
+/**
+ * Bulk-load `store-section:*` and other tags for every ingredient that
+ * appears in the need set. Single query, indexed by `ingredient_tags.tag`
+ * via PRD-151's `idx_ingredient_tags_namespace` expression index for the
+ * `store-section:` prefix.
+ *
+ * Returns a map keyed by `ingredient_id` so the sectioner can look up each
+ * ingredient's full tag list in O(1).
+ */
+import { inArray } from 'drizzle-orm';
+
+import { type FoodDb, ingredientTags } from '../../../db/index.js';
+
+export function loadTagsForIngredients(
+  db: FoodDb,
+  ingredientIds: readonly number[]
+): Map<number, string[]> {
+  const map = new Map<number, string[]>();
+  if (ingredientIds.length === 0) return map;
+  const rows = db
+    .select({ ingredientId: ingredientTags.ingredientId, tag: ingredientTags.tag })
+    .from(ingredientTags)
+    .where(inArray(ingredientTags.ingredientId, [...ingredientIds]))
+    .all();
+  for (const r of rows) {
+    const list = map.get(r.ingredientId);
+    if (list === undefined) map.set(r.ingredientId, [r.tag]);
+    else list.push(r.tag);
+  }
+  return map;
+}

--- a/pillars/food/src/api/modules/shopping/pantry.ts
+++ b/pillars/food/src/api/modules/shopping/pantry.ts
@@ -1,0 +1,63 @@
+/**
+ * Pantry subtraction — strict by `(variant_id, unit)` per PRD-152.
+ *
+ * Loads a SUM of `batches.qty_remaining` per `(variant_id, unit)` for every
+ * variant referenced by the canonical-need set, filtered to non-deleted,
+ * non-empty batches. Needs with `variantId === null` get pantry = 0
+ * (`batches.variant_id` is NOT NULL — no way to match without a variant).
+ *
+ * A single query covers all variants in the need set — no per-need
+ * round-trip.
+ */
+import { and, gt, inArray, isNull, sql } from 'drizzle-orm';
+
+import { batches, type FoodDb } from '../../../db/index.js';
+import { type CanonicalNeed } from './aggregate.js';
+import { type CanonicalUnit } from './types.js';
+
+export interface PantrySums {
+  /** Map keyed by `<variantId>|<unit>` → summed qty_remaining. */
+  byVariantUnit: Map<string, number>;
+}
+
+export function loadPantrySums(db: FoodDb, canonicalNeeds: readonly CanonicalNeed[]): PantrySums {
+  const variantIds = collectVariantIds(canonicalNeeds);
+  const byVariantUnit = new Map<string, number>();
+  if (variantIds.length === 0) return { byVariantUnit };
+
+  const rows = db
+    .select({
+      variantId: batches.variantId,
+      unit: batches.unit,
+      qty: sql<number>`sum(${batches.qtyRemaining})`,
+    })
+    .from(batches)
+    .where(
+      and(
+        inArray(batches.variantId, [...variantIds]),
+        gt(batches.qtyRemaining, 0),
+        isNull(batches.deletedAt)
+      )
+    )
+    .groupBy(batches.variantId, batches.unit)
+    .all();
+
+  for (const r of rows) {
+    const qty = Number(r.qty ?? 0);
+    if (qty <= 0) continue;
+    byVariantUnit.set(pantryKey(r.variantId, r.unit), qty);
+  }
+  return { byVariantUnit };
+}
+
+export function pantryKey(variantId: number, unit: CanonicalUnit): string {
+  return `${variantId}|${unit}`;
+}
+
+function collectVariantIds(needs: readonly CanonicalNeed[]): number[] {
+  const set = new Set<number>();
+  for (const n of needs) {
+    if (n.variantId !== null) set.add(n.variantId);
+  }
+  return [...set];
+}

--- a/pillars/food/src/api/modules/shopping/preview.ts
+++ b/pillars/food/src/api/modules/shopping/preview.ts
@@ -1,0 +1,117 @@
+/**
+ * `food.shopping.previewFromPlan` orchestrator — PRD-152.
+ *
+ * Single round-trip computation:
+ *   1. Validate dates.
+ *   2. Load plan entries in range (`recipe_run_id IS NULL`); resolve
+ *      effective `recipe_version_id`; skip uncookable entries.
+ *   3. Aggregate recipe lines × planned-servings scale → canonical /
+ *      unconverted need groups.
+ *   4. Subtract pantry batches by `(variant_id, canonical_unit)`.
+ *   5. Resolve `store-section:*` tags + assemble sections.
+ *   6. Return.
+ */
+import { aggregatePlanNeeds, type CanonicalNeed, type UnconvertedNeed } from './aggregate.js';
+import { loadPlanEntriesForRange } from './load-plan.js';
+import { loadTagsForIngredients } from './load-tags.js';
+import { loadPantrySums, pantryKey } from './pantry.js';
+import { buildSections } from './sections.js';
+import { type GeneratorItem, type GeneratorPreview } from './types.js';
+import { validateDateRange } from './validate.js';
+
+import type { FoodDb } from '../../../db/index.js';
+
+export interface PreviewInput {
+  startDate: string;
+  endDate: string;
+}
+
+export type PreviewResult =
+  | { ok: true; preview: GeneratorPreview }
+  | { ok: false; reason: 'BadDateRange' };
+
+export function previewFromPlan(db: FoodDb, input: PreviewInput): PreviewResult {
+  const validation = validateDateRange(input.startDate, input.endDate);
+  if (!validation.ok) return { ok: false, reason: 'BadDateRange' };
+
+  const planLoad = loadPlanEntriesForRange(db, input.startDate, input.endDate);
+  const aggregate = aggregatePlanNeeds(db, planLoad.entries);
+  const pantry = loadPantrySums(db, aggregate.canonical);
+
+  const canonicalItems = aggregate.canonical.map((n) => toCanonicalItem(n, pantry.byVariantUnit));
+  const unconvertedItems = aggregate.unconverted.map(toUnconvertedItem);
+
+  const ingredientIds = collectIngredientIds(aggregate.canonical, aggregate.unconverted);
+  const tagsByIngredientId = loadTagsForIngredients(db, ingredientIds);
+
+  const sectioned = buildSections({
+    canonicalItems,
+    unconvertedItems,
+    tagsByIngredientId,
+  });
+
+  return {
+    ok: true,
+    preview: {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      planEntryCount: planLoad.entries.length,
+      skippedPlanEntryCount: planLoad.skippedCount,
+      sections: sectioned.sections,
+      uncategorisedIngredientIds: sectioned.uncategorisedIngredientIds,
+      recipeTitles: aggregate.recipeTitles,
+    },
+  };
+}
+
+function toCanonicalItem(
+  need: CanonicalNeed,
+  pantrySums: ReadonlyMap<string, number>
+): GeneratorItem {
+  const pantryQty =
+    need.variantId === null
+      ? 0
+      : (pantrySums.get(pantryKey(need.variantId, need.canonicalUnit)) ?? 0);
+  const buyQty = Math.max(need.needQty - pantryQty, 0);
+  return {
+    ingredientId: need.ingredientId,
+    ingredientName: need.ingredientName,
+    variantId: need.variantId,
+    variantName: need.variantName,
+    needQty: need.needQty,
+    pantryQty,
+    buyQty,
+    canonicalUnit: need.canonicalUnit,
+    isUnconverted: false,
+    originalQty: null,
+    originalUnit: null,
+    sourceLineIds: [...need.sourceLineIds],
+  };
+}
+
+function toUnconvertedItem(need: UnconvertedNeed): GeneratorItem {
+  return {
+    ingredientId: need.ingredientId,
+    ingredientName: need.ingredientName,
+    variantId: need.variantId,
+    variantName: need.variantName,
+    needQty: need.originalQty,
+    pantryQty: 0,
+    buyQty: need.originalQty,
+    canonicalUnit: need.canonicalUnit,
+    isUnconverted: true,
+    originalQty: need.originalQty,
+    originalUnit: need.originalUnit,
+    sourceLineIds: [need.sourceLineId],
+  };
+}
+
+function collectIngredientIds(
+  canonical: readonly CanonicalNeed[],
+  unconverted: readonly UnconvertedNeed[]
+): number[] {
+  const set = new Set<number>();
+  for (const c of canonical) set.add(c.ingredientId);
+  for (const u of unconverted) set.add(u.ingredientId);
+  return [...set];
+}

--- a/pillars/food/src/api/modules/shopping/sections.ts
+++ b/pillars/food/src/api/modules/shopping/sections.ts
@@ -1,0 +1,99 @@
+/**
+ * Section assembly — PRD-152.
+ *
+ * Resolves each ingredient's `store-section:*` tag (alphabetically first if
+ * multiple), groups items into sections ordered alphabetically by
+ * `sectionLabel`, with "Other / Uncategorised" last among regular sections
+ * and "Unconverted" last-of-all. Pure function over already-loaded data;
+ * the caller hands in the canonical items, unconverted items, and the
+ * full tag map.
+ */
+import { type GeneratorItem, type GeneratorSection } from './types.js';
+
+export const STORE_SECTION_PREFIX = 'store-section:';
+const OTHER_LABEL = 'Other / Uncategorised';
+const UNCONVERTED_LABEL = 'Unconverted';
+
+export interface SectionsInput {
+  canonicalItems: readonly GeneratorItem[];
+  unconvertedItems: readonly GeneratorItem[];
+  /** ingredientId → all tags carried by that ingredient (already trimmed/lowered). */
+  tagsByIngredientId: ReadonlyMap<number, readonly string[]>;
+}
+
+export interface SectionsResult {
+  sections: GeneratorSection[];
+  /** Distinct ingredientIds whose row landed in the Other bucket. */
+  uncategorisedIngredientIds: number[];
+}
+
+export function buildSections(input: SectionsInput): SectionsResult {
+  const buckets = new Map<string, GeneratorItem[]>();
+  const otherItems: GeneratorItem[] = [];
+  const uncategorisedSet = new Set<number>();
+
+  for (const item of input.canonicalItems) {
+    const tag = pickStoreSectionTag(input.tagsByIngredientId.get(item.ingredientId));
+    if (tag === null) {
+      otherItems.push(item);
+      uncategorisedSet.add(item.ingredientId);
+      continue;
+    }
+    const list = buckets.get(tag);
+    if (list === undefined) buckets.set(tag, [item]);
+    else list.push(item);
+  }
+
+  const sections: GeneratorSection[] = [];
+  const sortedTags = [...buckets.keys()].toSorted((a, b) =>
+    sectionLabelFromTag(a).localeCompare(sectionLabelFromTag(b))
+  );
+  for (const tag of sortedTags) {
+    const items = buckets.get(tag) ?? [];
+    sortIntraSection(items);
+    sections.push({ sectionTag: tag, sectionLabel: sectionLabelFromTag(tag), items });
+  }
+  if (otherItems.length > 0) {
+    sortIntraSection(otherItems);
+    sections.push({ sectionTag: null, sectionLabel: OTHER_LABEL, items: otherItems });
+  }
+  if (input.unconvertedItems.length > 0) {
+    const unconverted = [...input.unconvertedItems];
+    sortIntraSection(unconverted);
+    sections.push({ sectionTag: null, sectionLabel: UNCONVERTED_LABEL, items: unconverted });
+  }
+  return { sections, uncategorisedIngredientIds: [...uncategorisedSet] };
+}
+
+export function sectionLabelFromTag(tag: string): string {
+  const slug = tag.startsWith(STORE_SECTION_PREFIX) ? tag.slice(STORE_SECTION_PREFIX.length) : tag;
+  // Title-case the trailing slug: `store-section:bakery` -> `Bakery`.
+  return slug
+    .split('-')
+    .filter((s) => s.length > 0)
+    .map(titleCaseWord)
+    .join(' ');
+}
+
+function titleCaseWord(word: string): string {
+  const first = word.charAt(0);
+  return first.toUpperCase() + word.slice(1);
+}
+
+export function pickStoreSectionTag(tags: readonly string[] | undefined): string | null {
+  if (tags === undefined || tags.length === 0) return null;
+  const storeTags = tags.filter((t) => t.startsWith(STORE_SECTION_PREFIX));
+  if (storeTags.length === 0) return null;
+  const sorted = [...storeTags].toSorted((a, b) => a.localeCompare(b));
+  return sorted[0] ?? null;
+}
+
+function sortIntraSection(items: GeneratorItem[]): void {
+  items.sort((a, b) => {
+    const nameCompare = a.ingredientName.localeCompare(b.ingredientName);
+    if (nameCompare !== 0) return nameCompare;
+    const aVariant = a.variantName ?? '';
+    const bVariant = b.variantName ?? '';
+    return aVariant.localeCompare(bVariant);
+  });
+}

--- a/pillars/food/src/api/modules/shopping/types.ts
+++ b/pillars/food/src/api/modules/shopping/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Wire shapes for `food.shopping.previewFromPlan` and
+ * `food.shopping.generateFromPlan` — PRD-152.
+ *
+ * The preview is computed twice: once server-side for the picker page, and a
+ * second time as the first step of `generateFromPlan` so the server never
+ * trusts the client's view. Both share the same shape.
+ */
+
+export type CanonicalUnit = 'g' | 'ml' | 'count';
+
+export interface GeneratorItem {
+  ingredientId: number;
+  ingredientName: string;
+  variantId: number | null;
+  variantName: string | null;
+  /** Sum across plan entries in the range, in `canonicalUnit`, at scaled servings. */
+  needQty: number;
+  /** Sum of non-deleted, non-empty batches matching `(variant_id, unit)`. */
+  pantryQty: number;
+  /** `max(needQty - pantryQty, 0)`. */
+  buyQty: number;
+  canonicalUnit: CanonicalUnit;
+  /**
+   * True when the source `recipe_lines` row had all three canonical qty
+   * fields null — PRD-116 couldn't compute a canonical qty even though it
+   * set `canonical_unit` to the ingredient's default unit.
+   */
+  isUnconverted: boolean;
+  /** For unconverted items: the original DSL qty. */
+  originalQty: number | null;
+  /** For unconverted items: the original DSL unit. */
+  originalUnit: string | null;
+  sourceLineIds: number[];
+}
+
+export interface GeneratorSection {
+  /** `'store-section:produce'` etc.; null for the Other / Unconverted buckets. */
+  sectionTag: string | null;
+  /** Human-readable label (`'Produce'`, `'Other / Uncategorised'`, `'Unconverted'`). */
+  sectionLabel: string;
+  items: GeneratorItem[];
+}
+
+export interface GeneratorPreview {
+  startDate: string;
+  endDate: string;
+  planEntryCount: number;
+  /**
+   * `recipe_id` of plan entries that resolved to no current version. The
+   * preview UI shows "<N> entries skipped — recipe has no current version".
+   */
+  skippedPlanEntryCount: number;
+  sections: GeneratorSection[];
+  /**
+   * Ingredients that landed in the Other bucket — emitted so the UI can wire
+   * each row's [Tag it] link to PRD-122 without an extra round-trip.
+   */
+  uncategorisedIngredientIds: number[];
+  /** Distinct recipe titles in range, ordered by first plan entry date — used by the default list-name and item-notes provenance string. */
+  recipeTitles: string[];
+}
+
+export type GenerateError = 'BadDateRange' | 'NoPlanEntries' | 'ListNameEmpty' | 'BulkAddFailed';
+
+export type GenerateResult =
+  | { ok: true; listId: number; itemCount: number }
+  | { ok: false; reason: GenerateError };

--- a/pillars/food/src/api/modules/shopping/validate.ts
+++ b/pillars/food/src/api/modules/shopping/validate.ts
@@ -1,0 +1,31 @@
+/**
+ * Date-range validation — PRD-152.
+ *
+ * Both ends inclusive. End must be ≥ start; range ≤ 90 days (cap).
+ * Returns a discriminated result so the caller can route to either the
+ * preview path or the `BadDateRange` error without throws.
+ */
+import { MAX_RANGE_DAYS } from './inputs.js';
+
+export type ValidateRangeResult =
+  | { ok: true; days: number }
+  | { ok: false; reason: 'BadDateRange' };
+
+const MS_PER_DAY = 86_400_000;
+
+export function validateDateRange(startDate: string, endDate: string): ValidateRangeResult {
+  const start = parseIsoDate(startDate);
+  const end = parseIsoDate(endDate);
+  if (start === null || end === null) return { ok: false, reason: 'BadDateRange' };
+  if (end < start) return { ok: false, reason: 'BadDateRange' };
+  const days = Math.round((end - start) / MS_PER_DAY) + 1;
+  if (days > MAX_RANGE_DAYS) return { ok: false, reason: 'BadDateRange' };
+  return { ok: true, days };
+}
+
+function parseIsoDate(iso: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return null;
+  const ms = Date.parse(`${iso}T00:00:00Z`);
+  if (Number.isNaN(ms)) return null;
+  return ms;
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -22,9 +22,11 @@ import { makeHeroImageHandlers } from './hero-image-handlers.js';
 import { makeInboxHandlers } from './inbox-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
+import { makePlanHandlers } from './plan-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
 import { makeRecipesHandlers } from './recipes-handlers.js';
 import { makeSendToListHandlers } from './send-to-list-handlers.js';
+import { makeShoppingHandlers } from './shopping-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
 import { makeSolverHandlers } from './solver-handlers.js';
 import { makeSubstitutionsHandlers } from './substitutions-handlers.js';
@@ -51,9 +53,11 @@ export function makeFoodRestHandlers(
     inbox: makeInboxHandlers(db),
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
+    plan: makePlanHandlers(db),
     prepStates: makePrepStatesHandlers(db),
     recipes: makeRecipesHandlers(db),
     sendToList: makeSendToListHandlers(db, resolveListsClient),
+    shopping: makeShoppingHandlers(db, resolveListsClient),
     slugs: makeSlugsHandlers(db),
     solver: makeSolverHandlers(db),
     substitutions: makeSubstitutionsHandlers(db),

--- a/pillars/food/src/api/rest/plan-handlers.ts
+++ b/pillars/food/src/api/rest/plan-handlers.ts
@@ -1,0 +1,163 @@
+/**
+ * Handlers for the `plan.*` sub-router (PRD-143). Mutations return the
+ * discriminated `{ ok, ... }` result on 200; `weekView` maps a bad ISO date
+ * to 400. Guard/validation logic lives in the lifted `modules/plan/`
+ * helpers; the slot mutations live in `modules/plan/slot-mutations.ts`.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import {
+  type FoodDb,
+  planEntries,
+  planService,
+  PlanEntryHasCookEvent,
+  PlanEntryNotFound,
+} from '../../db/index.js';
+import { BadIsoDateError, isValidIsoDate } from '../modules/plan/iso-week.js';
+import {
+  nextPositionForSlot,
+  planEntryById,
+  planEntryFail,
+  recipeGuard,
+  slotExists,
+} from '../modules/plan/router-helpers.js';
+import {
+  addSlotResult,
+  deleteSlotResult,
+  updateSlotResult,
+} from '../modules/plan/slot-mutations.js';
+import { buildWeekView, listWireSlots } from '../modules/plan/week-view.js';
+import { HttpError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodPlanContract } from '../../contract/rest-plan.js';
+
+type Req = ServerInferRequest<typeof foodPlanContract>;
+
+function ok<T>(body: T): { status: 200; body: T } {
+  return { status: 200, body };
+}
+
+function applyEntryPatch(
+  db: FoodDb,
+  id: number,
+  patch: { plannedServings?: number; recipeVersionId?: number | null; notes?: string | null }
+): void {
+  const updates: Record<string, unknown> = {};
+  if (patch.plannedServings !== undefined) updates['plannedServings'] = patch.plannedServings;
+  if (patch.recipeVersionId !== undefined) updates['recipeVersionId'] = patch.recipeVersionId;
+  if (patch.notes !== undefined) updates['notes'] = patch.notes;
+  if (Object.keys(updates).length === 0) return;
+  db.update(planEntries).set(updates).where(eq(planEntries.id, id)).run();
+}
+
+export function makePlanHandlers(db: FoodDb) {
+  return {
+    weekView: ({ query }: Req['weekView']) =>
+      runHttp(() => {
+        try {
+          return ok(buildWeekView(db, query.weekStart));
+        } catch (err) {
+          if (err instanceof BadIsoDateError) {
+            throw new HttpError(400, err.message, undefined, 'common.validationFailed');
+          }
+          throw err;
+        }
+      }),
+
+    listSlots: () => runHttp(() => ok({ slots: listWireSlots(db) })),
+
+    addSlot: ({ body }: Req['addSlot']) =>
+      runHttp(() => ok(addSlotResult(db, body.slug, body.name))),
+
+    updateSlot: ({ params, body }: Req['updateSlot']) =>
+      runHttp(() => ok(updateSlotResult(db, params.slug, body))),
+
+    deleteSlot: ({ params }: Req['deleteSlot']) =>
+      runHttp(() => ok(deleteSlotResult(db, params.slug))),
+
+    addEntry: ({ body }: Req['addEntry']) =>
+      runHttp(() => {
+        if (!isValidIsoDate(body.date)) return ok(planEntryFail('BadDate'));
+        if (!slotExists(db, body.slot)) return ok(planEntryFail('BadSlot'));
+        const guard = recipeGuard(db, body.recipeId, body.recipeVersionId ?? null);
+        if (guard !== null) return ok(guard);
+        const row = db.transaction(() =>
+          planService.addPlanEntry(db, {
+            date: body.date,
+            slot: body.slot,
+            recipeId: body.recipeId,
+            recipeVersionId: body.recipeVersionId ?? null,
+            plannedServings: body.plannedServings,
+            notes: body.notes ?? null,
+          })
+        );
+        return ok({ ok: true as const, id: row.id, position: row.position });
+      }),
+
+    updateEntry: ({ params, body }: Req['updateEntry']) =>
+      runHttp(() =>
+        db.transaction(() => {
+          const existing = planEntryById(db, params.id);
+          if (existing === null) return ok(planEntryFail('NotFound'));
+          if (existing.recipeRunId !== null) return ok(planEntryFail('AlreadyCooked'));
+          if (body.recipeVersionId !== undefined) {
+            const guard = recipeGuard(db, existing.recipeId, body.recipeVersionId);
+            if (guard !== null) return ok(guard);
+          }
+          applyEntryPatch(db, params.id, body);
+          return ok({ ok: true as const });
+        })
+      ),
+
+    moveEntry: ({ params, body }: Req['moveEntry']) =>
+      runHttp(() => {
+        if (!isValidIsoDate(body.date)) return ok(planEntryFail('BadDate'));
+        return db.transaction(() => {
+          const existing = planEntryById(db, params.id);
+          if (existing === null) return ok(planEntryFail('NotFound'));
+          if (existing.recipeRunId !== null) return ok(planEntryFail('AlreadyCooked'));
+          if (!slotExists(db, body.slot)) return ok(planEntryFail('BadSlot'));
+          const position = body.position ?? nextPositionForSlot(db, body.date, body.slot);
+          db.update(planEntries)
+            .set({ date: body.date, slot: body.slot, position })
+            .where(eq(planEntries.id, params.id))
+            .run();
+          return ok({ ok: true as const });
+        });
+      }),
+
+    deleteEntry: ({ params }: Req['deleteEntry']) =>
+      runHttp(() => {
+        try {
+          planService.removePlanEntry(db, params.id);
+          return ok({ ok: true as const });
+        } catch (err) {
+          if (err instanceof PlanEntryNotFound) return ok(planEntryFail('NotFound'));
+          if (err instanceof PlanEntryHasCookEvent) return ok(planEntryFail('AlreadyCooked'));
+          throw err;
+        }
+      }),
+
+    reorderSlot: ({ body }: Req['reorderSlot']) =>
+      runHttp(() =>
+        db.transaction(() => {
+          const cellRows = db
+            .select({ id: planEntries.id })
+            .from(planEntries)
+            .where(and(eq(planEntries.date, body.date), eq(planEntries.slot, body.slot)))
+            .all();
+          const cellIds = new Set(cellRows.map((r) => r.id));
+          const allBelong = body.orderedIds.every((id) => cellIds.has(id));
+          const uniqueIds = new Set(body.orderedIds);
+          if (!allBelong || uniqueIds.size !== body.orderedIds.length) {
+            return ok({ ok: false as const, reason: 'BadIds' as const });
+          }
+          planService.reorderSlot(db, body.orderedIds);
+          return ok({ ok: true as const });
+        })
+      ),
+  };
+}

--- a/pillars/food/src/api/rest/shopping-handlers.ts
+++ b/pillars/food/src/api/rest/shopping-handlers.ts
@@ -1,0 +1,45 @@
+/**
+ * Handlers for the `shopping.*` sub-router (PRD-152). `preview` maps a bad
+ * date range to 400; `generate` returns the discriminated result on 200 and
+ * writes to the lists pillar via the lazily-resolved ListsClient.
+ */
+import { type ListsClient } from '../modules/recipes/send-to-list/lists-client.js';
+import { generateFromPlan } from '../modules/shopping/generate.js';
+import { previewFromPlan } from '../modules/shopping/preview.js';
+import { HttpError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodShoppingContract } from '../../contract/rest-shopping.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodShoppingContract>;
+
+export function makeShoppingHandlers(db: FoodDb, resolveClient: () => ListsClient) {
+  return {
+    preview: ({ body }: Req['preview']) =>
+      runHttp(() => {
+        const result = previewFromPlan(db, { startDate: body.startDate, endDate: body.endDate });
+        if (!result.ok) {
+          throw new HttpError(
+            400,
+            `Invalid date range: ${result.reason}`,
+            undefined,
+            'common.validationFailed'
+          );
+        }
+        return { status: 200 as const, body: result.preview };
+      }),
+
+    generate: ({ body }: Req['generate']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await generateFromPlan(db, resolveClient(), {
+          startDate: body.startDate,
+          endDate: body.endDate,
+          listName: body.listName,
+        }),
+      })),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -642,6 +642,128 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/plan/entries': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Add a plan entry */
+    post: operations['plan.addEntry'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/entries/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a plan entry */
+    delete: operations['plan.deleteEntry'];
+    options?: never;
+    head?: never;
+    /** Update a plan entry */
+    patch: operations['plan.updateEntry'];
+    trace?: never;
+  };
+  '/plan/entries/{id}/move': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Move a plan entry to another date/slot */
+    post: operations['plan.moveEntry'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/reorder': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reorder entries within a date/slot cell */
+    post: operations['plan.reorderSlot'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/slots': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List plan slots */
+    get: operations['plan.listSlots'];
+    put?: never;
+    /** Add a plan slot */
+    post: operations['plan.addSlot'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/slots/{slug}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a plan slot */
+    delete: operations['plan.deleteSlot'];
+    options?: never;
+    head?: never;
+    /** Update a plan slot */
+    patch: operations['plan.updateSlot'];
+    trace?: never;
+  };
+  '/plan/week': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Denormalised meal-plan week view */
+    get: operations['plan.weekView'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/prep-states': {
     parameters: {
       query?: never;
@@ -877,6 +999,40 @@ export interface paths {
     put?: never;
     /** Fork a new draft from a recipe’s current version */
     post: operations['recipes.createNewDraft'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/shopping/generate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate a shopping list from a plan range (writes to lists) */
+    post: operations['shopping.generate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/shopping/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Preview the shopping list a plan range would generate */
+    post: operations['shopping.preview'];
     delete?: never;
     options?: never;
     head?: never;
@@ -3706,6 +3862,460 @@ export interface operations {
       };
     };
   };
+  'plan.addEntry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          date: string;
+          notes?: string;
+          plannedServings: number;
+          recipeId: number;
+          recipeVersionId?: number;
+          slot: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                id: number;
+                /** @enum {boolean} */
+                ok: true;
+                position: number;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotFound'
+                  | 'AlreadyCooked'
+                  | 'BadDate'
+                  | 'BadSlot'
+                  | 'RecipeArchived'
+                  | 'RecipeHasNoCurrentVersion';
+              };
+        };
+      };
+    };
+  };
+  'plan.deleteEntry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotFound'
+                  | 'AlreadyCooked'
+                  | 'BadDate'
+                  | 'BadSlot'
+                  | 'RecipeArchived'
+                  | 'RecipeHasNoCurrentVersion';
+              };
+        };
+      };
+    };
+  };
+  'plan.updateEntry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          notes?: string | null;
+          plannedServings?: number;
+          recipeVersionId?: number | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotFound'
+                  | 'AlreadyCooked'
+                  | 'BadDate'
+                  | 'BadSlot'
+                  | 'RecipeArchived'
+                  | 'RecipeHasNoCurrentVersion';
+              };
+        };
+      };
+    };
+  };
+  'plan.moveEntry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          date: string;
+          position?: number;
+          slot: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotFound'
+                  | 'AlreadyCooked'
+                  | 'BadDate'
+                  | 'BadSlot'
+                  | 'RecipeArchived'
+                  | 'RecipeHasNoCurrentVersion';
+              };
+        };
+      };
+    };
+  };
+  'plan.reorderSlot': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          date: string;
+          orderedIds: number[];
+          slot: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'BadIds' | 'EmptySlot';
+              };
+        };
+      };
+    };
+  };
+  'plan.listSlots': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            readonly slots: {
+              displayOrder: number;
+              isDefault: boolean;
+              name: string;
+              slug: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'plan.addSlot': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          name: string;
+          slug: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'SlugTaken' | 'SlugInvalid';
+              };
+        };
+      };
+    };
+  };
+  'plan.deleteSlot': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'SlotNotFound' | 'CannotDeleteDefault' | 'SlotInUse';
+              };
+        };
+      };
+    };
+  };
+  'plan.updateSlot': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          displayOrder?: number;
+          name?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'SlotNotFound' | 'CannotEditDefault';
+              };
+        };
+      };
+    };
+  };
+  'plan.weekView': {
+    parameters: {
+      query: {
+        weekStart: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            readonly entries: {
+              date: string;
+              heroImagePath: string | null;
+              id: number;
+              notes: string | null;
+              plannedServings: number;
+              position: number;
+              recipeId: number;
+              recipeRunCookedAt: string | null;
+              recipeRunId: number | null;
+              recipeSlug: string;
+              recipeTitle: string;
+              recipeType: string | null;
+              recipeVersionId: number | null;
+              slot: string;
+            }[];
+            readonly slots: {
+              displayOrder: number;
+              isDefault: boolean;
+              name: string;
+              slug: string;
+            }[];
+            weekEnd: string;
+            weekStart: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'prepStates.list': {
     parameters: {
       query?: never;
@@ -4728,6 +5338,113 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'shopping.generate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          endDate: string;
+          listName: string;
+          startDate: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                itemCount: number;
+                listId: number;
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'BadDateRange' | 'NoPlanEntries' | 'ListNameEmpty' | 'BulkAddFailed';
+              };
+        };
+      };
+    };
+  };
+  'shopping.preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          endDate: string;
+          startDate: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            endDate: string;
+            planEntryCount: number;
+            recipeTitles: string[];
+            sections: {
+              items: {
+                buyQty: number;
+                /** @enum {string} */
+                canonicalUnit: 'g' | 'ml' | 'count';
+                ingredientId: number;
+                ingredientName: string;
+                isUnconverted: boolean;
+                needQty: number;
+                originalQty: number | null;
+                originalUnit: string | null;
+                pantryQty: number;
+                sourceLineIds: number[];
+                variantId: number | null;
+                variantName: string | null;
+              }[];
+              sectionLabel: string;
+              sectionTag: string | null;
+            }[];
+            skippedPlanEntryCount: number;
+            startDate: string;
+            uncategorisedIngredientIds: number[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
           };
         };
       };

--- a/pillars/food/src/contract/rest-plan.ts
+++ b/pillars/food/src/contract/rest-plan.ts
@@ -1,0 +1,186 @@
+/**
+ * `plan.*` sub-router — PRD-143 meal planning. The week view is a
+ * denormalised read; mutations return the service's discriminated
+ * `{ ok, ... }` result on 200 (the FE narrows on the reason). Only
+ * `weekView` can 400 (a date that passes the regex but isn't a real day).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, NonEmptyString, PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+const SlugLike = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'lowercase-kebab-case');
+
+const PlanSlotRowSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  displayOrder: z.number().int(),
+  isDefault: z.boolean(),
+});
+
+const PlanEntryRowSchema = z.object({
+  id: z.number().int(),
+  date: z.string(),
+  slot: z.string(),
+  position: z.number().int(),
+  recipeId: z.number().int(),
+  recipeSlug: z.string(),
+  recipeTitle: z.string(),
+  recipeType: z.string().nullable(),
+  heroImagePath: z.string().nullable(),
+  plannedServings: z.number().int(),
+  recipeVersionId: z.number().int().nullable(),
+  recipeRunId: z.number().int().nullable(),
+  recipeRunCookedAt: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+
+const WeekViewSchema = z.object({
+  weekStart: z.string(),
+  weekEnd: z.string(),
+  slots: z.array(PlanSlotRowSchema).readonly(),
+  entries: z.array(PlanEntryRowSchema).readonly(),
+});
+
+const PlanEntryError = z.enum([
+  'NotFound',
+  'AlreadyCooked',
+  'BadDate',
+  'BadSlot',
+  'RecipeArchived',
+  'RecipeHasNoCurrentVersion',
+]);
+const EntryFail = z.object({ ok: z.literal(false), reason: PlanEntryError });
+const AddEntryResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), id: z.number().int(), position: z.number().int() }),
+  EntryFail,
+]);
+const EntryMutationResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  EntryFail,
+]);
+const ReorderResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: z.enum(['BadIds', 'EmptySlot']) }),
+]);
+const SlotAddResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: z.enum(['SlugTaken', 'SlugInvalid']) }),
+]);
+const SlotUpdateResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: z.enum(['SlotNotFound', 'CannotEditDefault']) }),
+]);
+const SlotDeleteResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.enum(['SlotNotFound', 'CannotDeleteDefault', 'SlotInUse']),
+  }),
+]);
+
+export const foodPlanContract = c.router({
+  weekView: {
+    method: 'GET',
+    path: '/plan/week',
+    query: z.object({ weekStart: IsoDate }),
+    responses: { 200: WeekViewSchema, ...ERR_RESPONSES },
+    summary: 'Denormalised meal-plan week view',
+  },
+  listSlots: {
+    method: 'GET',
+    path: '/plan/slots',
+    responses: { 200: z.object({ slots: z.array(PlanSlotRowSchema).readonly() }) },
+    summary: 'List plan slots',
+  },
+  addSlot: {
+    method: 'POST',
+    path: '/plan/slots',
+    body: z.object({ slug: SlugLike, name: z.string().min(1).max(64) }),
+    responses: { 200: SlotAddResult },
+    summary: 'Add a plan slot',
+  },
+  updateSlot: {
+    method: 'PATCH',
+    path: '/plan/slots/:slug',
+    pathParams: z.object({ slug: NonEmptyString }),
+    body: z.object({
+      name: z.string().min(1).max(64).optional(),
+      displayOrder: z.number().int().nonnegative().optional(),
+    }),
+    responses: { 200: SlotUpdateResult },
+    summary: 'Update a plan slot',
+  },
+  deleteSlot: {
+    method: 'DELETE',
+    path: '/plan/slots/:slug',
+    pathParams: z.object({ slug: NonEmptyString }),
+    body: z.object({}).optional(),
+    responses: { 200: SlotDeleteResult },
+    summary: 'Delete a plan slot',
+  },
+  addEntry: {
+    method: 'POST',
+    path: '/plan/entries',
+    body: z.object({
+      date: IsoDate,
+      slot: SlugLike,
+      recipeId: z.number().int().positive(),
+      plannedServings: z.number().int().positive(),
+      recipeVersionId: z.number().int().positive().optional(),
+      notes: z.string().max(1000).optional(),
+    }),
+    responses: { 200: AddEntryResult },
+    summary: 'Add a plan entry',
+  },
+  updateEntry: {
+    method: 'PATCH',
+    path: '/plan/entries/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({
+      plannedServings: z.number().int().positive().optional(),
+      recipeVersionId: z.number().int().positive().nullish(),
+      notes: z.string().max(1000).nullish(),
+    }),
+    responses: { 200: EntryMutationResult },
+    summary: 'Update a plan entry',
+  },
+  moveEntry: {
+    method: 'POST',
+    path: '/plan/entries/:id/move',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({
+      date: IsoDate,
+      slot: SlugLike,
+      position: z.number().int().nonnegative().optional(),
+    }),
+    responses: { 200: EntryMutationResult },
+    summary: 'Move a plan entry to another date/slot',
+  },
+  deleteEntry: {
+    method: 'DELETE',
+    path: '/plan/entries/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: EntryMutationResult },
+    summary: 'Delete a plan entry',
+  },
+  reorderSlot: {
+    method: 'POST',
+    path: '/plan/reorder',
+    body: z.object({
+      date: IsoDate,
+      slot: SlugLike,
+      orderedIds: z.array(z.number().int().positive()).min(1),
+    }),
+    responses: { 200: ReorderResult },
+    summary: 'Reorder entries within a date/slot cell',
+  },
+});

--- a/pillars/food/src/contract/rest-shopping.ts
+++ b/pillars/food/src/contract/rest-shopping.ts
@@ -1,0 +1,72 @@
+/**
+ * `shopping.*` sub-router — PRD-152 shopping-list generation from a meal
+ * plan. `preview` computes the buy-list (pantry-subtracted, sectioned);
+ * `generate` writes it to the lists pillar over REST (reuses the
+ * send-to-list ListsClient). Both are POST-with-body (date-range compute).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+const CanonicalUnit = z.enum(['g', 'ml', 'count']);
+
+const GeneratorItemSchema = z.object({
+  ingredientId: z.number().int(),
+  ingredientName: z.string(),
+  variantId: z.number().int().nullable(),
+  variantName: z.string().nullable(),
+  needQty: z.number(),
+  pantryQty: z.number(),
+  buyQty: z.number(),
+  canonicalUnit: CanonicalUnit,
+  isUnconverted: z.boolean(),
+  originalQty: z.number().nullable(),
+  originalUnit: z.string().nullable(),
+  sourceLineIds: z.array(z.number().int()),
+});
+
+const GeneratorSectionSchema = z.object({
+  sectionTag: z.string().nullable(),
+  sectionLabel: z.string(),
+  items: z.array(GeneratorItemSchema),
+});
+
+const GeneratorPreviewSchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+  planEntryCount: z.number().int(),
+  skippedPlanEntryCount: z.number().int(),
+  sections: z.array(GeneratorSectionSchema),
+  uncategorisedIngredientIds: z.array(z.number().int()),
+  recipeTitles: z.array(z.string()),
+});
+
+const GenerateResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), listId: z.number().int(), itemCount: z.number().int() }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.enum(['BadDateRange', 'NoPlanEntries', 'ListNameEmpty', 'BulkAddFailed']),
+  }),
+]);
+
+export const foodShoppingContract = c.router({
+  preview: {
+    method: 'POST',
+    path: '/shopping/preview',
+    body: z.object({ startDate: IsoDate, endDate: IsoDate }),
+    responses: {
+      200: GeneratorPreviewSchema,
+      400: z.object({ message: z.string(), code: z.string().optional() }),
+    },
+    summary: 'Preview the shopping list a plan range would generate',
+  },
+  generate: {
+    method: 'POST',
+    path: '/shopping/generate',
+    body: z.object({ startDate: IsoDate, endDate: IsoDate, listName: z.string() }),
+    responses: { 200: GenerateResultSchema },
+    summary: 'Generate a shopping list from a plan range (writes to lists)',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -22,9 +22,11 @@ import { foodHeroImageContract } from './rest-hero-image.js';
 import { foodInboxContract } from './rest-inbox.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
+import { foodPlanContract } from './rest-plan.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
 import { foodRecipesContract } from './rest-recipes.js';
 import { foodSendToListContract } from './rest-send-to-list.js';
+import { foodShoppingContract } from './rest-shopping.js';
 import { foodSlugsContract } from './rest-slugs.js';
 import { foodSolverContract } from './rest-solver.js';
 import { foodSubstitutionsContract } from './rest-substitutions.js';
@@ -42,9 +44,11 @@ export const foodContract = c.router(
     inbox: foodInboxContract,
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
+    plan: foodPlanContract,
     prepStates: foodPrepStatesContract,
     recipes: foodRecipesContract,
     sendToList: foodSendToListContract,
+    shopping: foodShoppingContract,
     slugs: foodSlugsContract,
     solver: foodSolverContract,
     substitutions: foodSubstitutionsContract,


### PR DESCRIPTION
Slice 5 of the food tRPC→REST migration, after #3353/#3354/#3356. Ports **plan** (meal planning) and **shopping** (shopping-list generation).

## plan (PRD-143) — 10 procedures
`GET /plan/week` (weekView), `GET/POST /plan/slots`, `PATCH/DELETE /plan/slots/:slug`, `POST /plan/entries`, `PATCH /plan/entries/:id`, `POST /plan/entries/:id/move`, `DELETE /plan/entries/:id`, `POST /plan/reorder`. Helpers (iso-week, week-view, guards, slot-mutations) lifted into `src/api/modules/plan/` over `planService`. Mutations return the service's discriminated `{ ok, ... }` on 200; `weekView` maps a bad ISO date to 400.

## shopping (PRD-152) — 2 procedures
`POST /shopping/preview` (pantry-subtracted, sectioned buy-list) + `POST /shopping/generate`. Food-only aggregation helpers lift over the pillar db; **`generate.ts` is rewired off `@pops/app-lists-db` onto the lists REST API**, reusing the slice-4c `ListsClient` (`createShoppingList` + sequential `addItem` in section-then-name order). Bad range → 400; `ListNameEmpty`/`NoPlanEntries`/`BulkAddFailed` surface in the result.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **872 tests (73 files) green** incl. a promoted-recipe plan entry round-trip + a stub-client shopping generate. OpenAPI idempotent.

## Remaining
ingest/ai (6) → Phase C (dep-cruiser ban + Dockerfile) → D (FE rewire) → E (consumers + pops-api retirement).