### PR TITLE
feat(food): REST migration slice 6a — ai.logInference + internal-token auth

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -9,6 +9,119 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/ai/log-inference": {
+      "post": {
+        "operationId": "ai.logInference",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cached": {
+                    "type": "boolean"
+                  },
+                  "contextId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "costUsd": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "errorMessage": {
+                    "type": "string"
+                  },
+                  "inputTokens": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "latencyMs": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "metadata": {
+                    "additionalProperties": {},
+                    "type": "object"
+                  },
+                  "model": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "operation": {
+                    "enum": [
+                      "recipe-extract-web-llm",
+                      "recipe-extract-ig-vision",
+                      "recipe-extract-ig-text-fallback",
+                      "recipe-extract-screenshot",
+                      "recipe-extract-text"
+                    ],
+                    "type": "string"
+                  },
+                  "outputTokens": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "promptVersion": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "provider": {
+                    "enum": ["claude"],
+                    "type": "string"
+                  },
+                  "status": {
+                    "enum": ["success", "error"],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation",
+                  "contextId",
+                  "provider",
+                  "model",
+                  "promptVersion",
+                  "inputTokens",
+                  "outputTokens",
+                  "costUsd",
+                  "latencyMs",
+                  "status",
+                  "cached"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Record a food AI inference (internal; worker → ai_inference_log)",
+        "tags": ["ai"]
+      }
+    },
     "/aliases": {
       "get": {
         "operationId": "aliases.list",

--- a/pillars/food/src/api/__tests__/ai.test.ts
+++ b/pillars/food/src/api/__tests__/ai.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration tests for `ai.logInference` (PRD-133). Internal-only (gated on
+ * x-pops-internal-token); writes one best-effort row to the pillar's
+ * ai_inference_log with domain='food' and server-authored prompt_version.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { aiInferenceLog, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+const TOKEN = 'test-internal-token';
+
+const SAMPLE = {
+  operation: 'recipe-extract-web-llm' as const,
+  contextId: 'ingest_source:7',
+  provider: 'claude' as const,
+  model: 'claude-haiku-4-5-20251001',
+  promptVersion: 'web-llm-v1.0',
+  inputTokens: 1200,
+  outputTokens: 400,
+  costUsd: 0.0008,
+  latencyMs: 42,
+  status: 'success' as const,
+  cached: false,
+};
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-ai-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  process.env['POPS_API_INTERNAL_TOKEN'] = TOKEN;
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env['POPS_API_INTERNAL_TOKEN'];
+});
+
+describe('ai.logInference REST', () => {
+  it('writes a food row with merged prompt_version when authorised', async () => {
+    const res = await client().ai.logInference(
+      { ...SAMPLE, metadata: { prompt_version: 'stale', extra: 1 } },
+      TOKEN
+    );
+    expect(res).toEqual({ ok: true });
+
+    const rows = foodDb.db
+      .select()
+      .from(aiInferenceLog)
+      .where(eq(aiInferenceLog.contextId, 'ingest_source:7'))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.domain).toBe('food');
+    expect(rows[0]?.operation).toBe('recipe-extract-web-llm');
+    // Server-authored prompt_version wins over caller-supplied metadata.
+    expect(JSON.parse(rows[0]?.metadata ?? '{}').prompt_version).toBe('web-llm-v1.0');
+  });
+
+  it('rejects a request without the internal token (401)', async () => {
+    await expect(client().ai.logInference(SAMPLE)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('rejects an invalid operation at the zod boundary (400) when authorised', async () => {
+    await expect(
+      client().ai.logInference({ ...SAMPLE, operation: 'not-a-real-op' }, TOKEN)
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -254,9 +254,32 @@ interface CreateWeightBody {
   notes?: string;
 }
 
+interface LogInferenceBody {
+  operation: string;
+  contextId: string;
+  provider: 'claude';
+  model: string;
+  promptVersion: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  status: 'success' | 'error';
+  cached: boolean;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
+    ai: {
+      logInference: (body: LogInferenceBody, token?: string) => {
+        const req = r.post('/ai/log-inference');
+        if (token !== undefined) req.set('x-pops-internal-token', token);
+        return send<{ ok: true }>(req.send(body));
+      },
+    },
     conversions: {
       listUnits: (query: { search?: string; seededOnly?: boolean } = {}) =>
         send<{ items: UnitConversion[] }>(r.get('/conversions/units').query(query)),

--- a/pillars/food/src/api/app.ts
+++ b/pillars/food/src/api/app.ts
@@ -11,7 +11,7 @@
  * lists/inventory).
  */
 import { createExpressEndpoints } from '@ts-rest/express';
-import express, { type Express, type Request, type Response } from 'express';
+import express, { type Express, type NextFunction, type Request, type Response } from 'express';
 
 import { foodContract } from '../contract/rest.js';
 import { type FoodApiDeps, makeRequestHandler } from './handlers.js';
@@ -25,10 +25,31 @@ import { makeFoodRestHandlers } from './rest/handlers.js';
  */
 const JSON_BODY_LIMIT = '20mb';
 
+/**
+ * Endpoints the food worker calls back on — gated by the shared internal
+ * token. Everything else trusts the docker network (the dispatcher in front
+ * authenticates user traffic).
+ */
+const INTERNAL_PATHS = new Set(['/ai/log-inference', '/ingest/worker-complete']);
+
+function requireInternalToken(req: Request, res: Response, next: NextFunction): void {
+  if (!INTERNAL_PATHS.has(req.path)) {
+    next();
+    return;
+  }
+  const expected = process.env['POPS_API_INTERNAL_TOKEN'];
+  if (expected === undefined || req.headers['x-pops-internal-token'] !== expected) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+  next();
+}
+
 export function createFoodApiApp(deps: FoodApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
   app.use(express.json({ limit: JSON_BODY_LIMIT }));
+  app.use(requireInternalToken);
 
   // Build the handler shape once at factory time so static deps don't
   // get re-allocated on every request.

--- a/pillars/food/src/api/rest/ai-handlers.ts
+++ b/pillars/food/src/api/rest/ai-handlers.ts
@@ -1,0 +1,49 @@
+/**
+ * Handler for `ai.logInference`. Writes one row to the pillar's
+ * `ai_inference_log` with `domain='food'`; server-authored `promptVersion`
+ * wins over caller metadata. Best-effort: a DB-write failure is logged and
+ * swallowed so logging never blocks an ingest.
+ */
+import { aiInferenceLog, type FoodDb } from '../../db/index.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodAiContract } from '../../contract/rest-ai.js';
+
+type Req = ServerInferRequest<typeof foodAiContract>;
+
+export function makeAiHandlers(db: FoodDb) {
+  return {
+    logInference: ({ body }: Req['logInference']) =>
+      runHttp(() => {
+        const merged: Record<string, unknown> = {
+          ...body.metadata,
+          prompt_version: body.promptVersion,
+        };
+        try {
+          db.insert(aiInferenceLog)
+            .values({
+              provider: body.provider,
+              model: body.model,
+              operation: body.operation,
+              domain: 'food',
+              inputTokens: body.inputTokens,
+              outputTokens: body.outputTokens,
+              costUsd: body.costUsd,
+              latencyMs: body.latencyMs,
+              status: body.status,
+              cached: body.cached ? 1 : 0,
+              contextId: body.contextId,
+              errorMessage: body.errorMessage ?? null,
+              metadata: JSON.stringify(merged),
+              createdAt: new Date().toISOString(),
+            })
+            .run();
+        } catch (err) {
+          console.warn('[food.ai.logInference] failed to insert ai_inference_log row', err);
+        }
+        return { status: 200 as const, body: { ok: true as const } };
+      }),
+  };
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -14,6 +14,7 @@ import {
   type ListsClient,
   resolveListsBaseUrl,
 } from '../modules/recipes/send-to-list/lists-client.js';
+import { makeAiHandlers } from './ai-handlers.js';
 import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
@@ -45,6 +46,7 @@ export function makeFoodRestHandlers(
   const resolveListsClient = (): ListsClient =>
     deps.listsClient ?? (realClient ??= createListsHttpClient(resolveListsBaseUrl()));
   return server.router(foodContract, {
+    ai: makeAiHandlers(db),
     aliases: makeAliasesHandlers(db),
     batches: makeBatchesHandlers(db),
     conversions: makeConversionsHandlers(db),

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -3,6 +3,23 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/food generate:api-types`.
  */
 export interface paths {
+  '/ai/log-inference': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Record a food AI inference (internal; worker → ai_inference_log) */
+    post: operations['ai.logInference'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/aliases': {
     parameters: {
       query?: never;
@@ -1207,6 +1224,58 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'ai.logInference': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cached: boolean;
+          contextId: string;
+          costUsd: number;
+          errorMessage?: string;
+          inputTokens: number;
+          latencyMs: number;
+          metadata?: {
+            [key: string]: unknown;
+          };
+          model: string;
+          /** @enum {string} */
+          operation:
+            | 'recipe-extract-web-llm'
+            | 'recipe-extract-ig-vision'
+            | 'recipe-extract-ig-text-fallback'
+            | 'recipe-extract-screenshot'
+            | 'recipe-extract-text';
+          outputTokens: number;
+          promptVersion: string;
+          /** @enum {string} */
+          provider: 'claude';
+          /** @enum {string} */
+          status: 'success' | 'error';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+    };
+  };
   'aliases.list': {
     parameters: {
       query?: {

--- a/pillars/food/src/contract/rest-ai.ts
+++ b/pillars/food/src/contract/rest-ai.ts
@@ -1,0 +1,43 @@
+/**
+ * `ai.*` sub-router — PRD-133 `logInference`. The pops-worker-food container
+ * posts here on every Claude call so usage lands in the AI-ops surface.
+ * Internal-only: the auth middleware in `app.ts` gates `/ai/log-inference`
+ * on `x-pops-internal-token`. Best-effort — a write failure still returns
+ * `{ ok: true }` so a logging hiccup never blocks an ingest.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+export const LogFoodInferenceBody = z.object({
+  operation: z.enum([
+    'recipe-extract-web-llm',
+    'recipe-extract-ig-vision',
+    'recipe-extract-ig-text-fallback',
+    'recipe-extract-screenshot',
+    'recipe-extract-text',
+  ]),
+  contextId: z.string().min(1),
+  provider: z.literal('claude'),
+  model: z.string().min(1),
+  promptVersion: z.string().min(1),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  latencyMs: z.number().int().nonnegative(),
+  status: z.enum(['success', 'error']),
+  cached: z.boolean(),
+  errorMessage: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const foodAiContract = c.router({
+  logInference: {
+    method: 'POST',
+    path: '/ai/log-inference',
+    body: LogFoodInferenceBody,
+    responses: { 200: z.object({ ok: z.literal(true) }) },
+    summary: 'Record a food AI inference (internal; worker → ai_inference_log)',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -14,6 +14,7 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { foodAiContract } from './rest-ai.js';
 import { foodAliasesContract } from './rest-aliases.js';
 import { foodBatchesContract } from './rest-batches.js';
 import { foodConversionsContract } from './rest-conversions.js';
@@ -36,6 +37,7 @@ const c = initContract();
 
 export const foodContract = c.router(
   {
+    ai: foodAiContract,
     aliases: foodAliasesContract,
     batches: foodBatchesContract,
     conversions: foodConversionsContract,


### PR DESCRIPTION
First part of slice 6, after #3358. Ports the **ai.logInference** internal endpoint and adds the shared worker-callback auth middleware. Ingest (6b) — the bullmq enqueue/status/cancel surface — follows.

## What changed
- `POST /ai/log-inference` (ts-rest): the food worker posts here on every Claude call; the handler writes one best-effort row to the pillar's `ai_inference_log` (present since the 0062 migration) with `domain='food'`. Server-authored `promptVersion` wins over caller metadata; a DB-write failure is logged and swallowed (still `{ ok:true }`) so logging never blocks an ingest. The generic plan assumed a cross-pillar core-db write — unnecessary here since food owns its own `ai_inference_log`.
- Shared **internal-token middleware** in `app.ts` gating the worker-callback paths (`/ai/log-inference` + the forthcoming `/ingest/worker-complete`) on `x-pops-internal-token === POPS_API_INTERNAL_TOKEN`; all other routes stay docker-net-trusted.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **875 tests (74 files) green** (authorised write + merged prompt_version, 401 unauthorised, 400 invalid op). OpenAPI idempotent.

## Remaining
6b ingest (bullmq producer + status/cancel/retry + worker-complete callback + base64 file upload + worker api-client URL flip) → Phase C/D/E.