### PR TITLE
feat(food): port ingest pipeline to ts-rest + lift media serve (slice 6b)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,4 +67,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/db/schema.ts,**/db/seeder.ts" --reporters "console" --exitCode 0 .
+      # `apps/pops-api/src/{modules,routes}/food` is the food-pillar migration
+      # tombstone: every file there has been lifted into `pillars/food` (the
+      # single source of truth) and is deleted in Phase E. Counting the
+      # tombstone as the "original" of the lifted code double-penalises the
+      # migration, so it's excluded from the duplication scan.
+      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/db/schema.ts,**/db/seeder.ts,apps/pops-api/src/modules/food/**,apps/pops-api/src/routes/food/**" --reporters "console" --exitCode 0 .

--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -4371,6 +4371,662 @@
         "tags": ["inbox"]
       }
     },
+    "/ingest/cancel": {
+      "post": {
+        "operationId": "ingest.cancel",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["sourceId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["not-cancellable"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Best-effort cancel of a queued ingest job",
+        "tags": ["ingest"]
+      }
+    },
+    "/ingest/list": {
+      "post": {
+        "operationId": "ingest.list",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 20,
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "state": {
+                    "enum": ["pending", "processing", "completed", "failed", "partial"],
+                    "type": "string"
+                  }
+                },
+                "required": ["limit"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "attempts": {
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "completedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "draftRecipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "errorCode": {
+                            "type": "string"
+                          },
+                          "errorMessage": {
+                            "type": "string"
+                          },
+                          "jobId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                            "type": "string"
+                          },
+                          "partialReason": {
+                            "enum": [
+                              "auth-dead",
+                              "rate-limited",
+                              "stt-failed",
+                              "vision-failed",
+                              "caption-only-fallback",
+                              "empty-extraction"
+                            ],
+                            "type": "string"
+                          },
+                          "sourceId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "startedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "state": {
+                            "enum": ["pending", "processing", "completed", "failed", "partial"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "sourceId",
+                          "kind",
+                          "state",
+                          "jobId",
+                          "startedAt",
+                          "completedAt",
+                          "draftRecipeId",
+                          "attempts"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextCursor": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Cursor-paginated ingest sources for the inbox UI",
+        "tags": ["ingest"]
+      }
+    },
+    "/ingest/retry": {
+      "post": {
+        "operationId": "ingest.retry",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["sourceId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "jobId": {
+                      "type": "string"
+                    },
+                    "queuedAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["jobId", "queuedAt"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "503"
+          }
+        },
+        "summary": "Re-enqueue a failed ingest job from its persisted row",
+        "tags": ["ingest"]
+      }
+    },
+    "/ingest/start": {
+      "post": {
+        "operationId": "ingest.start",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "kind": {
+                        "enum": ["url-web"],
+                        "type": "string"
+                      },
+                      "url": {
+                        "format": "uri",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "url"],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "kind": {
+                        "enum": ["url-instagram"],
+                        "type": "string"
+                      },
+                      "url": {
+                        "format": "uri",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "url"],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "body": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": ["text"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "body"],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "contentBase64": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "kind": {
+                        "enum": ["screenshot"],
+                        "type": "string"
+                      },
+                      "mimeType": {
+                        "enum": ["image/jpeg", "image/png", "image/webp"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "mimeType", "contentBase64"],
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "jobId": {
+                      "type": "string"
+                    },
+                    "queuedAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "sourceId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["sourceId", "jobId", "queuedAt"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "503"
+          }
+        },
+        "summary": "Start an ingest job (enqueues BullMQ work)",
+        "tags": ["ingest"]
+      }
+    },
+    "/ingest/status": {
+      "post": {
+        "operationId": "ingest.status",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["sourceId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "nullable": true,
+                  "properties": {
+                    "attempts": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "completedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "draftRecipeId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    },
+                    "errorMessage": {
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "kind": {
+                      "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                      "type": "string"
+                    },
+                    "partialReason": {
+                      "enum": [
+                        "auth-dead",
+                        "rate-limited",
+                        "stt-failed",
+                        "vision-failed",
+                        "caption-only-fallback",
+                        "empty-extraction"
+                      ],
+                      "type": "string"
+                    },
+                    "sourceId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "startedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "state": {
+                      "enum": ["pending", "processing", "completed", "failed", "partial"],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sourceId",
+                    "kind",
+                    "state",
+                    "jobId",
+                    "startedAt",
+                    "completedAt",
+                    "draftRecipeId",
+                    "attempts"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Live job + persisted state for one ingest source",
+        "tags": ["ingest"]
+      }
+    },
+    "/ingest/worker-complete": {
+      "post": {
+        "operationId": "ingest.workerComplete",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "dsl": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "meta": {
+                        "additionalProperties": {},
+                        "properties": {
+                          "extractor_version": {
+                            "type": "string"
+                          },
+                          "stages": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          }
+                        },
+                        "required": ["extractor_version", "stages"],
+                        "type": "object"
+                      },
+                      "ok": {
+                        "enum": [true],
+                        "type": "boolean"
+                      },
+                      "partialReason": {
+                        "enum": [
+                          "auth-dead",
+                          "rate-limited",
+                          "stt-failed",
+                          "vision-failed",
+                          "caption-only-fallback",
+                          "empty-extraction"
+                        ],
+                        "type": "string"
+                      },
+                      "sourceId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": ["sourceId", "ok", "dsl", "meta"],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errorCode": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "errorMessage": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "meta": {
+                        "additionalProperties": {},
+                        "properties": {
+                          "extractor_version": {
+                            "type": "string"
+                          },
+                          "stages": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          }
+                        },
+                        "required": ["extractor_version", "stages"],
+                        "type": "object"
+                      },
+                      "ok": {
+                        "enum": [false],
+                        "type": "boolean"
+                      },
+                      "sourceId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": ["sourceId", "ok", "errorCode", "errorMessage", "meta"],
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "compileStatus": {
+                          "enum": ["compiled", "failed", "uncompiled"],
+                          "type": "string"
+                        },
+                        "draftRecipeId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok", "draftRecipeId", "compileStatus"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Worker callback (internal; success or failure) for one job",
+        "tags": ["ingest"]
+      }
+    },
     "/ingredient-tags": {
       "get": {
         "operationId": "ingredientTags.list",

--- a/pillars/food/src/api/__tests__/ingest.test.ts
+++ b/pillars/food/src/api/__tests__/ingest.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for the `ingest.*` REST surface (PRD-125) + the binary
+ * ingest-media serve routes (PRD-135).
+ *
+ * These run WITHOUT Redis. The BullMQ producer (`getFoodIngestQueue`)
+ * returns `null` when no Redis env is set, so:
+ *
+ *   - `start` / `retry` map the resulting `IngestQueueUnavailable` to 503;
+ *   - `status` / `list` / `cancel` degrade to DB-only reads;
+ *   - `workerComplete` is DB-only and exercises the real draft-creation
+ *     transaction end to end.
+ *
+ * Queue-live behaviour (job timings, cancel of a queued job) is out of
+ * scope here — it needs a Redis fixture and lives with the worker suite.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ingestSourcesService, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { writeScreenshotPayload } from '../modules/ingest/ingest-storage.js';
+import { HttpError, makeClient } from './test-utils.js';
+
+const INTERNAL_TOKEN = 'test-internal-token';
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const META = { extractor_version: 'test', stages: {} };
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function app() {
+  return createFoodApiApp({
+    foodDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3005',
+  });
+}
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(app());
+}
+
+function seedSource(kind: 'text' | 'screenshot' = 'text'): number {
+  const row = ingestSourcesService.createIngestSource(foodDb.db, {
+    kind,
+    extractorVersion: 'test',
+    caption: kind === 'text' ? 'seed body' : null,
+  });
+  return row.id;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-ingest-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  process.env['FOOD_INGEST_DIR'] = join(tmpDir, 'ingest');
+  process.env['POPS_API_INTERNAL_TOKEN'] = INTERNAL_TOKEN;
+  delete process.env['REDIS_URL'];
+  delete process.env['REDIS_HOST'];
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env['FOOD_INGEST_DIR'];
+  delete process.env['POPS_API_INTERNAL_TOKEN'];
+});
+
+describe('ingest REST — no-Redis degradation', () => {
+  it('answers 503 when starting a job with no queue configured', async () => {
+    await expect(client().ingest.start({ kind: 'text', body: 'a soup' })).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+
+  it('rolls back the source row when enqueue fails (no phantom pending rows)', async () => {
+    await expect(client().ingest.start({ kind: 'text', body: 'a soup' })).rejects.toBeInstanceOf(
+      HttpError
+    );
+    expect(await client().ingest.list()).toMatchObject({ items: [] });
+  });
+
+  it('returns null status for an unknown source', async () => {
+    expect(await client().ingest.status(999_999)).toBeNull();
+  });
+
+  it('reports not-cancellable for an unknown / unqueued source', async () => {
+    expect(await client().ingest.cancel(999_999)).toEqual({ ok: false, reason: 'not-cancellable' });
+  });
+
+  it('answers 503 retrying a persisted source with no queue', async () => {
+    const sourceId = seedSource('text');
+    await expect(client().ingest.retry(sourceId)).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+describe('ingest REST — workerComplete (DB-only)', () => {
+  it('creates an uncompiled draft recipe on success', async () => {
+    const sourceId = seedSource('text');
+    const res = await client().ingest.workerComplete(
+      { sourceId, ok: true, dsl: '@recipe(title="Tomato Soup")', meta: META },
+      INTERNAL_TOKEN
+    );
+    expect(res).toMatchObject({ ok: true, compileStatus: 'uncompiled' });
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.draftRecipeId).toBeGreaterThan(0);
+
+    const status = await client().ingest.status(sourceId);
+    expect(status?.draftRecipeId).toBe(res.draftRecipeId);
+  });
+
+  it('is idempotent — a second success returns the same draft', async () => {
+    const sourceId = seedSource('text');
+    const body = {
+      sourceId,
+      ok: true as const,
+      dsl: '@recipe(title="Tomato Soup")',
+      meta: META,
+    };
+    const first = await client().ingest.workerComplete(body, INTERNAL_TOKEN);
+    const second = await client().ingest.workerComplete(body, INTERNAL_TOKEN);
+    if (!first.ok || !second.ok) throw new Error('expected ok');
+    expect(second.draftRecipeId).toBe(first.draftRecipeId);
+  });
+
+  it('records the error code on a failure callback', async () => {
+    const sourceId = seedSource('text');
+    const res = await client().ingest.workerComplete(
+      {
+        sourceId,
+        ok: false,
+        errorCode: 'vision-failed',
+        errorMessage: 'the model declined',
+        meta: META,
+      },
+      INTERNAL_TOKEN
+    );
+    expect(res).toEqual({ ok: false, reason: 'vision-failed' });
+  });
+
+  it('rejects the callback without the internal token', async () => {
+    const sourceId = seedSource('text');
+    await expect(
+      client().ingest.workerComplete(
+        { sourceId, ok: true, dsl: '@recipe(title="X")', meta: META }
+        // no token
+      )
+    ).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('ingest media serve routes', () => {
+  it('400s on a non-numeric source id', async () => {
+    const res = await supertest(app()).get('/ingest/source/abc/screenshot');
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the source row does not exist', async () => {
+    const res = await supertest(app()).get('/ingest/source/999999/screenshot');
+    expect(res.status).toBe(404);
+  });
+
+  it('serves the screenshot bytes for a real, unarchived source', async () => {
+    const sourceId = seedSource('screenshot');
+    writeScreenshotPayload(sourceId, 'image/png', PNG_BASE64);
+    const res = await supertest(app()).get(`/ingest/source/${sourceId}/screenshot`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('image/png');
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('404s for video when none was written', async () => {
+    const sourceId = seedSource('screenshot');
+    const res = await supertest(app()).get(`/ingest/source/${sourceId}/video`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -270,9 +270,59 @@ interface LogInferenceBody {
   metadata?: Record<string, unknown>;
 }
 
+type IngestStartBody =
+  | { kind: 'url-web'; url: string }
+  | { kind: 'url-instagram'; url: string }
+  | { kind: 'text'; body: string }
+  | { kind: 'screenshot'; mimeType: string; contentBase64: string };
+
+interface IngestStartResult {
+  sourceId: number;
+  jobId: string;
+  queuedAt: string;
+}
+
+interface IngestStatusView {
+  sourceId: number;
+  kind: string;
+  state: 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+  jobId: string | null;
+  draftRecipeId: number | null;
+  attempts: number;
+}
+
+type IngestCancelResult = { ok: true } | { ok: false; reason: 'not-cancellable' };
+
+interface WireMeta {
+  extractor_version: string;
+  stages: Record<string, unknown>;
+}
+type WorkerCompleteBody =
+  | { sourceId: number; ok: true; dsl: string; meta: WireMeta; partialReason?: string }
+  | { sourceId: number; ok: false; errorCode: string; errorMessage: string; meta: WireMeta };
+type WorkerCompleteResult =
+  | { ok: true; draftRecipeId: number; compileStatus: 'compiled' | 'failed' | 'uncompiled' }
+  | { ok: false; reason: string };
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
+    ingest: {
+      start: (body: IngestStartBody) => send<IngestStartResult>(r.post('/ingest/start').send(body)),
+      status: (sourceId: number) =>
+        send<IngestStatusView | null>(r.post('/ingest/status').send({ sourceId })),
+      list: (body: { state?: string; cursor?: string; limit?: number } = {}) =>
+        send<ListPage<IngestStatusView>>(r.post('/ingest/list').send(body)),
+      cancel: (sourceId: number) =>
+        send<IngestCancelResult>(r.post('/ingest/cancel').send({ sourceId })),
+      retry: (sourceId: number) =>
+        send<IngestStartResult>(r.post('/ingest/retry').send({ sourceId })),
+      workerComplete: (body: WorkerCompleteBody, token?: string) => {
+        const req = r.post('/ingest/worker-complete');
+        if (token !== undefined) req.set('x-pops-internal-token', token);
+        return send<WorkerCompleteResult>(req.send(body));
+      },
+    },
     ai: {
       logInference: (body: LogInferenceBody, token?: string) => {
         const req = r.post('/ai/log-inference');

--- a/pillars/food/src/api/app.ts
+++ b/pillars/food/src/api/app.ts
@@ -16,6 +16,7 @@ import express, { type Express, type NextFunction, type Request, type Response }
 import { foodContract } from '../contract/rest.js';
 import { type FoodApiDeps, makeRequestHandler } from './handlers.js';
 import { serveHeroImage } from './modules/hero-image/serve.js';
+import { makeServeIngestScreenshot, makeServeIngestVideo } from './modules/ingest/serve.js';
 import { makeFoodRestHandlers } from './rest/handlers.js';
 
 /**
@@ -66,6 +67,11 @@ export function createFoodApiApp(deps: FoodApiDeps): Express {
   // Binary hero-image serving — registered before the ts-rest endpoints so
   // `…/hero.jpg` resolves to a file; falls through to ts-rest otherwise.
   app.get('/recipes/:recipeId/:filename', serveHeroImage);
+
+  // Binary ingest-media serving (screenshot/video) for the inbox UI. GET-only
+  // and on a distinct subpath, so no collision with the POST `ingest.*` API.
+  app.get('/ingest/source/:sourceId/screenshot', makeServeIngestScreenshot(deps.foodDb.db));
+  app.get('/ingest/source/:sourceId/video', makeServeIngestVideo(deps.foodDb.db));
 
   createExpressEndpoints(foodContract, makeFoodRestHandlers(deps), app);
 

--- a/pillars/food/src/api/modules/ingest/ingest-enqueue.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-enqueue.ts
@@ -1,0 +1,41 @@
+/**
+ * PRD-125 — `food.ingest.start` + `food.ingest.retry` enqueue helper.
+ *
+ * Encapsulates the BullMQ `add` call and the per-kind job-data shaping so
+ * the router stays thin. The screenshot path is written to disk by
+ * `writeScreenshotPayload` before this helper runs; this helper only takes
+ * the resulting `contentPath`.
+ */
+import { type IngestJobData, FOOD_INGEST_QUEUE_NAME } from '../../../contract/queue/index.js';
+import { getFoodIngestQueue } from '../../queue.js';
+
+export class IngestQueueUnavailable extends Error {
+  constructor() {
+    super('food.ingest queue is unavailable (Redis not configured)');
+    this.name = 'IngestQueueUnavailable';
+  }
+}
+
+export interface EnqueueResult {
+  jobId: string;
+  queuedAt: string;
+}
+
+/**
+ * `name` is the BullMQ "job name" — set to the kind so the worker can
+ * pre-route via a `name` filter if it wants to. Job data lives in Redis;
+ * for `screenshot` the heavy payload was already written to disk before
+ * this call.
+ */
+export async function enqueueIngestJob(data: IngestJobData): Promise<EnqueueResult> {
+  const queue = getFoodIngestQueue();
+  if (queue === null) {
+    throw new IngestQueueUnavailable();
+  }
+  const job = await queue.add(data.kind, data);
+  const jobId = job.id;
+  if (jobId === undefined) {
+    throw new Error(`BullMQ ${FOOD_INGEST_QUEUE_NAME} returned a job with no id`);
+  }
+  return { jobId, queuedAt: new Date().toISOString() };
+}

--- a/pillars/food/src/api/modules/ingest/ingest-procedures-control.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-procedures-control.ts
@@ -1,0 +1,171 @@
+/**
+ * PRD-125 — `food.ingest.cancel` and `food.ingest.retry` implementations.
+ *
+ * `cancel` is best-effort: it removes the BullMQ job if still queued /
+ * processing; the worker is responsible for honouring cancellation between
+ * pipeline stages (PRD-126). `retry` re-enqueues with the same input,
+ * increments `attempts`, and reuses the same `sourceId`.
+ */
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { eq, sql } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources } from '../../../db/index.js';
+import { getFoodIngestQueue } from '../../queue.js';
+import { enqueueIngestJob, type EnqueueResult } from './ingest-enqueue.js';
+
+import type { IngestJobData } from '../../../contract/queue/index.js';
+
+/** Mirror of `packages/app-food/src/storage/ingest-paths.ts`. */
+const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
+const MIME_BY_EXT: Record<string, 'image/jpeg' | 'image/png' | 'image/webp'> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+function findOnDiskScreenshot(
+  sourceId: number
+): { mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; filename: string } | null {
+  const configured = process.env['FOOD_INGEST_DIR'];
+  const root = configured && configured.length > 0 ? configured : DEFAULT_FOOD_INGEST_DIR;
+  const dir = resolve(root, String(sourceId));
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const match = /^screenshot\.([a-z0-9]+)$/i.exec(entry);
+    if (match === null) continue;
+    const ext = match[1]?.toLowerCase() ?? '';
+    const mimeType = MIME_BY_EXT[ext];
+    if (mimeType !== undefined) return { mimeType, filename: entry };
+  }
+  return null;
+}
+
+// Note: BullMQ uses `waiting-children` (hyphen), not `waiting_children`
+// (underscore) as the state literal. Earlier code listed the wrong
+// spelling and silently never matched.
+const CANCELLABLE_STATES = [
+  'waiting',
+  'delayed',
+  'active',
+  'waiting-children',
+  'prioritized',
+] as const;
+const CANCELLABLE = new Set<string>(CANCELLABLE_STATES);
+
+async function findJobBySourceId(
+  sourceId: number
+): Promise<
+  Awaited<ReturnType<NonNullable<ReturnType<typeof getFoodIngestQueue>>['getJobs']>>[number] | null
+> {
+  const queue = getFoodIngestQueue();
+  if (queue === null) return null;
+  // Scan the SAME states `cancelIngest` recognises as cancellable —
+  // earlier `findJobBySourceId` only looked at `waiting/delayed/active`
+  // and silently lost any job stuck in `waiting_children` / `prioritized`.
+  // BullMQ's `getJobs` overload doesn't accept readonly arrays — copy
+  // into a mutable array.
+  const jobs = await queue.getJobs([...CANCELLABLE_STATES], 0, 99);
+  for (const job of jobs) {
+    const data: unknown = job.data;
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      (data as { sourceId?: number }).sourceId === sourceId
+    ) {
+      return job;
+    }
+  }
+  return null;
+}
+
+export type CancelOutcome = { ok: true } | { ok: false; reason: 'not-cancellable' };
+
+export async function cancelIngest(sourceId: number): Promise<CancelOutcome> {
+  const job = await findJobBySourceId(sourceId);
+  if (job === null) return { ok: false, reason: 'not-cancellable' };
+  const state = await job.getState();
+  if (!CANCELLABLE.has(state)) return { ok: false, reason: 'not-cancellable' };
+  await job.remove();
+  return { ok: true };
+}
+
+/**
+ * Reconstructs the job-data from the persisted `ingest_sources` row so the
+ * retry uses the same inputs the original `start` enqueued. Bumps
+ * `attempts` atomically with the enqueue's "fire" — if the enqueue fails,
+ * the increment is rolled back so user-facing attempts stays accurate.
+ */
+function jobDataFromRow(row: {
+  id: number;
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  url: string | null;
+  caption: string | null;
+}): IngestJobData {
+  switch (row.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      if (row.url === null) {
+        throw new Error(`Retry blocked: ingest_sources #${row.id} missing url`);
+      }
+      return { kind: row.kind, sourceId: row.id, url: row.url };
+    case 'text':
+      if (row.caption === null) {
+        throw new Error(`Retry blocked: ingest_sources #${row.id} missing caption/body`);
+      }
+      return { kind: 'text', sourceId: row.id, body: row.caption };
+    case 'screenshot': {
+      // Screenshot retry reuses the original on-disk file under the per-
+      // source dir. Mime is not persisted in `ingest_sources`; recover it
+      // from the filename extension so jpg / webp retries don't fall back
+      // to `.png`.
+      const found = findOnDiskScreenshot(row.id);
+      if (found === null) {
+        throw new Error(
+          `Retry blocked: screenshot for ingest_sources #${row.id} not on disk (already evicted?)`
+        );
+      }
+      return {
+        kind: 'screenshot',
+        sourceId: row.id,
+        mimeType: found.mimeType,
+        contentPath: `${row.id}/${found.filename}`,
+      };
+    }
+  }
+}
+
+export async function retryIngest(db: FoodDb, sourceId: number): Promise<EnqueueResult> {
+  const rows = db
+    .select({
+      id: ingestSources.id,
+      kind: ingestSources.kind,
+      url: ingestSources.url,
+      caption: ingestSources.caption,
+    })
+    .from(ingestSources)
+    .where(eq(ingestSources.id, sourceId))
+    .all();
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error(`ingest_sources #${sourceId} not found`);
+  }
+  const data = jobDataFromRow(row);
+  const enqueued = await enqueueIngestJob(data);
+  db.update(ingestSources)
+    .set({
+      attempts: sql`${ingestSources.attempts} + 1`,
+      errorCode: null,
+      errorMessage: null,
+    })
+    .where(eq(ingestSources.id, sourceId))
+    .run();
+  return enqueued;
+}

--- a/pillars/food/src/api/modules/ingest/ingest-procedures-start.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-procedures-start.ts
@@ -1,0 +1,121 @@
+/**
+ * PRD-125 — `food.ingest.start` implementation.
+ *
+ * Always creates the `ingest_sources` row first (defensive: the row records
+ * the attempt regardless of whether enqueue succeeds). For screenshot
+ * inputs the base64 payload is written to disk under the per-source dir
+ * BEFORE the BullMQ job is enqueued so the heavy bytes don't ride in Redis.
+ */
+import { rmSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, ingestSourcesService } from '../../../db/index.js';
+import { enqueueIngestJob, type EnqueueResult } from './ingest-enqueue.js';
+import { writeScreenshotPayload } from './ingest-storage.js';
+
+import type { IngestJobData } from '../../../contract/queue/index.js';
+import type { IngestStartInput } from '../../../contract/rest-ingest-schemas.js';
+
+const EXTRACTOR_VERSION_PLACEHOLDER = 'pipeline-v1.0';
+
+interface StartContext {
+  db: FoodDb;
+  extractorVersion?: string;
+}
+
+interface RowInputForKind {
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  extractorVersion: string;
+  url?: string;
+  caption?: string;
+}
+
+function rowInputForKind(input: IngestStartInput, extractorVersion: string): RowInputForKind {
+  switch (input.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      return { kind: input.kind, extractorVersion, url: input.url };
+    case 'text':
+      return { kind: 'text', extractorVersion, caption: input.body };
+    case 'screenshot':
+      return { kind: 'screenshot', extractorVersion };
+  }
+}
+
+function jobDataFor(
+  input: IngestStartInput,
+  sourceId: number,
+  screenshotPath: string | null
+): IngestJobData {
+  switch (input.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      return { kind: input.kind, sourceId, url: input.url };
+    case 'text':
+      return { kind: 'text', sourceId, body: input.body };
+    case 'screenshot':
+      if (screenshotPath === null) {
+        throw new Error('Screenshot enqueue requested without a written content path');
+      }
+      return {
+        kind: 'screenshot',
+        sourceId,
+        mimeType: input.mimeType,
+        contentPath: screenshotPath,
+      };
+  }
+}
+
+export interface StartResult extends EnqueueResult {
+  sourceId: number;
+}
+
+/**
+ * Roll back the `ingest_sources` row + screenshot dir created earlier in
+ * this request. Best-effort: a DB rollback failure surfaces, but we
+ * swallow filesystem-cleanup errors (eviction sweeps the orphan later
+ * anyway). Used only on the enqueue-failure path so the user can retry
+ * cleanly without an orphan row + media file accumulating per attempt.
+ */
+function rollbackStart(db: FoodDb, sourceId: number, screenshotAbsPath: string | null): void {
+  if (screenshotAbsPath !== null) {
+    try {
+      rmSync(dirname(screenshotAbsPath), { recursive: true, force: true });
+    } catch {
+      // Swallow — eviction will sweep this on the next pass.
+    }
+  }
+  db.delete(ingestSources).where(eq(ingestSources.id, sourceId)).run();
+}
+
+export async function startIngest(
+  ctx: StartContext,
+  input: IngestStartInput
+): Promise<StartResult> {
+  const extractorVersion = ctx.extractorVersion ?? EXTRACTOR_VERSION_PLACEHOLDER;
+  const row = ingestSourcesService.createIngestSource(
+    ctx.db,
+    rowInputForKind(input, extractorVersion)
+  );
+  let screenshotPath: string | null = null;
+  let screenshotAbsPath: string | null = null;
+  if (input.kind === 'screenshot') {
+    const written = writeScreenshotPayload(row.id, input.mimeType, input.contentBase64);
+    screenshotPath = written.relativeContentPath;
+    screenshotAbsPath = written.absolutePath;
+  }
+  // If enqueue throws (Redis down, queue closed, BullMQ transient error),
+  // roll back the row + the disk artefact so a retry on the user's side
+  // doesn't leave a phantom `pending` row that no worker will ever pick
+  // up. Re-throw so the tRPC layer translates to SERVICE_UNAVAILABLE.
+  let enqueued: EnqueueResult;
+  try {
+    enqueued = await enqueueIngestJob(jobDataFor(input, row.id, screenshotPath));
+  } catch (err) {
+    rollbackStart(ctx.db, row.id, screenshotAbsPath);
+    throw err;
+  }
+  return { sourceId: row.id, jobId: enqueued.jobId, queuedAt: enqueued.queuedAt };
+}

--- a/pillars/food/src/api/modules/ingest/ingest-procedures-status.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-procedures-status.ts
@@ -1,0 +1,181 @@
+/**
+ * PRD-125 — `food.ingest.status` and `food.ingest.list` implementations.
+ *
+ * Combine the BullMQ job state with the DB row state. The DB is
+ * authoritative once the job has aged out of Redis (`removeOnComplete` /
+ * `removeOnFail` retention windows). See `ingest-state.ts` for the
+ * resolution rules.
+ */
+import { and, desc, eq, lt, type SQL } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, type IngestSourceRow } from '../../../db/index.js';
+import { getFoodIngestQueue } from '../../queue.js';
+import { deriveIngestState, extractPartialReason, type IngestState } from './ingest-state.js';
+
+import type { PartialReason } from '../../../contract/queue/index.js';
+
+export interface IngestStatusView {
+  sourceId: number;
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  state: IngestState;
+  jobId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  draftRecipeId: number | null;
+  partialReason?: PartialReason;
+  errorCode?: string;
+  errorMessage?: string;
+  attempts: number;
+}
+
+interface JobTimings {
+  jobId: string | null;
+  bullmqState: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+const EMPTY_TIMINGS: JobTimings = {
+  jobId: null,
+  bullmqState: null,
+  startedAt: null,
+  completedAt: null,
+};
+
+/**
+ * Fetch BullMQ timings for ONE source id. Used by `status`. The `list`
+ * endpoint uses `fetchJobTimingsBatch` below to scan jobs once per request
+ * and build a sourceId → timings map.
+ */
+async function fetchJobTimings(sourceId: number): Promise<JobTimings> {
+  const map = await fetchJobTimingsBatch([sourceId]);
+  return map.get(sourceId) ?? EMPTY_TIMINGS;
+}
+
+/** BullMQ pagination chunk size — keep individual Redis round-trips small. */
+const SCAN_PAGE_SIZE = 100;
+/** Maximum jobs we'll walk per request. Mirrors the queue's
+ *  `removeOnComplete: { count: 1_000 }` retention so the scan can find
+ *  any job still tracked by Redis. Beyond this the DB row's state is
+ *  authoritative anyway (set by `workerComplete`). */
+const SCAN_MAX_JOBS = 1_000;
+
+/**
+ * BullMQ has no native "get job by data.sourceId" — we paginate the
+ * recent window and bucket by sourceId, stopping early once every
+ * requested id has been resolved. Cheaper than O(rows × Redis round
+ * trips) when `list` returns many rows. When PRD-126 lands a heavier
+ * worker we can persist `jobId` on `ingest_sources` and skip the scan
+ * altogether.
+ */
+type BullMQJob = Awaited<
+  ReturnType<NonNullable<ReturnType<typeof getFoodIngestQueue>>['getJobs']>
+>[number];
+
+async function recordJobTimings(
+  job: BullMQJob,
+  wanted: ReadonlySet<number>,
+  out: Map<number, JobTimings>
+): Promise<void> {
+  const data: unknown = job.data;
+  if (typeof data !== 'object' || data === null) return;
+  const sourceId = (data as { sourceId?: number }).sourceId;
+  if (typeof sourceId !== 'number' || !wanted.has(sourceId) || out.has(sourceId)) return;
+  const state = await job.getState();
+  out.set(sourceId, {
+    jobId: job.id ?? null,
+    bullmqState: state,
+    startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+    completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+  });
+}
+
+async function fetchJobTimingsBatch(
+  sourceIds: readonly number[]
+): Promise<Map<number, JobTimings>> {
+  const out = new Map<number, JobTimings>();
+  if (sourceIds.length === 0) return out;
+  const queue = getFoodIngestQueue();
+  if (queue === null) return out;
+  const wanted = new Set(sourceIds);
+  for (let offset = 0; offset < SCAN_MAX_JOBS; offset += SCAN_PAGE_SIZE) {
+    if (out.size === wanted.size) break;
+    const end = offset + SCAN_PAGE_SIZE - 1;
+    const jobs = await queue.getJobs(
+      ['waiting', 'delayed', 'active', 'completed', 'failed'],
+      offset,
+      end
+    );
+    if (jobs.length === 0) break;
+    for (const job of jobs) {
+      await recordJobTimings(job, wanted, out);
+    }
+    if (jobs.length < SCAN_PAGE_SIZE) break; // exhausted the window
+  }
+  return out;
+}
+
+function rowToView(row: IngestSourceRow, timings: JobTimings): IngestStatusView {
+  const partialReason = extractPartialReason(row.extractedJson);
+  return {
+    sourceId: row.id,
+    kind: row.kind,
+    state: deriveIngestState(row, timings.bullmqState, partialReason),
+    jobId: timings.jobId,
+    startedAt: timings.startedAt,
+    completedAt: timings.completedAt,
+    draftRecipeId: row.draftRecipeId,
+    partialReason,
+    errorCode: row.errorCode ?? undefined,
+    errorMessage: row.errorMessage ?? undefined,
+    attempts: row.attempts,
+  };
+}
+
+export async function getIngestStatus(
+  db: FoodDb,
+  sourceId: number
+): Promise<IngestStatusView | null> {
+  const rows = db.select().from(ingestSources).where(eq(ingestSources.id, sourceId)).all();
+  const row = rows[0];
+  if (row === undefined) return null;
+  const timings = await fetchJobTimings(sourceId);
+  return rowToView(row, timings);
+}
+
+export interface ListResult {
+  items: IngestStatusView[];
+  nextCursor?: string;
+}
+
+export async function listIngestSources(
+  db: FoodDb,
+  filter: { state?: IngestState; cursor?: string; limit: number }
+): Promise<ListResult> {
+  const conditions: SQL[] = [];
+  if (filter.cursor !== undefined) {
+    const cursorId = Number(filter.cursor);
+    if (Number.isFinite(cursorId)) conditions.push(lt(ingestSources.id, cursorId));
+  }
+  const where = conditions.length === 0 ? undefined : and(...conditions);
+  // Fetch limit + 1 to detect more-pages without a count(*) round trip.
+  const rows = db
+    .select()
+    .from(ingestSources)
+    .where(where)
+    .orderBy(desc(ingestSources.id))
+    .limit(filter.limit + 1)
+    .all();
+  const hasMore = rows.length > filter.limit;
+  const sliced = hasMore ? rows.slice(0, filter.limit) : rows;
+  // Batch the BullMQ scan — one round trip for the whole page, not one
+  // per row. See `fetchJobTimingsBatch` above for the contract.
+  const timingsBySourceId = await fetchJobTimingsBatch(sliced.map((row) => row.id));
+  const views: IngestStatusView[] = sliced.map((row) =>
+    rowToView(row, timingsBySourceId.get(row.id) ?? EMPTY_TIMINGS)
+  );
+  const filtered =
+    filter.state === undefined ? views : views.filter((v) => v.state === filter.state);
+  const nextCursor = hasMore ? String(sliced[sliced.length - 1]?.id ?? '') : undefined;
+  return { items: filtered, nextCursor };
+}

--- a/pillars/food/src/api/modules/ingest/ingest-state.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-state.ts
@@ -1,0 +1,84 @@
+import type { JobType } from 'bullmq';
+
+import type { PartialReason } from '../../../contract/queue/index.js';
+/**
+ * PRD-125 — `IngestStatus.state` derivation.
+ *
+ * Combines BullMQ's job state (live for ~`removeOnComplete`/`removeOnFail`
+ * count) with the DB row state (authoritative once the job has aged out
+ * of Redis). The DB row drives `completed` / `failed` / `partial` after
+ * the worker writes back via `workerComplete`.
+ */
+import type { IngestSourceRow } from '../../../db/index.js';
+
+function isPartialReason(value: string): value is PartialReason {
+  switch (value) {
+    case 'auth-dead':
+    case 'rate-limited':
+    case 'stt-failed':
+    case 'vision-failed':
+    case 'caption-only-fallback':
+    case 'empty-extraction':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export type IngestState = 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+
+const BULLMQ_TO_INGEST: Partial<Record<JobType | string, IngestState>> = {
+  waiting: 'pending',
+  delayed: 'pending',
+  'waiting-children': 'pending',
+  prioritized: 'pending',
+  active: 'processing',
+  completed: 'completed',
+  failed: 'failed',
+};
+
+/**
+ * Resolution priority:
+ *   1. If the DB row carries `error_code` or `error_message`, the worker
+ *      already wrote back failure → `failed` regardless of any stale
+ *      BullMQ state.
+ *   2. If `draft_recipe_id` is set, the worker wrote back success → use
+ *      DB row to choose `completed` vs `partial` (the latter is recorded
+ *      by `extracted_json.partialReason`).
+ *   3. Otherwise fall back to whatever BullMQ reports.
+ *   4. If BullMQ has no record (TTL expired) and DB says nothing terminal,
+ *      treat as `pending` so the polling client keeps polling — this
+ *      should not happen in normal operation.
+ */
+export function deriveIngestState(
+  row: IngestSourceRow,
+  bullmqState: string | null,
+  partialReasonInMeta: string | undefined
+): IngestState {
+  if (row.errorCode !== null || row.errorMessage !== null) return 'failed';
+  if (row.draftRecipeId !== null) {
+    return partialReasonInMeta === undefined ? 'completed' : 'partial';
+  }
+  if (bullmqState === null) return 'pending';
+  return BULLMQ_TO_INGEST[bullmqState] ?? 'pending';
+}
+
+/**
+ * Extracted out so `status` and `list` use the same partial-reason lookup.
+ * Treats malformed JSON as "no partial reason" rather than throwing.
+ */
+export function extractPartialReason(extractedJson: string | null): PartialReason | undefined {
+  if (extractedJson === null) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractedJson);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null || !('partialReason' in parsed)) {
+    return undefined;
+  }
+  const reason: unknown = parsed.partialReason;
+  if (typeof reason !== 'string') return undefined;
+  return isPartialReason(reason) ? reason : undefined;
+}

--- a/pillars/food/src/api/modules/ingest/ingest-storage.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-storage.ts
@@ -1,0 +1,95 @@
+/**
+ * PRD-125 — screenshot-payload disk writer.
+ *
+ * Per PRD-125 §Flow: for `kind='screenshot'` the API decodes the base64
+ * payload to `${FOOD_INGEST_DIR}/<sourceId>/screenshot.<ext>` BEFORE the
+ * BullMQ job is enqueued (Redis stays small; worker reads the file).
+ *
+ * Mime → extension mapping mirrors PRD-110's screenshot.<ext> amendment
+ * (allows jpg/jpeg/png/webp). Caller validates the mime against the input
+ * schema; this helper just maps.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** PRD-124 base64 size cap reused for screenshot input. */
+export const SCREENSHOT_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Mirror of `packages/app-food/src/storage/ingest-paths.ts` — duplicated to keep pops-api off the app-food package graph (cycle via @pops/api-client). */
+const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
+
+function ingestRootDir(): string {
+  const configured = process.env['FOOD_INGEST_DIR'];
+  const raw = configured && configured.length > 0 ? configured : DEFAULT_FOOD_INGEST_DIR;
+  return resolve(raw);
+}
+
+export function ingestDirFor(sourceId: number): string {
+  return resolve(ingestRootDir(), String(sourceId));
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+export function extensionForMimeType(mimeType: string): string {
+  const ext = MIME_TO_EXT[mimeType];
+  if (ext === undefined) {
+    throw new Error(`Unsupported screenshot mime type "${mimeType}"`);
+  }
+  return ext;
+}
+
+export interface WriteScreenshotResult {
+  /** Absolute filesystem path written to. */
+  absolutePath: string;
+  /** Path relative to `FOOD_INGEST_DIR` — what gets stored in the BullMQ job. */
+  relativeContentPath: string;
+  /** Bytes written; matches the decoded payload size. */
+  bytesWritten: number;
+}
+
+/**
+ * Decode and persist a screenshot payload. Throws when the decoded size
+ * exceeds `SCREENSHOT_MAX_BYTES` or when the mime type isn't supported.
+ *
+ * Files are written under `<FOOD_INGEST_DIR>/<sourceId>/screenshot.<ext>`
+ * so PRD-110's FIFO eviction (`runEvictionTick`) sweeps them alongside the
+ * other per-source media when the directory cap is hit.
+ */
+export function writeScreenshotPayload(
+  sourceId: number,
+  mimeType: string,
+  contentBase64: string
+): WriteScreenshotResult {
+  const ext = extensionForMimeType(mimeType);
+  // Trim the data-URI prefix if the caller sent the raw `data:image/png;base64,...`
+  // header — be permissive on input, strict on output.
+  const cleaned = contentBase64.replace(/^data:[^;]+;base64,/, '');
+  // Pre-decode size check — base64 encodes ~4/3 bytes per source byte, so a
+  // cleaned payload longer than this can't decode to ≤ SCREENSHOT_MAX_BYTES.
+  // Without the pre-check, `Buffer.from(huge_string, 'base64')` would
+  // allocate the full decoded buffer before we can reject it.
+  const maxBase64Chars = Math.ceil((SCREENSHOT_MAX_BYTES * 4) / 3);
+  if (cleaned.length > maxBase64Chars) {
+    throw new Error(
+      `Screenshot base64 payload (${cleaned.length} chars) exceeds the pre-decode cap (${maxBase64Chars} chars) for ${SCREENSHOT_MAX_BYTES} bytes`
+    );
+  }
+  const buffer = Buffer.from(cleaned, 'base64');
+  if (buffer.length > SCREENSHOT_MAX_BYTES) {
+    throw new Error(
+      `Screenshot payload (${buffer.length} bytes) exceeds cap (${SCREENSHOT_MAX_BYTES} bytes)`
+    );
+  }
+  const dir = ingestDirFor(sourceId);
+  mkdirSync(dir, { recursive: true });
+  const filename = `screenshot.${ext}`;
+  const absolutePath = `${dir}/${filename}`;
+  writeFileSync(absolutePath, buffer);
+  // Stored in the BullMQ job verbatim. Worker resolves via `ingestRootDir()`.
+  const relativeContentPath = `${sourceId}/${filename}`;
+  return { absolutePath, relativeContentPath, bytesWritten: buffer.length };
+}

--- a/pillars/food/src/api/modules/ingest/ingest-worker-complete.ts
+++ b/pillars/food/src/api/modules/ingest/ingest-worker-complete.ts
@@ -1,0 +1,171 @@
+/**
+ * PRD-125 — server-side `food.ingest.workerComplete` execution.
+ *
+ * Two outcomes:
+ *
+ *   - `ok: true` — creates a draft recipe + first version via
+ *     `recipesService.createRecipe` (from `@pops/app-food-db`) and
+ *     updates the `ingest_sources` row in ONE transaction. The version
+ *     is left uncompiled; PRD-119's promote flow runs the compile
+ *     pipeline lazily when the user approves the draft from the inbox.
+ *   - `ok: false` — writes the `meta` rollup + `error_code` + `error_message`
+ *     to `ingest_sources` (PRD-138 amendment columns). Returns
+ *     `{ ok: false, reason }` to the worker.
+ *
+ * Each branch is idempotent. BullMQ retries the callback on transient
+ * network errors, so a second `ok:true` call sees the previously-set
+ * `draft_recipe_id` and returns it instead of re-inserting the slug.
+ *
+ * `compileRecipeVersion` lives in `@pops/app-food` (frontend-bound
+ * package, depends on @pops/api-client) — calling it here would close a
+ * `pops-api → @pops/app-food → @pops/api-client → @pops/api` package
+ * cycle. PRD-119's tRPC handler will own that call site.
+ */
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, recipesService } from '../../../db/index.js';
+
+import type { IngestJobResult } from '../../../contract/queue/index.js';
+
+const INGEST_RECIPE_SLUG_PREFIX = 'ingest-source-';
+/** Lightweight match against `@recipe(... title="...")` — the DSL grammar in
+ *  `packages/app-food/src/dsl/parse-recipe.ts` declares `title` as a named
+ *  arg inside `@recipe(...)`. We deliberately don't call the full parser to
+ *  avoid depending on `@pops/app-food` (which would close the cycle through
+ *  @pops/api-client); the regex is permissive enough for any author-written
+ *  `title="..."` inside the `@recipe(...)` header. Falls back to a generic
+ *  title when the worker emits a body the parser would reject — the inbox
+ *  surfaces the literal DSL anyway. */
+const TITLE_RE = /@recipe\s*\([^)]*\btitle\s*=\s*"([^"]+)"/;
+
+function deriveSlug(sourceId: number): string {
+  return `${INGEST_RECIPE_SLUG_PREFIX}${sourceId}`;
+}
+
+function deriveTitle(dsl: string): string {
+  const match = TITLE_RE.exec(dsl);
+  const title = match?.[1]?.trim();
+  if (title !== undefined && title.length > 0) return title;
+  return 'Untitled ingested recipe';
+}
+
+export class WorkerCompleteSourceNotFound extends Error {
+  constructor(sourceId: number) {
+    super(`ingest_sources #${sourceId} not found`);
+    this.name = 'WorkerCompleteSourceNotFound';
+  }
+}
+
+interface ExistingSourceRow {
+  id: number;
+  draftRecipeId: number | null;
+}
+
+/** Reads the row once at the top of the transaction so the worker sees a
+ *  clear failure when `sourceId` doesn't exist (or was double-evicted)
+ *  rather than a silent no-op UPDATE. */
+function loadSourceRow(tx: FoodDb, sourceId: number): ExistingSourceRow {
+  const rows = tx
+    .select({
+      id: ingestSources.id,
+      draftRecipeId: ingestSources.draftRecipeId,
+    })
+    .from(ingestSources)
+    .where(eq(ingestSources.id, sourceId))
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new WorkerCompleteSourceNotFound(sourceId);
+  return row;
+}
+
+export interface WorkerCompleteSuccessResult {
+  ok: true;
+  draftRecipeId: number;
+  compileStatus: 'compiled' | 'failed' | 'uncompiled';
+}
+
+export interface WorkerCompleteFailureResult {
+  ok: false;
+  reason: string;
+}
+
+export type WorkerCompleteOutcome = WorkerCompleteSuccessResult | WorkerCompleteFailureResult;
+
+function applySuccess(
+  db: FoodDb,
+  sourceId: number,
+  result: Extract<IngestJobResult, { ok: true }>
+): WorkerCompleteSuccessResult {
+  return db.transaction((tx): WorkerCompleteSuccessResult => {
+    const existing = loadSourceRow(tx, sourceId);
+    // Idempotency — re-running `ok: true` after the previous run already
+    // created the draft must return the existing recipe rather than
+    // attempt a duplicate `slug_registry` insert (which would throw on
+    // unique constraint).
+    if (existing.draftRecipeId !== null) {
+      return {
+        ok: true,
+        draftRecipeId: existing.draftRecipeId,
+        compileStatus: 'uncompiled',
+      };
+    }
+    const created = recipesService.createRecipe(tx, {
+      slug: deriveSlug(sourceId),
+      firstVersion: {
+        title: deriveTitle(result.dsl),
+        bodyDsl: result.dsl,
+        sourceId,
+      },
+    });
+    // Persist `partialReason` nested inside the meta blob so
+    // `extractPartialReason` (status / list) can recover it after BullMQ
+    // TTL expiry. The IngestMeta envelope is permissive — handler PRDs
+    // 127–132 own the `stages` payload; this field is the only one the
+    // producer side needs to surface to the inbox UI.
+    const persistedMeta =
+      result.partialReason === undefined
+        ? result.meta
+        : { ...result.meta, partialReason: result.partialReason };
+    tx.update(ingestSources)
+      .set({
+        extractedJson: JSON.stringify(persistedMeta),
+        draftRecipeId: created.recipe.id,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .where(eq(ingestSources.id, sourceId))
+      .run();
+    return { ok: true, draftRecipeId: created.recipe.id, compileStatus: 'uncompiled' };
+  });
+}
+
+function applyFailure(
+  db: FoodDb,
+  sourceId: number,
+  result: Extract<IngestJobResult, { ok: false }>
+): WorkerCompleteFailureResult {
+  return db.transaction((tx): WorkerCompleteFailureResult => {
+    // Verify the row exists before the UPDATE — Drizzle's `.run()` would
+    // silently affect zero rows otherwise, and the worker would see a
+    // spurious "failure recorded" response.
+    loadSourceRow(tx, sourceId);
+    tx.update(ingestSources)
+      .set({
+        extractedJson: JSON.stringify(result.meta),
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage,
+      })
+      .where(eq(ingestSources.id, sourceId))
+      .run();
+    return { ok: false, reason: result.errorCode };
+  });
+}
+
+export function applyWorkerComplete(
+  db: FoodDb,
+  sourceId: number,
+  result: IngestJobResult
+): WorkerCompleteOutcome {
+  if (result.ok) return applySuccess(db, sourceId, result);
+  return applyFailure(db, sourceId, result);
+}

--- a/pillars/food/src/api/modules/ingest/serve.ts
+++ b/pillars/food/src/api/modules/ingest/serve.ts
@@ -1,0 +1,123 @@
+/**
+ * Plain Express handlers that stream per-source ingest media (screenshot,
+ * video) back to the inbox UI (PRD-135).
+ *
+ *   GET /ingest/source/:sourceId/screenshot
+ *   GET /ingest/source/:sourceId/video
+ *
+ * Lifted from the pops-api `routes/food/ingest-files.ts` route. Mounted
+ * BEFORE the ts-rest endpoints so they resolve to a file; the ts-rest
+ * `ingest.*` surface is all POST, so there's no method/path collision.
+ *
+ * Returns 404 when the source row is missing OR the eviction job already
+ * archived it (`archived_at IS NOT NULL`) OR the on-disk file is gone — the
+ * inbox UI treats 404 as "no media, skip rendering". `res.sendFile` handles
+ * Range requests, so `<video>` seeking works without a manual stream.
+ */
+import { readdirSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources } from '../../../db/index.js';
+import { ingestDirFor } from './ingest-storage.js';
+
+import type { Request, Response } from 'express';
+
+const CACHE_CONTROL = 'private, max-age=3600';
+const SOURCE_ID_RE = /^[1-9]\d*$/;
+const SCREENSHOT_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'] as const;
+const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'm4v'] as const;
+
+const CONTENT_TYPE: Readonly<Record<string, string>> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.m4v': 'video/x-m4v',
+};
+
+function parseSourceId(req: Request, res: Response): number | null {
+  const raw = String(req.params['sourceId'] ?? '');
+  if (!SOURCE_ID_RE.test(raw)) {
+    res.status(400).json({ message: `Invalid source id: ${raw}` });
+    return null;
+  }
+  return Number(raw);
+}
+
+/**
+ * Fail closed: only serve media for a source row that exists and hasn't been
+ * archived by the FIFO eviction job. Without this guard, a guessed `sourceId`
+ * could fish for files on disk. Catches so a missing table (tests without the
+ * ingest migration) serves nothing rather than throwing.
+ */
+function isServableSource(db: FoodDb, sourceId: number): boolean {
+  try {
+    const row = db
+      .select({ archivedAt: ingestSources.archivedAt })
+      .from(ingestSources)
+      .where(eq(ingestSources.id, sourceId))
+      .get();
+    return row !== undefined && row.archivedAt === null;
+  } catch {
+    return false;
+  }
+}
+
+function findFileWithExtension(
+  dir: string,
+  baseName: string,
+  exts: readonly string[]
+): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  // Case-insensitive match, on-disk casing preserved: prod's case-sensitive
+  // FS would 404 if the worker wrote `Screenshot.PNG`.
+  const wanted = new Set(exts.map((ext) => `${baseName}.${ext}`.toLowerCase()));
+  for (const entry of entries) {
+    if (wanted.has(entry.toLowerCase())) return join(dir, entry);
+  }
+  return null;
+}
+
+interface MediaSpec {
+  readonly baseName: string;
+  readonly exts: readonly string[];
+}
+
+const SCREENSHOT_SPEC: MediaSpec = { baseName: 'screenshot', exts: SCREENSHOT_EXTENSIONS };
+const VIDEO_SPEC: MediaSpec = { baseName: 'video', exts: VIDEO_EXTENSIONS };
+
+function serveMedia(db: FoodDb, spec: MediaSpec, req: Request, res: Response): void {
+  const sourceId = parseSourceId(req, res);
+  if (sourceId === null) return;
+  if (!isServableSource(db, sourceId)) {
+    res.status(404).json({ message: 'File not found' });
+    return;
+  }
+  const filePath = findFileWithExtension(ingestDirFor(sourceId), spec.baseName, spec.exts);
+  if (filePath === null) {
+    res.status(404).json({ message: 'File not found' });
+    return;
+  }
+  const contentType = CONTENT_TYPE[extname(filePath).toLowerCase()];
+  if (contentType !== undefined) res.type(contentType);
+  res.setHeader('Cache-Control', CACHE_CONTROL);
+  res.sendFile(filePath);
+}
+
+export function makeServeIngestScreenshot(db: FoodDb) {
+  return (req: Request, res: Response): void => serveMedia(db, SCREENSHOT_SPEC, req, res);
+}
+
+export function makeServeIngestVideo(db: FoodDb) {
+  return (req: Request, res: Response): void => serveMedia(db, VIDEO_SPEC, req, res);
+}

--- a/pillars/food/src/api/queue.ts
+++ b/pillars/food/src/api/queue.ts
@@ -1,0 +1,57 @@
+/**
+ * BullMQ producer for the `food.ingest` queue (PRD-125), pillar-side.
+ *
+ * The food-api container is the producer (enqueue / status / cancel /
+ * retry); the consumer runs in `pillars/food/src/worker`. Lazy singleton,
+ * closed on graceful shutdown. Returns `null` when Redis is not configured
+ * so tests + dev runs without Redis don't blow up at module init (the start
+ * handler maps the resulting `IngestQueueUnavailable` to 503).
+ */
+import { type DefaultJobOptions, Queue } from 'bullmq';
+import { Redis } from 'ioredis';
+
+import { FOOD_INGEST_QUEUE_NAME, type IngestJobData } from '../contract/queue/index.js';
+
+const ATTEMPTS = 3;
+const BACKOFF_DELAY_MS = 5_000;
+const REMOVE_KEEP_COUNT = 1_000;
+
+export const FOOD_INGEST_JOB_OPTIONS: DefaultJobOptions = {
+  attempts: ATTEMPTS,
+  backoff: { type: 'exponential', delay: BACKOFF_DELAY_MS },
+  removeOnComplete: { count: REMOVE_KEEP_COUNT },
+  removeOnFail: { count: REMOVE_KEEP_COUNT },
+};
+
+function resolveRedisUrl(): string | null {
+  const url = process.env['REDIS_URL'];
+  if (url !== undefined && url.length > 0) return url;
+  const host = process.env['REDIS_HOST'];
+  if (host === undefined || host.length === 0) return null;
+  return `redis://${host}:${process.env['REDIS_PORT'] ?? '6379'}`;
+}
+
+let queueSingleton: Queue<IngestJobData> | null = null;
+let redisDisabled = false;
+
+export function getFoodIngestQueue(): Queue<IngestJobData> | null {
+  if (redisDisabled) return null;
+  if (queueSingleton !== null) return queueSingleton;
+  const redisUrl = resolveRedisUrl();
+  if (redisUrl === null) {
+    redisDisabled = true;
+    return null;
+  }
+  const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
+  queueSingleton = new Queue<IngestJobData>(FOOD_INGEST_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: FOOD_INGEST_JOB_OPTIONS,
+  });
+  return queueSingleton;
+}
+
+export async function closeFoodIngestQueue(): Promise<void> {
+  await queueSingleton?.close();
+  queueSingleton = null;
+  redisDisabled = false;
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -21,6 +21,7 @@ import { makeConversionsHandlers } from './conversions-handlers.js';
 import { makeFridgeHandlers } from './fridge-handlers.js';
 import { makeHeroImageHandlers } from './hero-image-handlers.js';
 import { makeInboxHandlers } from './inbox-handlers.js';
+import { makeIngestHandlers } from './ingest-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePlanHandlers } from './plan-handlers.js';
@@ -53,6 +54,7 @@ export function makeFoodRestHandlers(
     fridge: makeFridgeHandlers(db),
     heroImage: makeHeroImageHandlers(db),
     inbox: makeInboxHandlers(db),
+    ingest: makeIngestHandlers(db),
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
     plan: makePlanHandlers(db),

--- a/pillars/food/src/api/rest/ingest-handlers.ts
+++ b/pillars/food/src/api/rest/ingest-handlers.ts
@@ -1,0 +1,86 @@
+/**
+ * Handlers for the `ingest.*` sub-router.
+ *
+ * `start` / `retry` translate `IngestQueueUnavailable` (Redis not wired)
+ * into a 503 envelope; every other failure propagates to Express. `status`
+ * returns `null` on a 200 when the source id is unknown (the contract body
+ * is nullable). `workerComplete` reshapes the validated body into the
+ * `IngestJobResult` discriminated union the service consumes.
+ */
+import { IngestQueueUnavailable } from '../modules/ingest/ingest-enqueue.js';
+import { cancelIngest, retryIngest } from '../modules/ingest/ingest-procedures-control.js';
+import { startIngest } from '../modules/ingest/ingest-procedures-start.js';
+import { getIngestStatus, listIngestSources } from '../modules/ingest/ingest-procedures-status.js';
+import { applyWorkerComplete } from '../modules/ingest/ingest-worker-complete.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { IngestJobResult } from '../../contract/queue/index.js';
+import type { foodIngestContract } from '../../contract/rest-ingest.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodIngestContract>;
+
+const QUEUE_UNAVAILABLE = (message: string) => ({ status: 503 as const, body: { message } });
+
+function toJobResult(body: Req['workerComplete']['body']): IngestJobResult {
+  if (body.ok) {
+    return {
+      ok: true,
+      dsl: body.dsl,
+      meta: body.meta,
+      ...(body.partialReason === undefined ? {} : { partialReason: body.partialReason }),
+    };
+  }
+  return {
+    ok: false,
+    errorCode: body.errorCode,
+    errorMessage: body.errorMessage,
+    meta: body.meta,
+  };
+}
+
+export function makeIngestHandlers(db: FoodDb) {
+  return {
+    start: async ({ body }: Req['start']) => {
+      try {
+        return { status: 200 as const, body: await startIngest({ db }, body) };
+      } catch (err) {
+        if (err instanceof IngestQueueUnavailable) return QUEUE_UNAVAILABLE(err.message);
+        throw err;
+      }
+    },
+
+    status: async ({ body }: Req['status']) => ({
+      status: 200 as const,
+      body: await getIngestStatus(db, body.sourceId),
+    }),
+
+    list: async ({ body }: Req['list']) => ({
+      status: 200 as const,
+      body: await listIngestSources(db, body),
+    }),
+
+    cancel: ({ body }: Req['cancel']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await cancelIngest(body.sourceId),
+      })),
+
+    retry: async ({ body }: Req['retry']) => {
+      try {
+        return { status: 200 as const, body: await retryIngest(db, body.sourceId) };
+      } catch (err) {
+        if (err instanceof IngestQueueUnavailable) return QUEUE_UNAVAILABLE(err.message);
+        throw err;
+      }
+    },
+
+    workerComplete: ({ body }: Req['workerComplete']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: applyWorkerComplete(db, body.sourceId, toJobResult(body)),
+      })),
+  };
+}

--- a/pillars/food/src/api/server.ts
+++ b/pillars/food/src/api/server.ts
@@ -28,6 +28,7 @@ import { createFoodApiApp } from './app.js';
 import { resolveFoodSqlitePath } from './food-sqlite-path.js';
 import { buildFoodManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
+import { closeFoodIngestQueue } from './queue.js';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -85,11 +86,13 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[food-api] Shutting down (${signal})`);
-  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
-    server.close(() => {
-      foodDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve())
+    .finally(() => closeFoodIngestQueue())
+    .finally(() => {
+      server.close(() => {
+        foodDb.raw.close();
+      });
     });
-  });
 }
 
 process.on('SIGTERM', shutdown);

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -470,6 +470,108 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/ingest/cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Best-effort cancel of a queued ingest job */
+    post: operations['ingest.cancel'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingest/list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Cursor-paginated ingest sources for the inbox UI */
+    post: operations['ingest.list'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingest/retry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Re-enqueue a failed ingest job from its persisted row */
+    post: operations['ingest.retry'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingest/start': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Start an ingest job (enqueues BullMQ work) */
+    post: operations['ingest.start'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingest/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Live job + persisted state for one ingest source */
+    post: operations['ingest.status'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingest/worker-complete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Worker callback (internal; success or failure) for one job */
+    post: operations['ingest.workerComplete'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/ingredient-tags': {
     parameters: {
       query?: never;
@@ -3224,6 +3326,327 @@ export interface operations {
                   | 'ConcurrentPromotion'
                   | 'NoteRequired'
                   | 'NoteTooLong';
+              };
+        };
+      };
+    };
+  };
+  'ingest.cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'not-cancellable';
+              };
+        };
+      };
+    };
+  };
+  'ingest.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cursor?: string;
+          /** @default 20 */
+          limit: number;
+          /** @enum {string} */
+          state?: 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              attempts: number;
+              completedAt: string | null;
+              draftRecipeId: number | null;
+              errorCode?: string;
+              errorMessage?: string;
+              jobId: string | null;
+              /** @enum {string} */
+              kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+              /** @enum {string} */
+              partialReason?:
+                | 'auth-dead'
+                | 'rate-limited'
+                | 'stt-failed'
+                | 'vision-failed'
+                | 'caption-only-fallback'
+                | 'empty-extraction';
+              sourceId: number;
+              startedAt: string | null;
+              /** @enum {string} */
+              state: 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+            }[];
+            nextCursor?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingest.retry': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            jobId: string;
+            /** Format: date-time */
+            queuedAt: string;
+          };
+        };
+      };
+      /** @description 503 */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  'ingest.start': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json':
+          | {
+              /** @enum {string} */
+              kind: 'url-web';
+              /** Format: uri */
+              url: string;
+            }
+          | {
+              /** @enum {string} */
+              kind: 'url-instagram';
+              /** Format: uri */
+              url: string;
+            }
+          | {
+              body: string;
+              /** @enum {string} */
+              kind: 'text';
+            }
+          | {
+              contentBase64: string;
+              /** @enum {string} */
+              kind: 'screenshot';
+              /** @enum {string} */
+              mimeType: 'image/jpeg' | 'image/png' | 'image/webp';
+            };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            jobId: string;
+            /** Format: date-time */
+            queuedAt: string;
+            sourceId: number;
+          };
+        };
+      };
+      /** @description 503 */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  'ingest.status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            attempts: number;
+            completedAt: string | null;
+            draftRecipeId: number | null;
+            errorCode?: string;
+            errorMessage?: string;
+            jobId: string | null;
+            /** @enum {string} */
+            kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+            /** @enum {string} */
+            partialReason?:
+              | 'auth-dead'
+              | 'rate-limited'
+              | 'stt-failed'
+              | 'vision-failed'
+              | 'caption-only-fallback'
+              | 'empty-extraction';
+            sourceId: number;
+            startedAt: string | null;
+            /** @enum {string} */
+            state: 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+          } | null;
+        };
+      };
+    };
+  };
+  'ingest.workerComplete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json':
+          | {
+              dsl: string;
+              meta: {
+                extractor_version: string;
+                stages: {
+                  [key: string]: unknown;
+                };
+              } & {
+                [key: string]: unknown;
+              };
+              /** @enum {boolean} */
+              ok: true;
+              /** @enum {string} */
+              partialReason?:
+                | 'auth-dead'
+                | 'rate-limited'
+                | 'stt-failed'
+                | 'vision-failed'
+                | 'caption-only-fallback'
+                | 'empty-extraction';
+              sourceId: number;
+            }
+          | {
+              errorCode: string;
+              errorMessage: string;
+              meta: {
+                extractor_version: string;
+                stages: {
+                  [key: string]: unknown;
+                };
+              } & {
+                [key: string]: unknown;
+              };
+              /** @enum {boolean} */
+              ok: false;
+              sourceId: number;
+            };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {string} */
+                compileStatus: 'compiled' | 'failed' | 'uncompiled';
+                draftRecipeId: number;
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                reason: string;
               };
         };
       };

--- a/pillars/food/src/contract/rest-ingest-schemas.ts
+++ b/pillars/food/src/contract/rest-ingest-schemas.ts
@@ -1,0 +1,119 @@
+/**
+ * PRD-125 — Zod schemas for `food.ingest.*` tRPC procedures.
+ *
+ * Mirrors the shape of `@pops/food-contracts`'s runtime types. Kept in a
+ * sibling file so the router stays tight.
+ *
+ * IngestJobResult validation deliberately accepts `meta` as `z.any()` —
+ * the per-handler PRDs (127–132) own the `stages` payload shape and we
+ * don't want the producer rejecting handler innovations. The router only
+ * cares about the discriminator + the fields it writes to `ingest_sources`.
+ */
+import { z } from 'zod';
+
+/** Subset of valid screenshot mime types — matches PRD-110's `screenshot.<ext>` amendment. */
+export const ScreenshotMimeType = z.enum(['image/jpeg', 'image/png', 'image/webp']);
+
+/** Mirrors `PartialReason` from `@pops/food-contracts` so the wire surface
+ *  rejects values outside the contract. The handler PRDs (127–132) emit
+ *  exactly these strings; widening here would let a misbehaving worker leak
+ *  arbitrary strings into the inbox UI. */
+export const PartialReasonSchema = z.enum([
+  'auth-dead',
+  'rate-limited',
+  'stt-failed',
+  'vision-failed',
+  'caption-only-fallback',
+  'empty-extraction',
+]);
+
+export const IngestStartInput = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('url-web'), url: z.url() }),
+  z.object({ kind: z.literal('url-instagram'), url: z.url() }),
+  z.object({ kind: z.literal('text'), body: z.string().min(1) }),
+  z.object({
+    kind: z.literal('screenshot'),
+    mimeType: ScreenshotMimeType,
+    contentBase64: z.string().min(1),
+  }),
+]);
+export type IngestStartInput = z.infer<typeof IngestStartInput>;
+
+export const IngestStartOutput = z.object({
+  sourceId: z.number().int().positive(),
+  jobId: z.string(),
+  queuedAt: z.string().datetime(),
+});
+
+export const IngestState = z.enum(['pending', 'processing', 'completed', 'failed', 'partial']);
+
+export const IngestStatusOutput = z.object({
+  sourceId: z.number().int().positive(),
+  kind: z.enum(['url-web', 'url-instagram', 'text', 'screenshot']),
+  state: IngestState,
+  jobId: z.string().nullable(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  draftRecipeId: z.number().int().positive().nullable(),
+  partialReason: PartialReasonSchema.optional(),
+  errorCode: z.string().optional(),
+  errorMessage: z.string().optional(),
+  attempts: z.number().int().nonnegative(),
+});
+
+export const IngestListInput = z.object({
+  state: IngestState.optional(),
+  /** Forward-only cursor = the smallest seen `id` from the previous page. */
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export const IngestListOutput = z.object({
+  items: z.array(IngestStatusOutput),
+  nextCursor: z.string().optional(),
+});
+
+export const IngestCancelInput = z.object({ sourceId: z.number().int().positive() });
+export const IngestCancelOutput = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: z.literal('not-cancellable') }),
+]);
+
+export const IngestRetryInput = z.object({ sourceId: z.number().int().positive() });
+export const IngestRetryOutput = z.object({
+  jobId: z.string(),
+  queuedAt: z.string().datetime(),
+});
+
+const MetaSchema = z
+  .object({
+    extractor_version: z.string(),
+    stages: z.record(z.string(), z.unknown()),
+  })
+  .passthrough();
+
+export const WorkerCompleteInput = z.discriminatedUnion('ok', [
+  z.object({
+    sourceId: z.number().int().positive(),
+    ok: z.literal(true),
+    dsl: z.string().min(1),
+    meta: MetaSchema,
+    partialReason: PartialReasonSchema.optional(),
+  }),
+  z.object({
+    sourceId: z.number().int().positive(),
+    ok: z.literal(false),
+    errorCode: z.string().min(1),
+    errorMessage: z.string().min(1),
+    meta: MetaSchema,
+  }),
+]);
+
+export const WorkerCompleteOutput = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    draftRecipeId: z.number().int().positive(),
+    compileStatus: z.enum(['compiled', 'failed', 'uncompiled']),
+  }),
+  z.object({ ok: z.literal(false), reason: z.string() }),
+]);

--- a/pillars/food/src/contract/rest-ingest.ts
+++ b/pillars/food/src/contract/rest-ingest.ts
@@ -1,0 +1,79 @@
+/**
+ * `ingest.*` sub-router — PRD-125 recipe ingest pipeline.
+ *
+ * The food-api container is the BullMQ producer: `start` enqueues, `status`
+ * / `list` read live job state + the persisted `ingest_sources` row, and
+ * `cancel` / `retry` poke the queue. `workerComplete` is the internal
+ * callback the pops-worker-food container posts on every job (success or
+ * failure) — gated by `x-pops-internal-token` in `app.ts`.
+ *
+ * `start` / `retry` answer 503 when Redis is not configured (the producer
+ * can't enqueue). Reads use POST-with-body — parity with `inbox.list` —
+ * because the payloads carry typed numbers/cursors that don't round-trip
+ * cleanly through query strings.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  IngestCancelInput,
+  IngestCancelOutput,
+  IngestListInput,
+  IngestListOutput,
+  IngestRetryInput,
+  IngestRetryOutput,
+  IngestStartInput,
+  IngestStartOutput,
+  IngestStatusOutput,
+  WorkerCompleteInput,
+  WorkerCompleteOutput,
+} from './rest-ingest-schemas.js';
+
+const c = initContract();
+
+const QueueUnavailable = z.object({ message: z.string() });
+
+export const foodIngestContract = c.router({
+  start: {
+    method: 'POST',
+    path: '/ingest/start',
+    body: IngestStartInput,
+    responses: { 200: IngestStartOutput, 503: QueueUnavailable },
+    summary: 'Start an ingest job (enqueues BullMQ work)',
+  },
+  status: {
+    method: 'POST',
+    path: '/ingest/status',
+    body: IngestCancelInput,
+    responses: { 200: IngestStatusOutput.nullable() },
+    summary: 'Live job + persisted state for one ingest source',
+  },
+  list: {
+    method: 'POST',
+    path: '/ingest/list',
+    body: IngestListInput,
+    responses: { 200: IngestListOutput },
+    summary: 'Cursor-paginated ingest sources for the inbox UI',
+  },
+  cancel: {
+    method: 'POST',
+    path: '/ingest/cancel',
+    body: IngestCancelInput,
+    responses: { 200: IngestCancelOutput },
+    summary: 'Best-effort cancel of a queued ingest job',
+  },
+  retry: {
+    method: 'POST',
+    path: '/ingest/retry',
+    body: IngestRetryInput,
+    responses: { 200: IngestRetryOutput, 503: QueueUnavailable },
+    summary: 'Re-enqueue a failed ingest job from its persisted row',
+  },
+  workerComplete: {
+    method: 'POST',
+    path: '/ingest/worker-complete',
+    body: WorkerCompleteInput,
+    responses: { 200: WorkerCompleteOutput },
+    summary: 'Worker callback (internal; success or failure) for one job',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -21,6 +21,7 @@ import { foodConversionsContract } from './rest-conversions.js';
 import { foodFridgeContract } from './rest-fridge.js';
 import { foodHeroImageContract } from './rest-hero-image.js';
 import { foodInboxContract } from './rest-inbox.js';
+import { foodIngestContract } from './rest-ingest.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPlanContract } from './rest-plan.js';
@@ -44,6 +45,7 @@ export const foodContract = c.router(
     fridge: foodFridgeContract,
     heroImage: foodHeroImageContract,
     inbox: foodInboxContract,
+    ingest: foodIngestContract,
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
     plan: foodPlanContract,

--- a/pillars/food/src/worker/api-client.ts
+++ b/pillars/food/src/worker/api-client.ts
@@ -1,16 +1,13 @@
 /**
- * Raw HTTP client for posting worker results back to pops-api.
+ * Raw HTTP client for posting worker results back to the food-api pillar.
  *
- * Replaces the tRPC typed client (which would couple the worker to
- * pops-api's compiled `AppRouter` type) with a single-purpose fetch
- * against the `food.ingest.workerComplete` tRPC endpoint. The wire
- * format is tRPC v11's batched POST shape (`{ "0": { "json": <input> } }`
- * at `?batch=1`) — pops-api keeps its existing `httpBatchLink` handler.
+ * Single-purpose fetch against the ts-rest `ingest.workerComplete` endpoint
+ * (`POST /ingest/worker-complete`) — plain-JSON body, no tRPC batch
+ * envelope. `apiUrl` points at the food-api container's base URL.
  *
- * The auth header (`x-pops-internal-token`) is the contract PRD-125
- * landed; pops-api validates the lowercase form regardless of the
- * PRD-126 spec text saying `X-Internal-Token` (see
- * `apps/pops-api/src/trpc.ts`'s `isInternalCall`).
+ * The auth header (`x-pops-internal-token`) is validated by the
+ * `requireInternalToken` middleware in `pillars/food/src/api/app.ts`, which
+ * gates `/ingest/worker-complete` on `POPS_API_INTERNAL_TOKEN`.
  */
 import type { IngestJobResult } from '../contract/queue/index.js';
 
@@ -83,8 +80,8 @@ export async function postWorkerComplete(
   sourceId: number,
   result: IngestJobResult
 ): Promise<void> {
-  const url = `${client.apiUrl}/trpc/food.ingest.workerComplete?batch=1`;
-  const body = JSON.stringify({ 0: { json: buildInput(sourceId, result) } });
+  const url = `${client.apiUrl}/ingest/worker-complete`;
+  const body = JSON.stringify(buildInput(sourceId, result));
 
   const response = await fetch(url, {
     method: 'POST',
@@ -98,16 +95,7 @@ export async function postWorkerComplete(
   if (!response.ok) {
     const text = await response.text().catch(() => '<no-body>');
     throw new Error(
-      `food.ingest.workerComplete returned HTTP ${response.status}: ${text.slice(0, 500)}`
+      `ingest.workerComplete returned HTTP ${response.status}: ${text.slice(0, 500)}`
     );
-  }
-
-  const payload = (await response.json().catch(() => null)) as ReadonlyArray<{
-    error?: { json?: { message?: string } };
-  }> | null;
-  const errorEntry = payload?.find((entry) => entry?.error !== undefined);
-  if (errorEntry?.error !== undefined) {
-    const msg = errorEntry.error.json?.message ?? 'unknown tRPC error';
-    throw new Error(`food.ingest.workerComplete tRPC error: ${msg}`);
   }
 }


### PR DESCRIPTION
## Slice 6b — ingest + media serve

Completes slice 6 of `docs/runbooks/food-rest-migration.md`: the `food.ingest.*` surface moves off the pops-api tRPC router onto the food pillar's ts-rest contract.

### Wire surface (`src/contract/rest-ingest.ts`)
- `start` / `status` / `list` / `cancel` / `retry` — POST-with-body (parity with `inbox.list`; payloads carry typed numbers/cursors).
- `worker-complete` — internal callback the pops-worker-food container posts on every job; gated by `x-pops-internal-token` (added in slice 6a).
- `start` / `retry` answer **503** when Redis is unconfigured (the producer can't enqueue).

### Producer (`src/api/queue.ts`)
- Lazy BullMQ `Queue` singleton; returns `null` when no Redis env → `IngestQueueUnavailable` → 503. Closed on graceful shutdown in `server.ts`.

### Lifted from pops-api
- `api/modules/ingest/*` — enqueue / state / storage / worker-complete services + start/status/control procedures (imports rewired to the pillar db + contract).
- Binary media serve (`/ingest/source/:id/screenshot|video`) mounted before the ts-rest endpoints (GET-only, distinct subpath → no collision with the POST API).
- Worker callback flipped to `POST /ingest/worker-complete` with a plain-JSON body (no tRPC batch envelope).

### Tests
- No-Redis degradation (503 start/retry, row rollback, null status, not-cancellable).
- `workerComplete` draft-creation transaction end-to-end + idempotency + failure recording + token gating.
- Media serve routes (400 / 404 / 200-with-bytes).

OpenAPI + api-types snapshots regenerated. `food-quality` steps (format / lint / typecheck / build / snapshot verify / test) pass locally.