### PR TITLE
feat(food): migrate cook domain to ts-rest (missed slice)

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -3134,6 +3134,489 @@
         "tags": ["conversions"]
       }
     },
+    "/cook/mark-cooked": {
+      "post": {
+        "operationId": "cook.markCooked",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "consumptionOverrides": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "batchId": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "consumeQty": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "kind": {
+                              "enum": ["batch-override"],
+                              "type": "string"
+                            },
+                            "lineIndex": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "substitutionEdgeId": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "unit": {
+                              "enum": ["g", "ml", "count"],
+                              "type": "string"
+                            }
+                          },
+                          "required": ["lineIndex", "kind", "batchId", "consumeQty", "unit"],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "externalQty": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "externalUnit": {
+                              "enum": ["g", "ml", "count"],
+                              "type": "string"
+                            },
+                            "kind": {
+                              "enum": ["external"],
+                              "type": "string"
+                            },
+                            "lineIndex": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": ["lineIndex", "kind", "externalQty", "externalUnit"],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "batchId": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "consumeQty": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "externalQty": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "kind": {
+                              "enum": ["partial"],
+                              "type": "string"
+                            },
+                            "lineIndex": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "substitutionEdgeId": {
+                              "exclusiveMinimum": true,
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "unit": {
+                              "enum": ["g", "ml", "count"],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "lineIndex",
+                            "kind",
+                            "batchId",
+                            "consumeQty",
+                            "externalQty",
+                            "unit"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "notes": {
+                    "maxLength": 1000,
+                    "type": "string"
+                  },
+                  "planEntryId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "rating": {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  "recipeVersionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "scaleFactor": {
+                    "type": "number"
+                  },
+                  "yield": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "expiresAt": {
+                        "format": "date-time",
+                        "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                        "type": "string"
+                      },
+                      "location": {
+                        "enum": ["pantry", "fridge", "freezer", "other"],
+                        "type": "string"
+                      },
+                      "notes": {
+                        "maxLength": 1000,
+                        "type": "string"
+                      },
+                      "qty": {
+                        "type": "number"
+                      },
+                      "unit": {
+                        "enum": ["g", "ml", "count"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["qty", "unit", "location"],
+                    "type": "object"
+                  }
+                },
+                "required": ["recipeVersionId", "scaleFactor"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "recipeRunId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "yieldedBatchId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["ok", "recipeRunId", "yieldedBatchId"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "RecipeVersionNotFound",
+                            "RecipeNotCompiled",
+                            "PlanEntryNotFound",
+                            "PlanEntryAlreadyCooked",
+                            "YieldRequired",
+                            "YieldForbidden",
+                            "BadScaleFactor",
+                            "BadYieldQty",
+                            "BadRating",
+                            "BadExpiry",
+                            "ShortfallUnresolved",
+                            "SubstitutionEdgeInvalid"
+                          ],
+                          "type": "string"
+                        },
+                        "shortfalls": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "available": {
+                                "type": "number"
+                              },
+                              "needed": {
+                                "type": "number"
+                              },
+                              "prepStateId": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "unit": {
+                                "enum": ["g", "ml", "count"],
+                                "type": "string"
+                              },
+                              "variantId": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["variantId", "prepStateId", "needed", "available", "unit"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Record a cook event in one transaction",
+        "tags": ["cook"]
+      }
+    },
+    "/cook/prepare": {
+      "post": {
+        "operationId": "cook.prepareCook",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "planEntryId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeVersionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "scaleFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": ["recipeVersionId", "scaleFactor"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "alreadyCooked": {
+                      "type": "boolean"
+                    },
+                    "consumeNeeds": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonicalUnit": {
+                            "enum": ["g", "ml", "count"],
+                            "type": "string"
+                          },
+                          "ingredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingredientName": {
+                            "type": "string"
+                          },
+                          "lineIndex": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "prepStateId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "prepStateLabel": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qty": {
+                            "type": "number"
+                          },
+                          "variantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "variantName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "lineIndex",
+                          "ingredientId",
+                          "ingredientName",
+                          "variantId",
+                          "variantName",
+                          "prepStateId",
+                          "prepStateLabel",
+                          "qty",
+                          "canonicalUnit",
+                          "optional"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "defaultScaleFactor": {
+                      "type": "number"
+                    },
+                    "recipeSlug": {
+                      "type": "string"
+                    },
+                    "recipeTitle": {
+                      "type": "string"
+                    },
+                    "versionNo": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "yieldDefault": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "prepStateLabel": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "qty": {
+                          "type": "number"
+                        },
+                        "shelfLifeFreezerDays": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "shelfLifeFridgeDays": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "unit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "variantName": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "qty",
+                        "unit",
+                        "variantName",
+                        "prepStateLabel",
+                        "shelfLifeFridgeDays",
+                        "shelfLifeFreezerDays"
+                      ],
+                      "type": "object"
+                    },
+                    "yieldsBatch": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "recipeTitle",
+                    "recipeSlug",
+                    "versionNo",
+                    "defaultScaleFactor",
+                    "yieldsBatch",
+                    "yieldDefault",
+                    "consumeNeeds",
+                    "alreadyCooked"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Pre-flight data for the cook modal",
+        "tags": ["cook"]
+      }
+    },
     "/fridge/recipes-using-batch": {
       "get": {
         "operationId": "fridge.recipesUsingBatch",

--- a/pillars/food/src/api/__tests__/cook.test.ts
+++ b/pillars/food/src/api/__tests__/cook.test.ts
@@ -1,0 +1,909 @@
+/**
+ * Integration tests for the `cook.*` REST surface (PRD-144 / PRD-146 /
+ * PRD-149), ported from the pops-api tRPC cook suites.
+ *
+ * `prepareCook` happy path + 404; `markCooked` happy path, scale, yieldless,
+ * every `MarkCookedError` branch, plan-entry linkage + race, plus the
+ * consumption-override matrix (batch-override / external / partial,
+ * optional-line skip, coverage/variant/unit guards) and the substitution
+ * edge path. The consumption maths live in the db tests; here we assert the
+ * wire envelopes + the transactional side effects via direct table reads.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  batchConsumptions,
+  batches,
+  type FoodDb,
+  type OpenedFoodDb,
+  openFoodDb,
+  planEntries,
+  planSlots,
+  recipeLines,
+  recipeRuns,
+  recipeVersions,
+} from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createRecipe } from '../../db/services/recipes.js';
+import { createSubstitution } from '../../db/services/substitutions.js';
+import { createVariant } from '../../db/services/variants.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function db(): FoodDb {
+  return foodDb.db;
+}
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+interface SeededRecipe {
+  recipeId: number;
+  versionId: number;
+  ingredientId: number;
+  variantId: number;
+  yieldIngredientId: number;
+  yieldVariantId: number;
+}
+
+function seedTomatoVariant(slug: string): { ingredientId: number; variantId: number } {
+  const ing = createIngredient(db(), { name: 'Tomato', slug: `${slug}-tomato`, defaultUnit: 'g' });
+  const variant = createVariant(db(), {
+    ingredientId: ing.id,
+    name: 'Diced',
+    slug: `${slug}-diced`,
+    defaultUnit: 'g',
+    defaultShelfLifeDaysFridge: 5,
+    defaultShelfLifeDaysFreezer: 90,
+  });
+  return { ingredientId: ing.id, variantId: variant.id };
+}
+
+function seedYieldVariant(slug: string): { ingredientId: number; variantId: number } {
+  const yieldIng = createIngredient(db(), {
+    name: 'Sauce',
+    slug: `${slug}-sauce`,
+    defaultUnit: 'g',
+  });
+  const yieldVar = createVariant(db(), {
+    ingredientId: yieldIng.id,
+    name: 'Default',
+    slug: `${slug}-sauce-default`,
+    defaultUnit: 'g',
+    defaultShelfLifeDaysFridge: 3,
+    defaultShelfLifeDaysFreezer: 60,
+  });
+  return { ingredientId: yieldIng.id, variantId: yieldVar.id };
+}
+
+function finaliseRecipeVersion(
+  versionId: number,
+  yieldShape: { ingredientId: number; variantId: number } | null
+): void {
+  const yields = yieldShape !== null;
+  db()
+    .update(recipeVersions)
+    .set({
+      compileStatus: 'compiled',
+      compiledAt: new Date().toISOString(),
+      servings: 4,
+      yieldIngredientId: yields ? yieldShape.ingredientId : null,
+      yieldVariantId: yields ? yieldShape.variantId : null,
+      yieldQty: yields ? 800 : null,
+      yieldUnit: yields ? 'g' : null,
+    })
+    .where(eq(recipeVersions.id, versionId))
+    .run();
+}
+
+interface RecipeLineArgs {
+  versionId: number;
+  position: number;
+  ingredientId: number;
+  variantId: number;
+  qtyG: number;
+  optional?: boolean;
+}
+
+function seedRecipeLine(args: RecipeLineArgs): void {
+  db()
+    .insert(recipeLines)
+    .values({
+      recipeVersionId: args.versionId,
+      position: args.position,
+      ingredientId: args.ingredientId,
+      variantId: args.variantId,
+      prepStateId: null,
+      isRecipeRef: 0,
+      recipeRefId: null,
+      originalText: `line-${args.position}`,
+      originalQty: args.qtyG,
+      originalUnit: 'g',
+      qtyG: args.qtyG,
+      qtyMl: null,
+      qtyCount: null,
+      canonicalUnit: 'g',
+      optional: args.optional === true ? 1 : 0,
+      notes: null,
+    })
+    .run();
+}
+
+function seedCompiledRecipe(slug: string, opts: { yields?: boolean } = {}): SeededRecipe {
+  const yields = opts.yields ?? true;
+  const tomato = seedTomatoVariant(slug);
+  const yieldShape = yields ? seedYieldVariant(slug) : tomato;
+  const { recipe, version } = createRecipe(db(), {
+    slug,
+    firstVersion: { title: `Test ${slug}`, bodyDsl: `@recipe(slug="${slug}", title="Test")` },
+  });
+  finaliseRecipeVersion(version.id, yields ? yieldShape : null);
+  seedRecipeLine({
+    versionId: version.id,
+    position: 1,
+    variantId: tomato.variantId,
+    ingredientId: tomato.ingredientId,
+    qtyG: 200,
+  });
+  return {
+    recipeId: recipe.id,
+    versionId: version.id,
+    ingredientId: tomato.ingredientId,
+    variantId: tomato.variantId,
+    yieldIngredientId: yieldShape.ingredientId,
+    yieldVariantId: yieldShape.variantId,
+  };
+}
+
+function seedBatch(variantId: number, qty: number): number {
+  const rows = db()
+    .insert(batches)
+    .values({
+      variantId,
+      prepStateId: null,
+      qtyRemaining: qty,
+      unit: 'g',
+      sourceType: 'purchase',
+      sourceId: null,
+      location: 'fridge',
+      producedAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: null,
+      notes: null,
+    })
+    .returning()
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new Error('seedBatch failed');
+  return row.id;
+}
+
+function seedExtraIngredientLine(args: {
+  slug: string;
+  versionId: number;
+  position: number;
+  qtyG: number;
+  optional?: boolean;
+}): number {
+  const ing = createIngredient(db(), {
+    name: `Extra ${args.slug}`,
+    slug: `${args.slug}-extra-${args.position}`,
+    defaultUnit: 'g',
+  });
+  const variant = createVariant(db(), {
+    ingredientId: ing.id,
+    name: 'Default',
+    slug: `${args.slug}-extra-${args.position}-default`,
+    defaultUnit: 'g',
+  });
+  seedRecipeLine({
+    versionId: args.versionId,
+    position: args.position,
+    ingredientId: ing.id,
+    variantId: variant.id,
+    qtyG: args.qtyG,
+    optional: args.optional,
+  });
+  return variant.id;
+}
+
+function seedDinnerSlot(): void {
+  db()
+    .insert(planSlots)
+    .values({ slug: 'dinner', name: 'Dinner', displayOrder: 30, isDefault: 1 })
+    .run();
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-cook-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  seedDinnerSlot();
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('cook REST — prepareCook', () => {
+  it('returns CookPreparation for a yielding recipe', async () => {
+    const seed = seedCompiledRecipe('prep-happy');
+    const result = await client().cook.prepareCook({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+    });
+    expect(result.recipeSlug).toBe('prep-happy');
+    expect(result.yieldsBatch).toBe(true);
+    expect(result.yieldDefault?.qty).toBe(800);
+    expect(result.consumeNeeds).toHaveLength(1);
+    expect(result.consumeNeeds[0]).toMatchObject({
+      variantId: seed.variantId,
+      qty: 200,
+      canonicalUnit: 'g',
+    });
+    expect(result.alreadyCooked).toBe(false);
+  });
+
+  it('uses the plan entry servings ratio for defaultScaleFactor', async () => {
+    const seed = seedCompiledRecipe('prep-plan-scale');
+    db()
+      .insert(planEntries)
+      .values({
+        date: '2026-06-15',
+        slot: 'dinner',
+        recipeId: seed.recipeId,
+        recipeVersionId: seed.versionId,
+        plannedServings: 8,
+      })
+      .run();
+    const planEntryId = db().select().from(planEntries).all()[0]?.id;
+    if (planEntryId === undefined) throw new Error('plan entry missing');
+    const result = await client().cook.prepareCook({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      planEntryId,
+    });
+    expect(result.defaultScaleFactor).toBeCloseTo(2);
+    expect(result.alreadyCooked).toBe(false);
+  });
+
+  it('maps a missing recipe version to 404', async () => {
+    await expect(
+      client().cook.prepareCook({ recipeVersionId: 99999, scaleFactor: 1 })
+    ).rejects.toMatchObject({ status: 404, body: { message: 'RecipeVersionNotFound' } });
+  });
+
+  it('maps a missing plan entry to 404', async () => {
+    const seed = seedCompiledRecipe('prep-plan-missing');
+    await expect(
+      client().cook.prepareCook({
+        recipeVersionId: seed.versionId,
+        scaleFactor: 1,
+        planEntryId: 99999,
+      })
+    ).rejects.toMatchObject({ status: 404, body: { message: 'PlanEntryNotFound' } });
+  });
+});
+
+describe('cook REST — markCooked happy path', () => {
+  it('writes recipe_run + consumption + yielded batch + auto-expiry in one tx', async () => {
+    const seed = seedCompiledRecipe('cook-happy');
+    const batchId = seedBatch(seed.variantId, 1000);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      rating: 4,
+      notes: 'tasty',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.yieldedBatchId).not.toBeNull();
+    const run = db()
+      .select()
+      .from(recipeRuns)
+      .where(eq(recipeRuns.id, result.recipeRunId))
+      .all()[0];
+    expect(run?.rating).toBe(4);
+    expect(run?.notes).toBe('tasty');
+    expect(run?.completedAt).not.toBeNull();
+    expect(run?.yieldedBatchId).toBe(result.yieldedBatchId);
+    const source = db().select().from(batches).where(eq(batches.id, batchId)).all()[0];
+    expect(source?.qtyRemaining).toBe(800);
+    const consumptions = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]?.qtyConsumed).toBe(200);
+    const yielded = db()
+      .select()
+      .from(batches)
+      .where(eq(batches.id, result.yieldedBatchId ?? -1))
+      .all()[0];
+    expect(yielded?.expiresAt).not.toBeNull();
+  });
+
+  it('runs yieldless recipes with yieldedBatchId === null', async () => {
+    const seed = seedCompiledRecipe('cook-yieldless', { yields: false });
+    seedBatch(seed.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.yieldedBatchId).toBeNull();
+  });
+
+  it('scales consumption with scaleFactor', async () => {
+    const seed = seedCompiledRecipe('cook-scaled');
+    const batchId = seedBatch(seed.variantId, 1000);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1.5,
+      yield: { qty: 1200, unit: 'g', location: 'fridge' },
+    });
+    expect(result.ok).toBe(true);
+    const source = db().select().from(batches).where(eq(batches.id, batchId)).all()[0];
+    expect(source?.qtyRemaining).toBe(700);
+  });
+});
+
+describe('cook REST — markCooked error branches', () => {
+  it('rejects RecipeVersionNotFound', async () => {
+    const result = await client().cook.markCooked({ recipeVersionId: 99999, scaleFactor: 1 });
+    expect(result).toEqual({ ok: false, reason: 'RecipeVersionNotFound' });
+  });
+
+  it('rejects RecipeNotCompiled', async () => {
+    const seed = seedCompiledRecipe('cook-uncompiled');
+    db()
+      .update(recipeVersions)
+      .set({ compileStatus: 'uncompiled' })
+      .where(eq(recipeVersions.id, seed.versionId))
+      .run();
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'RecipeNotCompiled' });
+  });
+
+  it('rejects BadScaleFactor for scale <= 0', async () => {
+    const seed = seedCompiledRecipe('cook-bad-scale');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 0,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'BadScaleFactor' });
+  });
+
+  it('rejects YieldRequired when yield omitted for yielding recipe', async () => {
+    const seed = seedCompiledRecipe('cook-yield-required');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+    });
+    expect(result).toEqual({ ok: false, reason: 'YieldRequired' });
+  });
+
+  it('rejects YieldForbidden when yield supplied for yieldless recipe', async () => {
+    const seed = seedCompiledRecipe('cook-yield-forbidden', { yields: false });
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'YieldForbidden' });
+  });
+
+  it('rejects BadYieldQty for negative yield', async () => {
+    const seed = seedCompiledRecipe('cook-bad-yield');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: -1, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'BadYieldQty' });
+  });
+
+  it('rejects BadRating for rating > 5', async () => {
+    const seed = seedCompiledRecipe('cook-bad-rating');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      rating: 6,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'BadRating' });
+  });
+
+  it('rejects BadExpiry for a past expiresAt', async () => {
+    const seed = seedCompiledRecipe('cook-bad-expiry');
+    seedBatch(seed.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge', expiresAt: '2025-01-01T00:00:00.000Z' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'BadExpiry' });
+  });
+
+  it('rejects ShortfallUnresolved and rolls back the recipe_run', async () => {
+    const seed = seedCompiledRecipe('cook-shortfall');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('ShortfallUnresolved');
+      expect(result.shortfalls?.[0]).toMatchObject({ needed: 200, available: 0 });
+    }
+    expect(db().select().from(recipeRuns).all()).toHaveLength(0);
+  });
+});
+
+describe('cook REST — plan entry integration', () => {
+  it('links recipe_run_id back to plan_entries on success', async () => {
+    const seed = seedCompiledRecipe('cook-plan-link');
+    seedBatch(seed.variantId, 500);
+    db()
+      .insert(planEntries)
+      .values({ date: '2026-06-15', slot: 'dinner', recipeId: seed.recipeId, plannedServings: 4 })
+      .run();
+    const planEntryId = db().select().from(planEntries).all()[0]?.id;
+    if (planEntryId === undefined) throw new Error('plan entry missing');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      planEntryId,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result.ok).toBe(true);
+    const updated = db().select().from(planEntries).where(eq(planEntries.id, planEntryId)).all()[0];
+    if (result.ok) expect(updated?.recipeRunId).toBe(result.recipeRunId);
+  });
+
+  it('rejects PlanEntryAlreadyCooked when recipe_run_id is set', async () => {
+    const seed = seedCompiledRecipe('cook-already-cooked');
+    seedBatch(seed.variantId, 1000);
+    db()
+      .insert(planEntries)
+      .values({ date: '2026-06-15', slot: 'dinner', recipeId: seed.recipeId, plannedServings: 4 })
+      .run();
+    const planEntryId = db().select().from(planEntries).all()[0]?.id;
+    if (planEntryId === undefined) throw new Error('plan entry missing');
+    const api = client();
+    await api.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      planEntryId,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    const second = await api.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      planEntryId,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(second).toEqual({ ok: false, reason: 'PlanEntryAlreadyCooked' });
+  });
+
+  it('rejects PlanEntryNotFound for a stale id', async () => {
+    const seed = seedCompiledRecipe('cook-plan-stale');
+    seedBatch(seed.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      planEntryId: 99999,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'PlanEntryNotFound' });
+  });
+});
+
+describe('cook REST — consumption overrides (PRD-146)', () => {
+  it("kind='batch-override' draws from the chosen batch, leaving FIFO untouched", async () => {
+    const seed = seedCompiledRecipe('override-batch');
+    const fifoBatchId = seedBatch(seed.variantId, 1000);
+    const chosenBatchId = seedBatch(seed.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: chosenBatchId,
+          consumeQty: 200,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const consumptions = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]).toMatchObject({ batchId: chosenBatchId, qtyConsumed: 200, unit: 'g' });
+    expect(
+      db().select().from(batches).where(eq(batches.id, chosenBatchId)).all()[0]?.qtyRemaining
+    ).toBe(300);
+    expect(
+      db().select().from(batches).where(eq(batches.id, fifoBatchId)).all()[0]?.qtyRemaining
+    ).toBe(1000);
+  });
+
+  it("kind='external' writes no consumption row and appends an audit line", async () => {
+    const seed = seedCompiledRecipe('override-external');
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      notes: 'tasted great',
+      consumptionOverrides: [
+        { lineIndex: 1, kind: 'external', externalQty: 200, externalUnit: 'g' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const consumptions = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toEqual([]);
+    const run = db()
+      .select()
+      .from(recipeRuns)
+      .where(eq(recipeRuns.id, result.recipeRunId))
+      .all()[0];
+    expect(run?.notes).toBe('tasted great\ncook-override:external line=1 qty=200 unit=g');
+  });
+
+  it("kind='partial' draws a batch row and appends the external audit line", async () => {
+    const seed = seedCompiledRecipe('override-partial');
+    const chosenBatchId = seedBatch(seed.variantId, 150);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'partial',
+          batchId: chosenBatchId,
+          consumeQty: 150,
+          externalQty: 50,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const consumptions = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]).toMatchObject({ batchId: chosenBatchId, qtyConsumed: 150, unit: 'g' });
+    expect(
+      db().select().from(batches).where(eq(batches.id, chosenBatchId)).all()[0]?.qtyRemaining
+    ).toBe(0);
+    const run = db()
+      .select()
+      .from(recipeRuns)
+      .where(eq(recipeRuns.id, result.recipeRunId))
+      .all()[0];
+    expect(run?.notes).toBe('cook-override:external line=1 qty=50 unit=g');
+  });
+
+  it('silently skips an override targeting an optional line', async () => {
+    const seed = seedCompiledRecipe('override-optional');
+    seedBatch(seed.variantId, 1000);
+    const optionalVariantId = seedExtraIngredientLine({
+      slug: 'override-optional',
+      versionId: seed.versionId,
+      position: 2,
+      qtyG: 100,
+      optional: true,
+    });
+    const optionalBatchId = seedBatch(optionalVariantId, 100);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 2,
+          kind: 'batch-override',
+          batchId: optionalBatchId,
+          consumeQty: 100,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const optionalDraws = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all()
+      .filter((c) => c.batchId === optionalBatchId);
+    expect(optionalDraws).toEqual([]);
+    expect(
+      db().select().from(batches).where(eq(batches.id, optionalBatchId)).all()[0]?.qtyRemaining
+    ).toBe(100);
+  });
+
+  it('returns ShortfallUnresolved when the chosen batch lacks the qty, rolling back', async () => {
+    const seed = seedCompiledRecipe('override-depleted');
+    const depletedBatchId = seedBatch(seed.variantId, 50);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: depletedBatchId,
+          consumeQty: 200,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+    expect(
+      db().select().from(batches).where(eq(batches.id, depletedBatchId)).all()[0]?.qtyRemaining
+    ).toBe(50);
+    expect(db().select().from(batchConsumptions).all()).toEqual([]);
+  });
+
+  it('rejects a zero-qty batch-override so it cannot mask the line from FIFO', async () => {
+    const seed = seedCompiledRecipe('override-zero-qty');
+    seedBatch(seed.variantId, 1000);
+    const overrideBatchId = seedBatch(seed.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: overrideBatchId,
+          consumeQty: 0,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+  });
+
+  it('rejects a batch-override pointing at a different variant', async () => {
+    const seed = seedCompiledRecipe('override-wrong-variant');
+    seedBatch(seed.variantId, 1000);
+    const wrongBatchId = seedBatch(seed.yieldVariantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        { lineIndex: 1, kind: 'batch-override', batchId: wrongBatchId, consumeQty: 200, unit: 'g' },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+  });
+
+  it('rejects an override whose qty does not cover the full scaled line need', async () => {
+    const seed = seedCompiledRecipe('override-qty-mismatch');
+    seedBatch(seed.variantId, 1000);
+    const overrideBatchId = seedBatch(seed.variantId, 1000);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1.5,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: overrideBatchId,
+          consumeQty: 100,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+    expect(
+      db().select().from(batches).where(eq(batches.id, overrideBatchId)).all()[0]?.qtyRemaining
+    ).toBe(1000);
+    expect(db().select().from(batchConsumptions).all()).toEqual([]);
+  });
+
+  it('rejects an external override whose unit does not match the line', async () => {
+    const seed = seedCompiledRecipe('override-unit-mismatch');
+    seedBatch(seed.variantId, 1000);
+    const result = await client().cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        { lineIndex: 1, kind: 'external', externalQty: 200, externalUnit: 'ml' },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+  });
+});
+
+describe('cook REST — substitution overrides (PRD-149)', () => {
+  function makeVariant(
+    slug: string,
+    variantSlug: string
+  ): { ingredientId: number; variantId: number } {
+    const ing = createIngredient(db(), { name: slug, slug, defaultUnit: 'g' });
+    const variant = createVariant(db(), {
+      ingredientId: ing.id,
+      name: variantSlug,
+      slug: variantSlug,
+      defaultUnit: 'g',
+    });
+    return { ingredientId: ing.id, variantId: variant.id };
+  }
+
+  function makeYieldlessRecipe(slug: string): { recipeId: number; versionId: number } {
+    const { recipe, version } = createRecipe(db(), {
+      slug,
+      firstVersion: { title: slug, bodyDsl: `@recipe(slug="${slug}", title="${slug}")` },
+    });
+    db()
+      .update(recipeVersions)
+      .set({ compileStatus: 'compiled', servings: 4 })
+      .where(eq(recipeVersions.id, version.id))
+      .run();
+    return { recipeId: recipe.id, versionId: version.id };
+  }
+
+  it('draws from the sub batch and writes the substitution audit line', async () => {
+    const butter = makeVariant('butter', 'unsalted');
+    const oil = makeVariant('coconut-oil', 'refined');
+    const recipe = makeYieldlessRecipe('cookies');
+    seedRecipeLine({
+      versionId: recipe.versionId,
+      position: 1,
+      ingredientId: butter.ingredientId,
+      variantId: butter.variantId,
+      qtyG: 200,
+    });
+    const oilBatchId = seedBatch(oil.variantId, 500);
+    const edge = createSubstitution(db(), {
+      from: { ingredientId: butter.ingredientId },
+      to: { variantId: oil.variantId },
+      ratio: 1,
+      scope: 'global',
+    });
+    const result = await client().cook.markCooked({
+      recipeVersionId: recipe.versionId,
+      scaleFactor: 1,
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: oilBatchId,
+          consumeQty: 200,
+          unit: 'g',
+          substitutionEdgeId: edge.id,
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const consumptions = db()
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]?.batchId).toBe(oilBatchId);
+    expect(
+      db().select().from(batches).where(eq(batches.id, oilBatchId)).all()[0]?.qtyRemaining
+    ).toBe(300);
+    const run = db()
+      .select()
+      .from(recipeRuns)
+      .where(eq(recipeRuns.id, result.recipeRunId))
+      .all()[0];
+    expect(run?.notes ?? '').toContain('cook-override:substitution');
+    expect(run?.notes ?? '').toContain(`edge=${edge.id}`);
+    expect(run?.notes ?? '').toContain(`batch=${oilBatchId}`);
+    expect(run?.notes ?? '').toContain('coconut-oil');
+  });
+
+  it('returns SubstitutionEdgeInvalid for an unknown edge id', async () => {
+    const butter = makeVariant('butter', 'unsalted');
+    const oil = makeVariant('coconut-oil', 'refined');
+    const recipe = makeYieldlessRecipe('cookies');
+    seedRecipeLine({
+      versionId: recipe.versionId,
+      position: 1,
+      ingredientId: butter.ingredientId,
+      variantId: butter.variantId,
+      qtyG: 200,
+    });
+    const oilBatchId = seedBatch(oil.variantId, 500);
+    const result = await client().cook.markCooked({
+      recipeVersionId: recipe.versionId,
+      scaleFactor: 1,
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: oilBatchId,
+          consumeQty: 200,
+          unit: 'g',
+          substitutionEdgeId: 99999,
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('SubstitutionEdgeInvalid');
+  });
+
+  it('returns SubstitutionEdgeInvalid when the batch variant misses the edge to-side', async () => {
+    const butter = makeVariant('butter', 'unsalted');
+    const oil = makeVariant('coconut-oil', 'refined');
+    const ghee = makeVariant('ghee', 'clarified');
+    const recipe = makeYieldlessRecipe('cookies');
+    seedRecipeLine({
+      versionId: recipe.versionId,
+      position: 1,
+      ingredientId: butter.ingredientId,
+      variantId: butter.variantId,
+      qtyG: 200,
+    });
+    const gheeBatchId = seedBatch(ghee.variantId, 500);
+    const edge = createSubstitution(db(), {
+      from: { ingredientId: butter.ingredientId },
+      to: { variantId: oil.variantId },
+      ratio: 1,
+      scope: 'global',
+    });
+    const result = await client().cook.markCooked({
+      recipeVersionId: recipe.versionId,
+      scaleFactor: 1,
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: gheeBatchId,
+          consumeQty: 200,
+          unit: 'g',
+          substitutionEdgeId: edge.id,
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('SubstitutionEdgeInvalid');
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -304,9 +304,103 @@ type WorkerCompleteResult =
   | { ok: true; draftRecipeId: number; compileStatus: 'compiled' | 'failed' | 'uncompiled' }
   | { ok: false; reason: string };
 
+interface PrepareCookBody {
+  recipeVersionId: number;
+  scaleFactor: number;
+  planEntryId?: number;
+}
+
+type CookUnit = 'g' | 'ml' | 'count';
+type CookLocation = 'pantry' | 'fridge' | 'freezer' | 'other';
+
+interface CookYieldBody {
+  qty: number;
+  unit: CookUnit;
+  location: CookLocation;
+  expiresAt?: string;
+  notes?: string;
+}
+
+type ConsumptionOverrideBody =
+  | {
+      lineIndex: number;
+      kind: 'batch-override';
+      batchId: number;
+      consumeQty: number;
+      unit: CookUnit;
+      substitutionEdgeId?: number;
+    }
+  | { lineIndex: number; kind: 'external'; externalQty: number; externalUnit: CookUnit }
+  | {
+      lineIndex: number;
+      kind: 'partial';
+      batchId: number;
+      consumeQty: number;
+      externalQty: number;
+      unit: CookUnit;
+      substitutionEdgeId?: number;
+    };
+
+interface MarkCookedBody {
+  recipeVersionId: number;
+  scaleFactor: number;
+  planEntryId?: number;
+  yield?: CookYieldBody;
+  rating?: number;
+  notes?: string;
+  consumptionOverrides?: ConsumptionOverrideBody[];
+}
+
+interface CookPreparation {
+  recipeTitle: string;
+  recipeSlug: string;
+  versionNo: number;
+  defaultScaleFactor: number;
+  yieldsBatch: boolean;
+  yieldDefault: {
+    qty: number;
+    unit: CookUnit;
+    variantName: string | null;
+    prepStateLabel: string | null;
+    shelfLifeFridgeDays: number | null;
+    shelfLifeFreezerDays: number | null;
+  } | null;
+  consumeNeeds: {
+    lineIndex: number;
+    ingredientId: number;
+    ingredientName: string;
+    variantId: number;
+    variantName: string;
+    prepStateId: number | null;
+    prepStateLabel: string | null;
+    qty: number;
+    canonicalUnit: CookUnit;
+    optional: boolean;
+  }[];
+  alreadyCooked: boolean;
+}
+
+interface CookShortfall {
+  variantId: number;
+  prepStateId: number | null;
+  needed: number;
+  available: number;
+  unit: CookUnit;
+}
+
+type MarkCookedResult =
+  | { ok: true; recipeRunId: number; yieldedBatchId: number | null }
+  | { ok: false; reason: string; shortfalls?: CookShortfall[] };
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
+    cook: {
+      prepareCook: (body: PrepareCookBody) =>
+        send<CookPreparation>(r.post('/cook/prepare').send(body)),
+      markCooked: (body: MarkCookedBody) =>
+        send<MarkCookedResult>(r.post('/cook/mark-cooked').send(body)),
+    },
     ingest: {
       start: (body: IngestStartBody) => send<IngestStartResult>(r.post('/ingest/start').send(body)),
       status: (sourceId: number) =>

--- a/pillars/food/src/api/modules/cook/mark-cooked-helpers.ts
+++ b/pillars/food/src/api/modules/cook/mark-cooked-helpers.ts
@@ -1,0 +1,193 @@
+/**
+ * Internal helpers for `markCooked` — split out of `mark-cooked.ts` so the
+ * main file stays under the 200-line/60-per-function lint caps.
+ *
+ * Exports:
+ *   - `validatePreflight` — every `MarkCookedError` branch reachable
+ *     before the transaction opens
+ *   - `computeRemainingNeeds` — recipe_lines × scale minus
+ *     overridden-line indices
+ *   - `composeFinalNotes` — user notes + override audit lines, capped
+ *   - `MarkCookedRollback` — sentinel thrown inside the tx to roll back
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { type FoodDb, planEntries, recipeLines, recipeVersions } from '../../../db/index.js';
+
+import type { ConsumptionNeed, MarkCookedError, Shortfall } from '../../../domain/types/cook.js';
+import type { MarkCookedArgs } from './mark-cooked.js';
+
+const NOTES_CAP_CHARS = 1000;
+const MIN_RATING = 1;
+const MAX_RATING = 5;
+
+interface PreflightOk {
+  ok: true;
+  yield: { variantId: number; prepStateId: number | null } | null;
+}
+
+type PreflightFail = { ok: false; reason: MarkCookedError };
+
+export type PreflightResult = PreflightOk | PreflightFail;
+
+export function validatePreflight(db: FoodDb, args: MarkCookedArgs): PreflightResult {
+  const rangeError = validateRanges(args);
+  if (rangeError !== null) return { ok: false, reason: rangeError };
+  const versionRow = loadVersionRow(db, args.recipeVersionId);
+  if (versionRow === null) return { ok: false, reason: 'RecipeVersionNotFound' };
+  if (versionRow.compileStatus !== 'compiled') return { ok: false, reason: 'RecipeNotCompiled' };
+  const yieldError = validateYieldShape(versionRow, args);
+  if (yieldError !== null) return { ok: false, reason: yieldError };
+  const planError = validatePlanEntry(db, args);
+  if (planError !== null) return { ok: false, reason: planError };
+  return { ok: true, yield: extractResolvedYield(versionRow, args) };
+}
+
+function validateRanges(args: MarkCookedArgs): MarkCookedError | null {
+  if (!Number.isFinite(args.scaleFactor) || args.scaleFactor <= 0) return 'BadScaleFactor';
+  if (args.yield !== undefined && args.yield.qty < 0) return 'BadYieldQty';
+  if (args.rating !== undefined && (args.rating < MIN_RATING || args.rating > MAX_RATING)) {
+    return 'BadRating';
+  }
+  // Reject `expiresAt` parseable as before-now (Copilot R1). `producedAt`
+  // is set to the current instant inside the cook transaction; we
+  // approximate it here with `Date.now()` for the boundary check so the
+  // failure surfaces before the tx opens. PRD-145's batch services apply
+  // the same rule on the manual-create path; matching here keeps the
+  // canonical `MarkCookedError.BadExpiry` reachable from end-to-end.
+  if (args.yield?.expiresAt !== undefined) {
+    const expires = Date.parse(args.yield.expiresAt);
+    if (Number.isNaN(expires) || expires < Date.now()) return 'BadExpiry';
+  }
+  return null;
+}
+
+interface VersionRow {
+  id: number;
+  compileStatus: string;
+  yieldIngredientId: number | null;
+  yieldVariantId: number | null;
+  yieldPrepStateId: number | null;
+}
+
+function loadVersionRow(db: FoodDb, versionId: number): VersionRow | null {
+  const rows = db
+    .select({
+      id: recipeVersions.id,
+      compileStatus: recipeVersions.compileStatus,
+      yieldIngredientId: recipeVersions.yieldIngredientId,
+      yieldVariantId: recipeVersions.yieldVariantId,
+      yieldPrepStateId: recipeVersions.yieldPrepStateId,
+    })
+    .from(recipeVersions)
+    .where(eq(recipeVersions.id, versionId))
+    .all();
+  return rows[0] ?? null;
+}
+
+function validateYieldShape(version: VersionRow, args: MarkCookedArgs): MarkCookedError | null {
+  // Align the yields-batch predicate with the fields that
+  // `createBatchFromRun` actually needs (Copilot R1). A recipe whose
+  // `yield_ingredient_id` is set but `yield_variant_id` is null can't
+  // produce a batch, so we treat it as yieldless rather than silently
+  // dropping the user-supplied yield.
+  const yieldsBatch = version.yieldIngredientId !== null && version.yieldVariantId !== null;
+  if (yieldsBatch && args.yield === undefined) return 'YieldRequired';
+  if (!yieldsBatch && args.yield !== undefined) return 'YieldForbidden';
+  return null;
+}
+
+function extractResolvedYield(
+  version: VersionRow,
+  args: MarkCookedArgs
+): { variantId: number; prepStateId: number | null } | null {
+  if (args.yield === undefined) return null;
+  if (version.yieldVariantId === null) return null;
+  return {
+    variantId: version.yieldVariantId,
+    prepStateId: version.yieldPrepStateId,
+  };
+}
+
+function validatePlanEntry(db: FoodDb, args: MarkCookedArgs): MarkCookedError | null {
+  if (args.planEntryId === undefined) return null;
+  const row = db
+    .select({ recipeRunId: planEntries.recipeRunId })
+    .from(planEntries)
+    .where(eq(planEntries.id, args.planEntryId))
+    .all()[0];
+  if (row === undefined) return 'PlanEntryNotFound';
+  if (row.recipeRunId !== null) return 'PlanEntryAlreadyCooked';
+  return null;
+}
+
+export function computeRemainingNeeds(
+  tx: FoodDb,
+  versionId: number,
+  scaleFactor: number,
+  coveredLineIndices: ReadonlySet<number>
+): ConsumptionNeed[] {
+  const rows = tx
+    .select({
+      position: recipeLines.position,
+      variantId: recipeLines.variantId,
+      prepStateId: recipeLines.prepStateId,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+    })
+    .from(recipeLines)
+    .where(and(eq(recipeLines.recipeVersionId, versionId), eq(recipeLines.optional, 0)))
+    .all();
+  const needs: ConsumptionNeed[] = [];
+  for (const r of rows) {
+    if (coveredLineIndices.has(r.position)) continue;
+    if (r.variantId === null) continue;
+    const baseQty = canonicalQty(r);
+    if (baseQty === null || baseQty <= 0) continue;
+    needs.push({
+      variantId: r.variantId,
+      prepStateId: r.prepStateId ?? null,
+      qty: baseQty * scaleFactor,
+      canonicalUnit: r.canonicalUnit,
+    });
+  }
+  return needs;
+}
+
+interface LineQtyRow {
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}
+
+function canonicalQty(row: LineQtyRow): number | null {
+  if (row.canonicalUnit === 'g') return row.qtyG;
+  if (row.canonicalUnit === 'ml') return row.qtyMl;
+  return row.qtyCount;
+}
+
+export function composeFinalNotes(
+  userNotes: string | null,
+  auditLines: readonly string[]
+): string | null {
+  const parts: string[] = [];
+  if (userNotes !== null && userNotes.length > 0) parts.push(userNotes);
+  if (auditLines.length > 0) parts.push(...auditLines);
+  if (parts.length === 0) return null;
+  const joined = parts.join('\n');
+  return joined.length > NOTES_CAP_CHARS ? joined.slice(0, NOTES_CAP_CHARS) : joined;
+}
+
+export class MarkCookedRollback extends Error {
+  readonly reason: MarkCookedError;
+  readonly shortfalls: readonly Shortfall[] | null;
+  constructor(reason: MarkCookedError, shortfalls: readonly Shortfall[] | null = null) {
+    super(reason);
+    this.name = 'MarkCookedRollback';
+    this.reason = reason;
+    this.shortfalls = shortfalls;
+  }
+}

--- a/pillars/food/src/api/modules/cook/mark-cooked-overrides.ts
+++ b/pillars/food/src/api/modules/cook/mark-cooked-overrides.ts
@@ -1,0 +1,250 @@
+/**
+ * Apply PRD-146 `ConsumptionOverride[]` rows inside PRD-144's
+ * `markCooked` transaction.
+ *
+ * Per the PRD-146 claim, the override-processing logic for the cook
+ * mutation lives here — PRD-146 owns the modal-side resolution UX, and
+ * delegates the persistence step to PRD-144 so the whole cook-finalisation
+ * surface stays single-owner.
+ *
+ *   - `batch-override` → INSERT one `batch_consumptions` row + decrement
+ *     the chosen batch's `qty_remaining`.
+ *   - `external`       → append an audit line to `recipe_runs.notes`.
+ *   - `partial`        → both of the above on a single line.
+ *
+ * The function returns the set of `recipe_lines.position` values that the
+ * override array covered. The remaining lines fall through to PRD-108's
+ * FIFO `consumeForRun`.
+ */
+import { eq } from 'drizzle-orm';
+
+import { batchConsumptions, batches, type FoodDb, recipeLines } from '../../../db/index.js';
+import { resolveSubstitutionContext, type LineDescriptor } from './mark-cooked-substitution.js';
+
+import type { ConsumptionOverride, MarkCookedError } from '../../../domain/types/cook.js';
+
+export interface ApplyOverridesArgs {
+  runId: number;
+  versionId: number;
+  scaleFactor: number;
+  overrides: readonly ConsumptionOverride[];
+}
+
+export type ApplyOverridesResult =
+  | { ok: true; coveredLineIndices: ReadonlySet<number>; auditLines: readonly string[] }
+  | { ok: false; reason: MarkCookedError };
+
+export function applyConsumptionOverrides(
+  tx: FoodDb,
+  args: ApplyOverridesArgs
+): ApplyOverridesResult {
+  if (args.overrides.length === 0) {
+    return { ok: true, coveredLineIndices: EMPTY_SET, auditLines: [] };
+  }
+
+  const lineIndex = buildLineIndex(tx, args.versionId);
+  const covered = new Set<number>();
+  const auditLines: string[] = [];
+
+  for (const o of args.overrides) {
+    const line = lineIndex.get(o.lineIndex);
+    if (line === undefined) continue; // line position not in this version — silently skip
+    // PRD-146 §"Integration with PRD-144's cook mutation": optional
+    // lines never reach FIFO (see `computeRemainingNeeds` filter) so any
+    // override the modal sent for one is silently dropped. Without this
+    // guard a batch-override on an optional line would write a stray
+    // `batch_consumptions` row that no longer maps to a tracked need.
+    if (line.optional) continue;
+    // Refuse to mark a line "covered" unless the override accounts for
+    // the full scaled need (Copilot R2). Without this gate a client can
+    // send `consumeQty: 1` on a 200g line, get added to `coveredLineIndices`,
+    // and silently bypass FIFO for the remaining 199g.
+    if (!overrideCoversLine(o, line, args.scaleFactor)) {
+      return { ok: false, reason: 'ShortfallUnresolved' };
+    }
+    const result = applyOneOverride(tx, args.runId, line, o);
+    if (!result.ok) return { ok: false, reason: result.reason };
+    covered.add(o.lineIndex);
+    for (const note of result.auditNotes) auditLines.push(note);
+  }
+
+  return { ok: true, coveredLineIndices: covered, auditLines };
+}
+
+type OverrideResult =
+  | { ok: true; auditNotes: readonly string[] }
+  | { ok: false; reason: MarkCookedError };
+
+function applyOneOverride(
+  tx: FoodDb,
+  runId: number,
+  line: LineDescriptor,
+  o: ConsumptionOverride
+): OverrideResult {
+  if (o.kind === 'external') {
+    if (o.externalQty <= 0) return { ok: false, reason: 'ShortfallUnresolved' };
+    return {
+      ok: true,
+      auditNotes: [formatExternalNote(o.lineIndex, o.externalQty, o.externalUnit)],
+    };
+  }
+  // `batch-override` and `partial` share the batch-draw path.
+  if (o.consumeQty <= 0) return { ok: false, reason: 'ShortfallUnresolved' };
+  const subContext = resolveSubstitutionContext({
+    tx,
+    edgeId: o.substitutionEdgeId,
+    batchId: o.batchId,
+    line,
+  });
+  if (!subContext.ok) return { ok: false, reason: 'SubstitutionEdgeInvalid' };
+  const draw = drawFromBatch({
+    tx,
+    runId,
+    batchId: o.batchId,
+    qty: o.consumeQty,
+    unit: o.unit,
+    expectedVariantId: subContext.expectedVariantId,
+    expectedPrepStateId: subContext.expectedPrepStateId,
+    ignorePrepStateMismatch: o.substitutionEdgeId !== undefined,
+  });
+  if (!draw.ok) return { ok: false, reason: 'ShortfallUnresolved' };
+  const notes: string[] = [];
+  if (subContext.auditNote !== null) notes.push(subContext.auditNote);
+  if (o.kind === 'partial') {
+    notes.push(formatExternalNote(o.lineIndex, o.externalQty, o.unit));
+  }
+  return { ok: true, auditNotes: notes };
+}
+
+const EMPTY_SET: ReadonlySet<number> = new Set<number>();
+
+// Float-comparison tolerance for override qty validation. SQLite stores
+// qty columns as REAL so a 1e-6 epsilon keeps us off the rounding edge
+// without admitting a meaningful shortfall.
+const QTY_EPSILON = 1e-6;
+
+function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescriptor> {
+  const rows = tx
+    .select({
+      position: recipeLines.position,
+      variantId: recipeLines.variantId,
+      prepStateId: recipeLines.prepStateId,
+      optional: recipeLines.optional,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+    })
+    .from(recipeLines)
+    .where(eq(recipeLines.recipeVersionId, versionId))
+    .all();
+  const map = new Map<number, LineDescriptor>();
+  for (const r of rows) {
+    const need = canonicalQty(r);
+    map.set(r.position, {
+      position: r.position,
+      variantId: r.variantId ?? null,
+      prepStateId: r.prepStateId ?? null,
+      optional: r.optional === 1,
+      needQty: need,
+      canonicalUnit: r.canonicalUnit,
+    });
+  }
+  return map;
+}
+
+function canonicalQty(row: {
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}): number {
+  if (row.canonicalUnit === 'g') return row.qtyG ?? 0;
+  if (row.canonicalUnit === 'ml') return row.qtyMl ?? 0;
+  return row.qtyCount ?? 0;
+}
+
+function overrideCoversLine(
+  override: ConsumptionOverride,
+  line: LineDescriptor,
+  scaleFactor: number
+): boolean {
+  const required = line.needQty * scaleFactor;
+  if (required <= 0) return true; // nothing to cover — treat as covered.
+  if (override.kind === 'external') {
+    if (override.externalUnit !== line.canonicalUnit) return false;
+    return Math.abs(override.externalQty - required) <= QTY_EPSILON;
+  }
+  if (override.unit !== line.canonicalUnit) return false;
+  const supplied =
+    override.kind === 'partial' ? override.consumeQty + override.externalQty : override.consumeQty;
+  return Math.abs(supplied - required) <= QTY_EPSILON;
+}
+
+interface DrawArgs {
+  tx: FoodDb;
+  runId: number;
+  batchId: number;
+  qty: number;
+  unit: 'g' | 'ml' | 'count';
+  expectedVariantId: number | null;
+  expectedPrepStateId: number | null;
+  /**
+   * PRD-149 — set true when the override carries a `substitutionEdgeId`,
+   * since the sub batch's prep state may legitimately differ from the
+   * line's per the prep-mismatch-is-informational rule.
+   */
+  ignorePrepStateMismatch?: boolean;
+}
+
+function drawFromBatch(args: DrawArgs): { ok: true } | { ok: false } {
+  const {
+    tx,
+    runId,
+    batchId,
+    qty,
+    unit,
+    expectedVariantId,
+    expectedPrepStateId,
+    ignorePrepStateMismatch,
+  } = args;
+  if (qty <= 0) return { ok: false };
+  const rows = tx
+    .select({
+      id: batches.id,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      variantId: batches.variantId,
+      prepStateId: batches.prepStateId,
+      deletedAt: batches.deletedAt,
+    })
+    .from(batches)
+    .where(eq(batches.id, batchId))
+    .all();
+  const batch = rows[0];
+  if (batch === undefined) return { ok: false };
+  if (batch.deletedAt !== null) return { ok: false };
+  if (batch.unit !== unit) return { ok: false };
+  // Reject overrides that point at a batch with a different variant /
+  // prep state than the recipe line they're covering (Copilot R1).
+  // Without this guard a client could "cover" a tomato line by drawing
+  // from an unrelated chicken batch.
+  if (expectedVariantId !== null && batch.variantId !== expectedVariantId) return { ok: false };
+  if (ignorePrepStateMismatch !== true && batch.prepStateId !== expectedPrepStateId) {
+    return { ok: false };
+  }
+  if (batch.qtyRemaining < qty) return { ok: false };
+
+  tx.update(batches)
+    .set({ qtyRemaining: batch.qtyRemaining - qty })
+    .where(eq(batches.id, batchId))
+    .run();
+  tx.insert(batchConsumptions)
+    .values({ recipeRunId: runId, batchId, qtyConsumed: qty, unit })
+    .run();
+  return { ok: true };
+}
+
+function formatExternalNote(lineIndex: number, qty: number, unit: 'g' | 'ml' | 'count'): string {
+  return `cook-override:external line=${lineIndex} qty=${qty} unit=${unit}`;
+}

--- a/pillars/food/src/api/modules/cook/mark-cooked-substitution.ts
+++ b/pillars/food/src/api/modules/cook/mark-cooked-substitution.ts
@@ -1,0 +1,152 @@
+/**
+ * PRD-149 — substitution-edge validation for the cook override path.
+ *
+ * Split out of `mark-cooked-overrides.ts` so each file stays under the
+ * 200-line per-file lint cap. Given a `substitutionEdgeId` on a
+ * `batch-override` / `partial` override, validates that:
+ *
+ *   1. The edge exists in `substitutions`.
+ *   2. The chosen batch's variant matches the edge's `to` side
+ *      (either `to_variant_id` directly, or `to_ingredient_id` when the
+ *      sub is ingredient-level).
+ *
+ * On success returns the relaxed expectations the draw step should use
+ * (variant pinned to the sub batch, prep mismatch tolerated) plus the
+ * audit line to append to `recipe_runs.notes`.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  batches,
+  type FoodDb,
+  ingredients,
+  ingredientVariants,
+  substitutions,
+} from '../../../db/index.js';
+
+export interface LineDescriptor {
+  position: number;
+  variantId: number | null;
+  prepStateId: number | null;
+  optional: boolean;
+  needQty: number;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}
+
+export interface SubstitutionContextArgs {
+  tx: FoodDb;
+  edgeId: number | undefined;
+  batchId: number;
+  line: LineDescriptor;
+}
+
+export type SubstitutionContext =
+  | {
+      ok: true;
+      expectedVariantId: number | null;
+      expectedPrepStateId: number | null;
+      auditNote: string | null;
+    }
+  | { ok: false };
+
+export function resolveSubstitutionContext(args: SubstitutionContextArgs): SubstitutionContext {
+  if (args.edgeId === undefined) {
+    return {
+      ok: true,
+      expectedVariantId: args.line.variantId,
+      expectedPrepStateId: args.line.prepStateId,
+      auditNote: null,
+    };
+  }
+  const edgeRow = loadEdge(args.tx, args.edgeId);
+  if (edgeRow === null) return { ok: false };
+  const batchRow = loadBatchIdentity(args.tx, args.batchId);
+  if (batchRow === null) return { ok: false };
+  if (!edgeMatchesBatch(edgeRow, batchRow)) return { ok: false };
+  return {
+    ok: true,
+    expectedVariantId: batchRow.variantId,
+    expectedPrepStateId: null,
+    auditNote: formatSubstitutionNote({
+      slot: { lineIndex: args.line.position, edgeId: edgeRow.id, ratio: edgeRow.ratio },
+      target: {
+        batchId: args.batchId,
+        ingredientName: batchRow.ingredientName,
+        variantName: batchRow.variantName,
+      },
+    }),
+  };
+}
+
+interface EdgeRow {
+  id: number;
+  fromIngredientId: number | null;
+  fromVariantId: number | null;
+  toIngredientId: number | null;
+  toVariantId: number | null;
+  ratio: number;
+}
+
+function loadEdge(tx: FoodDb, edgeId: number): EdgeRow | null {
+  const row = tx
+    .select({
+      id: substitutions.id,
+      fromIngredientId: substitutions.fromIngredientId,
+      fromVariantId: substitutions.fromVariantId,
+      toIngredientId: substitutions.toIngredientId,
+      toVariantId: substitutions.toVariantId,
+      ratio: substitutions.ratio,
+    })
+    .from(substitutions)
+    .where(eq(substitutions.id, edgeId))
+    .all()[0];
+  return row ?? null;
+}
+
+interface BatchIdentity {
+  variantId: number;
+  ingredientId: number;
+  ingredientName: string;
+  variantName: string;
+}
+
+function loadBatchIdentity(tx: FoodDb, batchId: number): BatchIdentity | null {
+  const row = tx
+    .select({
+      variantId: batches.variantId,
+      ingredientId: ingredientVariants.ingredientId,
+      ingredientName: ingredients.name,
+      variantName: ingredientVariants.name,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .where(eq(batches.id, batchId))
+    .all()[0];
+  return row ?? null;
+}
+
+function edgeMatchesBatch(edge: EdgeRow, batch: BatchIdentity): boolean {
+  if (edge.toVariantId !== null) return edge.toVariantId === batch.variantId;
+  if (edge.toIngredientId !== null) return edge.toIngredientId === batch.ingredientId;
+  return false;
+}
+
+interface SubstitutionNoteArgs {
+  readonly slot: {
+    readonly lineIndex: number;
+    readonly edgeId: number;
+    readonly ratio: number;
+  };
+  readonly target: {
+    readonly batchId: number;
+    readonly ingredientName: string;
+    readonly variantName: string;
+  };
+}
+
+function formatSubstitutionNote(args: SubstitutionNoteArgs): string {
+  const { slot, target } = args;
+  const ratioStr = Number.isInteger(slot.ratio) ? slot.ratio.toFixed(1) : String(slot.ratio);
+  return `cook-override:substitution line=${slot.lineIndex} edge=${slot.edgeId} ratio=${ratioStr} batch=${target.batchId} sub=${target.ingredientName}/${target.variantName}`;
+}

--- a/pillars/food/src/api/modules/cook/mark-cooked.ts
+++ b/pillars/food/src/api/modules/cook/mark-cooked.ts
@@ -1,0 +1,150 @@
+/**
+ * `food.cook.markCooked` — transactional cook mutation per PRD-144.
+ *
+ * One Drizzle transaction wraps:
+ *   1. recipe_runs INSERT (with scale + rating + notes)
+ *   2. consumption-override application (per PRD-146's deferred slice)
+ *   3. PRD-108's `consumeForRun` against the remaining (non-overridden,
+ *      non-optional) needs
+ *   4. PRD-145's `createBatchFromRun` (sets `completed_at` for yieldless
+ *      too and INSERTs the yielded batch when `yield` is given)
+ *   5. plan_entries.recipe_run_id link
+ *
+ * Failures roll the whole thing back via a private sentinel.
+ */
+import { and, eq, isNull } from 'drizzle-orm';
+
+import {
+  batchesLifecycleService,
+  batchesService,
+  type FoodDb,
+  planEntries,
+  recipeRuns,
+  recipeRunsService,
+} from '../../../db/index.js';
+import {
+  composeFinalNotes,
+  computeRemainingNeeds,
+  MarkCookedRollback,
+  validatePreflight,
+  type PreflightResult,
+} from './mark-cooked-helpers.js';
+import { applyConsumptionOverrides } from './mark-cooked-overrides.js';
+
+import type { YieldArgs } from '../../../domain/types/batches.js';
+import type {
+  ConsumptionOverride,
+  CookYieldInput,
+  MarkCookedResult,
+} from '../../../domain/types/cook.js';
+
+export interface MarkCookedArgs {
+  recipeVersionId: number;
+  scaleFactor: number;
+  planEntryId?: number;
+  yield?: CookYieldInput;
+  rating?: number;
+  notes?: string;
+  consumptionOverrides?: readonly ConsumptionOverride[];
+}
+
+export function markCooked(db: FoodDb, args: MarkCookedArgs): MarkCookedResult {
+  const validation = validatePreflight(db, args);
+  if (!validation.ok) return { ok: false, reason: validation.reason };
+  try {
+    return db.transaction((tx): MarkCookedResult => runCookTransaction(tx, args, validation));
+  } catch (err) {
+    if (err instanceof MarkCookedRollback) {
+      if (err.shortfalls !== null) {
+        return { ok: false, reason: err.reason, shortfalls: err.shortfalls };
+      }
+      return { ok: false, reason: err.reason };
+    }
+    throw err;
+  }
+}
+
+function runCookTransaction(
+  tx: FoodDb,
+  args: MarkCookedArgs,
+  validation: Extract<PreflightResult, { ok: true }>
+): MarkCookedResult {
+  const run = recipeRunsService.createRun(tx, {
+    recipeVersionId: args.recipeVersionId,
+    scaleFactor: args.scaleFactor,
+    startedAt: new Date().toISOString(),
+  });
+  const overrides = applyConsumptionOverrides(tx, {
+    runId: run.id,
+    overrides: args.consumptionOverrides ?? [],
+    versionId: args.recipeVersionId,
+    scaleFactor: args.scaleFactor,
+  });
+  if (!overrides.ok) throw new MarkCookedRollback(overrides.reason);
+
+  const remainingNeeds = computeRemainingNeeds(
+    tx,
+    args.recipeVersionId,
+    args.scaleFactor,
+    overrides.coveredLineIndices
+  );
+  const consume = batchesService.consumeForRun(tx, run.id, remainingNeeds);
+  if (!consume.ok) throw new MarkCookedRollback('ShortfallUnresolved', consume.shortfalls);
+
+  const yieldArgs = buildYieldArgs(args.yield, validation.yield);
+  const created = batchesLifecycleService.createBatchFromRun(tx, run.id, yieldArgs);
+
+  finaliseRunRow(tx, run.id, args, overrides.auditLines);
+  // Plan-entry link is a conditional UPDATE on `recipe_run_id IS NULL`
+  // so a parallel cook racing past preflight can't overwrite the first
+  // run's id (Copilot R1). On zero affected rows we roll back via the
+  // shared rollback sentinel.
+  if (!linkPlanEntry(tx, run.id, args.planEntryId)) {
+    throw new MarkCookedRollback('PlanEntryAlreadyCooked');
+  }
+
+  return { ok: true, recipeRunId: run.id, yieldedBatchId: created.batchId };
+}
+
+function buildYieldArgs(
+  input: CookYieldInput | undefined,
+  resolved: { variantId: number; prepStateId: number | null } | null
+): YieldArgs | null {
+  if (input === undefined || resolved === null) return null;
+  return {
+    variantId: resolved.variantId,
+    prepStateId: resolved.prepStateId,
+    qty: input.qty,
+    unit: input.unit,
+    location: input.location,
+    expiresAt: input.expiresAt,
+    notes: input.notes,
+  };
+}
+
+function finaliseRunRow(
+  tx: FoodDb,
+  runId: number,
+  args: MarkCookedArgs,
+  auditLines: readonly string[]
+): void {
+  // `createBatchFromRun` (via PRD-108's `markRunComplete`) sets
+  // `recipe_runs.notes` + `rating` to null because the wrapper doesn't
+  // thread them through. Compose the final values here.
+  const finalNotes = composeFinalNotes(args.notes ?? null, auditLines);
+  const rating = args.rating ?? null;
+  if (rating === null && finalNotes === null) return;
+  tx.update(recipeRuns).set({ rating, notes: finalNotes }).where(eq(recipeRuns.id, runId)).run();
+}
+
+function linkPlanEntry(tx: FoodDb, runId: number, planEntryId: number | undefined): boolean {
+  if (planEntryId === undefined) return true;
+  const result = tx
+    .update(planEntries)
+    .set({ recipeRunId: runId })
+    .where(and(eq(planEntries.id, planEntryId), isNull(planEntries.recipeRunId)))
+    .run();
+  // better-sqlite3 returns `{ changes }` so we can detect the race-lost
+  // case at the SQL boundary instead of re-SELECTing.
+  return result.changes > 0;
+}

--- a/pillars/food/src/api/modules/cook/prepare-error.ts
+++ b/pillars/food/src/api/modules/cook/prepare-error.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal error class for `prepareCook`. Lives in its own file so the
+ * loaders module can import it without a circular dep on `prepare.ts`.
+ */
+export class PrepareCookError extends Error {
+  readonly reason: 'RecipeVersionNotFound' | 'PlanEntryNotFound';
+  constructor(reason: 'RecipeVersionNotFound' | 'PlanEntryNotFound') {
+    super(reason);
+    this.name = 'PrepareCookError';
+    this.reason = reason;
+  }
+}

--- a/pillars/food/src/api/modules/cook/prepare-loaders.ts
+++ b/pillars/food/src/api/modules/cook/prepare-loaders.ts
@@ -1,0 +1,203 @@
+/**
+ * Internal data loaders for `prepareCook` — split out of `prepare.ts` so
+ * the public file stays under the 200-line lint cap.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  type FoodDb,
+  ingredients,
+  ingredientVariants,
+  planEntries,
+  prepStates,
+  recipeLines,
+  recipes,
+  recipeVersions,
+} from '../../../db/index.js';
+import { PrepareCookError } from './prepare-error.js';
+
+import type { LineConsumeNeed } from '../../../domain/types/batches.js';
+import type { CookYieldDefault } from '../../../domain/types/cook.js';
+
+export interface VersionRow {
+  id: number;
+  title: string;
+  slug: string;
+  versionNo: number;
+  servings: number | null;
+  yieldIngredientId: number | null;
+  yieldVariantId: number | null;
+  yieldPrepStateId: number | null;
+  yieldQty: number | null;
+  yieldUnit: string | null;
+}
+
+export function loadVersion(db: FoodDb, versionId: number): VersionRow | null {
+  const rows = db
+    .select({
+      id: recipeVersions.id,
+      title: recipeVersions.title,
+      slug: recipes.slug,
+      versionNo: recipeVersions.versionNo,
+      servings: recipeVersions.servings,
+      yieldIngredientId: recipeVersions.yieldIngredientId,
+      yieldVariantId: recipeVersions.yieldVariantId,
+      yieldPrepStateId: recipeVersions.yieldPrepStateId,
+      yieldQty: recipeVersions.yieldQty,
+      yieldUnit: recipeVersions.yieldUnit,
+    })
+    .from(recipeVersions)
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(eq(recipeVersions.id, versionId))
+    .all();
+  return rows[0] ?? null;
+}
+
+export interface PlanContext {
+  defaultScaleFactor: number;
+  alreadyCooked: boolean;
+}
+
+export function resolvePlanContext(db: FoodDb, planEntryId: number | undefined): PlanContext {
+  if (planEntryId === undefined) return { defaultScaleFactor: 1, alreadyCooked: false };
+  const rows = db
+    .select({
+      plannedServings: planEntries.plannedServings,
+      recipeRunId: planEntries.recipeRunId,
+      recipeVersionId: planEntries.recipeVersionId,
+    })
+    .from(planEntries)
+    .where(eq(planEntries.id, planEntryId))
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new PrepareCookError('PlanEntryNotFound');
+  const defaultScale = resolveDefaultScale(db, row.recipeVersionId, row.plannedServings);
+  return { defaultScaleFactor: defaultScale, alreadyCooked: row.recipeRunId !== null };
+}
+
+function resolveDefaultScale(
+  db: FoodDb,
+  versionId: number | null,
+  plannedServings: number
+): number {
+  if (versionId === null) return 1;
+  const v = db
+    .select({ servings: recipeVersions.servings })
+    .from(recipeVersions)
+    .where(eq(recipeVersions.id, versionId))
+    .all()[0];
+  const servings = v?.servings ?? null;
+  if (servings === null || servings <= 0 || plannedServings <= 0) return 1;
+  return plannedServings / servings;
+}
+
+export function resolveYieldDefault(db: FoodDb, version: VersionRow): CookYieldDefault | null {
+  const validUnit = asCanonicalUnit(version.yieldUnit);
+  if (version.yieldIngredientId === null) return null;
+  if (version.yieldVariantId === null) return null;
+  if (version.yieldQty === null) return null;
+  if (validUnit === null) return null;
+  const variant = loadVariantShelfLife(db, version.yieldVariantId);
+  const prepStateLabel = loadPrepStateLabel(db, version.yieldPrepStateId);
+  return {
+    qty: version.yieldQty,
+    unit: validUnit,
+    variantName: variant?.name ?? null,
+    prepStateLabel,
+    shelfLifeFridgeDays: variant?.shelfFridge ?? null,
+    shelfLifeFreezerDays: variant?.shelfFreezer ?? null,
+  };
+}
+
+function asCanonicalUnit(raw: string | null): 'g' | 'ml' | 'count' | null {
+  if (raw === 'g' || raw === 'ml' || raw === 'count') return raw;
+  return null;
+}
+
+interface VariantShelf {
+  name: string;
+  shelfFridge: number | null;
+  shelfFreezer: number | null;
+}
+
+function loadVariantShelfLife(db: FoodDb, variantId: number): VariantShelf | null {
+  const row = db
+    .select({
+      name: ingredientVariants.name,
+      shelfFridge: ingredientVariants.defaultShelfLifeDaysFridge,
+      shelfFreezer: ingredientVariants.defaultShelfLifeDaysFreezer,
+    })
+    .from(ingredientVariants)
+    .where(eq(ingredientVariants.id, variantId))
+    .all()[0];
+  return row ?? null;
+}
+
+function loadPrepStateLabel(db: FoodDb, prepStateId: number | null): string | null {
+  if (prepStateId === null) return null;
+  const row = db
+    .select({ name: prepStates.name })
+    .from(prepStates)
+    .where(eq(prepStates.id, prepStateId))
+    .all()[0];
+  return row?.name ?? null;
+}
+
+export function loadConsumeNeeds(db: FoodDb, versionId: number): LineConsumeNeed[] {
+  // PRD-146 expects the enriched `LineConsumeNeed` shape (lineIndex +
+  // ingredient/variant names + optional flag). We left-join on
+  // prep_states so lines without one fall through with a null label.
+  const rows = db
+    .select({
+      lineIndex: recipeLines.position,
+      ingredientId: recipeLines.ingredientId,
+      ingredientName: ingredients.name,
+      variantId: recipeLines.variantId,
+      variantName: ingredientVariants.name,
+      prepStateId: recipeLines.prepStateId,
+      prepStateLabel: prepStates.name,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+      optional: recipeLines.optional,
+    })
+    .from(recipeLines)
+    .innerJoin(ingredients, eq(ingredients.id, recipeLines.ingredientId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .leftJoin(prepStates, eq(prepStates.id, recipeLines.prepStateId))
+    .where(eq(recipeLines.recipeVersionId, versionId))
+    .all();
+  const needs: LineConsumeNeed[] = [];
+  for (const r of rows) {
+    if (r.variantId === null) continue;
+    const qty = canonicalQty(r);
+    if (qty === null || qty <= 0) continue;
+    needs.push({
+      lineIndex: r.lineIndex,
+      ingredientId: r.ingredientId,
+      ingredientName: r.ingredientName,
+      variantId: r.variantId,
+      variantName: r.variantName ?? '',
+      prepStateId: r.prepStateId ?? null,
+      prepStateLabel: r.prepStateLabel ?? null,
+      qty,
+      canonicalUnit: r.canonicalUnit,
+      optional: r.optional === 1,
+    });
+  }
+  return needs;
+}
+
+interface LineQtyRow {
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}
+
+function canonicalQty(row: LineQtyRow): number | null {
+  if (row.canonicalUnit === 'g') return row.qtyG;
+  if (row.canonicalUnit === 'ml') return row.qtyMl;
+  return row.qtyCount;
+}

--- a/pillars/food/src/api/modules/cook/prepare.ts
+++ b/pillars/food/src/api/modules/cook/prepare.ts
@@ -1,0 +1,44 @@
+import { PrepareCookError } from './prepare-error.js';
+import {
+  loadConsumeNeeds,
+  loadVersion,
+  resolvePlanContext,
+  resolveYieldDefault,
+} from './prepare-loaders.js';
+
+/**
+ * `food.cook.prepareCook` — pre-flight query that powers the cook modal's
+ * initial render. Returns recipe + yield default + per-line consumption
+ * needs at `scaleFactor=1`; the client multiplies as the user adjusts.
+ *
+ * See PRD-144 §`prepareCook` server-side flow.
+ */
+import type { FoodDb } from '../../../db/index.js';
+import type { CookPreparation } from '../../../domain/types/cook.js';
+
+export { PrepareCookError };
+
+export interface PrepareCookArgs {
+  recipeVersionId: number;
+  planEntryId?: number;
+}
+
+export function prepareCook(db: FoodDb, args: PrepareCookArgs): CookPreparation {
+  const versionRow = loadVersion(db, args.recipeVersionId);
+  if (versionRow === null) throw new PrepareCookError('RecipeVersionNotFound');
+
+  const planContext = resolvePlanContext(db, args.planEntryId);
+  const yieldDefault = resolveYieldDefault(db, versionRow);
+  const consumeNeeds = loadConsumeNeeds(db, versionRow.id);
+
+  return {
+    recipeTitle: versionRow.title,
+    recipeSlug: versionRow.slug,
+    versionNo: versionRow.versionNo,
+    defaultScaleFactor: planContext.defaultScaleFactor,
+    yieldsBatch: yieldDefault !== null,
+    yieldDefault,
+    consumeNeeds,
+    alreadyCooked: planContext.alreadyCooked,
+  };
+}

--- a/pillars/food/src/api/rest/cook-handlers.ts
+++ b/pillars/food/src/api/rest/cook-handlers.ts
@@ -1,0 +1,61 @@
+/**
+ * Handlers for the `cook.*` sub-router (PRD-144).
+ *
+ * `prepareCook` maps the internal `PrepareCookError` (missing recipe
+ * version / plan entry) to a 404 `{ message }` envelope, mirroring the
+ * tRPC `NOT_FOUND` the old router threw; every other failure propagates to
+ * Express. `markCooked` returns its full `MarkCookedResult` discriminated
+ * union on a 200 — domain failures are `{ ok: false, reason }`, not HTTP
+ * errors — wrapped in the shared `runHttp` passthrough.
+ */
+import { markCooked } from '../modules/cook/mark-cooked.js';
+import { prepareCook, PrepareCookError } from '../modules/cook/prepare.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+import type { z } from 'zod';
+
+import type { MarkCookedResultSchema } from '../../contract/rest-cook-schemas.js';
+import type { foodCookContract } from '../../contract/rest-cook.js';
+import type { FoodDb } from '../../db/index.js';
+import type { MarkCookedResult } from '../../domain/types/cook.js';
+
+type Req = ServerInferRequest<typeof foodCookContract>;
+type MarkCookedBody = z.infer<typeof MarkCookedResultSchema>;
+
+export function makeCookHandlers(db: FoodDb) {
+  return {
+    prepareCook: async ({ body }: Req['prepareCook']) => {
+      try {
+        const prep = prepareCook(db, {
+          recipeVersionId: body.recipeVersionId,
+          planEntryId: body.planEntryId,
+        });
+        // The contract projects `consumeNeeds` as a mutable array; the
+        // domain type returns it `readonly`, so copy it to match.
+        return {
+          status: 200 as const,
+          body: { ...prep, consumeNeeds: [...prep.consumeNeeds] },
+        };
+      } catch (err) {
+        if (err instanceof PrepareCookError) {
+          return { status: 404 as const, body: { message: err.reason } };
+        }
+        throw err;
+      }
+    },
+
+    markCooked: ({ body }: Req['markCooked']) =>
+      runHttp(() => ({ status: 200 as const, body: toMarkCookedBody(markCooked(db, body)) })),
+  };
+}
+
+/**
+ * The contract projects `shortfalls` as a mutable array; the domain result
+ * types it `readonly`, so copy it to match the inferred response shape.
+ */
+function toMarkCookedBody(result: MarkCookedResult): MarkCookedBody {
+  if (result.ok) return result;
+  if (result.shortfalls === undefined) return { ok: false, reason: result.reason };
+  return { ok: false, reason: result.reason, shortfalls: [...result.shortfalls] };
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -18,6 +18,7 @@ import { makeAiHandlers } from './ai-handlers.js';
 import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
+import { makeCookHandlers } from './cook-handlers.js';
 import { makeFridgeHandlers } from './fridge-handlers.js';
 import { makeHeroImageHandlers } from './hero-image-handlers.js';
 import { makeInboxHandlers } from './inbox-handlers.js';
@@ -51,6 +52,7 @@ export function makeFoodRestHandlers(
     aliases: makeAliasesHandlers(db),
     batches: makeBatchesHandlers(db),
     conversions: makeConversionsHandlers(db),
+    cook: makeCookHandlers(db),
     fridge: makeFridgeHandlers(db),
     heroImage: makeHeroImageHandlers(db),
     inbox: makeInboxHandlers(db),

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -283,6 +283,40 @@ export interface paths {
     patch: operations['conversions.updateWeight'];
     trace?: never;
   };
+  '/cook/mark-cooked': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Record a cook event in one transaction */
+    post: operations['cook.markCooked'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/cook/prepare': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Pre-flight data for the cook modal */
+    post: operations['cook.prepareCook'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/fridge/recipes-using-batch': {
     parameters: {
       query?: never;
@@ -2772,6 +2806,179 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'cook.markCooked': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          consumptionOverrides?: (
+            | {
+                batchId: number;
+                consumeQty: number;
+                /** @enum {string} */
+                kind: 'batch-override';
+                lineIndex: number;
+                substitutionEdgeId?: number;
+                /** @enum {string} */
+                unit: 'g' | 'ml' | 'count';
+              }
+            | {
+                externalQty: number;
+                /** @enum {string} */
+                externalUnit: 'g' | 'ml' | 'count';
+                /** @enum {string} */
+                kind: 'external';
+                lineIndex: number;
+              }
+            | {
+                batchId: number;
+                consumeQty: number;
+                externalQty: number;
+                /** @enum {string} */
+                kind: 'partial';
+                lineIndex: number;
+                substitutionEdgeId?: number;
+                /** @enum {string} */
+                unit: 'g' | 'ml' | 'count';
+              }
+          )[];
+          notes?: string;
+          planEntryId?: number;
+          rating?: number;
+          recipeVersionId: number;
+          scaleFactor: number;
+          yield?: {
+            /** Format: date-time */
+            expiresAt?: string;
+            /** @enum {string} */
+            location: 'pantry' | 'fridge' | 'freezer' | 'other';
+            notes?: string;
+            qty: number;
+            /** @enum {string} */
+            unit: 'g' | 'ml' | 'count';
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+                recipeRunId: number;
+                yieldedBatchId: number | null;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'RecipeVersionNotFound'
+                  | 'RecipeNotCompiled'
+                  | 'PlanEntryNotFound'
+                  | 'PlanEntryAlreadyCooked'
+                  | 'YieldRequired'
+                  | 'YieldForbidden'
+                  | 'BadScaleFactor'
+                  | 'BadYieldQty'
+                  | 'BadRating'
+                  | 'BadExpiry'
+                  | 'ShortfallUnresolved'
+                  | 'SubstitutionEdgeInvalid';
+                shortfalls?: {
+                  available: number;
+                  needed: number;
+                  prepStateId: number | null;
+                  /** @enum {string} */
+                  unit: 'g' | 'ml' | 'count';
+                  variantId: number;
+                }[];
+              };
+        };
+      };
+    };
+  };
+  'cook.prepareCook': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          planEntryId?: number;
+          recipeVersionId: number;
+          scaleFactor: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            alreadyCooked: boolean;
+            consumeNeeds: {
+              /** @enum {string} */
+              canonicalUnit: 'g' | 'ml' | 'count';
+              ingredientId: number;
+              ingredientName: string;
+              lineIndex: number;
+              optional: boolean;
+              prepStateId: number | null;
+              prepStateLabel: string | null;
+              qty: number;
+              variantId: number;
+              variantName: string;
+            }[];
+            defaultScaleFactor: number;
+            recipeSlug: string;
+            recipeTitle: string;
+            versionNo: number;
+            yieldDefault: {
+              prepStateLabel: string | null;
+              qty: number;
+              shelfLifeFreezerDays: number | null;
+              shelfLifeFridgeDays: number | null;
+              /** @enum {string} */
+              unit: 'g' | 'ml' | 'count';
+              variantName: string | null;
+            } | null;
+            yieldsBatch: boolean;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
           };
         };
       };

--- a/pillars/food/src/contract/rest-cook-schemas.ts
+++ b/pillars/food/src/contract/rest-cook-schemas.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure-zod schemas for the `cook.*` REST surface (PRD-144 / PRD-146 / PRD-149).
+ *
+ * Lives in `contract/` (zod-only — no `src/api/` or `src/db/` imports) so it
+ * honours the package boundary and can be imported by both the ts-rest
+ * contract and the lifted procedures.
+ *
+ * Input range constraints (`scaleFactor > 0`, `yield.qty >= 0`, `rating in
+ * 1..5`) are enforced server-side in `markCooked` so the corresponding
+ * `MarkCookedError` codes stay reachable. Per the PRD-142 / PRD-145 lesson,
+ * zod's job here is shape + finiteness; the service is the authoritative
+ * range validator.
+ */
+import { z } from 'zod';
+
+const UNIT = z.enum(['g', 'ml', 'count']);
+const LOCATION = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+
+const LineIndex = z.number().int().positive();
+
+const SubstitutionEdgeId = z.number().int().positive().optional();
+
+const ConsumptionOverrideSchema = z.discriminatedUnion('kind', [
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('batch-override'),
+    batchId: z.number().int().positive(),
+    consumeQty: z.number().finite().nonnegative(),
+    unit: UNIT,
+    /** PRD-149 — substitution edge that produced this override. */
+    substitutionEdgeId: SubstitutionEdgeId,
+  }),
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('external'),
+    externalQty: z.number().finite().nonnegative(),
+    externalUnit: UNIT,
+  }),
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('partial'),
+    batchId: z.number().int().positive(),
+    consumeQty: z.number().finite().nonnegative(),
+    externalQty: z.number().finite().nonnegative(),
+    unit: UNIT,
+    /** PRD-149 — substitution edge that produced this override. */
+    substitutionEdgeId: SubstitutionEdgeId,
+  }),
+]);
+
+const CookYieldInputSchema = z.object({
+  qty: z.number().finite(),
+  unit: UNIT,
+  location: LOCATION,
+  /**
+   * ISO 8601 datetime. Validated at the API boundary so invalid
+   * timestamps fail before `markCooked` opens its transaction.
+   */
+  expiresAt: z.string().datetime().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export const PrepareCookInputSchema = z.object({
+  recipeVersionId: z.number().int().positive(),
+  scaleFactor: z.number().finite(),
+  planEntryId: z.number().int().positive().optional(),
+});
+
+export const MarkCookedInputSchema = z.object({
+  recipeVersionId: z.number().int().positive(),
+  scaleFactor: z.number().finite(),
+  planEntryId: z.number().int().positive().optional(),
+  yield: CookYieldInputSchema.optional(),
+  rating: z.number().int().optional(),
+  notes: z.string().max(1000).optional(),
+  consumptionOverrides: z.array(ConsumptionOverrideSchema).optional(),
+});
+
+export type PrepareCookInput = z.infer<typeof PrepareCookInputSchema>;
+export type MarkCookedInput = z.infer<typeof MarkCookedInputSchema>;
+
+const CookYieldDefaultSchema = z.object({
+  qty: z.number(),
+  unit: UNIT,
+  variantName: z.string().nullable(),
+  prepStateLabel: z.string().nullable(),
+  shelfLifeFridgeDays: z.number().nullable(),
+  shelfLifeFreezerDays: z.number().nullable(),
+});
+
+const LineConsumeNeedSchema = z.object({
+  lineIndex: z.number().int(),
+  ingredientId: z.number().int(),
+  ingredientName: z.string(),
+  variantId: z.number().int(),
+  variantName: z.string(),
+  prepStateId: z.number().int().nullable(),
+  prepStateLabel: z.string().nullable(),
+  qty: z.number(),
+  canonicalUnit: UNIT,
+  optional: z.boolean(),
+});
+
+export const CookPreparationSchema = z.object({
+  recipeTitle: z.string(),
+  recipeSlug: z.string(),
+  versionNo: z.number().int(),
+  defaultScaleFactor: z.number(),
+  yieldsBatch: z.boolean(),
+  yieldDefault: CookYieldDefaultSchema.nullable(),
+  consumeNeeds: z.array(LineConsumeNeedSchema),
+  alreadyCooked: z.boolean(),
+});
+
+const MarkCookedErrorSchema = z.enum([
+  'RecipeVersionNotFound',
+  'RecipeNotCompiled',
+  'PlanEntryNotFound',
+  'PlanEntryAlreadyCooked',
+  'YieldRequired',
+  'YieldForbidden',
+  'BadScaleFactor',
+  'BadYieldQty',
+  'BadRating',
+  'BadExpiry',
+  'ShortfallUnresolved',
+  'SubstitutionEdgeInvalid',
+]);
+
+const ShortfallSchema = z.object({
+  variantId: z.number().int(),
+  prepStateId: z.number().int().nullable(),
+  needed: z.number(),
+  available: z.number(),
+  unit: UNIT,
+});
+
+export const MarkCookedResultSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    recipeRunId: z.number().int(),
+    yieldedBatchId: z.number().int().nullable(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    reason: MarkCookedErrorSchema,
+    shortfalls: z.array(ShortfallSchema).optional(),
+  }),
+]);

--- a/pillars/food/src/contract/rest-cook.ts
+++ b/pillars/food/src/contract/rest-cook.ts
@@ -1,0 +1,43 @@
+/**
+ * `cook.*` sub-router — PRD-144's cook flow.
+ *
+ * `prepareCook` is the modal-open pre-flight; `markCooked` is the
+ * single-transaction cook event. Both are POST-with-body: the inputs carry
+ * typed numbers + a discriminated `consumptionOverrides[]` union that
+ * doesn't round-trip cleanly through query strings, and `prepareCook` is a
+ * read modelled the same way as `solver.canICook` / `inbox.list`.
+ *
+ * `prepareCook` answers 404 (`{ message }`) when the recipe version (or a
+ * supplied plan entry) is missing — the handler maps the internal
+ * `PrepareCookError` onto that envelope. `markCooked` returns its full
+ * `MarkCookedResult` discriminated union on 200; failures are domain
+ * outcomes (`{ ok: false, reason }`), not HTTP errors.
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  CookPreparationSchema,
+  MarkCookedInputSchema,
+  MarkCookedResultSchema,
+  PrepareCookInputSchema,
+} from './rest-cook-schemas.js';
+import { MessageSchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const foodCookContract = c.router({
+  prepareCook: {
+    method: 'POST',
+    path: '/cook/prepare',
+    body: PrepareCookInputSchema,
+    responses: { 200: CookPreparationSchema, 404: MessageSchema },
+    summary: 'Pre-flight data for the cook modal',
+  },
+  markCooked: {
+    method: 'POST',
+    path: '/cook/mark-cooked',
+    body: MarkCookedInputSchema,
+    responses: { 200: MarkCookedResultSchema },
+    summary: 'Record a cook event in one transaction',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -18,6 +18,7 @@ import { foodAiContract } from './rest-ai.js';
 import { foodAliasesContract } from './rest-aliases.js';
 import { foodBatchesContract } from './rest-batches.js';
 import { foodConversionsContract } from './rest-conversions.js';
+import { foodCookContract } from './rest-cook.js';
 import { foodFridgeContract } from './rest-fridge.js';
 import { foodHeroImageContract } from './rest-hero-image.js';
 import { foodInboxContract } from './rest-inbox.js';
@@ -42,6 +43,7 @@ export const foodContract = c.router(
     aliases: foodAliasesContract,
     batches: foodBatchesContract,
     conversions: foodConversionsContract,
+    cook: foodCookContract,
     fridge: foodFridgeContract,
     heroImage: foodHeroImageContract,
     inbox: foodInboxContract,


### PR DESCRIPTION
## Cook domain — the missed slice

`food.cook.*` (`prepareCook` query + `markCooked` mutation) was never migrated by slices 1–6, so the pillar had no `rest-cook` contract and the food FE's cook flow couldn't drop tRPC. This lifts it into `pillars/food`, mirroring solver/fridge/batches/ingest.

- **Services** lifted into `src/api/modules/cook/` (prepare + prepare-loaders + prepare-error; mark-cooked + helpers/overrides/substitution). `@pops/app-food-db` imports rewired to the pillar db/domain; `@trpc/server` removed.
- **Contract** `rest-cook.ts` (+ pure-zod `rest-cook-schemas.ts`): `POST /cook/prepare` (body `PrepareCookInput`, `200: CookPreparation`, `404` on `PrepareCookError`), `POST /cook/mark-cooked` (body `MarkCookedInput`, `200: MarkCookedResult` — domain `{ok:false,reason}` failures stay 200). Explicit zod response shapes (both are shallow enough to mirror honestly).
- **Handler** `cook-handlers.ts` (`makeCookHandlers(db)`); wired into the contract + handler composers.
- **31 supertest integration tests** (prepare happy/scale/404; markCooked happy/scale/yieldless + 9 error branches + override matrix + substitution edges).
- Regenerated OpenAPI + api-types.

Full pillar suite: **919 tests pass**; typecheck / oxfmt / oxlint clean. `food-quality` is green; pops-api stays red-by-design until Phase E.