### PR TITLE
feat(food): model deep recipe/inbox response types in the REST contract

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -4671,7 +4671,438 @@
                           "enum": [true],
                           "type": "boolean"
                         },
-                        "review": {}
+                        "review": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "draft": {
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "properties": {
+                                "bodyDsl": {
+                                  "type": "string"
+                                },
+                                "compileError": {
+                                  "additionalProperties": false,
+                                  "nullable": true,
+                                  "properties": {
+                                    "errorCount": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": -9007199254740991,
+                                      "type": "integer"
+                                    },
+                                    "errors": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "loc": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "endCol": {
+                                                "maximum": 9007199254740991,
+                                                "minimum": -9007199254740991,
+                                                "type": "integer"
+                                              },
+                                              "endLine": {
+                                                "maximum": 9007199254740991,
+                                                "minimum": -9007199254740991,
+                                                "type": "integer"
+                                              },
+                                              "startCol": {
+                                                "maximum": 9007199254740991,
+                                                "minimum": -9007199254740991,
+                                                "type": "integer"
+                                              },
+                                              "startLine": {
+                                                "maximum": 9007199254740991,
+                                                "minimum": -9007199254740991,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "startLine",
+                                              "startCol",
+                                              "endLine",
+                                              "endCol"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["code", "message"],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "phase": {
+                                      "enum": ["parse", "resolve", "cycle", "materialise"],
+                                      "type": "string"
+                                    },
+                                    "proposedSlugsCount": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": -9007199254740991,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "phase",
+                                    "errors",
+                                    "errorCount",
+                                    "proposedSlugsCount"
+                                  ],
+                                  "type": "object"
+                                },
+                                "compileStatus": {
+                                  "enum": ["uncompiled", "compiled", "failed"],
+                                  "type": "string"
+                                },
+                                "compiledAt": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "creations": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "createdAt": {
+                                        "type": "string"
+                                      },
+                                      "defaultUnit": {
+                                        "enum": ["g", "ml", "count"],
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "enum": ["ingredient", "variant"],
+                                        "type": "string"
+                                      },
+                                      "parentIngredientSlug": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "slug": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "slug",
+                                      "parentIngredientSlug",
+                                      "defaultUnit",
+                                      "createdAt"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "proposedSlugs": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "createdAt": {
+                                        "type": "string"
+                                      },
+                                      "fromLoc": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "endCol": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": -9007199254740991,
+                                            "type": "integer"
+                                          },
+                                          "endLine": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": -9007199254740991,
+                                            "type": "integer"
+                                          },
+                                          "startCol": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": -9007199254740991,
+                                            "type": "integer"
+                                          },
+                                          "startLine": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": -9007199254740991,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": ["startLine", "startCol", "endLine", "endCol"],
+                                        "type": "object"
+                                      },
+                                      "slug": {
+                                        "type": "string"
+                                      },
+                                      "suggestedKind": {
+                                        "enum": ["ingredient", "recipe", "prep_state"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["slug", "suggestedKind", "fromLoc", "createdAt"],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "quality": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "band": {
+                                      "enum": ["clean", "minor", "attention", "blocked"],
+                                      "type": "string"
+                                    },
+                                    "score": {
+                                      "type": "number"
+                                    },
+                                    "signals": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "detail": {
+                                            "type": "string"
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": ["code", "weight"],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": ["band", "score", "signals"],
+                                  "type": "object"
+                                },
+                                "recipeArchivedAt": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "recipeSlug": {
+                                  "type": "string"
+                                },
+                                "rejection": {
+                                  "additionalProperties": false,
+                                  "nullable": true,
+                                  "properties": {
+                                    "note": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "enum": [
+                                        "wrong-recipe",
+                                        "low-quality-extraction",
+                                        "duplicate",
+                                        "not-a-recipe",
+                                        "other"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "rejectedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["reason", "note", "rejectedAt"],
+                                  "type": "object"
+                                },
+                                "status": {
+                                  "enum": ["draft", "current", "archived"],
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "versionId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "versionNo": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "versionId",
+                                "versionNo",
+                                "recipeSlug",
+                                "recipeArchivedAt",
+                                "status",
+                                "title",
+                                "bodyDsl",
+                                "compileStatus",
+                                "compileError",
+                                "compiledAt",
+                                "rejection",
+                                "proposedSlugs",
+                                "creations",
+                                "quality"
+                              ],
+                              "type": "object"
+                            },
+                            "source": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "archivedAt": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "attempts": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "caption": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "errorCode": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "errorMessage": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "extractorVersion": {
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "inferenceLogs": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "cached": {
+                                        "type": "boolean"
+                                      },
+                                      "costUsd": {
+                                        "type": "number"
+                                      },
+                                      "createdAt": {
+                                        "type": "string"
+                                      },
+                                      "inputTokens": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "latencyMs": {
+                                        "type": "number"
+                                      },
+                                      "model": {
+                                        "type": "string"
+                                      },
+                                      "operation": {
+                                        "type": "string"
+                                      },
+                                      "outputTokens": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "provider": {
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "operation",
+                                      "provider",
+                                      "model",
+                                      "costUsd",
+                                      "inputTokens",
+                                      "outputTokens",
+                                      "latencyMs",
+                                      "status",
+                                      "cached",
+                                      "createdAt"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "ingestedAt": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                                  "type": "string"
+                                },
+                                "meta": {
+                                  "additionalProperties": {},
+                                  "nullable": true,
+                                  "type": "object"
+                                },
+                                "partialReason": {
+                                  "enum": [
+                                    "auth-dead",
+                                    "rate-limited",
+                                    "stt-failed",
+                                    "vision-failed",
+                                    "caption-only-fallback",
+                                    "empty-extraction"
+                                  ],
+                                  "type": "string"
+                                },
+                                "reviewedAt": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "state": {
+                                  "enum": [
+                                    "pending",
+                                    "processing",
+                                    "completed",
+                                    "failed",
+                                    "partial"
+                                  ],
+                                  "type": "string"
+                                },
+                                "totalCostUsd": {
+                                  "type": "number"
+                                },
+                                "url": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "kind",
+                                "url",
+                                "caption",
+                                "ingestedAt",
+                                "extractorVersion",
+                                "state",
+                                "reviewedAt",
+                                "archivedAt",
+                                "errorCode",
+                                "errorMessage",
+                                "attempts",
+                                "meta",
+                                "inferenceLogs",
+                                "totalCostUsd"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": ["source", "draft"],
+                          "type": "object"
+                        }
                       },
                       "required": ["ok", "review"],
                       "type": "object"
@@ -8194,7 +8625,101 @@
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
-                    "compile": {},
+                    "compile": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "creationCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "lineCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "ok": {
+                              "enum": [true],
+                              "type": "boolean"
+                            },
+                            "stepCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            }
+                          },
+                          "required": ["ok", "lineCount", "stepCount", "creationCount"],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errors": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "cause": {
+                                    "type": "string"
+                                  },
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "loc": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "endCol": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "endLine": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "startCol": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "startLine": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": ["startLine", "startCol", "endLine", "endCol"],
+                                    "type": "object"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "slug": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["code", "message"],
+                                "type": "object"
+                              },
+                              "readOnly": true,
+                              "type": "array"
+                            },
+                            "ok": {
+                              "enum": [false],
+                              "type": "boolean"
+                            },
+                            "phase": {
+                              "enum": ["parse", "resolve", "cycle", "materialise"],
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ok", "phase", "errors"],
+                          "type": "object"
+                        }
+                      ]
+                    },
                     "recipeId": {
                       "maximum": 9007199254740991,
                       "minimum": -9007199254740991,
@@ -8501,7 +9026,101 @@
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
-                    "compile": {}
+                    "compile": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "creationCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "lineCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "ok": {
+                              "enum": [true],
+                              "type": "boolean"
+                            },
+                            "stepCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            }
+                          },
+                          "required": ["ok", "lineCount", "stepCount", "creationCount"],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errors": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "cause": {
+                                    "type": "string"
+                                  },
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "loc": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "endCol": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "endLine": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "startCol": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      },
+                                      "startLine": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": ["startLine", "startCol", "endLine", "endCol"],
+                                    "type": "object"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "slug": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["code", "message"],
+                                "type": "object"
+                              },
+                              "readOnly": true,
+                              "type": "array"
+                            },
+                            "ok": {
+                              "enum": [false],
+                              "type": "boolean"
+                            },
+                            "phase": {
+                              "enum": ["parse", "resolve", "cycle", "materialise"],
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ok", "phase", "errors"],
+                          "type": "object"
+                        }
+                      ]
+                    }
                   },
                   "required": ["compile"],
                   "type": "object"
@@ -8746,7 +9365,33 @@
                           "createdAt": {
                             "type": "string"
                           },
-                          "fromLoc": {},
+                          "fromLoc": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "endCol": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "endLine": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "startCol": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "startLine": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["startLine", "startCol", "endLine", "endCol"],
+                            "type": "object"
+                          },
                           "slug": {
                             "type": "string"
                           },
@@ -9548,7 +10193,520 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "lines": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "canonicalUnit": {
+                            "enum": ["g", "ml", "count"],
+                            "type": "string"
+                          },
+                          "id": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingredientName": {
+                            "type": "string"
+                          },
+                          "ingredientSlug": {
+                            "type": "string"
+                          },
+                          "isRecipeRef": {
+                            "type": "boolean"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "originalQty": {
+                            "type": "number"
+                          },
+                          "originalText": {
+                            "type": "string"
+                          },
+                          "originalUnit": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "prepStateId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "prepStateName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "prepStateSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qtyCount": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "qtyG": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "qtyMl": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "recipeRefId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeRefSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "recipeRefTitle": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "variantName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "variantSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "position",
+                          "ingredientId",
+                          "variantId",
+                          "prepStateId",
+                          "isRecipeRef",
+                          "recipeRefId",
+                          "originalText",
+                          "originalQty",
+                          "originalUnit",
+                          "qtyG",
+                          "qtyMl",
+                          "qtyCount",
+                          "canonicalUnit",
+                          "optional",
+                          "notes",
+                          "ingredientName",
+                          "ingredientSlug",
+                          "variantName",
+                          "variantSlug",
+                          "prepStateName",
+                          "prepStateSlug",
+                          "recipeRefSlug",
+                          "recipeRefTitle"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "recipe": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "archivedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "currentVersionId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "heroImagePath": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "recipeType": {
+                          "enum": [
+                            "plate",
+                            "component",
+                            "technique",
+                            "sauce",
+                            "dressing",
+                            "drink",
+                            "condiment"
+                          ],
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "slug",
+                        "recipeType",
+                        "currentVersionId",
+                        "heroImagePath",
+                        "archivedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "steps": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "bodyMd": {
+                            "type": "string"
+                          },
+                          "bodyResolvedJson": {
+                            "type": "string"
+                          },
+                          "durationMinutes": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "id": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "position": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "recipeVersionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "temperatureUnit": {
+                            "enum": ["c", "f", "gas"],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "temperatureValue": {
+                            "nullable": true,
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "recipeVersionId",
+                          "position",
+                          "bodyMd",
+                          "bodyResolvedJson",
+                          "durationMinutes",
+                          "temperatureValue",
+                          "temperatureUnit"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bodyDsl": {
+                          "type": "string"
+                        },
+                        "compileError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "compileStatus": {
+                          "enum": ["uncompiled", "compiled", "failed"],
+                          "type": "string"
+                        },
+                        "compiledAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "cookMinutes": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "prepMinutes": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "recipeId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "servings": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "sourceId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "status": {
+                          "enum": ["draft", "current", "archived"],
+                          "type": "string"
+                        },
+                        "summary": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "versionNo": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "yieldIngredientId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "yieldPrepStateId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "yieldQty": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "yieldUnit": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "yieldVariantId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "recipeId",
+                        "versionNo",
+                        "status",
+                        "title",
+                        "summary",
+                        "bodyDsl",
+                        "yieldIngredientId",
+                        "yieldVariantId",
+                        "yieldPrepStateId",
+                        "yieldQty",
+                        "yieldUnit",
+                        "servings",
+                        "prepMinutes",
+                        "cookMinutes",
+                        "sourceId",
+                        "compileStatus",
+                        "compileError",
+                        "compiledAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "yieldIngredient": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "yieldPrepState": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["id", "name", "slug"],
+                      "type": "object"
+                    },
+                    "yieldVariant": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultShelfLifeDaysFreezer": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultShelfLifeDaysFridge": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "packageSizeG": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "ingredientId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "packageSizeG",
+                        "notes",
+                        "defaultShelfLifeDaysFridge",
+                        "defaultShelfLifeDaysFreezer",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "recipe",
+                    "lines",
+                    "steps",
+                    "yieldIngredient",
+                    "yieldVariant",
+                    "yieldPrepState",
+                    "tags"
+                  ],
+                  "type": "object"
+                }
               }
             },
             "description": "200"

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -3437,7 +3437,119 @@ export interface operations {
             | {
                 /** @enum {boolean} */
                 ok: true;
-                review: unknown;
+                review: {
+                  draft: {
+                    bodyDsl: string;
+                    compileError: {
+                      errorCount: number;
+                      errors: {
+                        code: string;
+                        loc?: {
+                          endCol: number;
+                          endLine: number;
+                          startCol: number;
+                          startLine: number;
+                        };
+                        message: string;
+                      }[];
+                      /** @enum {string} */
+                      phase: 'parse' | 'resolve' | 'cycle' | 'materialise';
+                      proposedSlugsCount: number;
+                    } | null;
+                    /** @enum {string} */
+                    compileStatus: 'uncompiled' | 'compiled' | 'failed';
+                    compiledAt: string | null;
+                    creations: {
+                      createdAt: string;
+                      /** @enum {string} */
+                      defaultUnit: 'g' | 'ml' | 'count';
+                      /** @enum {string} */
+                      kind: 'ingredient' | 'variant';
+                      parentIngredientSlug: string | null;
+                      slug: string;
+                    }[];
+                    proposedSlugs: {
+                      createdAt: string;
+                      fromLoc: {
+                        endCol: number;
+                        endLine: number;
+                        startCol: number;
+                        startLine: number;
+                      };
+                      slug: string;
+                      /** @enum {string|null} */
+                      suggestedKind: 'ingredient' | 'recipe' | 'prep_state' | null;
+                    }[];
+                    quality: {
+                      /** @enum {string} */
+                      band: 'clean' | 'minor' | 'attention' | 'blocked';
+                      score: number;
+                      signals: {
+                        code: string;
+                        detail?: string;
+                        weight: number;
+                      }[];
+                    };
+                    recipeArchivedAt: string | null;
+                    recipeSlug: string;
+                    rejection: {
+                      note: string | null;
+                      /** @enum {string} */
+                      reason:
+                        | 'wrong-recipe'
+                        | 'low-quality-extraction'
+                        | 'duplicate'
+                        | 'not-a-recipe'
+                        | 'other';
+                      rejectedAt: string;
+                    } | null;
+                    /** @enum {string} */
+                    status: 'draft' | 'current' | 'archived';
+                    title: string | null;
+                    versionId: number;
+                    versionNo: number;
+                  } | null;
+                  source: {
+                    archivedAt: string | null;
+                    attempts: number;
+                    caption: string | null;
+                    errorCode: string | null;
+                    errorMessage: string | null;
+                    extractorVersion: string;
+                    id: number;
+                    inferenceLogs: {
+                      cached: boolean;
+                      costUsd: number;
+                      createdAt: string;
+                      inputTokens: number;
+                      latencyMs: number;
+                      model: string;
+                      operation: string;
+                      outputTokens: number;
+                      provider: string;
+                      status: string;
+                    }[];
+                    ingestedAt: string;
+                    /** @enum {string} */
+                    kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+                    meta: {
+                      [key: string]: unknown;
+                    } | null;
+                    /** @enum {string} */
+                    partialReason?:
+                      | 'auth-dead'
+                      | 'rate-limited'
+                      | 'stt-failed'
+                      | 'vision-failed'
+                      | 'caption-only-fallback'
+                      | 'empty-extraction';
+                    reviewedAt: string | null;
+                    /** @enum {string} */
+                    state: 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+                    totalCostUsd: number;
+                    url: string | null;
+                  };
+                };
               }
             | {
                 /** @enum {boolean} */
@@ -5137,7 +5249,32 @@ export interface operations {
         };
         content: {
           'application/json': {
-            compile: unknown;
+            compile:
+              | {
+                  creationCount: number;
+                  lineCount: number;
+                  /** @enum {boolean} */
+                  ok: true;
+                  stepCount: number;
+                }
+              | {
+                  readonly errors: {
+                    cause?: string;
+                    code: string;
+                    loc?: {
+                      endCol: number;
+                      endLine: number;
+                      startCol: number;
+                      startLine: number;
+                    };
+                    message: string;
+                    slug?: string;
+                  }[];
+                  /** @enum {boolean} */
+                  ok: false;
+                  /** @enum {string} */
+                  phase: 'parse' | 'resolve' | 'cycle' | 'materialise';
+                };
             recipeId: number;
             slug: string;
             versionId: number;
@@ -5277,7 +5414,32 @@ export interface operations {
         };
         content: {
           'application/json': {
-            compile: unknown;
+            compile:
+              | {
+                  creationCount: number;
+                  lineCount: number;
+                  /** @enum {boolean} */
+                  ok: true;
+                  stepCount: number;
+                }
+              | {
+                  readonly errors: {
+                    cause?: string;
+                    code: string;
+                    loc?: {
+                      endCol: number;
+                      endLine: number;
+                      startCol: number;
+                      startLine: number;
+                    };
+                    message: string;
+                    slug?: string;
+                  }[];
+                  /** @enum {boolean} */
+                  ok: false;
+                  /** @enum {string} */
+                  phase: 'parse' | 'resolve' | 'cycle' | 'materialise';
+                };
           };
         };
       };
@@ -5413,7 +5575,12 @@ export interface operations {
           'application/json': {
             items: {
               createdAt: string;
-              fromLoc: unknown;
+              fromLoc: {
+                endCol: number;
+                endLine: number;
+                startCol: number;
+                startLine: number;
+              };
               slug: string;
               /** @enum {string|null} */
               suggestedKind: 'ingredient' | 'recipe' | 'prep_state' | null;
@@ -5789,7 +5956,117 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': unknown;
+          'application/json': {
+            lines: {
+              /** @enum {string} */
+              canonicalUnit: 'g' | 'ml' | 'count';
+              id: number;
+              ingredientId: number;
+              ingredientName: string;
+              ingredientSlug: string;
+              isRecipeRef: boolean;
+              notes: string | null;
+              optional: boolean;
+              originalQty: number;
+              originalText: string;
+              originalUnit: string;
+              position: number;
+              prepStateId: number | null;
+              prepStateName: string | null;
+              prepStateSlug: string | null;
+              qtyCount: number | null;
+              qtyG: number | null;
+              qtyMl: number | null;
+              recipeRefId: number | null;
+              recipeRefSlug: string | null;
+              recipeRefTitle: string | null;
+              variantId: number | null;
+              variantName: string | null;
+              variantSlug: string | null;
+            }[];
+            recipe: {
+              archivedAt: string | null;
+              createdAt: string;
+              currentVersionId: number | null;
+              heroImagePath: string | null;
+              id: number;
+              /** @enum {string} */
+              recipeType:
+                | 'plate'
+                | 'component'
+                | 'technique'
+                | 'sauce'
+                | 'dressing'
+                | 'drink'
+                | 'condiment';
+              slug: string;
+            };
+            steps: {
+              bodyMd: string;
+              bodyResolvedJson: string;
+              durationMinutes: number | null;
+              id: number;
+              position: number;
+              recipeVersionId: number;
+              /** @enum {string|null} */
+              temperatureUnit: 'c' | 'f' | 'gas' | null;
+              temperatureValue: number | null;
+            }[];
+            tags: string[];
+            version: {
+              bodyDsl: string;
+              compileError: string | null;
+              /** @enum {string} */
+              compileStatus: 'uncompiled' | 'compiled' | 'failed';
+              compiledAt: string | null;
+              cookMinutes: number | null;
+              createdAt: string;
+              id: number;
+              prepMinutes: number | null;
+              recipeId: number;
+              servings: number | null;
+              sourceId: number | null;
+              /** @enum {string} */
+              status: 'draft' | 'current' | 'archived';
+              summary: string | null;
+              title: string;
+              versionNo: number;
+              yieldIngredientId: number | null;
+              yieldPrepStateId: number | null;
+              yieldQty: number | null;
+              yieldUnit: string | null;
+              yieldVariantId: number | null;
+            };
+            yieldIngredient: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            } | null;
+            yieldPrepState: {
+              id: number;
+              name: string;
+              slug: string;
+            } | null;
+            yieldVariant: {
+              createdAt: string;
+              defaultShelfLifeDaysFreezer: number | null;
+              defaultShelfLifeDaysFridge: number | null;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              id: number;
+              ingredientId: number;
+              name: string;
+              notes: string | null;
+              packageSizeG: number | null;
+              slug: string;
+            } | null;
+          };
         };
       };
       /** @description 400 */

--- a/pillars/food/src/contract/rest-inbox-review-schemas.ts
+++ b/pillars/food/src/contract/rest-inbox-review-schemas.ts
@@ -1,0 +1,122 @@
+/**
+ * Zod for the `inbox.getForReview` inspector aggregate — mirrors
+ * `InspectorReviewView` / `InspectorResult` from
+ * `src/db/services/inbox-inspector-types.ts` verbatim so `api-types` fully
+ * describes the wire shape. Split from `rest-inbox-schemas.ts` to keep that
+ * file under the per-file line cap. Zod-only; no imports from `src/api/` or
+ * `src/db/`.
+ */
+import { z } from 'zod';
+
+import {
+  CompileStatus,
+  IngestKind,
+  PartialReason,
+  QualityBand,
+  RejectionReason,
+} from './rest-inbox-schemas.js';
+import { SourceSpanSchema } from './rest-recipe-render-schemas.js';
+
+const InspectorIngestState = z.enum(['pending', 'processing', 'completed', 'failed', 'partial']);
+
+const CompilePhase = z.enum(['parse', 'resolve', 'cycle', 'materialise']);
+
+const InspectorAiInferenceLogRowSchema = z.object({
+  operation: z.string(),
+  provider: z.string(),
+  model: z.string(),
+  costUsd: z.number(),
+  inputTokens: z.number().int(),
+  outputTokens: z.number().int(),
+  latencyMs: z.number(),
+  status: z.string(),
+  cached: z.boolean(),
+  createdAt: z.string(),
+});
+
+const InspectorSourceViewSchema = z.object({
+  id: z.number().int(),
+  kind: IngestKind,
+  url: z.string().nullable(),
+  caption: z.string().nullable(),
+  ingestedAt: z.string(),
+  extractorVersion: z.string(),
+  state: InspectorIngestState,
+  partialReason: PartialReason.optional(),
+  reviewedAt: z.string().nullable(),
+  archivedAt: z.string().nullable(),
+  errorCode: z.string().nullable(),
+  errorMessage: z.string().nullable(),
+  attempts: z.number().int(),
+  meta: z.record(z.string(), z.unknown()).nullable(),
+  inferenceLogs: z.array(InspectorAiInferenceLogRowSchema),
+  totalCostUsd: z.number(),
+});
+
+const InspectorProposedSlugRowSchema = z.object({
+  slug: z.string(),
+  suggestedKind: z.enum(['ingredient', 'recipe', 'prep_state']).nullable(),
+  fromLoc: SourceSpanSchema,
+  createdAt: z.string(),
+});
+
+const InspectorResolverCreationRowSchema = z.object({
+  kind: z.enum(['ingredient', 'variant']),
+  slug: z.string(),
+  parentIngredientSlug: z.string().nullable(),
+  defaultUnit: z.enum(['g', 'ml', 'count']),
+  createdAt: z.string(),
+});
+
+const InspectorCompileErrorParsedSchema = z.object({
+  phase: CompilePhase,
+  errors: z.array(
+    z.object({
+      code: z.string(),
+      message: z.string(),
+      loc: SourceSpanSchema.optional(),
+    })
+  ),
+  errorCount: z.number().int(),
+  proposedSlugsCount: z.number().int(),
+});
+
+const QualitySignalSchema = z.object({
+  code: z.string(),
+  weight: z.number(),
+  detail: z.string().optional(),
+});
+
+const QualityResultSchema = z.object({
+  band: QualityBand,
+  score: z.number(),
+  signals: z.array(QualitySignalSchema),
+});
+
+const InspectorDraftViewSchema = z.object({
+  versionId: z.number().int(),
+  versionNo: z.number().int(),
+  recipeSlug: z.string(),
+  recipeArchivedAt: z.string().nullable(),
+  status: z.enum(['draft', 'current', 'archived']),
+  title: z.string().nullable(),
+  bodyDsl: z.string(),
+  compileStatus: CompileStatus,
+  compileError: InspectorCompileErrorParsedSchema.nullable(),
+  compiledAt: z.string().nullable(),
+  rejection: z
+    .object({
+      reason: RejectionReason,
+      note: z.string().nullable(),
+      rejectedAt: z.string(),
+    })
+    .nullable(),
+  proposedSlugs: z.array(InspectorProposedSlugRowSchema),
+  creations: z.array(InspectorResolverCreationRowSchema),
+  quality: QualityResultSchema,
+});
+
+export const InspectorReviewViewSchema = z.object({
+  source: InspectorSourceViewSchema,
+  draft: InspectorDraftViewSchema.nullable(),
+});

--- a/pillars/food/src/contract/rest-inbox.ts
+++ b/pillars/food/src/contract/rest-inbox.ts
@@ -2,12 +2,13 @@
  * `inbox.*` sub-router — recipe-ingest triage (PRD-134/135/136/138). Pure
  * DB reads/writes. Mutations + inspector return the service's discriminated
  * `{ ok, ... }` result on 200. List endpoints are POST-with-body (array
- * filters + cursor). `getForReview.review` is projected as `unknown` (deep
- * aggregate; consumers import the rich type from the api layer directly).
+ * filters + cursor). `getForReview.review` is fully modelled in
+ * `rest-inbox-review-schemas.ts` so `api-types` describes the wire shape.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import { InspectorReviewViewSchema } from './rest-inbox-review-schemas.js';
 import {
   ApproveResult,
   DraftSort,
@@ -111,7 +112,7 @@ export const foodInboxContract = c.router({
     query: z.object({ sourceId: QueryPositiveInt }),
     responses: {
       200: z.discriminatedUnion('ok', [
-        z.object({ ok: z.literal(true), review: z.unknown() }),
+        z.object({ ok: z.literal(true), review: InspectorReviewViewSchema }),
         z.object({ ok: z.literal(false), reason: z.literal('SourceNotFound') }),
       ]),
       ...ERR_RESPONSES,

--- a/pillars/food/src/contract/rest-recipe-render-schemas.ts
+++ b/pillars/food/src/contract/rest-recipe-render-schemas.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared zod building blocks for the deep `recipes.*` REST response shapes:
+ * the DSL `SourceSpan`, the compile-pipeline `CompileResult`, and the
+ * `getForRendering` aggregate (`RecipeVersionWithCompiledData`).
+ *
+ * These mirror the in-pillar domain/dsl/db types verbatim so the generated
+ * `api-types` fully describes the wire shape — the food FE consumes these
+ * instead of importing the pillar's internal types. Split from
+ * `rest-recipes.ts` to keep that file under the per-file line cap. Zod-only;
+ * no imports from `src/api/` or `src/db/`.
+ *
+ * Source of truth:
+ * - `SourceSpan`               → `src/dsl/ast.ts`
+ * - `CompileResult` / errors   → `src/dsl/compile-types.ts` (+ `errors.ts`,
+ *                                `resolver-types.ts`, `cycle-types.ts`)
+ * - row shapes                 → `src/db/schema/food-{recipes,compile,ingredients}.ts`
+ * - aggregate                  → `src/domain/recipe-renderer-types.ts`
+ */
+import { z } from 'zod';
+
+const CanonicalUnit = z.enum(['g', 'ml', 'count']);
+const RecipeTypeLiteral = z.enum([
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+]);
+const CompileStatus = z.enum(['uncompiled', 'compiled', 'failed']);
+
+export const SourceSpanSchema = z.object({
+  startLine: z.number().int(),
+  startCol: z.number().int(),
+  endLine: z.number().int(),
+  endCol: z.number().int(),
+});
+
+const CompilePhase = z.enum(['parse', 'resolve', 'cycle', 'materialise']);
+
+const CompileErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  loc: SourceSpanSchema.optional(),
+  cause: z.string().optional(),
+  slug: z.string().optional(),
+});
+
+export const CompileResultSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    lineCount: z.number().int(),
+    stepCount: z.number().int(),
+    creationCount: z.number().int(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    phase: CompilePhase,
+    errors: z.array(CompileErrorSchema).readonly(),
+  }),
+]);
+
+const RecipeRowSchema = z.object({
+  id: z.number().int(),
+  slug: z.string(),
+  recipeType: RecipeTypeLiteral,
+  currentVersionId: z.number().int().nullable(),
+  heroImagePath: z.string().nullable(),
+  archivedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const RecipeVersionRowSchema = z.object({
+  id: z.number().int(),
+  recipeId: z.number().int(),
+  versionNo: z.number().int(),
+  status: z.enum(['draft', 'current', 'archived']),
+  title: z.string(),
+  summary: z.string().nullable(),
+  bodyDsl: z.string(),
+  yieldIngredientId: z.number().int().nullable(),
+  yieldVariantId: z.number().int().nullable(),
+  yieldPrepStateId: z.number().int().nullable(),
+  yieldQty: z.number().nullable(),
+  yieldUnit: z.string().nullable(),
+  servings: z.number().int().nullable(),
+  prepMinutes: z.number().int().nullable(),
+  cookMinutes: z.number().int().nullable(),
+  sourceId: z.number().int().nullable(),
+  compileStatus: CompileStatus,
+  compileError: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const RecipeStepRowSchema = z.object({
+  id: z.number().int(),
+  recipeVersionId: z.number().int(),
+  position: z.number().int(),
+  bodyMd: z.string(),
+  bodyResolvedJson: z.string(),
+  durationMinutes: z.number().int().nullable(),
+  temperatureValue: z.number().nullable(),
+  temperatureUnit: z.enum(['c', 'f', 'gas']).nullable(),
+});
+
+const IngredientRowSchema = z.object({
+  id: z.number().int(),
+  parentId: z.number().int().nullable(),
+  name: z.string(),
+  slug: z.string(),
+  defaultUnit: CanonicalUnit,
+  densityGPerMl: z.number().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const IngredientVariantRowSchema = z.object({
+  id: z.number().int(),
+  ingredientId: z.number().int(),
+  name: z.string(),
+  slug: z.string(),
+  defaultUnit: CanonicalUnit,
+  packageSizeG: z.number().nullable(),
+  notes: z.string().nullable(),
+  defaultShelfLifeDaysFridge: z.number().int().nullable(),
+  defaultShelfLifeDaysFreezer: z.number().int().nullable(),
+  createdAt: z.string(),
+});
+
+const PrepStateRowSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  slug: z.string(),
+});
+
+const RecipeLineWithResolvedSchema = z.object({
+  id: z.number().int(),
+  position: z.number().int(),
+  ingredientId: z.number().int(),
+  variantId: z.number().int().nullable(),
+  prepStateId: z.number().int().nullable(),
+  isRecipeRef: z.boolean(),
+  recipeRefId: z.number().int().nullable(),
+  originalText: z.string(),
+  originalQty: z.number(),
+  originalUnit: z.string(),
+  qtyG: z.number().nullable(),
+  qtyMl: z.number().nullable(),
+  qtyCount: z.number().nullable(),
+  canonicalUnit: CanonicalUnit,
+  optional: z.boolean(),
+  notes: z.string().nullable(),
+  ingredientName: z.string(),
+  ingredientSlug: z.string(),
+  variantName: z.string().nullable(),
+  variantSlug: z.string().nullable(),
+  prepStateName: z.string().nullable(),
+  prepStateSlug: z.string().nullable(),
+  recipeRefSlug: z.string().nullable(),
+  recipeRefTitle: z.string().nullable(),
+});
+
+export const RecipeVersionWithCompiledDataSchema = z.object({
+  version: RecipeVersionRowSchema,
+  recipe: RecipeRowSchema,
+  lines: z.array(RecipeLineWithResolvedSchema),
+  steps: z.array(RecipeStepRowSchema),
+  yieldIngredient: IngredientRowSchema.nullable(),
+  yieldVariant: IngredientVariantRowSchema.nullable(),
+  yieldPrepState: PrepStateRowSchema.nullable(),
+  tags: z.array(z.string()),
+});

--- a/pillars/food/src/contract/rest-recipes.ts
+++ b/pillars/food/src/contract/rest-recipes.ts
@@ -1,14 +1,19 @@
 /**
  * `recipes.*` sub-router — PRD-119 recipe CRUD + draft lifecycle. The DSL
  * compile result and the `getForRendering` aggregate are deep, renderer-
- * owned shapes; they are projected as `unknown` in OpenAPI (consumers
- * import the rich type from the api layer, as the inbox inspector does).
+ * owned shapes; they are fully modelled in `rest-recipe-render-schemas.ts`
+ * so `api-types` describes the wire shape end-to-end.
  *
  * send-to-list + hero-image are separate slices (4c / 4b).
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import {
+  CompileResultSchema,
+  RecipeVersionWithCompiledDataSchema,
+  SourceSpanSchema,
+} from './rest-recipe-render-schemas.js';
 import { ERR_RESPONSES, NonEmptyString, PathPositiveInt } from './rest-schemas.js';
 
 const c = initContract();
@@ -52,7 +57,7 @@ const RecipeDraftSummarySchema = z.object({
 const ProposedSlugRowSchema = z.object({
   slug: z.string(),
   suggestedKind: z.enum(['ingredient', 'recipe', 'prep_state']).nullable(),
-  fromLoc: z.unknown(),
+  fromLoc: SourceSpanSchema,
   createdAt: z.string(),
 });
 
@@ -94,7 +99,7 @@ export const foodRecipesContract = c.router({
         slug: z.string(),
         recipeId: z.number().int(),
         versionId: z.number().int(),
-        compile: z.unknown(),
+        compile: CompileResultSchema,
       }),
       ...ERR_RESPONSES,
     },
@@ -105,7 +110,7 @@ export const foodRecipesContract = c.router({
     path: '/recipes/:slug',
     pathParams: z.object({ slug: NonEmptyString }),
     query: z.object({ versionNo: z.coerce.number().int().positive().optional() }),
-    responses: { 200: z.unknown(), ...ERR_RESPONSES },
+    responses: { 200: RecipeVersionWithCompiledDataSchema, ...ERR_RESPONSES },
     summary: 'Get a recipe version assembled for rendering',
   },
   listDrafts: {
@@ -139,7 +144,7 @@ export const foodRecipesContract = c.router({
     path: '/recipes/versions/:versionId',
     pathParams: z.object({ versionId: PathPositiveInt }),
     body: z.object({ dsl: NonEmptyString }),
-    responses: { 200: z.object({ compile: z.unknown() }), ...ERR_RESPONSES },
+    responses: { 200: z.object({ compile: CompileResultSchema }), ...ERR_RESPONSES },
     summary: 'Save + compile a draft version',
   },
   promote: {


### PR DESCRIPTION
## Contract modeling (PR-A of the legacy-food sunset)

Replaces the remaining `z.unknown()` projections in the food REST contract with real zod schemas, so `@pops/food`'s OpenAPI + generated `api-types` fully describe the deep recipe/inbox response shapes. This is the prerequisite for repointing the food FE off the pillar's internal domain/db types (and the legacy `@pops/app-food-db`) onto pure wire types.

### Modeled
- `recipes.getForRendering` 200 → `RecipeVersionWithCompiledData`
- `recipes.create` / `recipes.saveDraft` `compile` → `CompileResult` (discriminated on `ok`)
- compile-error `fromLoc` + `recipes.listProposedSlugs` `fromLoc` → `SourceSpan`
- `inbox.getForReview` ok-branch `review` → `InspectorReviewView`

New schemas live in `rest-recipe-render-schemas.ts` + `rest-inbox-review-schemas.ts` (contract-layer, zod-only, no `api`/`db` imports), mirroring the pillar's domain TS types. ts-rest infers the response types from these, so the existing handlers' returns are checked against them (typecheck clean — no behavior change).

### Deliberately left as `record(unknown)` (genuinely arbitrary)
`ai.metadata`, `ingest.stages`, and `InspectorSourceView.meta` (the parsed PRD-125 stages blob).

### Verify
Regenerated OpenAPI + api-types (deterministic). Pillar: typecheck clean, **919 tests pass**, oxfmt/oxlint clean. `food-quality` green.

PR-B will repoint `packages/app-food` onto these wire types, relocate the misplaced backend code/tests into the pillar, and delete `@pops/app-food-db` + `@pops/food-contracts`.