### PR TITLE
feat(media): REST migration slice 6 — TMDB + TheTVDB client libraries

### DIFF
--- a/pillars/media/src/api/clients/env.ts
+++ b/pillars/media/src/api/clients/env.ts
@@ -1,0 +1,36 @@
+/**
+ * Pillar-local environment access for the upstream metadata clients.
+ *
+ * The media pillar must not depend on `core/settings` or `apps/pops-api`,
+ * so the TMDB / TheTVDB clients read their API keys and tuning knobs
+ * straight from `process.env` via these helpers instead of the monolith's
+ * `env.ts` / settings table.
+ */
+
+/** Read an env var, returning `undefined` when unset or empty. */
+export function getEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value === '' ? undefined : value;
+}
+
+/** Read a required env var, throwing a clear error when unset or empty. */
+export function requireEnv(name: string): string {
+  const value = getEnv(name);
+  if (value === undefined) {
+    throw new Error(
+      `${name} is not configured. Set it in .env (development) or Docker secrets (production).`
+    );
+  }
+  return value;
+}
+
+/**
+ * Read an integer env var, falling back to `fallback` when the value is
+ * unset, empty, or not a finite integer.
+ */
+export function getEnvInt(name: string, fallback: number): number {
+  const raw = getEnv(name);
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/pillars/media/src/api/clients/strip-surrounding-quotes.ts
+++ b/pillars/media/src/api/clients/strip-surrounding-quotes.ts
@@ -1,0 +1,30 @@
+/**
+ * Strip balanced surrounding double-quote characters from a media title.
+ *
+ * Mirrors the semantics of migration `0042_strip_quoted_movie_titles.sql`
+ * (and its TV-shows companion `0051`), which uses SQLite
+ * `TRIM(title, '"')` gated by `title LIKE '"%"'` and
+ * `TRIM(title, '"') != ''`.
+ *
+ * Use at upstream client mappers (TMDB / TheTVDB) so that titles returned
+ * by the source API with surrounding quotes never reach the database in
+ * that form (issues #2402 / #2403; root cause of #2343 — *Wuthering
+ * Heights* 2026 returned by TMDB as `"Wuthering Heights"`).
+ *
+ * Rules:
+ * - Must start AND end with `"` — one-sided quotes are preserved.
+ * - All leading and all trailing `"` chars are removed (matches `TRIM`).
+ * - If the trimmed result would be empty, the original is preserved
+ *   (so `""` and `"""` are left alone rather than blanked).
+ * - Internal quotes are preserved (e.g. `Film "Noir" Style` is untouched).
+ */
+export function stripSurroundingQuotes(value: string): string {
+  if (!value.startsWith('"') || !value.endsWith('"')) return value;
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '"') start++;
+  while (end > start && value[end - 1] === '"') end--;
+  if (start === 0 && end === value.length) return value;
+  const trimmed = value.slice(start, end);
+  return trimmed.length > 0 ? trimmed : value;
+}

--- a/pillars/media/src/api/clients/thetvdb/auth.ts
+++ b/pillars/media/src/api/clients/thetvdb/auth.ts
@@ -1,0 +1,78 @@
+/**
+ * TheTVDB v4 authentication — JWT token management.
+ *
+ * Handles login via POST /login, token caching, and auto-refresh.
+ */
+import { type RawTvdbLoginResponse, TvdbApiError } from './types.js';
+
+const LOGIN_URL = 'https://api4.thetvdb.com/v4/login';
+
+/** Token lifetime buffer — re-authenticate if token expires within 24 hours. */
+const EXPIRY_BUFFER_MS = 24 * 60 * 60 * 1000;
+
+/** Default token lifetime — TheTVDB tokens last ~1 month. */
+const TOKEN_LIFETIME_MS = 28 * 24 * 60 * 60 * 1000;
+
+export class TheTvdbAuth {
+  private readonly apiKey: string;
+  private token: string | null = null;
+  private expiresAt = 0;
+
+  constructor(apiKey: string) {
+    if (!apiKey) {
+      throw new Error('TheTVDB API key is required');
+    }
+    this.apiKey = apiKey;
+  }
+
+  /** Get a valid token, re-authenticating if needed. */
+  async getToken(): Promise<string> {
+    if (this.token && Date.now() < this.expiresAt - EXPIRY_BUFFER_MS) {
+      return this.token;
+    }
+    return this.login();
+  }
+
+  /** Force a fresh login and cache the new token. */
+  async login(): Promise<string> {
+    let response: Response;
+
+    try {
+      response = await fetch(LOGIN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apikey: this.apiKey }),
+      });
+    } catch (err) {
+      throw new TvdbApiError(
+        0,
+        `Network error during TheTVDB login: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (!response.ok) {
+      let message = `TheTVDB login failed: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as { message?: string };
+        if (body.message) {
+          message = body.message;
+        }
+      } catch {
+        // Ignore parse failures
+      }
+      throw new TvdbApiError(response.status, message);
+    }
+
+    const body = (await response.json()) as RawTvdbLoginResponse;
+    this.token = body.data.token;
+    this.expiresAt = Date.now() + TOKEN_LIFETIME_MS;
+
+    return this.token;
+  }
+
+  /** Invalidate the cached token, forcing re-auth on next getToken(). */
+  invalidate(): void {
+    this.token = null;
+    this.expiresAt = 0;
+  }
+}

--- a/pillars/media/src/api/clients/thetvdb/client.test.ts
+++ b/pillars/media/src/api/clients/thetvdb/client.test.ts
@@ -1,0 +1,472 @@
+/**
+ * TheTVDB client + auth unit tests — all HTTP calls mocked via vi.stubGlobal("fetch").
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TheTvdbAuth } from './auth.js';
+import { TheTvdbClient } from './client.js';
+import { TvdbApiError } from './types.js';
+
+/** Helper to create a mocked Response. */
+function mockResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+    redirected: false,
+    type: 'basic',
+    url: '',
+    clone: () => mockResponse(body, status, statusText),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+const FAKE_KEY = 'test-thetvdb-api-key';
+const FAKE_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake-token';
+const LOGIN_RESPONSE = { status: 'success', data: { token: FAKE_TOKEN } };
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let auth: TheTvdbAuth;
+let client: TheTvdbClient;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  auth = new TheTvdbAuth(FAKE_KEY);
+  client = new TheTvdbClient(auth);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- Auth tests ---
+
+describe('TheTvdbAuth', () => {
+  it('throws if API key is empty', () => {
+    expect(() => new TheTvdbAuth('')).toThrow('TheTVDB API key is required');
+  });
+
+  it('logs in and returns a token', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE));
+
+    const token = await auth.getToken();
+
+    expect(token).toBe(FAKE_TOKEN);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/login');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body as string)).toEqual({ apikey: FAKE_KEY });
+  });
+
+  it('caches the token on subsequent calls', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE));
+
+    await auth.getToken();
+    const token2 = await auth.getToken();
+
+    expect(token2).toBe(FAKE_TOKEN);
+    // Only one fetch call — token was cached
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('re-authenticates after invalidate()', async () => {
+    const FRESH_TOKEN = 'fresh-token-abc';
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse({ status: 'success', data: { token: FRESH_TOKEN } }));
+
+    await auth.getToken();
+    auth.invalidate();
+    const token = await auth.getToken();
+
+    expect(token).toBe(FRESH_TOKEN);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws TvdbApiError on login failure', async () => {
+    expect.assertions(2);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ message: 'Invalid API key' }, 401, 'Unauthorized')
+    );
+
+    try {
+      await auth.getToken();
+    } catch (err) {
+      expect(err).toBeInstanceOf(TvdbApiError);
+      expect((err as TvdbApiError).status).toBe(401);
+    }
+  });
+
+  it('throws TvdbApiError on network error during login', async () => {
+    expect.assertions(2);
+    fetchMock.mockRejectedValueOnce(new Error('DNS resolution failed'));
+
+    try {
+      await auth.getToken();
+    } catch (err) {
+      expect(err).toBeInstanceOf(TvdbApiError);
+      expect((err as TvdbApiError).message).toContain('Network error');
+    }
+  });
+});
+
+// --- Client tests ---
+
+describe('TheTvdbClient.searchSeries', () => {
+  const rawSearchResponse = {
+    status: 'success',
+    data: [
+      {
+        tvdb_id: '81189',
+        name: 'Breaking Bad',
+        overview: 'A high school chemistry teacher...',
+        first_air_time: '2008-01-20',
+        status: 'Ended',
+        image_url: 'https://artworks.thetvdb.com/banners/posters/81189-1.jpg',
+        genres: ['Drama', 'Thriller'],
+        primary_language: 'eng',
+        year: '2008',
+      },
+      {
+        objectID: '73255',
+        name: 'Better Call Saul',
+        overview: null,
+        first_air_time: null,
+        status: 'Ended',
+        thumbnail: 'https://artworks.thetvdb.com/banners/posters/73255.jpg',
+        genres: [],
+        primary_language: 'eng',
+        year: '2015',
+      },
+    ],
+  };
+
+  it('returns mapped search results', async () => {
+    // Login + search
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawSearchResponse));
+
+    const results = await client.searchSeries('breaking');
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      tvdbId: 81189,
+      name: 'Breaking Bad',
+      originalName: null,
+      overview: 'A high school chemistry teacher...',
+      firstAirDate: '2008-01-20',
+      status: 'Ended',
+      posterPath: 'https://artworks.thetvdb.com/banners/posters/81189-1.jpg',
+      genres: ['Drama', 'Thriller'],
+      originalLanguage: 'eng',
+      year: '2008',
+    });
+  });
+
+  it('handles missing fields with null defaults', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawSearchResponse));
+
+    const results = await client.searchSeries('saul');
+
+    expect(results[1]!.overview).toBeNull();
+    expect(results[1]!.firstAirDate).toBeNull();
+    // Falls back to thumbnail when image_url is missing
+    expect(results[1]!.posterPath).toBe('https://artworks.thetvdb.com/banners/posters/73255.jpg');
+  });
+
+  it('passes query and type=series in URL', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse({ status: 'success', data: [] }));
+
+    await client.searchSeries('breaking bad');
+
+    const [url] = fetchMock.mock.calls[1] as [string];
+    expect(url).toContain('q=breaking+bad');
+    expect(url).toContain('type=series');
+  });
+});
+
+describe('TheTvdbClient.getSeriesExtended', () => {
+  const rawExtended = {
+    status: 'success',
+    data: {
+      id: 81189,
+      name: 'Breaking Bad',
+      originalName: 'Breaking Bad',
+      overview: 'A high school chemistry teacher...',
+      firstAired: '2008-01-20',
+      lastAired: '2013-09-29',
+      status: { id: 2, name: 'Ended' },
+      originalLanguage: 'eng',
+      averageRuntime: 47,
+      genres: [
+        { id: 7, name: 'Drama' },
+        { id: 17, name: 'Thriller' },
+      ],
+      networks: [{ id: 52, name: 'AMC' }],
+      seasons: [
+        {
+          id: 30272,
+          number: 0,
+          name: 'Specials',
+          overview: null,
+          image: null,
+          type: { id: 1, name: 'Specials', type: 'default' },
+          episodes: [{ id: 1 }, { id: 2 }],
+        },
+        {
+          id: 30273,
+          number: 1,
+          name: 'Season 1',
+          overview: 'The first season.',
+          image: 'https://artworks.thetvdb.com/seasons/30273.jpg',
+          type: { id: 1, name: 'Season 1', type: 'default' },
+          episodes: [{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }],
+        },
+      ],
+      artworks: [
+        {
+          id: 100,
+          type: 2,
+          image: 'https://artworks.thetvdb.com/posters/81189-poster.jpg',
+          language: 'eng',
+          score: 100,
+        },
+        {
+          id: 101,
+          type: 3,
+          image: 'https://artworks.thetvdb.com/backdrops/81189-bg.jpg',
+          language: null,
+          score: 85,
+        },
+      ],
+    },
+  };
+
+  it('returns mapped show detail', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawExtended));
+
+    const result = await client.getSeriesExtended(81189);
+
+    expect(result.tvdbId).toBe(81189);
+    expect(result.name).toBe('Breaking Bad');
+    expect(result.status).toBe('Ended');
+    expect(result.averageRuntime).toBe(47);
+    expect(result.genres).toEqual([
+      { id: 7, name: 'Drama' },
+      { id: 17, name: 'Thriller' },
+    ]);
+    expect(result.networks).toEqual([{ id: 52, name: 'AMC' }]);
+  });
+
+  it('maps seasons with episode counts', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawExtended));
+
+    const result = await client.getSeriesExtended(81189);
+
+    expect(result.seasons).toHaveLength(2);
+    expect(result.seasons[0]!.tvdbId).toBe(30272);
+    expect(result.seasons[0]!.seasonNumber).toBe(0);
+    expect(result.seasons[0]!.episodeCount).toBe(2);
+    expect(result.seasons[1]!.seasonNumber).toBe(1);
+    expect(result.seasons[1]!.episodeCount).toBe(7);
+    expect(result.seasons[1]!.imageUrl).toBe('https://artworks.thetvdb.com/seasons/30273.jpg');
+  });
+
+  it('maps artworks', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawExtended));
+
+    const result = await client.getSeriesExtended(81189);
+
+    expect(result.artworks).toHaveLength(2);
+    expect(result.artworks[0]).toEqual({
+      id: 100,
+      type: 2,
+      imageUrl: 'https://artworks.thetvdb.com/posters/81189-poster.jpg',
+      language: 'eng',
+      score: 100,
+    });
+  });
+
+  it('calls correct URL', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawExtended));
+
+    await client.getSeriesExtended(81189);
+
+    const [url] = fetchMock.mock.calls[1] as [string];
+    expect(url).toContain('/series/81189/extended');
+  });
+});
+
+describe('TheTvdbClient.getSeriesEpisodes', () => {
+  const rawEpisodes = {
+    status: 'success',
+    data: {
+      series: { id: 81189 },
+      episodes: [
+        {
+          id: 349232,
+          number: 1,
+          seasonNumber: 1,
+          name: 'Pilot',
+          overview: 'Walter White, a chemistry teacher...',
+          aired: '2008-01-20',
+          runtime: 58,
+          image: 'https://artworks.thetvdb.com/episodes/349232.jpg',
+        },
+        {
+          id: 349233,
+          number: 2,
+          seasonNumber: 1,
+          name: "Cat's in the Bag...",
+          overview: null,
+          aired: '2008-01-27',
+          runtime: 48,
+          image: null,
+        },
+      ],
+    },
+  };
+
+  it('returns mapped episodes', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawEpisodes));
+
+    const episodes = await client.getSeriesEpisodes(81189, 1);
+
+    expect(episodes).toHaveLength(2);
+    expect(episodes[0]).toEqual({
+      tvdbId: 349232,
+      episodeNumber: 1,
+      seasonNumber: 1,
+      name: 'Pilot',
+      overview: 'Walter White, a chemistry teacher...',
+      airDate: '2008-01-20',
+      runtime: 58,
+      imageUrl: 'https://artworks.thetvdb.com/episodes/349232.jpg',
+    });
+    expect(episodes[1]!.overview).toBeNull();
+    expect(episodes[1]!.imageUrl).toBeNull();
+  });
+
+  it('calls correct URL with season parameter', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse(rawEpisodes));
+
+    await client.getSeriesEpisodes(81189, 1);
+
+    const [url] = fetchMock.mock.calls[1] as [string];
+    expect(url).toContain('/series/81189/episodes/default?season=1');
+  });
+});
+
+describe('TheTvdbClient error handling', () => {
+  it('throws TvdbApiError on 404', async () => {
+    expect.assertions(2);
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse({ message: 'Record not found' }, 404, 'Not Found'));
+
+    try {
+      await client.getSeriesExtended(999999);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TvdbApiError);
+      expect((err as TvdbApiError).status).toBe(404);
+    }
+  });
+
+  it('retries once on 401 (re-authenticates)', async () => {
+    const FRESH_TOKEN = 'refreshed-token';
+    fetchMock
+      // Initial login
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      // First request → 401
+      .mockResolvedValueOnce(mockResponse({ message: 'Token expired' }, 401, 'Unauthorized'))
+      // Re-login
+      .mockResolvedValueOnce(mockResponse({ status: 'success', data: { token: FRESH_TOKEN } }))
+      // Retry → success
+      .mockResolvedValueOnce(mockResponse({ status: 'success', data: [] }));
+
+    const results = await client.searchSeries('test');
+
+    expect(results).toEqual([]);
+    // 4 fetch calls: login, 401, re-login, retry
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    // Verify the retry used the new token
+    const [, retryOptions] = fetchMock.mock.calls[3] as [string, RequestInit];
+    expect((retryOptions.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${FRESH_TOKEN}`
+    );
+  });
+
+  it('throws TvdbApiError on persistent 401 (does not retry infinitely)', async () => {
+    expect.assertions(2);
+    fetchMock
+      // Initial login
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      // First request → 401
+      .mockResolvedValueOnce(mockResponse({ message: 'Unauthorized' }, 401, 'Unauthorized'))
+      // Re-login
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      // Retry → 401 again
+      .mockResolvedValueOnce(mockResponse({ message: 'Still unauthorized' }, 401, 'Unauthorized'));
+
+    try {
+      await client.searchSeries('test');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TvdbApiError);
+      expect((err as TvdbApiError).status).toBe(401);
+    }
+  });
+
+  it('throws TvdbApiError on network error', async () => {
+    expect.assertions(3);
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockRejectedValueOnce(new Error('Connection refused'));
+
+    try {
+      await client.searchSeries('test');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TvdbApiError);
+      expect((err as TvdbApiError).status).toBe(0);
+      expect((err as TvdbApiError).message).toContain('Connection refused');
+    }
+  });
+
+  it('sends Bearer token in Authorization header', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(LOGIN_RESPONSE))
+      .mockResolvedValueOnce(mockResponse({ status: 'success', data: [] }));
+
+    await client.searchSeries('test');
+
+    const [, options] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBe(`Bearer ${FAKE_TOKEN}`);
+  });
+});

--- a/pillars/media/src/api/clients/thetvdb/client.ts
+++ b/pillars/media/src/api/clients/thetvdb/client.ts
@@ -1,0 +1,96 @@
+import { fetchWithRetry } from './rate-limiter.js';
+import {
+  mapEpisode,
+  mapSearchResult,
+  mapShowDetail,
+  type RawTvdbEpisodesResponse,
+  type RawTvdbSearchResponse,
+  type RawTvdbSeriesExtendedResponse,
+  TvdbApiError,
+  type TvdbEpisode,
+  type TvdbSearchResult,
+  type TvdbShowDetail,
+} from './types.js';
+
+/**
+ * TheTVDB v4 HTTP client — typed wrapper around the TheTVDB REST API.
+ *
+ * Handles request construction, response parsing, error mapping,
+ * and automatic 401 re-authentication retry.
+ */
+import type { TheTvdbAuth } from './auth.js';
+
+const BASE_URL = 'https://api4.thetvdb.com/v4';
+
+export class TheTvdbClient {
+  private readonly auth: TheTvdbAuth;
+
+  constructor(auth: TheTvdbAuth) {
+    this.auth = auth;
+  }
+
+  /** Search for TV series by query string. */
+  async searchSeries(query: string): Promise<TvdbSearchResult[]> {
+    const params = new URLSearchParams({ q: query, type: 'series' });
+    const raw = await this.get<RawTvdbSearchResponse>(`/search?${params.toString()}`);
+    return raw.data.map(mapSearchResult);
+  }
+
+  /** Get extended series detail by TheTVDB ID. */
+  async getSeriesExtended(tvdbId: number): Promise<TvdbShowDetail> {
+    const raw = await this.get<RawTvdbSeriesExtendedResponse>(`/series/${tvdbId}/extended`);
+    return mapShowDetail(raw.data);
+  }
+
+  /** Get episodes for a specific season of a series. */
+  async getSeriesEpisodes(tvdbId: number, seasonNumber: number): Promise<TvdbEpisode[]> {
+    const raw = await this.get<RawTvdbEpisodesResponse>(
+      `/series/${tvdbId}/episodes/default?season=${seasonNumber}`
+    );
+    return raw.data.episodes.map(mapEpisode);
+  }
+
+  /** Generic GET with Bearer auth, error handling, and 401 retry. */
+  private async get<T>(path: string, isRetry = false): Promise<T> {
+    const token = await this.auth.getToken();
+    let response: Response;
+
+    try {
+      response = await fetchWithRetry(() =>
+        fetch(`${BASE_URL}${path}`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+          },
+        })
+      );
+    } catch (err) {
+      throw new TvdbApiError(
+        0,
+        `Network error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    // On 401, invalidate token and retry once
+    if (response.status === 401 && !isRetry) {
+      this.auth.invalidate();
+      return this.get<T>(path, true);
+    }
+
+    if (!response.ok) {
+      let message = `TheTVDB API error: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as { message?: string };
+        if (body.message) {
+          message = body.message;
+        }
+      } catch {
+        // Ignore parse failures
+      }
+      throw new TvdbApiError(response.status, message);
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/pillars/media/src/api/clients/thetvdb/index.test.ts
+++ b/pillars/media/src/api/clients/thetvdb/index.test.ts
@@ -1,0 +1,59 @@
+/**
+ * TheTVDB index module tests — startup validation and client factory.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getTvdbClient, setTvdbClient, validateTvdbConfig } from './index.js';
+
+// Mock auth + client so getTvdbClient doesn't make real HTTP calls
+vi.mock('./auth.js', () => ({
+  TheTvdbAuth: vi.fn(),
+}));
+vi.mock('./client.js', () => ({
+  TheTvdbClient: vi.fn(),
+}));
+
+beforeEach(() => {
+  // Reset the singleton between tests
+  setTvdbClient(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('validateTvdbConfig', () => {
+  it('throws when THETVDB_API_KEY is not set', () => {
+    vi.stubEnv('THETVDB_API_KEY', '');
+    expect(() => {
+      validateTvdbConfig();
+    }).toThrow('THETVDB_API_KEY');
+  });
+
+  it('does not throw when THETVDB_API_KEY is set', () => {
+    vi.stubEnv('THETVDB_API_KEY', 'test-key');
+    expect(() => {
+      validateTvdbConfig();
+    }).not.toThrow();
+  });
+});
+
+describe('getTvdbClient', () => {
+  it('throws when THETVDB_API_KEY is not set', () => {
+    vi.stubEnv('THETVDB_API_KEY', '');
+    expect(() => getTvdbClient()).toThrow('THETVDB_API_KEY');
+  });
+
+  it('returns a client when THETVDB_API_KEY is set', () => {
+    vi.stubEnv('THETVDB_API_KEY', 'test-key');
+    const client = getTvdbClient();
+    expect(client).toBeDefined();
+  });
+
+  it('returns the same singleton on subsequent calls', () => {
+    vi.stubEnv('THETVDB_API_KEY', 'test-key');
+    const client1 = getTvdbClient();
+    const client2 = getTvdbClient();
+    expect(client1).toBe(client2);
+  });
+});

--- a/pillars/media/src/api/clients/thetvdb/index.ts
+++ b/pillars/media/src/api/clients/thetvdb/index.ts
@@ -1,0 +1,39 @@
+import { requireEnv } from '../env.js';
+import { TheTvdbAuth } from './auth.js';
+import { TheTvdbClient } from './client.js';
+
+export { TheTvdbAuth, TheTvdbClient };
+export type {
+  TvdbArtwork,
+  TvdbEpisode,
+  TvdbSearchResult,
+  TvdbSeasonSummary,
+  TvdbShowDetail,
+} from './types.js';
+export { TvdbApiError } from './types.js';
+
+/**
+ * Validate that THETVDB_API_KEY is configured.
+ * Call at startup to fail fast with a clear error.
+ */
+export function validateTvdbConfig(): void {
+  requireEnv('THETVDB_API_KEY');
+}
+
+/**
+ * Shared TheTVDB client singleton — reuses JWT token across requests.
+ * Throws if THETVDB_API_KEY is not set.
+ */
+let sharedTvdbClient: TheTvdbClient | null = null;
+
+export function getTvdbClient(): TheTvdbClient {
+  if (sharedTvdbClient) return sharedTvdbClient;
+  const apiKey = requireEnv('THETVDB_API_KEY');
+  sharedTvdbClient = new TheTvdbClient(new TheTvdbAuth(apiKey));
+  return sharedTvdbClient;
+}
+
+/** Reset the shared client (for testing). */
+export function setTvdbClient(client: TheTvdbClient | null): void {
+  sharedTvdbClient = client;
+}

--- a/pillars/media/src/api/clients/thetvdb/rate-limiter.test.ts
+++ b/pillars/media/src/api/clients/thetvdb/rate-limiter.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TokenBucketRateLimiter } from '../tmdb/rate-limiter.js';
+import { fetchWithRetry, getTvdbRateLimiter, setTvdbRateLimiter } from './rate-limiter.js';
+
+describe('getTvdbRateLimiter', () => {
+  afterEach(() => {
+    setTvdbRateLimiter(null);
+  });
+
+  it('creates a singleton rate limiter', () => {
+    const limiter = getTvdbRateLimiter();
+    expect(limiter).toBeInstanceOf(TokenBucketRateLimiter);
+    expect(getTvdbRateLimiter()).toBe(limiter);
+  });
+
+  it('setTvdbRateLimiter replaces the singleton', () => {
+    const original = getTvdbRateLimiter();
+    const custom = new TokenBucketRateLimiter(10, 1);
+    setTvdbRateLimiter(custom);
+    expect(getTvdbRateLimiter()).toBe(custom);
+    expect(getTvdbRateLimiter()).not.toBe(original);
+    custom.destroy();
+    original.destroy();
+  });
+});
+
+describe('fetchWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Use a generous limiter so token acquisition doesn't interfere
+    setTvdbRateLimiter(new TokenBucketRateLimiter(100, 100));
+  });
+
+  afterEach(() => {
+    const limiter = getTvdbRateLimiter();
+    limiter.destroy();
+    setTvdbRateLimiter(null);
+    vi.useRealTimers();
+  });
+
+  it('returns response on success without retry', async () => {
+    const response = new Response('ok', { status: 200 });
+    const fn = vi.fn().mockResolvedValue(response);
+
+    const result = await fetchWithRetry(fn);
+    expect(result).toBe(response);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns non-429 error responses without retry', async () => {
+    const response = new Response('not found', { status: 404 });
+    const fn = vi.fn().mockResolvedValue(response);
+
+    const result = await fetchWithRetry(fn);
+    expect(result.status).toBe(404);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 429 with exponential backoff', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const promise = fetchWithRetry(fn);
+
+    // First call happens immediately
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // After 1s backoff, second call happens
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    const result = await promise;
+    expect(result.status).toBe(200);
+  });
+
+  it('retries up to 3 times on 429', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const promise = fetchWithRetry(fn);
+
+    // Initial call
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // 1s backoff → retry 1
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // 2s backoff → retry 2
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    // 4s backoff → retry 3
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(fn).toHaveBeenCalledTimes(4);
+
+    const result = await promise;
+    expect(result.status).toBe(200);
+  });
+
+  it('returns 429 response after max retries exhausted', async () => {
+    const fn = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
+
+    const promise = fetchWithRetry(fn);
+
+    // Initial + 3 retries = 4 calls total
+    await vi.advanceTimersByTimeAsync(0); // initial
+    await vi.advanceTimersByTimeAsync(1000); // retry 1
+    await vi.advanceTimersByTimeAsync(2000); // retry 2
+    await vi.advanceTimersByTimeAsync(4000); // retry 3
+
+    const result = await promise;
+    expect(result.status).toBe(429);
+    expect(fn).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  it('uses exponential backoff delays (1s, 2s, 4s)', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const promise = fetchWithRetry(fn);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Not enough time for first retry
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Complete first backoff (1s total)
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // Not enough for second retry (needs 2s)
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // Complete second backoff (2s total)
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    // Complete third backoff (4s)
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(fn).toHaveBeenCalledTimes(4);
+
+    const result = await promise;
+    expect(result.status).toBe(200);
+  });
+
+  it('propagates fetch errors without retry', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('network error'));
+
+    await expect(fetchWithRetry(fn)).rejects.toThrow('network error');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('acquires rate limiter token before each attempt', async () => {
+    const mockLimiter = new TokenBucketRateLimiter(100, 100);
+    const acquireSpy = vi.spyOn(mockLimiter, 'acquire');
+    setTvdbRateLimiter(mockLimiter);
+
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const promise = fetchWithRetry(fn);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    // acquire called once per attempt (initial + 1 retry = 2)
+    expect(acquireSpy).toHaveBeenCalledTimes(2);
+    mockLimiter.destroy();
+  });
+});

--- a/pillars/media/src/api/clients/thetvdb/rate-limiter.ts
+++ b/pillars/media/src/api/clients/thetvdb/rate-limiter.ts
@@ -1,0 +1,80 @@
+/**
+ * TheTVDB-specific rate limiter.
+ *
+ * Wraps a TokenBucketRateLimiter (20 tokens, 2/sec refill) with
+ * exponential backoff retry on 429 responses (up to 3 retries). Reuses the
+ * shared token-bucket implementation co-located with the TMDB client.
+ */
+import { getEnvInt } from '../env.js';
+import { TokenBucketRateLimiter } from '../tmdb/rate-limiter.js';
+
+const THETVDB_CAPACITY = 20;
+const THETVDB_REFILL_RATE = 2; // tokens per second
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function getCapacity(): number {
+  return getEnvInt('MEDIA_THETVDB_RATE_LIMIT_CAPACITY', THETVDB_CAPACITY);
+}
+
+function getRefillRate(): number {
+  return getEnvInt('MEDIA_THETVDB_RATE_LIMIT_REFILL_RATE', THETVDB_REFILL_RATE);
+}
+
+function getMaxRetries(): number {
+  return getEnvInt('MEDIA_THETVDB_MAX_RETRIES', MAX_RETRIES);
+}
+
+/** Pre-configured rate limiter instance for TheTVDB. */
+let instance: TokenBucketRateLimiter | null = null;
+
+/** Get or create the singleton TheTVDB rate limiter. */
+export function getTvdbRateLimiter(): TokenBucketRateLimiter {
+  instance ??= new TokenBucketRateLimiter(getCapacity(), getRefillRate());
+  return instance;
+}
+
+/** Replace the singleton (for testing). */
+export function setTvdbRateLimiter(limiter: TokenBucketRateLimiter | null): void {
+  instance = limiter;
+}
+
+/**
+ * Execute a fetch with rate limiting and 429 exponential backoff.
+ *
+ * Acquires a token before each attempt. On 429, waits with exponential
+ * backoff (1s, 2s, 4s) and retries up to 3 times.
+ *
+ * @param fn - Async function that performs the HTTP request
+ * @returns The Response from the successful request
+ * @throws The last error if all retries are exhausted
+ */
+export async function fetchWithRetry(fn: () => Promise<Response>): Promise<Response> {
+  const limiter = getTvdbRateLimiter();
+
+  const maxRetries = getMaxRetries();
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    await limiter.acquire();
+    const response = await fn();
+
+    if (response.status !== 429) {
+      return response;
+    }
+
+    // Last attempt — don't retry
+    if (attempt === maxRetries) {
+      return response;
+    }
+
+    // Exponential backoff: 1s, 2s, 4s
+    const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+    await sleep(delay);
+  }
+
+  // Unreachable, but TypeScript needs it
+  throw new Error('fetchWithRetry: unexpected code path');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/pillars/media/src/api/clients/thetvdb/types-domain.ts
+++ b/pillars/media/src/api/clients/thetvdb/types-domain.ts
@@ -1,0 +1,74 @@
+/** TheTVDB v4 domain types and error class. */
+
+/** Typed error for TheTVDB API failures. */
+export class TvdbApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TvdbApiError';
+  }
+}
+
+/** A single search result from TheTVDB. */
+export interface TvdbSearchResult {
+  tvdbId: number;
+  name: string;
+  originalName: string | null;
+  overview: string | null;
+  firstAirDate: string | null;
+  status: string | null;
+  posterPath: string | null;
+  genres: string[];
+  originalLanguage: string | null;
+  year: string | null;
+}
+
+/** Summary of a season within a show detail response. */
+export interface TvdbSeasonSummary {
+  tvdbId: number;
+  seasonNumber: number;
+  name: string | null;
+  overview: string | null;
+  imageUrl: string | null;
+  episodeCount: number;
+}
+
+/** Artwork entry from TheTVDB. */
+export interface TvdbArtwork {
+  id: number;
+  type: number;
+  imageUrl: string;
+  language: string | null;
+  score: number;
+}
+
+/** Full show detail from TheTVDB extended endpoint. */
+export interface TvdbShowDetail {
+  tvdbId: number;
+  name: string;
+  originalName: string | null;
+  overview: string | null;
+  firstAirDate: string | null;
+  lastAirDate: string | null;
+  status: string | null;
+  originalLanguage: string | null;
+  averageRuntime: number | null;
+  genres: { id: number; name: string }[];
+  networks: { id: number; name: string }[];
+  seasons: TvdbSeasonSummary[];
+  artworks: TvdbArtwork[];
+}
+
+/** A single episode from TheTVDB. */
+export interface TvdbEpisode {
+  tvdbId: number;
+  episodeNumber: number;
+  seasonNumber: number;
+  name: string | null;
+  overview: string | null;
+  airDate: string | null;
+  runtime: number | null;
+  imageUrl: string | null;
+}

--- a/pillars/media/src/api/clients/thetvdb/types-inserts.ts
+++ b/pillars/media/src/api/clients/thetvdb/types-inserts.ts
@@ -1,0 +1,57 @@
+import { extractGenreNames, extractNetworkNames, mapArtworks } from './types-mappers.js';
+
+/** Drizzle insert value builders for TheTVDB → POPS media DB. */
+import type { EpisodeInsert, SeasonInsert, TvShowInsert } from '../../../db/index.js';
+import type { TvdbEpisode, TvdbSeasonSummary, TvdbShowDetail } from './types-domain.js';
+
+/** Convert a TvdbShowDetail to a Drizzle insert value for tv_shows. */
+export function toTvShowInsert(detail: TvdbShowDetail): TvShowInsert {
+  const { posterUrl, backdropUrl } = mapArtworks(detail.artworks);
+  return {
+    tvdbId: detail.tvdbId,
+    name: detail.name,
+    originalName: detail.originalName,
+    overview: detail.overview,
+    firstAirDate: detail.firstAirDate,
+    lastAirDate: detail.lastAirDate,
+    status: detail.status,
+    originalLanguage: detail.originalLanguage,
+    numberOfSeasons: detail.seasons.length || null,
+    numberOfEpisodes: null,
+    episodeRunTime: detail.averageRuntime,
+    posterPath: posterUrl,
+    backdropPath: backdropUrl,
+    logoPath: null,
+    voteAverage: null,
+    voteCount: null,
+    genres: JSON.stringify(extractGenreNames(detail.genres)),
+    networks: JSON.stringify(extractNetworkNames(detail.networks)),
+  };
+}
+
+export function toSeasonInsert(season: TvdbSeasonSummary, tvShowId: number): SeasonInsert {
+  return {
+    tvShowId,
+    tvdbId: season.tvdbId,
+    seasonNumber: season.seasonNumber,
+    name: season.name,
+    overview: season.overview,
+    posterPath: season.imageUrl,
+    airDate: null,
+    episodeCount: season.episodeCount || null,
+  };
+}
+
+export function toEpisodeInsert(episode: TvdbEpisode, seasonId: number): EpisodeInsert {
+  return {
+    seasonId,
+    tvdbId: episode.tvdbId,
+    episodeNumber: episode.episodeNumber,
+    name: episode.name,
+    overview: episode.overview,
+    airDate: episode.airDate,
+    stillPath: episode.imageUrl,
+    voteAverage: null,
+    runtime: episode.runtime,
+  };
+}

--- a/pillars/media/src/api/clients/thetvdb/types-mappers.test.ts
+++ b/pillars/media/src/api/clients/thetvdb/types-mappers.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for TheTVDB raw → domain mappers — title quote guard (#2403).
+ *
+ * Mirror of the TMDB-side guard added for #2402. TheTVDB titles travel
+ * through `name` (search + extended) and `name_translated.eng` /
+ * `originalName`. All four are scrubbed of balanced surrounding quotes.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { mapSearchResult, mapShowDetail } from './types-mappers.js';
+
+import type { RawTvdbSearchResult, RawTvdbSeriesExtended } from './types-raw.js';
+
+function rawSearch(overrides: Partial<RawTvdbSearchResult> = {}): RawTvdbSearchResult {
+  return {
+    tvdb_id: '1',
+    name: 'Default',
+    overview: '',
+    first_air_time: '2026-01-01',
+    status: 'Continuing',
+    image_url: null,
+    thumbnail: null,
+    genres: [],
+    primary_language: 'en',
+    year: '2026',
+    ...overrides,
+  };
+}
+
+function rawSeries(overrides: Partial<RawTvdbSeriesExtended> = {}): RawTvdbSeriesExtended {
+  return {
+    id: 1,
+    name: 'Default',
+    originalName: null,
+    overview: '',
+    firstAired: '2026-01-01',
+    lastAired: null,
+    status: { id: 1, name: 'Continuing' },
+    originalLanguage: 'en',
+    averageRuntime: 60,
+    genres: [],
+    networks: [],
+    seasons: [],
+    artworks: [],
+    ...overrides,
+  };
+}
+
+describe('mapSearchResult — title quote guard (#2403)', () => {
+  it('strips surrounding quotes from name', () => {
+    const result = mapSearchResult(rawSearch({ name: '"The Wire"' }));
+    expect(result.name).toBe('The Wire');
+  });
+
+  it('strips surrounding quotes from name_translated.eng (originalName)', () => {
+    const result = mapSearchResult(rawSearch({ name_translated: { eng: '"Breaking Bad"' } }));
+    expect(result.originalName).toBe('Breaking Bad');
+  });
+
+  it('leaves originalName null when no translation is provided', () => {
+    const result = mapSearchResult(rawSearch({ name_translated: null }));
+    expect(result.originalName).toBeNull();
+  });
+
+  it('leaves clean names alone', () => {
+    const result = mapSearchResult(rawSearch({ name: 'Breaking Bad' }));
+    expect(result.name).toBe('Breaking Bad');
+  });
+
+  it('does not strip one-sided quotes', () => {
+    const result = mapSearchResult(rawSearch({ name: 'Lopsided"' }));
+    expect(result.name).toBe('Lopsided"');
+  });
+});
+
+describe('mapShowDetail — title quote guard (#2403)', () => {
+  it('strips surrounding quotes from name', () => {
+    const detail = mapShowDetail(rawSeries({ name: '"The Sopranos"' }));
+    expect(detail.name).toBe('The Sopranos');
+  });
+
+  it('strips surrounding quotes from originalName', () => {
+    const detail = mapShowDetail(rawSeries({ originalName: '"Los Soprano"' }));
+    expect(detail.originalName).toBe('Los Soprano');
+  });
+
+  it('preserves null originalName', () => {
+    const detail = mapShowDetail(rawSeries({ originalName: null }));
+    expect(detail.originalName).toBeNull();
+  });
+
+  it('leaves clean names alone', () => {
+    const detail = mapShowDetail(rawSeries({ name: 'Mad Men' }));
+    expect(detail.name).toBe('Mad Men');
+  });
+});

--- a/pillars/media/src/api/clients/thetvdb/types-mappers.ts
+++ b/pillars/media/src/api/clients/thetvdb/types-mappers.ts
@@ -1,0 +1,152 @@
+/** Mapping functions: Raw TheTVDB API → Domain. */
+import { stripSurroundingQuotes } from '../strip-surrounding-quotes.js';
+
+import type {
+  TvdbArtwork,
+  TvdbEpisode,
+  TvdbSearchResult,
+  TvdbSeasonSummary,
+  TvdbShowDetail,
+} from './types-domain.js';
+import type {
+  RawTvdbArtwork,
+  RawTvdbEpisode,
+  RawTvdbSearchResult,
+  RawTvdbSeasonSummary,
+  RawTvdbSeriesExtended,
+} from './types-raw.js';
+
+const ARTWORK_TYPE_POSTER = 2;
+const ARTWORK_TYPE_BACKDROP = 3;
+
+function pickFirst<T>(...values: Array<T | null | undefined>): T | null {
+  for (const v of values) {
+    if (v != null) return v;
+  }
+  return null;
+}
+
+/** Map a raw search result to a clean domain object. */
+export function mapSearchResult(raw: RawTvdbSearchResult): TvdbSearchResult {
+  return {
+    tvdbId: Number(pickFirst(raw.tvdb_id, raw.objectID) ?? 0),
+    name: stripSurroundingQuotes(raw.name),
+    originalName: raw.name_translated?.eng ? stripSurroundingQuotes(raw.name_translated.eng) : null,
+    overview: pickFirst(raw.overview, raw.overviews?.eng),
+    firstAirDate: raw.first_air_time ?? null,
+    status: raw.status ?? null,
+    posterPath: pickFirst(raw.image_url, raw.thumbnail),
+    genres: raw.genres ?? [],
+    originalLanguage: raw.primary_language ?? null,
+    year: raw.year ?? null,
+  };
+}
+
+function mapSeasonSummary(s: RawTvdbSeasonSummary): TvdbSeasonSummary {
+  return {
+    tvdbId: s.id,
+    seasonNumber: s.number,
+    name: s.name ?? null,
+    overview: s.overview ?? null,
+    imageUrl: s.image ?? null,
+    episodeCount: Array.isArray(s.episodes) ? s.episodes.length : 0,
+  };
+}
+
+function mapArtwork(a: RawTvdbArtwork): TvdbArtwork {
+  return {
+    id: a.id,
+    type: a.type,
+    imageUrl: a.image,
+    language: a.language,
+    score: a.score,
+  };
+}
+
+function isDefaultOrOfficialSeason(s: RawTvdbSeasonSummary): boolean {
+  return !s.type || s.type.type === 'default' || s.type.type === 'official';
+}
+
+interface ShowDetailScalars {
+  originalName: string | null;
+  overview: string | null;
+  firstAirDate: string | null;
+  lastAirDate: string | null;
+  status: string | null;
+  originalLanguage: string | null;
+  averageRuntime: number | null;
+}
+
+function mapShowDetailScalars(raw: RawTvdbSeriesExtended): ShowDetailScalars {
+  return {
+    originalName: raw.originalName ? stripSurroundingQuotes(raw.originalName) : null,
+    overview: raw.overview ?? null,
+    firstAirDate: raw.firstAired ?? null,
+    lastAirDate: raw.lastAired ?? null,
+    status: raw.status?.name ?? null,
+    originalLanguage: raw.originalLanguage ?? null,
+    averageRuntime: raw.averageRuntime ?? null,
+  };
+}
+
+/** Map a raw extended series response to a clean domain object. */
+export function mapShowDetail(raw: RawTvdbSeriesExtended): TvdbShowDetail {
+  const rawSeasons = (raw.seasons ?? []).filter(isDefaultOrOfficialSeason);
+  return {
+    tvdbId: raw.id,
+    name: stripSurroundingQuotes(raw.name),
+    ...mapShowDetailScalars(raw),
+    genres: (raw.genres ?? []).map((g) => ({ id: g.id, name: g.name })),
+    networks: (raw.networks ?? []).map((n) => ({ id: n.id, name: n.name })),
+    seasons: rawSeasons.map(mapSeasonSummary),
+    artworks: (raw.artworks ?? []).map(mapArtwork),
+  };
+}
+
+/** Map a raw episode to a clean domain object. */
+export function mapEpisode(raw: RawTvdbEpisode): TvdbEpisode {
+  return {
+    tvdbId: raw.id,
+    episodeNumber: raw.number,
+    seasonNumber: raw.seasonNumber,
+    name: raw.name ?? null,
+    overview: raw.overview ?? null,
+    airDate: raw.aired ?? null,
+    runtime: raw.runtime ?? null,
+    imageUrl: raw.image ?? null,
+  };
+}
+
+function pickBestArtwork(artworks: TvdbArtwork[], type: number): string | null {
+  const candidates = artworks.filter((a) => a.type === type);
+  if (candidates.length === 0) return null;
+  const sorted = [...candidates].toSorted((a, b) => {
+    const aEng = a.language === 'eng' ? 1 : 0;
+    const bEng = b.language === 'eng' ? 1 : 0;
+    if (aEng !== bEng) return bEng - aEng;
+    return b.score - a.score;
+  });
+  return sorted[0]?.imageUrl ?? null;
+}
+
+/**
+ * Select the best poster and backdrop URLs from an artwork array.
+ * Prefers English-language artwork with the highest score.
+ */
+export function mapArtworks(artworks: TvdbArtwork[]): {
+  posterUrl: string | null;
+  backdropUrl: string | null;
+} {
+  return {
+    posterUrl: pickBestArtwork(artworks, ARTWORK_TYPE_POSTER),
+    backdropUrl: pickBestArtwork(artworks, ARTWORK_TYPE_BACKDROP),
+  };
+}
+
+export function extractGenreNames(genres: { id: number; name: string }[]): string[] {
+  return genres.map((g) => g.name);
+}
+
+export function extractNetworkNames(networks: { id: number; name: string }[]): string[] {
+  return networks.map((n) => n.name);
+}

--- a/pillars/media/src/api/clients/thetvdb/types-raw.ts
+++ b/pillars/media/src/api/clients/thetvdb/types-raw.ts
@@ -1,0 +1,93 @@
+/** Raw TheTVDB v4 API response shapes. */
+
+export interface RawTvdbSearchResult {
+  tvdb_id?: string;
+  objectID?: string;
+  name: string;
+  name_translated?: Record<string, string> | null;
+  aliases?: string[];
+  overview?: string | null;
+  overviews?: Record<string, string> | null;
+  first_air_time?: string | null;
+  status?: string | null;
+  image_url?: string | null;
+  thumbnail?: string | null;
+  genres?: string[];
+  primary_language?: string | null;
+  year?: string | null;
+}
+
+export interface RawTvdbSearchResponse {
+  status: string;
+  data: RawTvdbSearchResult[];
+}
+
+export interface RawTvdbArtwork {
+  id: number;
+  type: number;
+  image: string;
+  language: string | null;
+  score: number;
+}
+
+export interface RawTvdbSeasonSummary {
+  id: number;
+  number: number;
+  name?: string | null;
+  overview?: string | null;
+  image?: string | null;
+  type?: { id: number; name: string; type: string } | null;
+  episodes?: unknown[] | null;
+}
+
+export interface RawTvdbGenre {
+  id: number;
+  name: string;
+}
+
+export interface RawTvdbSeriesExtended {
+  id: number;
+  name: string;
+  originalName?: string | null;
+  overview?: string | null;
+  firstAired?: string | null;
+  lastAired?: string | null;
+  status?: { id: number; name: string } | null;
+  originalLanguage?: string | null;
+  averageRuntime?: number | null;
+  genres?: RawTvdbGenre[];
+  networks?: RawTvdbGenre[];
+  seasons?: RawTvdbSeasonSummary[];
+  artworks?: RawTvdbArtwork[];
+}
+
+export interface RawTvdbSeriesExtendedResponse {
+  status: string;
+  data: RawTvdbSeriesExtended;
+}
+
+export interface RawTvdbEpisode {
+  id: number;
+  number: number;
+  seasonNumber: number;
+  name?: string | null;
+  overview?: string | null;
+  aired?: string | null;
+  runtime?: number | null;
+  image?: string | null;
+}
+
+export interface RawTvdbEpisodesResponse {
+  status: string;
+  data: {
+    series: { id: number };
+    episodes: RawTvdbEpisode[];
+  };
+}
+
+export interface RawTvdbLoginResponse {
+  status: string;
+  data: {
+    token: string;
+  };
+}

--- a/pillars/media/src/api/clients/thetvdb/types.test.ts
+++ b/pillars/media/src/api/clients/thetvdb/types.test.ts
@@ -1,0 +1,516 @@
+/**
+ * TheTVDB response mapping tests with realistic fixture data.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractGenreNames,
+  extractNetworkNames,
+  mapArtworks,
+  mapEpisode,
+  mapSearchResult,
+  mapShowDetail,
+  type RawTvdbEpisode,
+  type RawTvdbSearchResult,
+  type RawTvdbSeriesExtended,
+  toEpisodeInsert,
+  toSeasonInsert,
+  toTvShowInsert,
+  TvdbApiError,
+  type TvdbArtwork,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — realistic TheTVDB v4 API response shapes
+// ---------------------------------------------------------------------------
+
+const RAW_SEARCH_RESULT: RawTvdbSearchResult = {
+  tvdb_id: '81189',
+  objectID: '81189',
+  name: 'Breaking Bad',
+  name_translated: { eng: 'Breaking Bad' },
+  overview: 'Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer.',
+  first_air_time: '2008-01-20',
+  status: 'Ended',
+  primary_language: 'eng',
+  image_url: 'https://artworks.thetvdb.com/banners/posters/81189-1.jpg',
+  thumbnail: 'https://artworks.thetvdb.com/banners/posters/81189-1-thumb.jpg',
+  year: '2008',
+  genres: ['Drama', 'Thriller', 'Crime'],
+  overviews: { eng: 'Walter White...' },
+  aliases: ['BB'],
+};
+
+const RAW_SERIES_EXTENDED: RawTvdbSeriesExtended = {
+  id: 81189,
+  name: 'Breaking Bad',
+  originalName: null,
+  overview: 'Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer.',
+  firstAired: '2008-01-20',
+  lastAired: '2013-09-29',
+  status: { id: 2, name: 'Ended' },
+  originalLanguage: 'eng',
+  averageRuntime: 47,
+  genres: [
+    { id: 1, name: 'Drama' },
+    { id: 2, name: 'Thriller' },
+    { id: 3, name: 'Crime' },
+  ],
+  networks: [
+    { id: 1, name: 'AMC' },
+    { id: 2, name: 'Sony Pictures Television' },
+  ],
+  seasons: [
+    {
+      id: 30272,
+      number: 0,
+      name: 'Specials',
+      overview: null,
+      image: null,
+      type: { id: 1, name: 'Aired Order', type: 'default' },
+      episodes: [{ id: 1 }, { id: 2 }],
+    },
+    {
+      id: 30273,
+      number: 1,
+      name: 'Season 1',
+      overview: 'The first season.',
+      image: 'https://artworks.thetvdb.com/banners/seasons/81189-1.jpg',
+      type: { id: 1, name: 'Aired Order', type: 'default' },
+      episodes: [{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }],
+    },
+    {
+      id: 30274,
+      number: 2,
+      name: 'Season 2',
+      overview: 'The second season.',
+      image: 'https://artworks.thetvdb.com/banners/seasons/81189-2.jpg',
+      type: { id: 1, name: 'Aired Order', type: 'default' },
+      episodes: Array.from({ length: 13 }, (_, i) => ({ id: 100 + i })),
+    },
+    {
+      id: 99999,
+      number: 1,
+      name: 'DVD Order Season 1',
+      overview: null,
+      image: null,
+      type: { id: 2, name: 'DVD Order', type: 'dvd' },
+      episodes: [],
+    },
+  ],
+  artworks: [
+    {
+      id: 1001,
+      type: 2,
+      image: 'https://artworks.thetvdb.com/banners/posters/81189-eng.jpg',
+      language: 'eng',
+      score: 100,
+    },
+    {
+      id: 1002,
+      type: 2,
+      image: 'https://artworks.thetvdb.com/banners/posters/81189-jpn.jpg',
+      language: 'jpn',
+      score: 120,
+    },
+    {
+      id: 1003,
+      type: 3,
+      image: 'https://artworks.thetvdb.com/banners/backgrounds/81189-1.jpg',
+      language: 'eng',
+      score: 80,
+    },
+    {
+      id: 1004,
+      type: 1,
+      image: 'https://artworks.thetvdb.com/banners/banners/81189-1.jpg',
+      language: 'eng',
+      score: 50,
+    },
+  ],
+};
+
+const RAW_EPISODE: RawTvdbEpisode = {
+  id: 349232,
+  number: 1,
+  seasonNumber: 1,
+  name: 'Pilot',
+  overview: 'Walter White, a 50-year-old chemistry teacher, decides to cook meth.',
+  aired: '2008-01-20',
+  runtime: 58,
+  image: 'https://artworks.thetvdb.com/banners/episodes/81189/349232.jpg',
+};
+
+// ---------------------------------------------------------------------------
+// mapSearchResult
+// ---------------------------------------------------------------------------
+
+describe('mapSearchResult', () => {
+  it('maps a raw search result to domain shape', () => {
+    const result = mapSearchResult(RAW_SEARCH_RESULT);
+
+    expect(result).toEqual({
+      tvdbId: 81189,
+      name: 'Breaking Bad',
+      originalName: 'Breaking Bad',
+      overview: expect.stringContaining('chemistry teacher'),
+      firstAirDate: '2008-01-20',
+      status: 'Ended',
+      posterPath: 'https://artworks.thetvdb.com/banners/posters/81189-1.jpg',
+      genres: ['Drama', 'Thriller', 'Crime'],
+      originalLanguage: 'eng',
+      year: '2008',
+    });
+  });
+
+  it('handles missing/undefined fields gracefully', () => {
+    const minimal: RawTvdbSearchResult = {
+      name: 'Minimal Show',
+    };
+
+    const result = mapSearchResult(minimal);
+
+    expect(result.tvdbId).toBe(0);
+    expect(result.overview).toBeNull();
+    expect(result.firstAirDate).toBeNull();
+    expect(result.posterPath).toBeNull();
+    expect(result.genres).toEqual([]);
+    expect(result.originalLanguage).toBeNull();
+    expect(result.year).toBeNull();
+  });
+
+  it('falls back to objectID when tvdb_id missing', () => {
+    const result = mapSearchResult({ ...RAW_SEARCH_RESULT, tvdb_id: undefined, objectID: '12345' });
+    expect(result.tvdbId).toBe(12345);
+  });
+
+  it('falls back to thumbnail when image_url missing', () => {
+    const result = mapSearchResult({ ...RAW_SEARCH_RESULT, image_url: undefined });
+    expect(result.posterPath).toBe(
+      'https://artworks.thetvdb.com/banners/posters/81189-1-thumb.jpg'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapShowDetail
+// ---------------------------------------------------------------------------
+
+describe('mapShowDetail', () => {
+  it('maps a raw extended series response', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    expect(detail.tvdbId).toBe(81189);
+    expect(detail.name).toBe('Breaking Bad');
+    expect(detail.status).toBe('Ended');
+    expect(detail.originalLanguage).toBe('eng');
+    expect(detail.averageRuntime).toBe(47);
+    expect(detail.firstAirDate).toBe('2008-01-20');
+    expect(detail.lastAirDate).toBe('2013-09-29');
+  });
+
+  it('extracts genres as objects', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    expect(detail.genres).toEqual([
+      { id: 1, name: 'Drama' },
+      { id: 2, name: 'Thriller' },
+      { id: 3, name: 'Crime' },
+    ]);
+  });
+
+  it('extracts networks', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    expect(detail.networks).toEqual([
+      { id: 1, name: 'AMC' },
+      { id: 2, name: 'Sony Pictures Television' },
+    ]);
+  });
+
+  it('filters seasons to default/official order only', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    // 3 default seasons (0, 1, 2) — DVD order season filtered out
+    expect(detail.seasons).toHaveLength(3);
+    expect(detail.seasons.map((s) => s.seasonNumber)).toEqual([0, 1, 2]);
+  });
+
+  it('includes seasons with no type (fallback)', () => {
+    const raw: RawTvdbSeriesExtended = {
+      ...RAW_SERIES_EXTENDED,
+      seasons: [
+        {
+          id: 1,
+          number: 1,
+          // no type field — should be included
+          episodes: [{ id: 1 }],
+        },
+      ],
+    };
+    const detail = mapShowDetail(raw);
+    expect(detail.seasons).toHaveLength(1);
+  });
+
+  it("counts episodes from season's episodes array", () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    expect(detail.seasons[0]!.episodeCount).toBe(2);
+    expect(detail.seasons[1]!.episodeCount).toBe(7);
+    expect(detail.seasons[2]!.episodeCount).toBe(13);
+  });
+
+  it('maps artworks', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+
+    expect(detail.artworks).toHaveLength(4);
+    expect(detail.artworks[0]).toEqual({
+      id: 1001,
+      type: 2,
+      imageUrl: 'https://artworks.thetvdb.com/banners/posters/81189-eng.jpg',
+      language: 'eng',
+      score: 100,
+    });
+  });
+
+  it('handles show with no seasons', () => {
+    const detail = mapShowDetail({ ...RAW_SERIES_EXTENDED, seasons: undefined });
+    expect(detail.seasons).toEqual([]);
+  });
+
+  it('handles undefined genres/networks/artworks', () => {
+    const detail = mapShowDetail({
+      ...RAW_SERIES_EXTENDED,
+      genres: undefined,
+      networks: undefined,
+      artworks: undefined,
+    });
+    expect(detail.genres).toEqual([]);
+    expect(detail.networks).toEqual([]);
+    expect(detail.artworks).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapEpisode
+// ---------------------------------------------------------------------------
+
+describe('mapEpisode', () => {
+  it('maps a raw episode to domain shape', () => {
+    const episode = mapEpisode(RAW_EPISODE);
+
+    expect(episode).toEqual({
+      tvdbId: 349232,
+      episodeNumber: 1,
+      seasonNumber: 1,
+      name: 'Pilot',
+      overview: expect.stringContaining('50-year-old'),
+      airDate: '2008-01-20',
+      runtime: 58,
+      imageUrl: 'https://artworks.thetvdb.com/banners/episodes/81189/349232.jpg',
+    });
+  });
+
+  it('handles undefined fields', () => {
+    const raw: RawTvdbEpisode = {
+      id: 999,
+      number: 5,
+      seasonNumber: 2,
+    };
+
+    const episode = mapEpisode(raw);
+    expect(episode.name).toBeNull();
+    expect(episode.overview).toBeNull();
+    expect(episode.airDate).toBeNull();
+    expect(episode.runtime).toBeNull();
+    expect(episode.imageUrl).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapArtworks
+// ---------------------------------------------------------------------------
+
+describe('mapArtworks', () => {
+  const artworks: TvdbArtwork[] = [
+    { id: 1, type: 2, imageUrl: 'poster-eng.jpg', language: 'eng', score: 80 },
+    { id: 2, type: 2, imageUrl: 'poster-jpn.jpg', language: 'jpn', score: 120 },
+    { id: 3, type: 3, imageUrl: 'backdrop-eng.jpg', language: 'eng', score: 90 },
+    { id: 4, type: 3, imageUrl: 'backdrop-null.jpg', language: null, score: 100 },
+    { id: 5, type: 1, imageUrl: 'banner.jpg', language: 'eng', score: 50 },
+  ];
+
+  it('picks English poster over higher-scored non-English', () => {
+    expect(mapArtworks(artworks).posterUrl).toBe('poster-eng.jpg');
+  });
+
+  it('picks English backdrop over higher-scored null-language', () => {
+    expect(mapArtworks(artworks).backdropUrl).toBe('backdrop-eng.jpg');
+  });
+
+  it('falls back to highest score when no English artwork exists', () => {
+    const nonEngArt: TvdbArtwork[] = [
+      { id: 1, type: 2, imageUrl: 'poster-jpn.jpg', language: 'jpn', score: 80 },
+      { id: 2, type: 2, imageUrl: 'poster-kor.jpg', language: 'kor', score: 120 },
+    ];
+    expect(mapArtworks(nonEngArt).posterUrl).toBe('poster-kor.jpg');
+  });
+
+  it('returns null when no artwork of a type exists', () => {
+    const postersOnly: TvdbArtwork[] = [
+      { id: 1, type: 2, imageUrl: 'poster.jpg', language: 'eng', score: 100 },
+    ];
+    const result = mapArtworks(postersOnly);
+    expect(result.posterUrl).toBe('poster.jpg');
+    expect(result.backdropUrl).toBeNull();
+  });
+
+  it('returns both null for empty array', () => {
+    const result = mapArtworks([]);
+    expect(result.posterUrl).toBeNull();
+    expect(result.backdropUrl).toBeNull();
+  });
+
+  it('sorts by score among multiple English artworks', () => {
+    const multiEng: TvdbArtwork[] = [
+      { id: 1, type: 2, imageUrl: 'low.jpg', language: 'eng', score: 50 },
+      { id: 2, type: 2, imageUrl: 'high.jpg', language: 'eng', score: 100 },
+    ];
+    expect(mapArtworks(multiEng).posterUrl).toBe('high.jpg');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractGenreNames / extractNetworkNames
+// ---------------------------------------------------------------------------
+
+describe('extractGenreNames', () => {
+  it('extracts names from genre objects', () => {
+    expect(
+      extractGenreNames([
+        { id: 1, name: 'Drama' },
+        { id: 2, name: 'Comedy' },
+      ])
+    ).toEqual(['Drama', 'Comedy']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(extractGenreNames([])).toEqual([]);
+  });
+});
+
+describe('extractNetworkNames', () => {
+  it('extracts names from network objects', () => {
+    expect(
+      extractNetworkNames([
+        { id: 1, name: 'AMC' },
+        { id: 2, name: 'Netflix' },
+      ])
+    ).toEqual(['AMC', 'Netflix']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Insert builders
+// ---------------------------------------------------------------------------
+
+describe('toTvShowInsert', () => {
+  it('converts show detail to Drizzle insert value', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+    const insert = toTvShowInsert(detail);
+
+    expect(insert.tvdbId).toBe(81189);
+    expect(insert.name).toBe('Breaking Bad');
+    expect(insert.originalName).toBeNull();
+    expect(insert.firstAirDate).toBe('2008-01-20');
+    expect(insert.lastAirDate).toBe('2013-09-29');
+    expect(insert.status).toBe('Ended');
+    expect(insert.originalLanguage).toBe('eng');
+    expect(insert.episodeRunTime).toBe(47);
+    expect(insert.numberOfSeasons).toBe(3);
+    expect(insert.numberOfEpisodes).toBeNull();
+    expect(insert.logoPath).toBeNull();
+  });
+
+  it('serializes genres as JSON string array', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+    expect(toTvShowInsert(detail).genres).toBe(JSON.stringify(['Drama', 'Thriller', 'Crime']));
+  });
+
+  it('serializes networks as JSON string array', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+    expect(toTvShowInsert(detail).networks).toBe(
+      JSON.stringify(['AMC', 'Sony Pictures Television'])
+    );
+  });
+
+  it('picks best English poster from artworks', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+    const insert = toTvShowInsert(detail);
+    expect(insert.posterPath).toBe('https://artworks.thetvdb.com/banners/posters/81189-eng.jpg');
+    expect(insert.backdropPath).toBe(
+      'https://artworks.thetvdb.com/banners/backgrounds/81189-1.jpg'
+    );
+  });
+});
+
+describe('toSeasonInsert', () => {
+  it('converts season summary to Drizzle insert value', () => {
+    const detail = mapShowDetail(RAW_SERIES_EXTENDED);
+    const season = detail.seasons[1]!; // Season 1
+    const insert = toSeasonInsert(season, 42);
+
+    expect(insert.tvShowId).toBe(42);
+    expect(insert.tvdbId).toBe(30273);
+    expect(insert.seasonNumber).toBe(1);
+    expect(insert.name).toBe('Season 1');
+    expect(insert.overview).toBe('The first season.');
+    expect(insert.posterPath).toBe('https://artworks.thetvdb.com/banners/seasons/81189-1.jpg');
+    expect(insert.episodeCount).toBe(7);
+    expect(insert.airDate).toBeNull();
+  });
+
+  it('maps zero episodes to null', () => {
+    const season = {
+      tvdbId: 1,
+      seasonNumber: 3,
+      name: null,
+      overview: null,
+      imageUrl: null,
+      episodeCount: 0,
+    };
+    expect(toSeasonInsert(season, 1).episodeCount).toBeNull();
+  });
+});
+
+describe('toEpisodeInsert', () => {
+  it('converts episode to Drizzle insert value', () => {
+    const episode = mapEpisode(RAW_EPISODE);
+    const insert = toEpisodeInsert(episode, 99);
+
+    expect(insert.seasonId).toBe(99);
+    expect(insert.tvdbId).toBe(349232);
+    expect(insert.episodeNumber).toBe(1);
+    expect(insert.name).toBe('Pilot');
+    expect(insert.overview).toContain('50-year-old');
+    expect(insert.airDate).toBe('2008-01-20');
+    expect(insert.runtime).toBe(58);
+    expect(insert.stillPath).toBe('https://artworks.thetvdb.com/banners/episodes/81189/349232.jpg');
+    expect(insert.voteAverage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TvdbApiError
+// ---------------------------------------------------------------------------
+
+describe('TvdbApiError', () => {
+  it('creates an error with status and message', () => {
+    const err = new TvdbApiError(401, 'Unauthorized');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('TvdbApiError');
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('Unauthorized');
+  });
+});

--- a/pillars/media/src/api/clients/thetvdb/types.ts
+++ b/pillars/media/src/api/clients/thetvdb/types.ts
@@ -1,0 +1,14 @@
+/**
+ * TheTVDB v4 API types — re-exports of domain types, raw API shapes,
+ * mapping functions, and Drizzle insert builders.
+ *
+ * Implementation is split across:
+ *  - types-domain.ts   — domain types (TvdbShowDetail, TvdbEpisode, ...)
+ *  - types-raw.ts      — raw API response shapes (RawTvdb*)
+ *  - types-mappers.ts  — raw → domain mapping functions
+ *  - types-inserts.ts  — Drizzle insert builders
+ */
+export * from './types-domain.js';
+export * from './types-raw.js';
+export * from './types-mappers.js';
+export * from './types-inserts.js';

--- a/pillars/media/src/api/clients/tmdb/client-mappers.test.ts
+++ b/pillars/media/src/api/clients/tmdb/client-mappers.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for TMDB raw → domain mappers.
+ *
+ * Issue #2402 — guard at the mapper layer so titles returned by TMDB with
+ * surrounding double-quote characters never reach the database in that
+ * form (root cause of #2343, the *Wuthering Heights* 2026 record).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { mapMovieDetail, mapMovieResult } from './client-mappers.js';
+
+import type { RawTmdbMovieDetail, RawTmdbSearchResponse } from './types.js';
+
+type RawMovieResult = RawTmdbSearchResponse['results'][number];
+
+function rawSearchResult(overrides: Partial<RawMovieResult> = {}): RawMovieResult {
+  return {
+    id: 1,
+    title: 'Default Title',
+    original_title: 'Default Original',
+    overview: '',
+    release_date: '2026-01-01',
+    poster_path: null,
+    backdrop_path: null,
+    vote_average: 0,
+    vote_count: 0,
+    genre_ids: [],
+    original_language: 'en',
+    popularity: 0,
+    ...overrides,
+  };
+}
+
+function rawMovieDetail(overrides: Partial<RawTmdbMovieDetail> = {}): RawTmdbMovieDetail {
+  return {
+    id: 1,
+    imdb_id: null,
+    title: 'Default Title',
+    original_title: 'Default Original',
+    overview: '',
+    tagline: '',
+    release_date: '2026-01-01',
+    runtime: 0,
+    status: '',
+    original_language: 'en',
+    budget: 0,
+    revenue: 0,
+    poster_path: null,
+    backdrop_path: null,
+    vote_average: 0,
+    vote_count: 0,
+    genres: [],
+    production_companies: [],
+    spoken_languages: [],
+    ...overrides,
+  };
+}
+
+describe('mapMovieResult — title quote guard (#2402)', () => {
+  it('strips surrounding quotes from title', () => {
+    const result = mapMovieResult(rawSearchResult({ title: '"Wuthering Heights"' }));
+    expect(result.title).toBe('Wuthering Heights');
+  });
+
+  it('strips surrounding quotes from originalTitle', () => {
+    const result = mapMovieResult(rawSearchResult({ original_title: '"Cumbres Borrascosas"' }));
+    expect(result.originalTitle).toBe('Cumbres Borrascosas');
+  });
+
+  it('leaves clean titles alone', () => {
+    const result = mapMovieResult(rawSearchResult({ title: 'The Dark Knight' }));
+    expect(result.title).toBe('The Dark Knight');
+  });
+
+  it('preserves titles with internal quotes', () => {
+    const result = mapMovieResult(rawSearchResult({ title: 'Film "Noir" Style' }));
+    expect(result.title).toBe('Film "Noir" Style');
+  });
+
+  it('does not strip one-sided quotes', () => {
+    const result = mapMovieResult(rawSearchResult({ title: '"Lopsided' }));
+    expect(result.title).toBe('"Lopsided');
+  });
+});
+
+describe('mapMovieDetail — title quote guard (#2402)', () => {
+  it('strips surrounding quotes from title', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ title: '"Wuthering Heights"' }));
+    expect(detail.title).toBe('Wuthering Heights');
+  });
+
+  it('strips surrounding quotes from originalTitle', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ original_title: '"Cumbres Borrascosas"' }));
+    expect(detail.originalTitle).toBe('Cumbres Borrascosas');
+  });
+
+  it('leaves clean titles alone', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ title: 'Inception' }));
+    expect(detail.title).toBe('Inception');
+  });
+});

--- a/pillars/media/src/api/clients/tmdb/client-mappers.ts
+++ b/pillars/media/src/api/clients/tmdb/client-mappers.ts
@@ -1,0 +1,110 @@
+import { stripSurroundingQuotes } from '../strip-surrounding-quotes.js';
+
+import type {
+  RawTmdbImageResponse,
+  RawTmdbMovieDetail,
+  RawTmdbSearchResponse,
+  TmdbImage,
+  TmdbImageResponse,
+  TmdbMovieDetail,
+  TmdbSearchResponse,
+} from './types.js';
+
+type RawMovieResult = RawTmdbSearchResponse['results'][number];
+
+export function mapMovieResult(r: RawMovieResult): TmdbSearchResponse['results'][number] {
+  return {
+    tmdbId: r.id,
+    title: stripSurroundingQuotes(r.title),
+    originalTitle: stripSurroundingQuotes(r.original_title),
+    overview: r.overview,
+    releaseDate: r.release_date,
+    posterPath: r.poster_path,
+    backdropPath: r.backdrop_path,
+    voteAverage: r.vote_average,
+    voteCount: r.vote_count,
+    genreIds: r.genre_ids,
+    originalLanguage: r.original_language,
+    popularity: r.popularity,
+  };
+}
+
+export function mapSearchResponse(raw: RawTmdbSearchResponse): TmdbSearchResponse {
+  return {
+    page: raw.page,
+    totalResults: raw.total_results,
+    totalPages: raw.total_pages,
+    results: raw.results.map(mapMovieResult),
+  };
+}
+
+export function mapMovieDetail(raw: RawTmdbMovieDetail): TmdbMovieDetail {
+  return {
+    tmdbId: raw.id,
+    imdbId: raw.imdb_id,
+    title: stripSurroundingQuotes(raw.title),
+    originalTitle: stripSurroundingQuotes(raw.original_title),
+    overview: raw.overview,
+    tagline: raw.tagline,
+    releaseDate: raw.release_date,
+    runtime: raw.runtime,
+    status: raw.status,
+    originalLanguage: raw.original_language,
+    budget: raw.budget,
+    revenue: raw.revenue,
+    posterPath: raw.poster_path,
+    backdropPath: raw.backdrop_path,
+    voteAverage: raw.vote_average,
+    voteCount: raw.vote_count,
+    genres: raw.genres,
+    productionCompanies: raw.production_companies,
+    spokenLanguages: raw.spoken_languages,
+  };
+}
+
+function mapImage(img: RawTmdbImageResponse['backdrops'][number]): TmdbImage {
+  return {
+    filePath: img.file_path,
+    width: img.width,
+    height: img.height,
+    aspectRatio: img.aspect_ratio,
+    voteAverage: img.vote_average,
+    voteCount: img.vote_count,
+    languageCode: img.iso_639_1,
+  };
+}
+
+export function mapImageResponse(raw: RawTmdbImageResponse): TmdbImageResponse {
+  return {
+    id: raw.id,
+    backdrops: raw.backdrops.map(mapImage),
+    posters: raw.posters.map(mapImage),
+    logos: raw.logos.map(mapImage),
+  };
+}
+
+export interface DiscoverOpts {
+  genreIds?: number[];
+  keywordIds?: number[];
+  sortBy?: string;
+  voteCountGte?: number;
+  voteCountLte?: number;
+  voteAverageGte?: number;
+  releaseDateGte?: string;
+  releaseDateLte?: string;
+  page?: number;
+}
+
+export function buildDiscoverParams(opts: DiscoverOpts): URLSearchParams {
+  const params = new URLSearchParams({ language: 'en-US' });
+  if (opts.genreIds?.length) params.set('with_genres', opts.genreIds.join(','));
+  if (opts.keywordIds?.length) params.set('with_keywords', opts.keywordIds.join('|'));
+  if (opts.sortBy) params.set('sort_by', opts.sortBy);
+  if (opts.voteCountGte != null) params.set('vote_count.gte', String(opts.voteCountGte));
+  if (opts.voteCountLte != null) params.set('vote_count.lte', String(opts.voteCountLte));
+  if (opts.voteAverageGte != null) params.set('vote_average.gte', String(opts.voteAverageGte));
+  if (opts.releaseDateGte) params.set('primary_release_date.gte', opts.releaseDateGte);
+  if (opts.releaseDateLte) params.set('primary_release_date.lte', opts.releaseDateLte);
+  params.set('page', String(opts.page ?? 1));
+  return params;
+}

--- a/pillars/media/src/api/clients/tmdb/client.test.ts
+++ b/pillars/media/src/api/clients/tmdb/client.test.ts
@@ -1,0 +1,457 @@
+/**
+ * TMDB client unit tests — all HTTP calls mocked via vi.stubGlobal("fetch").
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TmdbClient } from './client.js';
+import { TokenBucketRateLimiter } from './rate-limiter.js';
+import { TmdbApiError } from './types.js';
+
+import type { RawTmdbImageResponse, RawTmdbMovieDetail, RawTmdbSearchResponse } from './types.js';
+
+/** Helper to create a mocked Response. */
+function mockResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+    redirected: false,
+    type: 'basic',
+    url: '',
+    clone: () => mockResponse(body, status, statusText),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+const FAKE_KEY = 'test-tmdb-api-key-123';
+
+let client: TmdbClient;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  client = new TmdbClient(FAKE_KEY);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TmdbClient constructor', () => {
+  it('throws if API key is empty', () => {
+    expect(() => new TmdbClient('')).toThrow('TMDB API key is required');
+  });
+
+  it('accepts a valid API key', () => {
+    expect(() => new TmdbClient('valid-key')).not.toThrow();
+  });
+});
+
+describe('TmdbClient authentication', () => {
+  it('sends Bearer token in Authorization header', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 })
+    );
+
+    await client.searchMovies('test');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBe(`Bearer ${FAKE_KEY}`);
+  });
+});
+
+describe('searchMovies', () => {
+  const rawSearch: RawTmdbSearchResponse = {
+    page: 1,
+    total_results: 2,
+    total_pages: 1,
+    results: [
+      {
+        id: 550,
+        title: 'Fight Club',
+        original_title: 'Fight Club',
+        overview: 'An insomniac office worker...',
+        release_date: '1999-10-15',
+        poster_path: '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg',
+        backdrop_path: '/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg',
+        vote_average: 8.4,
+        vote_count: 25000,
+        genre_ids: [18, 53],
+        original_language: 'en',
+        popularity: 55.3,
+      },
+      {
+        id: 680,
+        title: 'Pulp Fiction',
+        original_title: 'Pulp Fiction',
+        overview: 'A burger-loving hit man...',
+        release_date: '1994-09-10',
+        poster_path: '/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg',
+        backdrop_path: null,
+        vote_average: 8.5,
+        vote_count: 24000,
+        genre_ids: [53, 80],
+        original_language: 'en',
+        popularity: 48.1,
+      },
+    ],
+  };
+
+  it('returns mapped search results', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawSearch));
+
+    const result = await client.searchMovies('fight');
+
+    expect(result.page).toBe(1);
+    expect(result.totalResults).toBe(2);
+    expect(result.totalPages).toBe(1);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toEqual({
+      tmdbId: 550,
+      title: 'Fight Club',
+      originalTitle: 'Fight Club',
+      overview: 'An insomniac office worker...',
+      releaseDate: '1999-10-15',
+      posterPath: '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg',
+      backdropPath: '/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg',
+      voteAverage: 8.4,
+      voteCount: 25000,
+      genreIds: [18, 53],
+      originalLanguage: 'en',
+      popularity: 55.3,
+    });
+  });
+
+  it('passes query and page as URL parameters', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 3, results: [], total_results: 0, total_pages: 5 })
+    );
+
+    await client.searchMovies('inception', 3);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('query=inception');
+    expect(url).toContain('page=3');
+    expect(url).toContain('language=en-US');
+  });
+
+  it('defaults page to 1', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 })
+    );
+
+    await client.searchMovies('test');
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('page=1');
+  });
+
+  it('handles null backdrop_path in results', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawSearch));
+
+    const result = await client.searchMovies('pulp');
+
+    expect(result.results[1]!.backdropPath).toBeNull();
+  });
+});
+
+describe('getMovie', () => {
+  const rawDetail: RawTmdbMovieDetail = {
+    id: 550,
+    imdb_id: 'tt0137523',
+    title: 'Fight Club',
+    original_title: 'Fight Club',
+    overview: 'An insomniac office worker...',
+    tagline: 'Mischief. Mayhem. Soap.',
+    release_date: '1999-10-15',
+    runtime: 139,
+    status: 'Released',
+    original_language: 'en',
+    budget: 63000000,
+    revenue: 101200000,
+    poster_path: '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg',
+    backdrop_path: '/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg',
+    vote_average: 8.4,
+    vote_count: 25000,
+    genres: [
+      { id: 18, name: 'Drama' },
+      { id: 53, name: 'Thriller' },
+    ],
+    production_companies: [{ id: 508, name: 'Regency Enterprises' }],
+    spoken_languages: [{ iso_639_1: 'en', name: 'English' }],
+  };
+
+  it('returns mapped movie detail', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawDetail));
+
+    const result = await client.getMovie(550);
+
+    expect(result.tmdbId).toBe(550);
+    expect(result.imdbId).toBe('tt0137523');
+    expect(result.title).toBe('Fight Club');
+    expect(result.tagline).toBe('Mischief. Mayhem. Soap.');
+    expect(result.runtime).toBe(139);
+    expect(result.genres).toEqual([
+      { id: 18, name: 'Drama' },
+      { id: 53, name: 'Thriller' },
+    ]);
+    expect(result.productionCompanies).toEqual([{ id: 508, name: 'Regency Enterprises' }]);
+    expect(result.spokenLanguages).toEqual([{ iso_639_1: 'en', name: 'English' }]);
+  });
+
+  it('calls correct URL with tmdbId', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawDetail));
+
+    await client.getMovie(550);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('/3/movie/550');
+    expect(url).toContain('language=en-US');
+  });
+
+  it('handles null imdb_id', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ ...rawDetail, imdb_id: null }));
+
+    const result = await client.getMovie(550);
+    expect(result.imdbId).toBeNull();
+  });
+});
+
+describe('getMovieImages', () => {
+  const rawImages: RawTmdbImageResponse = {
+    id: 550,
+    backdrops: [
+      {
+        file_path: '/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg',
+        width: 1920,
+        height: 1080,
+        aspect_ratio: 1.778,
+        vote_average: 5.5,
+        vote_count: 10,
+        iso_639_1: null,
+      },
+    ],
+    posters: [
+      {
+        file_path: '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg',
+        width: 500,
+        height: 750,
+        aspect_ratio: 0.667,
+        vote_average: 5.3,
+        vote_count: 8,
+        iso_639_1: 'en',
+      },
+    ],
+    logos: [
+      {
+        file_path: '/logo123.png',
+        width: 400,
+        height: 200,
+        aspect_ratio: 2.0,
+        vote_average: 4.0,
+        vote_count: 2,
+        iso_639_1: 'en',
+      },
+    ],
+  };
+
+  it('returns mapped image response', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawImages));
+
+    const result = await client.getMovieImages(550);
+
+    expect(result.id).toBe(550);
+    expect(result.backdrops).toHaveLength(1);
+    expect(result.backdrops[0]!.filePath).toBe('/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg');
+    expect(result.backdrops[0]!.width).toBe(1920);
+    expect(result.posters).toHaveLength(1);
+    expect(result.posters[0]!.filePath).toBe('/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg');
+    expect(result.posters[0]!.languageCode).toBe('en');
+    expect(result.logos).toHaveLength(1);
+    expect(result.logos[0]!.filePath).toBe('/logo123.png');
+    expect(result.backdrops[0]!.languageCode).toBeNull();
+  });
+
+  it('calls correct images URL', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawImages));
+
+    await client.getMovieImages(550);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('/3/movie/550/images');
+  });
+});
+
+describe('getGenreList', () => {
+  it('returns genre list', async () => {
+    const body = {
+      genres: [
+        { id: 28, name: 'Action' },
+        { id: 35, name: 'Comedy' },
+        { id: 18, name: 'Drama' },
+      ],
+    };
+    fetchMock.mockResolvedValueOnce(mockResponse(body));
+
+    const result = await client.getGenreList();
+
+    expect(result.genres).toHaveLength(3);
+    expect(result.genres[0]).toEqual({ id: 28, name: 'Action' });
+    expect(result.genres[2]).toEqual({ id: 18, name: 'Drama' });
+  });
+
+  it('calls correct genre URL', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ genres: [] }));
+
+    await client.getGenreList();
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('/3/genre/movie/list');
+    expect(url).toContain('language=en-US');
+  });
+});
+
+describe('error handling', () => {
+  it('throws TmdbApiError on 404', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { status_message: 'The resource you requested could not be found.' },
+        404,
+        'Not Found'
+      )
+    );
+
+    await expect(client.getMovie(999999)).rejects.toThrow(TmdbApiError);
+
+    try {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(
+          { status_message: 'The resource you requested could not be found.' },
+          404,
+          'Not Found'
+        )
+      );
+      await client.getMovie(999999);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TmdbApiError);
+      expect((err as TmdbApiError).status).toBe(404);
+      expect((err as TmdbApiError).message).toBe('The resource you requested could not be found.');
+    }
+  });
+
+  it('throws TmdbApiError on 401 unauthorized', async () => {
+    expect.assertions(3);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { status_message: 'Invalid API key: You must be granted a valid key.' },
+        401,
+        'Unauthorized'
+      )
+    );
+
+    try {
+      await client.searchMovies('test');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TmdbApiError);
+      expect((err as TmdbApiError).status).toBe(401);
+      expect((err as TmdbApiError).message).toContain('Invalid API key');
+    }
+  });
+
+  it('throws TmdbApiError on 429 rate limited', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { status_message: 'Your request count is over the allowed limit.' },
+        429,
+        'Too Many Requests'
+      )
+    );
+
+    await expect(client.searchMovies('test')).rejects.toThrow(TmdbApiError);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { status_message: 'Your request count is over the allowed limit.' },
+        429,
+        'Too Many Requests'
+      )
+    );
+
+    try {
+      await client.searchMovies('test');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TmdbApiError);
+      expect((err as TmdbApiError).status).toBe(429);
+    }
+  });
+
+  it('throws TmdbApiError on network error', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('fetch failed'));
+
+    await expect(client.searchMovies('test')).rejects.toThrow(TmdbApiError);
+
+    fetchMock.mockRejectedValueOnce(new Error('fetch failed'));
+
+    try {
+      await client.searchMovies('test');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TmdbApiError);
+      expect((err as TmdbApiError).status).toBe(0);
+      expect((err as TmdbApiError).message).toContain('Network error');
+      expect((err as TmdbApiError).message).toContain('fetch failed');
+    }
+  });
+
+  it('uses fallback message when error response has no status_message', async () => {
+    expect.assertions(3);
+    fetchMock.mockResolvedValueOnce(mockResponse({}, 500, 'Internal Server Error'));
+
+    try {
+      await client.getMovie(1);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TmdbApiError);
+      expect((err as TmdbApiError).status).toBe(500);
+      expect((err as TmdbApiError).message).toContain('500');
+    }
+  });
+});
+
+describe('rate limiter integration', () => {
+  it('calls acquire() before each request when rate limiter is provided', async () => {
+    const limiter = new TokenBucketRateLimiter(40, 4);
+    const acquireSpy = vi.spyOn(limiter, 'acquire');
+    const rateLimitedClient = new TmdbClient(FAKE_KEY, limiter);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 })
+    );
+
+    await rateLimitedClient.searchMovies('test');
+
+    expect(acquireSpy).toHaveBeenCalledOnce();
+
+    limiter.destroy();
+  });
+
+  it('does not call acquire() when no rate limiter is provided', async () => {
+    // Default client has no rate limiter
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 })
+    );
+
+    await client.searchMovies('test');
+
+    // Just verify the request succeeded without rate limiting
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/pillars/media/src/api/clients/tmdb/client.ts
+++ b/pillars/media/src/api/clients/tmdb/client.ts
@@ -1,0 +1,166 @@
+import {
+  buildDiscoverParams,
+  mapImageResponse,
+  mapMovieDetail,
+  mapSearchResponse,
+  type DiscoverOpts,
+} from './client-mappers.js';
+import {
+  type RawTmdbImageResponse,
+  type RawTmdbMovieDetail,
+  type RawTmdbRecommendationsResponse,
+  type RawTmdbSearchResponse,
+  type RawTmdbTrendingResponse,
+  TmdbApiError,
+  type TmdbGenreListResponse,
+  type TmdbImageResponse,
+  type TmdbMovieCredits,
+  type TmdbMovieDetail,
+  type TmdbSearchResponse,
+} from './types.js';
+
+/**
+ * TMDB v3 HTTP client — typed wrapper around the TMDB REST API.
+ *
+ * Handles authentication (Bearer token), request construction,
+ * response parsing, and error mapping. Mapper functions live in
+ * `client-mappers.ts`; discover query params use `buildDiscoverParams`.
+ */
+import type { TokenBucketRateLimiter } from './rate-limiter.js';
+
+const BASE_URL = 'https://api.themoviedb.org';
+const PAGED_LANG = 'language=en-US';
+
+export class TmdbClient {
+  private readonly apiKey: string;
+  private readonly rateLimiter: TokenBucketRateLimiter | null;
+
+  constructor(apiKey: string, rateLimiter?: TokenBucketRateLimiter) {
+    if (!apiKey) throw new Error('TMDB API key is required');
+    this.apiKey = apiKey;
+    this.rateLimiter = rateLimiter ?? null;
+  }
+
+  /** Search movies by query string. */
+  async searchMovies(query: string, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({ query, page: String(page), language: 'en-US' });
+    const raw = await this.get<RawTmdbSearchResponse>(`/3/search/movie?${params.toString()}`);
+    return mapSearchResponse(raw);
+  }
+
+  /** Get full movie detail by TMDB ID. */
+  async getMovie(tmdbId: number): Promise<TmdbMovieDetail> {
+    const raw = await this.get<RawTmdbMovieDetail>(`/3/movie/${tmdbId}?${PAGED_LANG}`);
+    return mapMovieDetail(raw);
+  }
+
+  /** Get images (posters, backdrops, logos) for a movie. */
+  async getMovieImages(tmdbId: number): Promise<TmdbImageResponse> {
+    const raw = await this.get<RawTmdbImageResponse>(`/3/movie/${tmdbId}/images`);
+    return mapImageResponse(raw);
+  }
+
+  /** Get trending movies (daily or weekly). */
+  async getTrendingMovies(
+    timeWindow: 'day' | 'week' = 'week',
+    page = 1
+  ): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({ page: String(page), language: 'en-US' });
+    const raw = await this.get<RawTmdbTrendingResponse>(
+      `/3/trending/movie/${timeWindow}?${params.toString()}`
+    );
+    return mapSearchResponse(raw);
+  }
+
+  /** Get movie recommendations based on a specific movie. */
+  async getMovieRecommendations(tmdbId: number, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({ page: String(page), language: 'en-US' });
+    const raw = await this.get<RawTmdbRecommendationsResponse>(
+      `/3/movie/${tmdbId}/recommendations?${params.toString()}`
+    );
+    return mapSearchResponse(raw);
+  }
+
+  /** Get similar movies based on a specific movie. */
+  async getMovieSimilar(tmdbId: number, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({ page: String(page), language: 'en-US' });
+    const raw = await this.get<RawTmdbRecommendationsResponse>(
+      `/3/movie/${tmdbId}/similar?${params.toString()}`
+    );
+    return mapSearchResponse(raw);
+  }
+
+  /** Get crew and cast for a movie. */
+  async getMovieCredits(tmdbId: number): Promise<TmdbMovieCredits> {
+    return this.get<TmdbMovieCredits>(`/3/movie/${tmdbId}/credits?${PAGED_LANG}`);
+  }
+
+  /** Discover movies by crew person ID (e.g. director). */
+  async discoverMoviesByCrew(personId: number, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({
+      with_crew: String(personId),
+      sort_by: 'vote_average.desc',
+      'vote_count.gte': '50',
+      language: 'en-US',
+      page: String(page),
+    });
+    const raw = await this.get<RawTmdbSearchResponse>(`/3/discover/movie?${params.toString()}`);
+    return mapSearchResponse(raw);
+  }
+
+  /** Discover movies by cast person ID. */
+  async discoverMoviesByCast(personId: number, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({
+      with_cast: String(personId),
+      sort_by: 'vote_average.desc',
+      'vote_count.gte': '50',
+      language: 'en-US',
+      page: String(page),
+    });
+    const raw = await this.get<RawTmdbSearchResponse>(`/3/discover/movie?${params.toString()}`);
+    return mapSearchResponse(raw);
+  }
+
+  /** Discover movies by genre IDs and/or keyword IDs, with configurable sort and filters. */
+  async discoverMovies(opts: DiscoverOpts): Promise<TmdbSearchResponse> {
+    const params = buildDiscoverParams(opts);
+    const raw = await this.get<RawTmdbSearchResponse>(`/3/discover/movie?${params.toString()}`);
+    return mapSearchResponse(raw);
+  }
+
+  /** Get the full list of TMDB movie genres. */
+  async getGenreList(): Promise<TmdbGenreListResponse> {
+    return this.get<TmdbGenreListResponse>(`/3/genre/movie/list?${PAGED_LANG}`);
+  }
+
+  /** Generic GET with Bearer auth, rate limiting, and error handling. */
+  private async get<T>(path: string): Promise<T> {
+    if (this.rateLimiter) await this.rateLimiter.acquire();
+
+    let response: Response;
+    try {
+      response = await fetch(`${BASE_URL}${path}`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${this.apiKey}`, Accept: 'application/json' },
+      });
+    } catch (err) {
+      throw new TmdbApiError(
+        0,
+        `Network error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (!response.ok) {
+      let message = `TMDB API error: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as { status_message?: string };
+        if (body.status_message) message = body.status_message;
+      } catch {
+        // Ignore JSON parse failures — use default message
+      }
+      throw new TmdbApiError(response.status, message);
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/pillars/media/src/api/clients/tmdb/genre-cache.test.ts
+++ b/pillars/media/src/api/clients/tmdb/genre-cache.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CACHE_TTL_MS,
+  GenreCache,
+  type GenreListSource,
+  getGenreCache,
+  setGenreCache,
+} from './genre-cache.js';
+
+import type { TmdbGenreListResponse } from './types.js';
+
+const TEST_GENRES = [
+  { id: 28, name: 'Action' },
+  { id: 35, name: 'Comedy' },
+  { id: 18, name: 'Drama' },
+];
+
+function makeMockClient(genres = TEST_GENRES): GenreListSource {
+  return {
+    getGenreList: vi.fn<() => Promise<TmdbGenreListResponse>>().mockResolvedValue({ genres }),
+  };
+}
+
+describe('GenreCache', () => {
+  let cache: GenreCache;
+  let client: TmdbClient;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    cache = new GenreCache(client);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('ensureLoaded', () => {
+    it('fetches genres lazily on first call', async () => {
+      expect(cache.size).toBe(0);
+      await cache.ensureLoaded();
+      expect(cache.size).toBe(3);
+      expect(client.getGenreList).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-fetch within TTL', async () => {
+      await cache.ensureLoaded();
+      await cache.ensureLoaded();
+      expect(client.getGenreList).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after the default TTL expires', async () => {
+      vi.useFakeTimers();
+      try {
+        await cache.ensureLoaded();
+        expect(client.getGenreList).toHaveBeenCalledTimes(1);
+
+        // Advance past TTL
+        vi.advanceTimersByTime(CACHE_TTL_MS + 1);
+
+        await cache.ensureLoaded();
+        expect(client.getGenreList).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('honours MEDIA_TMDB_GENRE_CACHE_TTL_MS override for the TTL window', async () => {
+      vi.stubEnv('MEDIA_TMDB_GENRE_CACHE_TTL_MS', '1000');
+      vi.useFakeTimers();
+      try {
+        const envClient = makeMockClient();
+        const envCache = new GenreCache(envClient);
+
+        await envCache.ensureLoaded();
+        expect(envClient.getGenreList).toHaveBeenCalledTimes(1);
+
+        // Still inside the 1s window — no refetch.
+        vi.advanceTimersByTime(500);
+        await envCache.ensureLoaded();
+        expect(envClient.getGenreList).toHaveBeenCalledTimes(1);
+
+        // Past the overridden TTL — refetch.
+        vi.advanceTimersByTime(600);
+        await envCache.ensureLoaded();
+        expect(envClient.getGenreList).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('falls back to the default TTL when the env override is non-numeric', async () => {
+      vi.stubEnv('MEDIA_TMDB_GENRE_CACHE_TTL_MS', 'not-a-number');
+      vi.useFakeTimers();
+      try {
+        const envClient = makeMockClient();
+        const envCache = new GenreCache(envClient);
+
+        await envCache.ensureLoaded();
+        vi.advanceTimersByTime(CACHE_TTL_MS - 1);
+        await envCache.ensureLoaded();
+        expect(envClient.getGenreList).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(2);
+        await envCache.ensureLoaded();
+        expect(envClient.getGenreList).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('propagates client errors', async () => {
+      const failClient: GenreListSource = {
+        getGenreList: vi.fn().mockRejectedValue(new Error('TMDB API error: 401 Unauthorized')),
+      };
+      const failCache = new GenreCache(failClient);
+
+      await expect(failCache.ensureLoaded()).rejects.toThrow('TMDB API error: 401 Unauthorized');
+    });
+
+    it('deduplicates concurrent requests', async () => {
+      let resolvePromise: (value: TmdbGenreListResponse) => void;
+      const delayed = new Promise<TmdbGenreListResponse>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      const slowClient: GenreListSource = {
+        getGenreList: vi.fn<() => Promise<TmdbGenreListResponse>>().mockReturnValue(delayed),
+      };
+      const slowCache = new GenreCache(slowClient);
+
+      const p1 = slowCache.ensureLoaded();
+      const p2 = slowCache.ensureLoaded();
+
+      resolvePromise!({ genres: TEST_GENRES });
+      await Promise.all([p1, p2]);
+
+      expect(slowClient.getGenreList).toHaveBeenCalledTimes(1);
+      expect(slowCache.size).toBe(3);
+    });
+  });
+
+  describe('mapGenreIds', () => {
+    it('maps known genre IDs to names', async () => {
+      const names = await cache.mapGenreIds([28, 18]);
+      expect(names).toEqual(['Action', 'Drama']);
+    });
+
+    it('skips unknown genre IDs', async () => {
+      const names = await cache.mapGenreIds([28, 9999, 35]);
+      expect(names).toEqual(['Action', 'Comedy']);
+    });
+
+    it('returns empty array for all unknown IDs', async () => {
+      const names = await cache.mapGenreIds([100, 200]);
+      expect(names).toEqual([]);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const names = await cache.mapGenreIds([]);
+      expect(names).toEqual([]);
+    });
+  });
+
+  describe('clear', () => {
+    it('resets cache state and triggers re-fetch', async () => {
+      await cache.ensureLoaded();
+      expect(cache.size).toBe(3);
+
+      cache.clear();
+      expect(cache.size).toBe(0);
+
+      await cache.ensureLoaded();
+      expect(client.getGenreList).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('singleton helpers', () => {
+  afterEach(() => {
+    setGenreCache(null);
+  });
+
+  it('getGenreCache creates singleton from client', () => {
+    const client = makeMockClient();
+    const cache = getGenreCache(client);
+    expect(cache).toBeInstanceOf(GenreCache);
+    expect(getGenreCache(client)).toBe(cache);
+  });
+
+  it('setGenreCache replaces the singleton', () => {
+    const client = makeMockClient();
+    const original = getGenreCache(client);
+
+    const custom = new GenreCache(client);
+    setGenreCache(custom);
+
+    expect(getGenreCache(client)).toBe(custom);
+    expect(getGenreCache(client)).not.toBe(original);
+  });
+});

--- a/pillars/media/src/api/clients/tmdb/genre-cache.ts
+++ b/pillars/media/src/api/clients/tmdb/genre-cache.ts
@@ -1,0 +1,88 @@
+/**
+ * TMDB genre mapping cache.
+ *
+ * Composes with TmdbClient to lazily fetch and cache the genre list.
+ * Maps genre IDs (integers) to human-readable names for search results.
+ * Refreshes automatically after 24 hours.
+ */
+import { getEnvInt } from '../env.js';
+
+import type { TmdbClient } from './client.js';
+
+/** The single TMDB capability the genre cache needs — keeps the dep narrow + mockable. */
+export type GenreListSource = Pick<TmdbClient, 'getGenreList'>;
+
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getCacheTtlMs(): number {
+  return getEnvInt('MEDIA_TMDB_GENRE_CACHE_TTL_MS', CACHE_TTL_MS);
+}
+
+export class GenreCache {
+  private cache: Map<number, string> = new Map();
+  private lastFetchedAt = 0;
+  private inflightRequest: Promise<void> | null = null;
+
+  constructor(private readonly client: GenreListSource) {}
+
+  /** Ensure the cache is populated. Lazy — fetches on first call. */
+  async ensureLoaded(): Promise<void> {
+    if (this.cache.size > 0 && Date.now() - this.lastFetchedAt < getCacheTtlMs()) {
+      return;
+    }
+
+    if (this.inflightRequest) {
+      await this.inflightRequest;
+      return;
+    }
+
+    this.inflightRequest = this.fetchGenres();
+    try {
+      await this.inflightRequest;
+    } finally {
+      this.inflightRequest = null;
+    }
+  }
+
+  /** Map an array of TMDB genre IDs to their names. Unknown IDs are skipped. */
+  async mapGenreIds(ids: number[]): Promise<string[]> {
+    await this.ensureLoaded();
+    return ids.map((id) => this.cache.get(id)).filter((name): name is string => name !== undefined);
+  }
+
+  /** Get the current cache size (for testing). */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Clear the cache (for testing). */
+  clear(): void {
+    this.cache.clear();
+    this.lastFetchedAt = 0;
+    this.inflightRequest = null;
+  }
+
+  private async fetchGenres(): Promise<void> {
+    const data = await this.client.getGenreList();
+
+    this.cache.clear();
+    for (const genre of data.genres) {
+      this.cache.set(genre.id, genre.name);
+    }
+    this.lastFetchedAt = Date.now();
+  }
+}
+
+/** Singleton genre cache instance. */
+let instance: GenreCache | null = null;
+
+/** Get or create the singleton GenreCache. Requires a TmdbClient. */
+export function getGenreCache(client: GenreListSource): GenreCache {
+  instance ??= new GenreCache(client);
+  return instance;
+}
+
+/** Replace the singleton (for testing). */
+export function setGenreCache(cache: GenreCache | null): void {
+  instance = cache;
+}

--- a/pillars/media/src/api/clients/tmdb/image-cache.test.ts
+++ b/pillars/media/src/api/clients/tmdb/image-cache.test.ts
@@ -1,0 +1,653 @@
+/**
+ * Image cache service tests — mocks fetch and filesystem.
+ */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ImageCacheService } from './image-cache.js';
+
+vi.mock('node:fs/promises');
+
+const IMAGES_DIR = '/data/media/images';
+let service: ImageCacheService;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  service = new ImageCacheService(IMAGES_DIR);
+
+  // Default: mkdir succeeds, stat throws (file doesn't exist), writeFile succeeds
+  vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+  vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+/** Helper to create a mock fetch Response for binary data. */
+function mockImageResponse(data = new ArrayBuffer(100), status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Not Found',
+    arrayBuffer: () => Promise.resolve(data),
+    headers: new Headers(),
+    redirected: false,
+    type: 'basic',
+    url: '',
+    clone: () => mockImageResponse(data, status),
+    body: null,
+    bodyUsed: false,
+    json: () => Promise.resolve({}),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(''),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+describe('downloadMovieImages', () => {
+  it('creates directory and downloads all three images', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadMovieImages(550, '/poster123.jpg', '/backdrop456.jpg', '/logo789.png');
+
+    const movieDir = path.join(IMAGES_DIR, 'movies', '550');
+    expect(fs.mkdir).toHaveBeenCalledWith(movieDir, { recursive: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fs.writeFile).toHaveBeenCalledTimes(3);
+
+    // Verify correct TMDB URLs
+    const urls = fetchMock.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(urls).toContainEqual('https://image.tmdb.org/t/p/w780/poster123.jpg');
+    expect(urls).toContainEqual('https://image.tmdb.org/t/p/w1280/backdrop456.jpg');
+    expect(urls).toContainEqual('https://image.tmdb.org/t/p/original/logo789.png');
+
+    // Verify correct local paths
+    const paths = vi.mocked(fs.writeFile).mock.calls.map((c) => c[0]);
+    expect(paths).toContainEqual(path.join(movieDir, 'poster.jpg'));
+    expect(paths).toContainEqual(path.join(movieDir, 'backdrop.jpg'));
+    expect(paths).toContainEqual(path.join(movieDir, 'logo.png'));
+  });
+
+  it('skips null image paths', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadMovieImages(550, '/poster.jpg', null, null);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips all downloads when all paths are null', async () => {
+    await service.downloadMovieImages(550, null, null, null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+
+    // Still creates the directory
+    expect(fs.mkdir).toHaveBeenCalled();
+  });
+
+  it('skips download if file already exists', async () => {
+    // First stat call (for poster) succeeds = file exists
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    await service.downloadMovieImages(550, '/poster.jpg', null, null);
+
+    // Should not fetch or write since file exists
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('handles download failures gracefully without throwing', async () => {
+    // Poster succeeds, backdrop fails
+    fetchMock
+      .mockResolvedValueOnce(mockImageResponse())
+      .mockResolvedValueOnce(mockImageResponse(new ArrayBuffer(0), 404));
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      service.downloadMovieImages(550, '/poster.jpg', '/backdrop.jpg', null)
+    ).resolves.toBeUndefined();
+
+    // Poster was written, backdrop was not (failed)
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(consoleSpy.mock.calls[0]![0]).toContain('[ImageCache]');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles network failures gracefully with retries', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockRejectedValue(new Error('Network error'));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadMovieImages(550, '/poster.jpg', null, null);
+    await vi.advanceTimersByTimeAsync(500); // retry 1
+    await vi.advanceTimersByTimeAsync(1000); // retry 2
+    await promise;
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    // 2 retry warnings + 1 final failure
+    expect(consoleSpy).toHaveBeenCalledTimes(3);
+    expect(consoleSpy.mock.calls[2]![0]).toContain('after 3 attempts');
+
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});
+
+describe('getImagePath', () => {
+  it('returns path when file exists', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    const result = await service.getImagePath('movie', 550, 'poster');
+
+    expect(result).toBe(path.join(IMAGES_DIR, 'movies', '550', 'poster.jpg'));
+  });
+
+  it('returns null when file does not exist', async () => {
+    vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const result = await service.getImagePath('movie', 550, 'poster');
+
+    expect(result).toBeNull();
+  });
+
+  it('resolves correct paths for different image types', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    const poster = await service.getImagePath('movie', 550, 'poster');
+    const backdrop = await service.getImagePath('movie', 550, 'backdrop');
+    const logo = await service.getImagePath('movie', 550, 'logo');
+    const override = await service.getImagePath('movie', 550, 'override');
+
+    expect(poster).toContain('poster.jpg');
+    expect(backdrop).toContain('backdrop.jpg');
+    expect(logo).toContain('logo.png');
+    expect(override).toContain('override.jpg');
+  });
+});
+
+describe('deleteMovieImages', () => {
+  it('removes the movie image directory', async () => {
+    vi.mocked(fs.rm).mockResolvedValueOnce(undefined);
+
+    await service.deleteMovieImages(550);
+
+    expect(fs.rm).toHaveBeenCalledWith(path.join(IMAGES_DIR, 'movies', '550'), {
+      recursive: true,
+      force: true,
+    });
+  });
+});
+
+describe('downloadTvShowImages', () => {
+  it('creates directory and downloads poster and backdrop', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadTvShowImages(
+      81189,
+      'https://artworks.thetvdb.com/banners/posters/81189.jpg',
+      'https://artworks.thetvdb.com/banners/backgrounds/81189.jpg'
+    );
+
+    const tvDir = path.join(IMAGES_DIR, 'tv', '81189');
+    expect(fs.mkdir).toHaveBeenCalledWith(tvDir, { recursive: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
+
+    // TheTVDB uses full URLs (no size prefix)
+    const urls = fetchMock.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(urls).toContainEqual('https://artworks.thetvdb.com/banners/posters/81189.jpg');
+    expect(urls).toContainEqual('https://artworks.thetvdb.com/banners/backgrounds/81189.jpg');
+
+    const paths = vi.mocked(fs.writeFile).mock.calls.map((c) => c[0]);
+    expect(paths).toContainEqual(path.join(tvDir, 'poster.jpg'));
+    expect(paths).toContainEqual(path.join(tvDir, 'backdrop.jpg'));
+  });
+
+  it('skips null URLs', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadTvShowImages(81189, 'https://artworks.thetvdb.com/p.jpg', null);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips all downloads when both URLs are null', async () => {
+    await service.downloadTvShowImages(81189, null, null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(fs.mkdir).toHaveBeenCalled();
+  });
+
+  it('skips download if file already exists', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    await service.downloadTvShowImages(81189, 'https://artworks.thetvdb.com/poster.jpg', null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('handles network failures gracefully with retries', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockRejectedValue(new Error('Network error'));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadTvShowImages(81189, 'https://artworks.thetvdb.com/p.jpg', null);
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledTimes(3);
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('handles HTTP error status gracefully', async () => {
+    fetchMock.mockResolvedValueOnce(mockImageResponse(new ArrayBuffer(0), 404));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      service.downloadTvShowImages(81189, 'https://artworks.thetvdb.com/p.jpg', null)
+    ).resolves.toBeUndefined();
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
+  it('blocks downloads from untrusted hosts (SSRF defense)', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await service.downloadTvShowImages(81189, 'http://169.254.169.254/latest/meta-data', null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Blocked download from untrusted host')
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('getImagePath — tv', () => {
+  it('resolves tv path under tv/ directory (not tvs/)', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    const result = await service.getImagePath('tv', 81189, 'poster');
+
+    expect(result).toBe(path.join(IMAGES_DIR, 'tv', '81189', 'poster.jpg'));
+  });
+
+  it('returns null when tv file does not exist', async () => {
+    vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const result = await service.getImagePath('tv', 81189, 'poster');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteTvShowImages', () => {
+  it('removes the tv show image directory', async () => {
+    vi.mocked(fs.rm).mockResolvedValueOnce(undefined);
+
+    await service.deleteTvShowImages(81189);
+
+    expect(fs.rm).toHaveBeenCalledWith(path.join(IMAGES_DIR, 'tv', '81189'), {
+      recursive: true,
+      force: true,
+    });
+  });
+});
+
+describe('rate limiter integration', () => {
+  it('calls rateLimiter.acquire() before each fetch', async () => {
+    const mockAcquire = vi.fn().mockResolvedValue(undefined);
+    const rateLimitedService = new ImageCacheService(IMAGES_DIR, { acquire: mockAcquire });
+
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await rateLimitedService.downloadMovieImages(550, '/poster.jpg', '/backdrop.jpg', null);
+
+    expect(mockAcquire).toHaveBeenCalledTimes(2);
+    // acquire is called before each fetch
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call acquire when no rate limiter is provided', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadMovieImages(550, '/poster.jpg', null, null);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips fetch if acquire rejects (retries exhaust)', async () => {
+    vi.useFakeTimers();
+    const mockAcquire = vi.fn().mockRejectedValue(new Error('Rate limit destroyed'));
+    const rateLimitedService = new ImageCacheService(IMAGES_DIR, { acquire: mockAcquire });
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = rateLimitedService.downloadMovieImages(550, '/poster.jpg', null, null);
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});
+
+describe('generatePlaceholder', () => {
+  it('creates SVG placeholder with movie title', async () => {
+    await service.generatePlaceholder(550, 'Fight Club');
+
+    const movieDir = path.join(IMAGES_DIR, 'movies', '550');
+    expect(fs.mkdir).toHaveBeenCalledWith(movieDir, { recursive: true });
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+
+    const [destPath, content] = vi.mocked(fs.writeFile).mock.calls[0]!;
+    expect(destPath).toBe(path.join(movieDir, 'poster.jpg'));
+    expect(content).toContain('<svg');
+    expect(content).toContain('Fight Club');
+  });
+
+  it('skips generation if poster already exists', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    await service.generatePlaceholder(550, 'Fight Club');
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('escapes HTML entities in title', async () => {
+    await service.generatePlaceholder(999, 'Tom & Jerry <3');
+
+    const [, content] = vi.mocked(fs.writeFile).mock.calls[0]!;
+    expect(content).toContain('Tom &amp; Jerry &lt;3');
+    expect(content).not.toContain('Tom & Jerry <3');
+  });
+
+  it('generates deterministic colour from tmdbId', async () => {
+    await service.generatePlaceholder(550, 'Movie A');
+    const [, content1] = vi.mocked(fs.writeFile).mock.calls[0]!;
+
+    vi.mocked(fs.writeFile).mockClear();
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await service.generatePlaceholder(551, 'Movie B');
+    const [, content2] = vi.mocked(fs.writeFile).mock.calls[0]!;
+
+    // Different tmdbIds should produce different hues
+    const hue1 = (content1 as string).match(/hsl\((\d+)/)?.[1];
+    const hue2 = (content2 as string).match(/hsl\((\d+)/)?.[1];
+    expect(hue1).toBeDefined();
+    expect(hue2).toBeDefined();
+    expect(hue1).not.toBe(hue2);
+  });
+});
+
+describe('downloadSeasonPoster', () => {
+  it('downloads season poster to season_{num}.jpg', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadSeasonPoster(
+      81189,
+      1,
+      'https://artworks.thetvdb.com/banners/seasons/81189-1.jpg'
+    );
+
+    const tvDir = path.join(IMAGES_DIR, 'tv', '81189');
+    expect(fs.mkdir).toHaveBeenCalledWith(tvDir, { recursive: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://artworks.thetvdb.com/banners/seasons/81189-1.jpg'
+    );
+
+    const destPath = vi.mocked(fs.writeFile).mock.calls[0]![0];
+    expect(destPath).toBe(path.join(tvDir, 'season_1.jpg'));
+  });
+
+  it('uses season_0.jpg for specials', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadSeasonPoster(
+      81189,
+      0,
+      'https://artworks.thetvdb.com/banners/seasons/81189-0.jpg'
+    );
+
+    const destPath = vi.mocked(fs.writeFile).mock.calls[0]![0];
+    expect(destPath).toBe(path.join(IMAGES_DIR, 'tv', '81189', 'season_0.jpg'));
+  });
+
+  it('skips download when posterUrl is null', async () => {
+    await service.downloadSeasonPoster(81189, 1, null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.mkdir).not.toHaveBeenCalled();
+  });
+});
+
+describe('downloadTvShowImages — season posters', () => {
+  it('downloads season posters alongside show images', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadTvShowImages({
+      tvdbId: 81189,
+      posterUrl: 'https://artworks.thetvdb.com/banners/posters/81189.jpg',
+      backdropUrl: null,
+      seasonPosters: [
+        { seasonNumber: 1, posterUrl: 'https://artworks.thetvdb.com/banners/seasons/81189-1.jpg' },
+        { seasonNumber: 2, posterUrl: 'https://artworks.thetvdb.com/banners/seasons/81189-2.jpg' },
+      ],
+    });
+
+    // show poster + 2 season posters = 3 downloads
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const paths = vi.mocked(fs.writeFile).mock.calls.map((c) => c[0]);
+    expect(paths).toContainEqual(path.join(IMAGES_DIR, 'tv', '81189', 'poster.jpg'));
+    expect(paths).toContainEqual(path.join(IMAGES_DIR, 'tv', '81189', 'season_1.jpg'));
+    expect(paths).toContainEqual(path.join(IMAGES_DIR, 'tv', '81189', 'season_2.jpg'));
+  });
+
+  it('skips null season poster URLs', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadTvShowImages({
+      tvdbId: 81189,
+      posterUrl: null,
+      backdropUrl: null,
+      seasonPosters: [{ seasonNumber: 1, posterUrl: null }],
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('downloads logo alongside other TV images', async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadTvShowImages({
+      tvdbId: 81189,
+      posterUrl: 'https://artworks.thetvdb.com/banners/posters/81189.jpg',
+      backdropUrl: null,
+      logoUrl: 'https://artworks.thetvdb.com/banners/logos/81189.png',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const paths = vi.mocked(fs.writeFile).mock.calls.map((c) => c[0]);
+    expect(paths).toContainEqual(path.join(IMAGES_DIR, 'tv', '81189', 'poster.jpg'));
+    expect(paths).toContainEqual(path.join(IMAGES_DIR, 'tv', '81189', 'logo.png'));
+  });
+});
+
+describe('generateTvPlaceholder', () => {
+  it('creates SVG placeholder for a TV show', async () => {
+    await service.generateTvPlaceholder(81189, 'Breaking Bad');
+
+    const tvDir = path.join(IMAGES_DIR, 'tv', '81189');
+    expect(fs.mkdir).toHaveBeenCalledWith(tvDir, { recursive: true });
+
+    const [destPath, content] = vi.mocked(fs.writeFile).mock.calls[0]!;
+    expect(destPath).toBe(path.join(tvDir, 'poster.jpg'));
+    expect(content).toContain('<svg');
+    expect(content).toContain('Breaking Bad');
+  });
+
+  it('creates SVG placeholder for a season with season label', async () => {
+    await service.generateTvPlaceholder(81189, 'Breaking Bad', 1);
+
+    const [destPath, content] = vi.mocked(fs.writeFile).mock.calls[0]!;
+    expect(destPath).toBe(path.join(IMAGES_DIR, 'tv', '81189', 'season_1.jpg'));
+    expect(content).toContain('Breaking Bad');
+    expect(content).toContain('Season 1');
+  });
+
+  it('skips if file already exists', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    await service.generateTvPlaceholder(81189, 'Breaking Bad');
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSeasonImagePath', () => {
+  it('returns path when season poster exists', async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    const result = await service.getSeasonImagePath(81189, 1);
+
+    expect(result).toBe(path.join(IMAGES_DIR, 'tv', '81189', 'season_1.jpg'));
+  });
+
+  it('returns null when season poster does not exist', async () => {
+    vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const result = await service.getSeasonImagePath(81189, 1);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('retry behavior', () => {
+  it('succeeds on second attempt after transient failure', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(mockImageResponse());
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadMovieImages(550, '/poster.jpg', null, null);
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    // Only 1 retry warning, no final failure
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]![0]).toContain('Attempt 1 failed');
+
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('succeeds on third attempt after two transient failures', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce(mockImageResponse());
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadMovieImages(550, '/poster.jpg', null, null);
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('does not retry on 4xx client errors', async () => {
+    fetchMock.mockResolvedValueOnce(mockImageResponse(new ArrayBuffer(0), 403));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await service.downloadMovieImages(550, '/poster.jpg', null, null);
+
+    // Single warn, no retries
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]![0]).toContain('403');
+    expect(consoleSpy.mock.calls[0]![0]).toContain('skipping');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('retries on 5xx server errors', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(mockImageResponse(new ArrayBuffer(0), 502))
+      .mockResolvedValueOnce(mockImageResponse());
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadMovieImages(550, '/poster.jpg', null, null);
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('uses linear backoff for retry delays', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockRejectedValue(new Error('Network error'));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const promise = service.downloadMovieImages(550, '/poster.jpg', null, null);
+
+    // After 499ms, only first attempt should have run
+    await vi.advanceTimersByTimeAsync(499);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // At 500ms, second attempt fires
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // After another 999ms, still only 2 attempts
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // At 1000ms more, third attempt fires
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/pillars/media/src/api/clients/tmdb/image-cache.ts
+++ b/pillars/media/src/api/clients/tmdb/image-cache.ts
@@ -1,0 +1,242 @@
+/**
+ * Media image cache service — downloads and caches images locally.
+ *
+ * Movie images: {MEDIA_IMAGES_DIR}/movies/{tmdb_id}/ (via TMDB with size prefixes)
+ * TV images:    {MEDIA_IMAGES_DIR}/tv/{tvdb_id}/     (via TheTVDB full URLs)
+ *
+ * Helper modules:
+ *  - image-download.ts     — URL allow-list + retry + write to disk
+ *  - image-placeholders.ts — SVG placeholder generation
+ */
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { downloadImage, type RateLimiter } from './image-download.js';
+import {
+  generateMoviePlaceholder,
+  generateTvPlaceholder as generateTvShowPlaceholder,
+} from './image-placeholders.js';
+
+export type { RateLimiter } from './image-download.js';
+
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
+
+export const MEDIA_DIR_NAMES: Record<string, string> = {
+  movie: 'movies',
+  tv: 'tv',
+};
+
+const IMAGE_SIZES = {
+  poster: 'w780',
+  backdrop: 'w1280',
+  logo: 'original',
+} as const;
+
+const IMAGE_FILENAMES = {
+  poster: 'poster.jpg',
+  backdrop: 'backdrop.jpg',
+  logo: 'logo.png',
+  override: 'override.jpg',
+} as const;
+
+export type ImageType = keyof typeof IMAGE_FILENAMES;
+
+function seasonFilename(seasonNumber: number): string {
+  return `season_${seasonNumber}.jpg`;
+}
+
+interface TvImagesInput {
+  tvdbId: number;
+  posterUrl: string | null;
+  backdropUrl: string | null;
+  seasonPosters?: Array<{ seasonNumber: number; posterUrl: string | null }>;
+  logoUrl?: string | null;
+}
+
+export class ImageCacheService {
+  private readonly rateLimiter?: RateLimiter;
+
+  constructor(imagesDir: string, rateLimiter?: RateLimiter);
+  /** @internal Legacy signature without rate limiter. */
+  constructor(imagesDir: string);
+  constructor(
+    private readonly imagesDir: string,
+    rateLimiter?: RateLimiter
+  ) {
+    this.rateLimiter = rateLimiter;
+  }
+
+  /**
+   * Download movie images from TMDB to local cache.
+   */
+  async downloadMovieImages(
+    tmdbId: number,
+    posterPath: string | null,
+    backdropPath: string | null,
+    logoPath: string | null
+  ): Promise<void> {
+    const movieDir = this.movieDir(tmdbId);
+    await mkdir(movieDir, { recursive: true });
+
+    const downloads: Promise<void>[] = [];
+    if (posterPath) {
+      downloads.push(
+        downloadImage(
+          `${TMDB_IMAGE_BASE}/${IMAGE_SIZES.poster}${posterPath}`,
+          join(movieDir, IMAGE_FILENAMES.poster),
+          this.rateLimiter
+        )
+      );
+    }
+    if (backdropPath) {
+      downloads.push(
+        downloadImage(
+          `${TMDB_IMAGE_BASE}/${IMAGE_SIZES.backdrop}${backdropPath}`,
+          join(movieDir, IMAGE_FILENAMES.backdrop),
+          this.rateLimiter
+        )
+      );
+    }
+    if (logoPath) {
+      downloads.push(
+        downloadImage(
+          `${TMDB_IMAGE_BASE}/${IMAGE_SIZES.logo}${logoPath}`,
+          join(movieDir, IMAGE_FILENAMES.logo),
+          this.rateLimiter
+        )
+      );
+    }
+    if (downloads.length > 0) await Promise.allSettled(downloads);
+  }
+
+  /**
+   * Download TV show images from TheTVDB to local cache.
+   * TheTVDB provides full URLs (no size prefix needed).
+   *
+   * Accepts either a single options object or the legacy positional form
+   * (tvdbId, posterUrl, backdropUrl). For the season-poster / logo variants,
+   * use the options-object form.
+   */
+  downloadTvShowImages(input: TvImagesInput): Promise<void>;
+  downloadTvShowImages(
+    tvdbId: number,
+    posterUrl: string | null,
+    backdropUrl: string | null
+  ): Promise<void>;
+  downloadTvShowImages(
+    tvdbIdOrInput: number | TvImagesInput,
+    posterUrl: string | null = null,
+    backdropUrl: string | null = null
+  ): Promise<void> {
+    if (typeof tvdbIdOrInput === 'object') {
+      return this.downloadTvShowImagesImpl(tvdbIdOrInput);
+    }
+    return this.downloadTvShowImagesImpl({
+      tvdbId: tvdbIdOrInput,
+      posterUrl,
+      backdropUrl,
+    });
+  }
+
+  private async downloadTvShowImagesImpl(input: TvImagesInput): Promise<void> {
+    const { tvdbId, posterUrl, backdropUrl, seasonPosters, logoUrl } = input;
+    const tvDir = this.tvShowDir(tvdbId);
+    await mkdir(tvDir, { recursive: true });
+
+    const downloads: Promise<void>[] = [];
+    if (posterUrl) {
+      downloads.push(
+        downloadImage(posterUrl, join(tvDir, IMAGE_FILENAMES.poster), this.rateLimiter)
+      );
+    }
+    if (backdropUrl) {
+      downloads.push(
+        downloadImage(backdropUrl, join(tvDir, IMAGE_FILENAMES.backdrop), this.rateLimiter)
+      );
+    }
+    if (logoUrl) {
+      downloads.push(downloadImage(logoUrl, join(tvDir, IMAGE_FILENAMES.logo), this.rateLimiter));
+    }
+    if (seasonPosters) {
+      for (const sp of seasonPosters) {
+        if (sp.posterUrl) {
+          downloads.push(
+            downloadImage(
+              sp.posterUrl,
+              join(tvDir, seasonFilename(sp.seasonNumber)),
+              this.rateLimiter
+            )
+          );
+        }
+      }
+    }
+    if (downloads.length > 0) await Promise.allSettled(downloads);
+  }
+
+  /** Download a single season poster to the TV show's cache directory. */
+  async downloadSeasonPoster(
+    tvdbId: number,
+    seasonNumber: number,
+    posterUrl: string | null
+  ): Promise<void> {
+    if (!posterUrl) return;
+    const tvDir = this.tvShowDir(tvdbId);
+    await mkdir(tvDir, { recursive: true });
+    await downloadImage(posterUrl, join(tvDir, seasonFilename(seasonNumber)), this.rateLimiter);
+  }
+
+  /** Get the absolute path to a cached image file, or null if missing. */
+  async getImagePath(
+    mediaType: 'movie' | 'tv',
+    id: number,
+    imageType: ImageType
+  ): Promise<string | null> {
+    const dirName = MEDIA_DIR_NAMES[mediaType] ?? `${mediaType}s`;
+    const filePath = join(this.imagesDir, dirName, String(id), IMAGE_FILENAMES[imageType]);
+    try {
+      await stat(filePath);
+      return filePath;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Get the absolute path to a cached season poster, or null if missing. */
+  async getSeasonImagePath(tvdbId: number, seasonNumber: number): Promise<string | null> {
+    const filePath = join(this.tvShowDir(tvdbId), seasonFilename(seasonNumber));
+    try {
+      await stat(filePath);
+      return filePath;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Delete all cached images for a movie. */
+  async deleteMovieImages(tmdbId: number): Promise<void> {
+    await rm(this.movieDir(tmdbId), { recursive: true, force: true });
+  }
+
+  /** Delete all cached images for a TV show. */
+  async deleteTvShowImages(tvdbId: number): Promise<void> {
+    await rm(this.tvShowDir(tvdbId), { recursive: true, force: true });
+  }
+
+  private movieDir(tmdbId: number): string {
+    return join(this.imagesDir, 'movies', String(tmdbId));
+  }
+
+  private tvShowDir(tvdbId: number): string {
+    return join(this.imagesDir, 'tv', String(tvdbId));
+  }
+
+  /** Generate an SVG placeholder for a movie with no poster image. */
+  generatePlaceholder(tmdbId: number, title: string): Promise<void> {
+    return generateMoviePlaceholder(this.movieDir(tmdbId), tmdbId, title);
+  }
+
+  /** Generate an SVG placeholder for a TV show or season. */
+  generateTvPlaceholder(tvdbId: number, title: string, seasonNumber?: number): Promise<void> {
+    return generateTvShowPlaceholder(this.tvShowDir(tvdbId), tvdbId, title, seasonNumber);
+  }
+}

--- a/pillars/media/src/api/clients/tmdb/image-download.ts
+++ b/pillars/media/src/api/clients/tmdb/image-download.ts
@@ -1,0 +1,88 @@
+import { stat, writeFile } from 'node:fs/promises';
+
+/** Allowed hostnames for image downloads. */
+const ALLOWED_IMAGE_HOSTS = new Set(['image.tmdb.org', 'artworks.thetvdb.com']);
+
+export interface RateLimiter {
+  acquire(): Promise<void>;
+}
+
+export function isAllowedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (!ALLOWED_IMAGE_HOSTS.has(parsed.hostname)) {
+      console.warn(`[ImageCache] Blocked download from untrusted host: ${parsed.hostname}`);
+      return false;
+    }
+    return true;
+  } catch {
+    console.warn(`[ImageCache] Invalid URL: ${url}`);
+    return false;
+  }
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function attemptDownload(
+  url: string,
+  destPath: string,
+  rateLimiter?: RateLimiter
+): Promise<'success' | 'permanent-failure' | 'transient-failure'> {
+  try {
+    if (rateLimiter) await rateLimiter.acquire();
+    const response = await fetch(url);
+    if (response.status >= 400 && response.status < 500) {
+      console.warn(`[ImageCache] ${response.status} for ${url} — skipping`);
+      return 'permanent-failure';
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await writeFile(destPath, buffer);
+    return 'success';
+  } catch {
+    return 'transient-failure';
+  }
+}
+
+async function fetchWithRetries(
+  url: string,
+  destPath: string,
+  rateLimiter?: RateLimiter
+): Promise<void> {
+  const MAX_RETRIES = 2;
+  const RETRY_DELAY_MS = 500;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const result = await attemptDownload(url, destPath, rateLimiter);
+    if (result === 'success' || result === 'permanent-failure') return;
+    if (attempt === MAX_RETRIES) {
+      console.warn(`[ImageCache] Failed to download ${url} after ${MAX_RETRIES + 1} attempts`);
+      return;
+    }
+    const delay = RETRY_DELAY_MS * (attempt + 1);
+    console.warn(`[ImageCache] Attempt ${attempt + 1} failed for ${url}, retrying in ${delay}ms`);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+}
+
+/**
+ * Download a single image to disk, validating the URL host, skipping if the
+ * file already exists, and retrying transient failures.
+ */
+export async function downloadImage(
+  url: string,
+  destPath: string,
+  rateLimiter?: RateLimiter
+): Promise<void> {
+  if (!isAllowedUrl(url)) return;
+  if (await fileExists(destPath)) return;
+  await fetchWithRetries(url, destPath, rateLimiter);
+}

--- a/pillars/media/src/api/clients/tmdb/image-placeholders.ts
+++ b/pillars/media/src/api/clients/tmdb/image-placeholders.ts
@@ -1,0 +1,70 @@
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const IMAGE_FILENAMES = {
+  poster: 'poster.jpg',
+} as const;
+
+function seasonFilename(seasonNumber: number): string {
+  return `season_${seasonNumber}.jpg`;
+}
+
+function escapeForSvg(label: string): string {
+  return label
+    .replaceAll(/&/g, '&amp;')
+    .replaceAll(/</g, '&lt;')
+    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/"/g, '&quot;');
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Write an SVG placeholder to destPath unless the file already exists. */
+export async function writePlaceholderSvg(
+  destPath: string,
+  label: string,
+  seed: number
+): Promise<void> {
+  if (await fileExists(destPath)) return;
+
+  const hue = (seed * 137) % 360;
+  const escapedLabel = escapeForSvg(label);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="780" height="1170" viewBox="0 0 780 1170">
+  <rect width="780" height="1170" fill="hsl(${hue}, 40%, 30%)" />
+  <text x="390" y="585" text-anchor="middle" dominant-baseline="central"
+    font-family="system-ui, sans-serif" font-size="48" font-weight="bold"
+    fill="white" opacity="0.9">
+    <tspan>${escapedLabel}</tspan>
+  </text>
+</svg>`;
+  await writeFile(destPath, svg, 'utf-8');
+}
+
+export async function generateMoviePlaceholder(
+  movieDir: string,
+  tmdbId: number,
+  title: string
+): Promise<void> {
+  await mkdir(movieDir, { recursive: true });
+  await writePlaceholderSvg(join(movieDir, IMAGE_FILENAMES.poster), title, tmdbId);
+}
+
+export async function generateTvPlaceholder(
+  tvDir: string,
+  tvdbId: number,
+  title: string,
+  seasonNumber?: number
+): Promise<void> {
+  await mkdir(tvDir, { recursive: true });
+  const filename =
+    seasonNumber !== undefined ? seasonFilename(seasonNumber) : IMAGE_FILENAMES.poster;
+  const label = seasonNumber !== undefined ? `${title} — Season ${seasonNumber}` : title;
+  await writePlaceholderSvg(join(tvDir, filename), label, tvdbId);
+}

--- a/pillars/media/src/api/clients/tmdb/index.ts
+++ b/pillars/media/src/api/clients/tmdb/index.ts
@@ -1,0 +1,40 @@
+import { getEnv } from '../env.js';
+import { TmdbClient } from './client.js';
+import { ImageCacheService } from './image-cache.js';
+import { TokenBucketRateLimiter } from './rate-limiter.js';
+
+export { TmdbClient } from './client.js';
+export { GenreCache, getGenreCache, setGenreCache } from './genre-cache.js';
+export { ImageCacheService } from './image-cache.js';
+export type { TmdbGenre, TmdbGenreListResponse } from './types.js';
+export { TmdbApiError, type TmdbSearchResult } from './types.js';
+
+/** Shared rate limiter: TMDB allows 40 req / 10 s → 4 req/s. */
+const tmdbRateLimiter = new TokenBucketRateLimiter(40, 4);
+
+/**
+ * Shared TMDB client factory — reuses a single rate limiter across all callers.
+ * Throws immediately with a clear error if TMDB_API_KEY is not set.
+ */
+export function getTmdbClient(): TmdbClient {
+  const apiToken = getEnv('TMDB_API_KEY');
+  if (!apiToken) {
+    throw new Error(
+      'TMDB_API_KEY is not configured. Set it in .env (development) or Docker secrets (production).'
+    );
+  }
+  return new TmdbClient(apiToken, tmdbRateLimiter);
+}
+
+const DEFAULT_IMAGES_DIR = './data/media/images';
+
+/** Lazy singleton for the image cache service. */
+let imageCache: ImageCacheService | null = null;
+
+export function getImageCache(): ImageCacheService {
+  if (!imageCache) {
+    const dir = getEnv('MEDIA_IMAGES_DIR') ?? DEFAULT_IMAGES_DIR;
+    imageCache = new ImageCacheService(dir, tmdbRateLimiter);
+  }
+  return imageCache;
+}

--- a/pillars/media/src/api/clients/tmdb/rate-limiter.test.ts
+++ b/pillars/media/src/api/clients/tmdb/rate-limiter.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Token bucket rate limiter tests.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TokenBucketRateLimiter } from './rate-limiter.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('TokenBucketRateLimiter', () => {
+  it('allows immediate acquisition when tokens are available', async () => {
+    const limiter = new TokenBucketRateLimiter(5, 1);
+
+    // Should resolve immediately for first 5 calls
+    for (let i = 0; i < 5; i++) {
+      await limiter.acquire();
+    }
+
+    limiter.destroy();
+  });
+
+  it('exhausts bucket after capacity is reached', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(3, 1);
+
+    // Drain all 3 tokens
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // The 4th call should not resolve immediately
+    let resolved = false;
+    const promise = limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    // Give microtasks a chance to run
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    // After enough time for 1 token to refill (1 token / 1 per sec = 1000ms)
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    expect(resolved).toBe(true);
+
+    limiter.destroy();
+  });
+
+  it('refills tokens over time', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(2, 2); // 2 tokens/sec
+
+    // Drain bucket
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // Wait 1 second — should refill 2 tokens
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Should be able to acquire 2 more immediately
+    await limiter.acquire();
+    await limiter.acquire();
+
+    limiter.destroy();
+  });
+
+  it('does not exceed capacity on refill', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(3, 10); // Fast refill
+
+    // Only drain 1 token
+    await limiter.acquire();
+
+    // Wait a long time
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Should still only have 3 tokens (capacity), not more
+    // Drain all 3
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // 4th should wait
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    limiter.destroy();
+  });
+
+  it('processes queued waiters in FIFO order', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(1, 1);
+    const order: number[] = [];
+
+    // Drain the single token
+    await limiter.acquire();
+
+    // Queue 3 waiters
+    limiter.acquire().then(() => order.push(1));
+    limiter.acquire().then(() => order.push(2));
+    limiter.acquire().then(() => order.push(3));
+
+    // Advance enough for 3 tokens
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(order).toEqual([1, 2, 3]);
+
+    limiter.destroy();
+  });
+
+  it('works with TMDB-like settings (40 capacity, 4/sec refill)', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(40, 4);
+
+    // Should drain all 40 immediately
+    for (let i = 0; i < 40; i++) {
+      await limiter.acquire();
+    }
+
+    // 41st should wait
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    // At 4 tokens/sec, one token takes 250ms
+    await vi.advanceTimersByTimeAsync(250);
+    expect(resolved).toBe(true);
+
+    limiter.destroy();
+  });
+
+  it('destroy resolves pending waiters and clears timers', async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(1, 1);
+
+    await limiter.acquire();
+
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    limiter.destroy();
+
+    // Give microtasks a chance
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+});

--- a/pillars/media/src/api/clients/tmdb/rate-limiter.ts
+++ b/pillars/media/src/api/clients/tmdb/rate-limiter.ts
@@ -1,0 +1,83 @@
+/**
+ * Token bucket rate limiter for TMDB API requests.
+ *
+ * TMDB allows 40 requests per 10 seconds per API key.
+ * Bucket starts full and refills at a steady rate.
+ * acquire() waits when exhausted — callers never see 429 errors.
+ */
+
+export class TokenBucketRateLimiter {
+  private tokens: number;
+  private lastRefill: number;
+  private readonly waitQueue: Array<() => void> = [];
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillRate: number
+  ) {
+    this.tokens = capacity;
+    this.lastRefill = Date.now();
+  }
+
+  /** Consume one token. Resolves immediately if available, waits otherwise. */
+  async acquire(): Promise<void> {
+    this.refill();
+
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+      this.scheduleDrain();
+    });
+  }
+
+  /** Refill tokens based on elapsed time since last refill. */
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    const newTokens = elapsed * this.refillRate;
+
+    if (newTokens >= 1) {
+      this.tokens = Math.min(this.capacity, this.tokens + newTokens);
+      this.lastRefill = now;
+    }
+  }
+
+  /** Schedule a timer to drain the wait queue when tokens become available. */
+  private scheduleDrain(): void {
+    if (this.drainTimer !== null) return;
+
+    const msPerToken = 1000 / this.refillRate;
+
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      this.refill();
+
+      while (this.waitQueue.length > 0 && this.tokens >= 1) {
+        this.tokens -= 1;
+        const next = this.waitQueue.shift();
+        if (next) next();
+      }
+
+      if (this.waitQueue.length > 0) {
+        this.scheduleDrain();
+      }
+    }, msPerToken);
+  }
+
+  /** Clean up any pending timers. */
+  destroy(): void {
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    while (this.waitQueue.length > 0) {
+      const next = this.waitQueue.shift();
+      if (next) next();
+    }
+  }
+}

--- a/pillars/media/src/api/clients/tmdb/types.ts
+++ b/pillars/media/src/api/clients/tmdb/types.ts
@@ -1,0 +1,195 @@
+/**
+ * TMDB API v3 response types and error class.
+ */
+
+/** Typed error for TMDB API failures. */
+export class TmdbApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TmdbApiError';
+  }
+}
+
+/** A single movie result from TMDB search. */
+export interface TmdbSearchResult {
+  tmdbId: number;
+  title: string;
+  originalTitle: string;
+  overview: string;
+  releaseDate: string;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number;
+  voteCount: number;
+  genreIds: number[];
+  originalLanguage: string;
+  popularity: number;
+}
+
+/** Paginated search response from TMDB. */
+export interface TmdbSearchResponse {
+  results: TmdbSearchResult[];
+  totalResults: number;
+  totalPages: number;
+  page: number;
+}
+
+/** Full movie detail from TMDB. */
+export interface TmdbMovieDetail {
+  tmdbId: number;
+  imdbId: string | null;
+  title: string;
+  originalTitle: string;
+  overview: string;
+  tagline: string;
+  releaseDate: string;
+  runtime: number;
+  status: string;
+  originalLanguage: string;
+  budget: number;
+  revenue: number;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number;
+  voteCount: number;
+  genres: { id: number; name: string }[];
+  productionCompanies: { id: number; name: string }[];
+  spokenLanguages: { iso_639_1: string; name: string }[];
+}
+
+/** A single image entry from TMDB images endpoint. */
+export interface TmdbImage {
+  filePath: string;
+  width: number;
+  height: number;
+  aspectRatio: number;
+  voteAverage: number;
+  voteCount: number;
+  languageCode: string | null;
+}
+
+/** Response from TMDB movie images endpoint. */
+export interface TmdbImageResponse {
+  id: number;
+  backdrops: TmdbImage[];
+  posters: TmdbImage[];
+  logos: TmdbImage[];
+}
+
+/** A single genre from TMDB genre list. */
+export interface TmdbGenre {
+  id: number;
+  name: string;
+}
+
+/** Response from TMDB genre list endpoint. */
+export interface TmdbGenreListResponse {
+  genres: TmdbGenre[];
+}
+
+/** Raw TMDB API search result shape (snake_case). */
+export interface RawTmdbSearchResult {
+  id: number;
+  title: string;
+  original_title: string;
+  overview: string;
+  release_date: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  genre_ids: number[];
+  original_language: string;
+  popularity: number;
+}
+
+/** Raw TMDB API search response. */
+export interface RawTmdbSearchResponse {
+  page: number;
+  results: RawTmdbSearchResult[];
+  total_results: number;
+  total_pages: number;
+}
+
+/** Raw TMDB API movie detail shape (snake_case). */
+export interface RawTmdbMovieDetail {
+  id: number;
+  imdb_id: string | null;
+  title: string;
+  original_title: string;
+  overview: string;
+  tagline: string;
+  release_date: string;
+  runtime: number;
+  status: string;
+  original_language: string;
+  budget: number;
+  revenue: number;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  genres: { id: number; name: string }[];
+  production_companies: { id: number; name: string }[];
+  spoken_languages: { iso_639_1: string; name: string }[];
+}
+
+/** Raw TMDB API image entry. */
+export interface RawTmdbImage {
+  file_path: string;
+  width: number;
+  height: number;
+  aspect_ratio: number;
+  vote_average: number;
+  vote_count: number;
+  iso_639_1: string | null;
+}
+
+/** Raw TMDB API images response. */
+export interface RawTmdbImageResponse {
+  id: number;
+  backdrops: RawTmdbImage[];
+  posters: RawTmdbImage[];
+  logos: RawTmdbImage[];
+}
+
+/** Raw TMDB API trending response (same shape as search). */
+export interface RawTmdbTrendingResponse {
+  page: number;
+  results: RawTmdbSearchResult[];
+  total_results: number;
+  total_pages: number;
+}
+
+/** Raw TMDB API recommendations response (same shape as search). */
+export interface RawTmdbRecommendationsResponse {
+  page: number;
+  results: RawTmdbSearchResult[];
+  total_results: number;
+  total_pages: number;
+}
+
+/** A crew member from TMDB credits. */
+export interface TmdbCrewMember {
+  id: number;
+  name: string;
+  job: string;
+  department: string;
+}
+
+/** A cast member from TMDB credits. */
+export interface TmdbCastMember {
+  id: number;
+  name: string;
+  order: number;
+}
+
+/** Credits for a movie from TMDB. */
+export interface TmdbMovieCredits {
+  id: number;
+  crew: TmdbCrewMember[];
+  cast: TmdbCastMember[];
+}


### PR DESCRIPTION
Wave 2, part a. Relocates the two external metadata client libraries into the pillar as **internal, env-configured clients** (no REST surface yet — they're consumed by the library add/refresh + Plex sync slices that follow).

- `pillars/media/src/api/clients/{tmdb,thetvdb}/` — rate-limited HTTP clients, TMDB genre + image caches, TheTVDB JWT auth, response→db-insert mappers.
- **env-config** (no `core/settings` / `pops-api` dependency): API keys via env (`TMDB_API_KEY` / `THETVDB_API_KEY`); the tuning params that previously read the settings table now read env with the same defaults (`MEDIA_TMDB_GENRE_CACHE_TTL_MS`, `MEDIA_THETVDB_RATE_LIMIT_CAPACITY`/`_REFILL_RATE`, `MEDIA_THETVDB_MAX_RETRIES`).
- narrowed `GenreCache`'s dependency to `Pick<TmdbClient,'getGenreList'>` so mocks type cleanly (no casts).
- fetch-mocked unit tests carried over — **226 pillar tests** total.

TheTVDB's db-orchestration service (`refreshTvShow`) lands with the library-refresh slice. No new OpenAPI routes (internal libs only). Verified: typecheck ✓ · build ✓ · 226/226 ✓ · format ✓ · lint exit 0 ✓ · openapi unchanged ✓.