### PR TITLE
feat(media): REST migration slice 9b — Plex sync ops + in-process job runner

### DIFF
--- a/pillars/media/migrations/0035_sync_job_results_baseline.sql
+++ b/pillars/media/migrations/0035_sync_job_results_baseline.sql
@@ -1,0 +1,23 @@
+-- Media pillar baseline for the `sync_job_results` table — the single
+-- source of truth for in-process Plex sync job status (slice 9b). The
+-- monolith mirrored BullMQ job state into a same-named table; the pillar
+-- has no Redis/BullMQ, so this table holds the running/completed/failed
+-- lifecycle on its own.
+--
+-- Column types/defaults mirror the drizzle definition in
+-- `src/db/schema/sync-job-results.ts`.
+
+CREATE TABLE `sync_job_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`job_type` text NOT NULL,
+	`status` text NOT NULL,
+	`started_at` text NOT NULL,
+	`completed_at` text,
+	`duration_ms` integer,
+	`progress` text,
+	`result` text,
+	`error` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_sync_job_results_type_completed` ON `sync_job_results` (`job_type`,`completed_at`);

--- a/pillars/media/migrations/meta/_journal.json
+++ b/pillars/media/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1798000002000,
       "tag": "0034_plex_settings_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1798000003000,
+      "tag": "0035_sync_job_results_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -6895,6 +6895,144 @@
         "tags": ["plex"]
       }
     },
+    "/plex/sync": {
+      "post": {
+        "operationId": "plex.startSyncJob",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "jobType": {
+                    "enum": [
+                      "plexSyncMovies",
+                      "plexSyncTvShows",
+                      "plexSyncWatchlist",
+                      "plexSyncWatchHistory"
+                    ],
+                    "type": "string"
+                  },
+                  "movieSectionId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "sectionId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "tvSectionId": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["jobType"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "jobId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["jobId"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Start an on-demand Plex sync job (runs async in-process)",
+        "tags": ["plex"]
+      }
+    },
     "/plex/sync-status": {
       "get": {
         "operationId": "plex.getSyncStatus",
@@ -6935,6 +7073,332 @@
           }
         },
         "summary": "Connection-config snapshot (configured / hasUrl / hasToken)",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/sync/active": {
+      "get": {
+        "operationId": "plex.getActiveSyncJobs",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "completedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "durationMs": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "jobType": {
+                            "type": "string"
+                          },
+                          "progress": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "processed": {
+                                "type": "number"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "required": ["processed", "total"],
+                            "type": "object"
+                          },
+                          "result": {},
+                          "startedAt": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["running", "completed", "failed"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "jobType",
+                          "status",
+                          "startedAt",
+                          "completedAt",
+                          "durationMs",
+                          "progress",
+                          "result",
+                          "error"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List currently-running sync jobs",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/sync/last": {
+      "get": {
+        "operationId": "plex.getLastSyncResults",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": {
+                        "additionalProperties": false,
+                        "nullable": true,
+                        "properties": {
+                          "completedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "durationMs": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "jobType": {
+                            "type": "string"
+                          },
+                          "progress": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "processed": {
+                                "type": "number"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "required": ["processed", "total"],
+                            "type": "object"
+                          },
+                          "result": {},
+                          "startedAt": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["running", "completed", "failed"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "jobType",
+                          "status",
+                          "startedAt",
+                          "completedAt",
+                          "durationMs",
+                          "progress",
+                          "result",
+                          "error"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Most recent completed result per sync job type",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/sync/{jobId}": {
+      "get": {
+        "operationId": "plex.getSyncJobStatus",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "durationMs": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "error": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "jobType": {
+                          "type": "string"
+                        },
+                        "progress": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "processed": {
+                              "type": "number"
+                            },
+                            "total": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["processed", "total"],
+                          "type": "object"
+                        },
+                        "result": {},
+                        "startedAt": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["running", "completed", "failed"],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jobType",
+                        "status",
+                        "startedAt",
+                        "completedAt",
+                        "durationMs",
+                        "progress",
+                        "result",
+                        "error"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Poll a sync job by id (404 if unknown)",
         "tags": ["plex"]
       }
     },

--- a/pillars/media/src/api/__tests__/plex-sync.test.ts
+++ b/pillars/media/src/api/__tests__/plex-sync.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for the `plex.*` sync routes (slice 9b) via supertest.
+ *
+ * The Plex Media Server API is mocked at `globalThis.fetch` (method + url
+ * substring routes); the TMDB / TheTVDB client factories are mocked at the
+ * module boundary and their network methods spied — so the full handler →
+ * job-runner → sync-op → db-service path runs with zero network. Job
+ * execution is fire-and-forget; `waitForJob` polls `getSyncJobStatus` until a
+ * terminal state, mirroring finance's `waitForImportCompletion` helper.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb, plexSettingsService, type OpenedMediaDb } from '../../db/index.js';
+import { createMediaApiApp } from '../app.js';
+import { TheTvdbAuth } from '../clients/thetvdb/auth.js';
+import { TheTvdbClient } from '../clients/thetvdb/client.js';
+import { TmdbClient } from '../clients/tmdb/client.js';
+import { ImageCacheService } from '../clients/tmdb/image-cache.js';
+import { makeClient } from './test-utils.js';
+
+import type { SyncJob } from '../../db/index.js';
+import type { TmdbMovieDetail } from '../clients/tmdb/types.js';
+
+const PLEX_URL = 'http://plex.test:32400';
+const MOVIE_SECTION = '1';
+
+interface RouteRule {
+  method: string;
+  match: string;
+  handler: () => { status?: number; body: unknown };
+}
+
+let routes: RouteRule[];
+
+function route(method: string, match: string, handler: RouteRule['handler']): void {
+  routes.push({ method, match, handler });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const rule = routes.find((r) => r.method === method && url.includes(r.match));
+  if (!rule) return Promise.resolve(jsonResponse({ error: `unmatched ${method} ${url}` }, 404));
+  const res = rule.handler();
+  return Promise.resolve(jsonResponse(res.body, res.status ?? 200));
+});
+
+const { getTmdbClientMock, getImageCacheMock, getTvdbClientMock } = vi.hoisted(() => ({
+  getTmdbClientMock: vi.fn<() => TmdbClient>(),
+  getImageCacheMock: vi.fn<() => ImageCacheService>(),
+  getTvdbClientMock: vi.fn<() => TheTvdbClient>(),
+}));
+
+vi.mock('../clients/tmdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../clients/tmdb/index.js')>(
+    '../clients/tmdb/index.js'
+  );
+  return { ...actual, getTmdbClient: getTmdbClientMock, getImageCache: getImageCacheMock };
+});
+
+vi.mock('../clients/thetvdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../clients/thetvdb/index.js')>(
+    '../clients/thetvdb/index.js'
+  );
+  return { ...actual, getTvdbClient: getTvdbClientMock };
+});
+
+function movieDetail(overrides: Partial<TmdbMovieDetail> = {}): TmdbMovieDetail {
+  return {
+    tmdbId: 603,
+    imdbId: 'tt0133093',
+    title: 'The Matrix',
+    originalTitle: 'The Matrix',
+    overview: 'A hacker learns the truth.',
+    tagline: 'Free your mind.',
+    releaseDate: '1999-03-31',
+    runtime: 136,
+    status: 'Released',
+    originalLanguage: 'en',
+    budget: 63000000,
+    revenue: 463517383,
+    posterPath: '/poster.jpg',
+    backdropPath: '/backdrop.jpg',
+    voteAverage: 8.2,
+    voteCount: 24000,
+    genres: [{ id: 28, name: 'Action' }],
+    productionCompanies: [],
+    spokenLanguages: [],
+    ...overrides,
+  };
+}
+
+interface PlexItemStub {
+  ratingKey: string;
+  title: string;
+  type: string;
+  year?: number;
+  viewCount?: number;
+  Guid?: Array<{ id: string }>;
+}
+
+function sectionAll(items: PlexItemStub[]): { body: unknown } {
+  return {
+    body: { MediaContainer: { size: items.length, totalSize: items.length, Metadata: items } },
+  };
+}
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+let tmdb: TmdbClient;
+let tvdb: TheTvdbClient;
+let imageCache: ImageCacheService;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-plex-sync-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+  routes = [];
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+
+  tmdb = new TmdbClient('test-key');
+  tvdb = new TheTvdbClient(new TheTvdbAuth('test-key'));
+  imageCache = new ImageCacheService(join(tmpDir, 'images'));
+  vi.spyOn(imageCache, 'downloadMovieImages').mockResolvedValue();
+  vi.spyOn(imageCache, 'downloadTvShowImages').mockResolvedValue();
+  getTmdbClientMock.mockReturnValue(tmdb);
+  getTvdbClientMock.mockReturnValue(tvdb);
+  getImageCacheMock.mockReturnValue(imageCache);
+
+  plexSettingsService.setSetting(mediaDb.db, 'plex_url', PLEX_URL);
+  plexSettingsService.setSetting(mediaDb.db, 'plex_token', 'raw-token');
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+function client() {
+  return makeClient(
+    createMediaApiApp({ mediaDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3003' })
+  );
+}
+
+/** Poll a job until it leaves `running`. Fails fast rather than hanging. */
+async function waitForJob(jobId: string, maxPolls = 50): Promise<SyncJob> {
+  for (let i = 0; i < maxPolls; i++) {
+    const { data } = await client().plex.getSyncJobStatus(jobId);
+    if (data.status !== 'running') return data;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`job ${jobId} did not settle within ${maxPolls} polls`);
+}
+
+describe('plex sync — startSyncJob lifecycle', () => {
+  it('runs a movie sync running → completed and creates the movie', async () => {
+    route('GET', '/library/sections/1/all', () =>
+      sectionAll([
+        {
+          ratingKey: 'p1',
+          title: 'The Matrix',
+          type: 'movie',
+          year: 1999,
+          Guid: [{ id: 'tmdb://603' }],
+        },
+      ])
+    );
+    vi.spyOn(tmdb, 'getMovie').mockResolvedValue(movieDetail());
+
+    const { data } = await client().plex.startSyncJob({
+      jobType: 'plexSyncMovies',
+      sectionId: MOVIE_SECTION,
+    });
+    expect(data.jobId).toMatch(/[0-9a-f-]{36}/);
+
+    const job = await waitForJob(data.jobId);
+    expect(job.status).toBe('completed');
+    expect(job.completedAt).not.toBeNull();
+    expect(job.durationMs).not.toBeNull();
+    expect(job.result).toMatchObject({ total: 1, processed: 1, synced: 1, skipped: 0 });
+
+    const listed = await client().library.list();
+    expect(listed.data.map((i) => i.title)).toContain('The Matrix');
+  });
+
+  it('transitions to failed + error when the sync op throws', async () => {
+    route('GET', '/library/sections/1/all', () => ({ status: 500, body: { error: 'boom' } }));
+
+    const { data } = await client().plex.startSyncJob({
+      jobType: 'plexSyncMovies',
+      sectionId: MOVIE_SECTION,
+    });
+    const job = await waitForJob(data.jobId);
+
+    expect(job.status).toBe('failed');
+    expect(job.error).toBeTruthy();
+    expect(job.completedAt).not.toBeNull();
+  });
+
+  it('409s when Plex is not configured', async () => {
+    plexSettingsService.deleteSetting(mediaDb.db, 'plex_url');
+    plexSettingsService.deleteSetting(mediaDb.db, 'plex_token');
+    await expect(
+      client().plex.startSyncJob({ jobType: 'plexSyncMovies', sectionId: MOVIE_SECTION })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('400s a missing sectionId-dependent op at completion (failed job, not a 4xx)', async () => {
+    const { data } = await client().plex.startSyncJob({ jobType: 'plexSyncMovies' });
+    const job = await waitForJob(data.jobId);
+    expect(job.status).toBe('failed');
+    expect(job.error).toContain('sectionId is required');
+  });
+
+  it('rejects the deferred discover job type at the contract boundary', async () => {
+    await expect(
+      client().plex.startSyncJob({ jobType: 'plexSyncDiscoverWatches', sectionId: '1' })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('plex sync — status reads', () => {
+  it('404s an unknown job id', async () => {
+    await expect(client().plex.getSyncJobStatus('does-not-exist')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('getLastSyncResults returns the latest completed result per type', async () => {
+    route('GET', '/library/sections/1/all', () => sectionAll([]));
+
+    const first = await client().plex.startSyncJob({
+      jobType: 'plexSyncMovies',
+      sectionId: MOVIE_SECTION,
+    });
+    await waitForJob(first.data.jobId);
+    const second = await client().plex.startSyncJob({
+      jobType: 'plexSyncMovies',
+      sectionId: MOVIE_SECTION,
+    });
+    const secondJob = await waitForJob(second.data.jobId);
+
+    const { data } = await client().plex.getLastSyncResults();
+    expect(data['plexSyncMovies']?.id).toBe(secondJob.id);
+    expect(data['plexSyncTvShows']).toBeNull();
+    expect(data['plexSyncWatchlist']).toBeNull();
+    expect(data['plexSyncWatchHistory']).toBeNull();
+  });
+
+  it('getActiveSyncJobs lists only running jobs', async () => {
+    route('GET', '/library/sections/1/all', () => sectionAll([]));
+    const { data } = await client().plex.startSyncJob({
+      jobType: 'plexSyncMovies',
+      sectionId: MOVIE_SECTION,
+    });
+    await waitForJob(data.jobId);
+
+    const active = await client().plex.getActiveSyncJobs();
+    expect(active.data).toEqual([]);
+  });
+});

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -10,6 +10,7 @@ import supertest from 'supertest';
 
 import type { Express } from 'express';
 
+import type { SyncJob } from '../../db/index.js';
 import type { LibraryItem } from '../modules/library-types.js';
 import type { Movie } from '../modules/movie-types.js';
 import type { Episode, Season, TvShow } from '../modules/tv-show-types.js';
@@ -315,6 +316,16 @@ export function makeClient(app: Express) {
         ),
       saveSectionIds: (body: { movieSectionId?: string; tvSectionId?: string }) =>
         send<{ message: string }>(r.post('/plex/section-ids').send(body)),
+      startSyncJob: (body: {
+        jobType: string;
+        sectionId?: string;
+        movieSectionId?: string;
+        tvSectionId?: string;
+      }) => send<{ data: { jobId: string } }>(r.post('/plex/sync').send(body)),
+      getSyncJobStatus: (jobId: string) => send<{ data: SyncJob }>(r.get(`/plex/sync/${jobId}`)),
+      getActiveSyncJobs: () => send<{ data: SyncJob[] }>(r.get('/plex/sync/active')),
+      getLastSyncResults: () =>
+        send<{ data: Record<string, SyncJob | null> }>(r.get('/plex/sync/last')),
     },
   };
 }

--- a/pillars/media/src/api/clients/plex/client-http.ts
+++ b/pillars/media/src/api/clients/plex/client-http.ts
@@ -1,0 +1,59 @@
+/**
+ * Plex HTTP fetch helpers (no business logic).
+ *
+ *  - `getPath`     — GET against the Plex Media Server (appends the token query param)
+ *  - `getAbsolute` — GET an absolute cloud URL (token already in the query)
+ *  - `putAbsolute` — PUT an absolute cloud URL (appends the token query param)
+ */
+import { PlexApiError } from './types.js';
+
+async function readErrorMessage(response: Response): Promise<string> {
+  let message = `Plex API error: ${response.status} ${response.statusText}`;
+  try {
+    const text = await response.text();
+    if (text) message = text;
+  } catch {
+    // Ignore parse failures — keep the status-line message.
+  }
+  return message;
+}
+
+async function performFetch(url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    throw new PlexApiError(0, `Network error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Generic GET for cloud API endpoints (absolute URLs, token already in query). */
+export async function getAbsolute<T>(absoluteUrl: string): Promise<T> {
+  const response = await performFetch(absoluteUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new PlexApiError(response.status, await readErrorMessage(response));
+  }
+  return (await response.json()) as T;
+}
+
+/** Generic GET for the Plex Media Server API; appends the token query param. */
+export async function getPath<T>(baseUrl: string, token: string, path: string): Promise<T> {
+  const separator = path.includes('?') ? '&' : '?';
+  const url = `${baseUrl}${path}${separator}X-Plex-Token=${encodeURIComponent(token)}`;
+  return getAbsolute<T>(url);
+}
+
+/** Generic PUT for cloud API endpoints (absolute URLs); appends the token query param. */
+export async function putAbsolute(absoluteUrl: string, token: string): Promise<void> {
+  const separator = absoluteUrl.includes('?') ? '&' : '?';
+  const url = `${absoluteUrl}${separator}X-Plex-Token=${encodeURIComponent(token)}`;
+  const response = await performFetch(url, {
+    method: 'PUT',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new PlexApiError(response.status, await readErrorMessage(response));
+  }
+}

--- a/pillars/media/src/api/clients/plex/client-mappers.ts
+++ b/pillars/media/src/api/clients/plex/client-mappers.ts
@@ -1,0 +1,92 @@
+/**
+ * RawPlex* → mapped domain type converters (no I/O).
+ */
+import {
+  type PlexEpisode,
+  type PlexExternalId,
+  type PlexMediaItem,
+  type RawPlexEpisode,
+  type RawPlexMediaItem,
+} from './types.js';
+
+/** Parse a Plex `Guid` array into structured external IDs. */
+export function parseGuids(guids: RawPlexMediaItem['Guid'] | undefined): PlexExternalId[] {
+  if (!guids) return [];
+  return guids
+    .map((g) => {
+      const match = g.id.match(/^(\w+):\/\/(.+)$/);
+      if (!match) return null;
+      return { source: match[1], id: match[2] };
+    })
+    .filter((id): id is PlexExternalId => id !== null);
+}
+
+const NULLABLE_SCALAR_KEYS = [
+  ['originalTitle', 'originalTitle'],
+  ['summary', 'summary'],
+  ['tagline', 'tagline'],
+  ['year', 'year'],
+  ['thumbUrl', 'thumb'],
+  ['artUrl', 'art'],
+  ['durationMs', 'duration'],
+  ['lastViewedAt', 'lastViewedAt'],
+  ['rating', 'rating'],
+  ['audienceRating', 'audienceRating'],
+  ['contentRating', 'contentRating'],
+  ['leafCount', 'leafCount'],
+  ['viewedLeafCount', 'viewedLeafCount'],
+  ['childCount', 'childCount'],
+] as const satisfies ReadonlyArray<readonly [keyof PlexMediaItem, keyof RawPlexMediaItem]>;
+
+function readScalars(raw: RawPlexMediaItem): Partial<PlexMediaItem> {
+  const out: Record<string, unknown> = {};
+  for (const [outKey, rawKey] of NULLABLE_SCALAR_KEYS) {
+    out[outKey] = raw[rawKey] ?? null;
+  }
+  return out as Partial<PlexMediaItem>;
+}
+
+export function mapMediaItem(raw: RawPlexMediaItem): PlexMediaItem {
+  const base: PlexMediaItem = {
+    ratingKey: raw.ratingKey,
+    type: raw.type,
+    title: raw.title,
+    addedAt: raw.addedAt,
+    updatedAt: raw.updatedAt,
+    viewCount: raw.viewCount ?? 0,
+    externalIds: parseGuids(raw.Guid),
+    genres: (raw.Genre ?? []).map((g) => g.tag),
+    directors: (raw.Director ?? []).map((d) => d.tag),
+    originalTitle: null,
+    summary: null,
+    tagline: null,
+    year: null,
+    thumbUrl: null,
+    artUrl: null,
+    durationMs: null,
+    lastViewedAt: null,
+    rating: null,
+    audienceRating: null,
+    contentRating: null,
+    leafCount: null,
+    viewedLeafCount: null,
+    childCount: null,
+  };
+  return { ...base, ...readScalars(raw) };
+}
+
+export function mapEpisode(raw: RawPlexEpisode): PlexEpisode {
+  return {
+    ratingKey: raw.ratingKey,
+    title: raw.title,
+    episodeIndex: raw.index,
+    seasonIndex: raw.parentIndex,
+    summary: raw.summary ?? null,
+    thumbUrl: raw.thumb ?? null,
+    durationMs: raw.duration ?? null,
+    addedAt: raw.addedAt,
+    updatedAt: raw.updatedAt,
+    lastViewedAt: raw.lastViewedAt ?? null,
+    viewCount: raw.viewCount ?? 0,
+  };
+}

--- a/pillars/media/src/api/clients/plex/client.ts
+++ b/pillars/media/src/api/clients/plex/client.ts
@@ -1,35 +1,32 @@
 /**
- * Plex Media Server HTTP client — connection slice.
+ * Plex Media Server HTTP client.
  *
  * Typed wrapper around the Plex Media Server API (authenticated via the
- * `X-Plex-Token` query param). This slice ports only the library-listing
- * surface the connection/auth flow needs (`getLibraries`, used by the
- * connection test); the sync media/episode methods stay in the monolith
- * until slices 9b/9c.
+ * `X-Plex-Token` query param). The connection surface (`getLibraries`,
+ * slice 9a) and the sync surface (`getAllItems` / `getItemDetail` /
+ * `getEpisodes`, slice 9b) live here; the Plex Discover (cloud) endpoints
+ * stay deferred until the rotation/discover domain lands (wave 3).
+ *
+ * Sub-modules:
+ *  - client-http.ts    — fetch helpers (getPath, getAbsolute, putAbsolute)
+ *  - client-mappers.ts — RawPlex* → PlexMediaItem/PlexEpisode mappers
  *
  * Plex API docs: https://github.com/Arcanemagus/plex-api/wiki
  */
+import { getPath } from './client-http.js';
+import { mapEpisode, mapMediaItem } from './client-mappers.js';
 import {
   PlexApiError,
+  type PlexEpisode,
   type PlexLibrary,
+  type PlexMediaItem,
+  type RawPlexEpisodesContainer,
+  type RawPlexItemsContainer,
   type RawPlexLibrariesContainer,
   type RawPlexMediaContainer,
 } from './types.js';
 
-async function getPath<T>(baseUrl: string, token: string, path: string): Promise<T> {
-  const url = `${baseUrl}${path}${path.includes('?') ? '&' : '?'}X-Plex-Token=${encodeURIComponent(token)}`;
-  let response: Response;
-  try {
-    response = await fetch(url, { headers: { Accept: 'application/json' } });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new PlexApiError(0, `Plex request failed: ${message}`);
-  }
-  if (!response.ok) {
-    throw new PlexApiError(response.status, `Plex API error: ${response.status} ${path}`);
-  }
-  return (await response.json()) as T;
-}
+const PAGE_SIZE = 100;
 
 export class PlexClient {
   private readonly baseUrl: string;
@@ -61,5 +58,57 @@ export class PlexClient {
       updatedAt: d.updatedAt,
       scannedAt: d.scannedAt,
     }));
+  }
+
+  /** Get all items in a library section (includes external IDs). Paginates automatically. */
+  async getAllItems(sectionId: string): Promise<PlexMediaItem[]> {
+    const allItems: PlexMediaItem[] = [];
+    let start = 0;
+    for (;;) {
+      const raw = await getPath<RawPlexMediaContainer<RawPlexItemsContainer>>(
+        this.baseUrl,
+        this.token,
+        `/library/sections/${sectionId}/all?includeGuids=1&X-Plex-Container-Start=${start}&X-Plex-Container-Size=${PAGE_SIZE}`
+      );
+      const container = raw.MediaContainer;
+      const items = container.Metadata ?? [];
+      allItems.push(...items.map(mapMediaItem));
+      const totalSize = container.totalSize ?? items.length;
+      start += items.length;
+      if (start >= totalSize || items.length === 0) break;
+    }
+    return allItems;
+  }
+
+  /** Get detail for a single item by rating key. */
+  async getItemDetail(ratingKey: string): Promise<PlexMediaItem> {
+    const raw = await getPath<RawPlexMediaContainer<RawPlexItemsContainer>>(
+      this.baseUrl,
+      this.token,
+      `/library/metadata/${ratingKey}`
+    );
+    const first = (raw.MediaContainer.Metadata ?? [])[0];
+    if (!first) throw new PlexApiError(404, `Item ${ratingKey} not found`);
+    return mapMediaItem(first);
+  }
+
+  /** Get all episodes for a TV show by its rating key. Paginates automatically. */
+  async getEpisodes(showRatingKey: string): Promise<PlexEpisode[]> {
+    const allEpisodes: PlexEpisode[] = [];
+    let start = 0;
+    for (;;) {
+      const raw = await getPath<RawPlexMediaContainer<RawPlexEpisodesContainer>>(
+        this.baseUrl,
+        this.token,
+        `/library/metadata/${showRatingKey}/allLeaves?X-Plex-Container-Start=${start}&X-Plex-Container-Size=${PAGE_SIZE}`
+      );
+      const container = raw.MediaContainer;
+      const eps = container.Metadata ?? [];
+      allEpisodes.push(...eps.map(mapEpisode));
+      const totalSize = container.totalSize ?? eps.length;
+      start += eps.length;
+      if (start >= totalSize || eps.length === 0) break;
+    }
+    return allEpisodes;
   }
 }

--- a/pillars/media/src/api/clients/plex/index.ts
+++ b/pillars/media/src/api/clients/plex/index.ts
@@ -6,7 +6,13 @@
  * (`auth.ts`). Token crypto lives in `crypto.ts`.
  */
 export { PlexClient } from './client.js';
-export { PlexApiError, type PlexLibrary } from './types.js';
+export {
+  PlexApiError,
+  type PlexEpisode,
+  type PlexExternalId,
+  type PlexLibrary,
+  type PlexMediaItem,
+} from './types.js';
 
 export {
   getPlexClient,

--- a/pillars/media/src/api/clients/plex/sync/index.ts
+++ b/pillars/media/src/api/clients/plex/sync/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Barrel for the in-process Plex sync ops + job runner (slice 9b).
+ *
+ * Deferred: `plexSyncDiscoverWatches` and all `sync-discover-*` ops — they
+ * depend on the Plex Discover client + the rotation domain (wave 3).
+ */
+export { runSyncJob } from './run-sync-job.js';
+export {
+  SYNC_JOB_TYPES,
+  isSyncJobType,
+  type StartSyncJobInput,
+  type SyncJobType,
+} from './types.js';

--- a/pillars/media/src/api/clients/plex/sync/run-sync-job.ts
+++ b/pillars/media/src/api/clients/plex/sync/run-sync-job.ts
@@ -1,0 +1,92 @@
+/**
+ * In-process sync-job dispatcher (slice 9b re-architecture).
+ *
+ * The monolith enqueued sync jobs to a `pops-sync` BullMQ queue processed by
+ * a separate worker. The pillar has no Redis/BullMQ, so `startSyncJob`
+ * (handler) fires this dispatcher with `void runSyncJob(...)` and persists the
+ * outcome to `sync_job_results`. This module resolves the upstream clients +
+ * section ids and runs the matching op, returning its result payload.
+ *
+ * `plexSyncDiscoverWatches` is intentionally unsupported here — it needs the
+ * Plex Discover client + rotation domain, both deferred to wave 3.
+ */
+import { type MediaDb } from '../../../../db/index.js';
+import { getTvdbClient } from '../../thetvdb/index.js';
+import { getImageCache, getTmdbClient } from '../../tmdb/index.js';
+import { getPlexClient, getPlexClientId, getPlexToken } from '../service.js';
+import { importMoviesFromPlex } from './sync-movies.js';
+import { importTvShowsFromPlex } from './sync-tv.js';
+import { syncWatchHistoryFromPlex } from './sync-watch-history.js';
+import { syncWatchlistFromPlex } from './sync-watchlist.js';
+import { type StartSyncJobInput } from './types.js';
+
+import type { PlexClient } from '../client.js';
+
+function requireSectionId(sectionId: string | undefined, label: string): string {
+  if (!sectionId) throw new Error(`sectionId is required for ${label}`);
+  return sectionId;
+}
+
+function requirePlexClient(db: MediaDb): PlexClient {
+  const client = getPlexClient(db);
+  if (!client) throw new Error('Plex is not configured');
+  return client;
+}
+
+async function runMovies(db: MediaDb, input: StartSyncJobInput): Promise<unknown> {
+  const client = requirePlexClient(db);
+  return importMoviesFromPlex(
+    { db, plexClient: client, tmdbClient: getTmdbClient() },
+    requireSectionId(input.sectionId, 'movie sync')
+  );
+}
+
+async function runTvShows(db: MediaDb, input: StartSyncJobInput): Promise<unknown> {
+  const client = requirePlexClient(db);
+  return importTvShowsFromPlex(
+    {
+      db,
+      plexClient: client,
+      tvdbClient: getTvdbClient(),
+      imageCache: getImageCache(),
+    },
+    requireSectionId(input.sectionId, 'TV sync')
+  );
+}
+
+async function runWatchHistory(db: MediaDb, input: StartSyncJobInput): Promise<unknown> {
+  const client = requirePlexClient(db);
+  return syncWatchHistoryFromPlex(db, client, input.movieSectionId, input.tvSectionId);
+}
+
+async function runWatchlist(db: MediaDb): Promise<unknown> {
+  requirePlexClient(db);
+  const token = getPlexToken(db);
+  if (!token) throw new Error('Plex is not configured');
+  return syncWatchlistFromPlex({
+    db,
+    token,
+    clientId: getPlexClientId(db),
+    tmdbClient: getTmdbClient(),
+    tvdbClient: getTvdbClient(),
+    imageCache: getImageCache(),
+  });
+}
+
+/**
+ * Run a sync job synchronously (the caller fires it without awaiting).
+ * Resolves to the op's result payload; rejects on any failure so the caller
+ * can persist `failed` + the error message.
+ */
+export function runSyncJob(db: MediaDb, input: StartSyncJobInput): Promise<unknown> {
+  switch (input.jobType) {
+    case 'plexSyncMovies':
+      return runMovies(db, input);
+    case 'plexSyncTvShows':
+      return runTvShows(db, input);
+    case 'plexSyncWatchHistory':
+      return runWatchHistory(db, input);
+    case 'plexSyncWatchlist':
+      return runWatchlist(db);
+  }
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-episode-match.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-episode-match.ts
@@ -1,0 +1,140 @@
+/**
+ * Episode watch matching — maps Plex episodes to local DB episodes by
+ * season+episode number and logs watch history for watched episodes.
+ *
+ * Ported from the monolith `sync-helpers.ts` (`syncEpisodeWatches` +
+ * `processSingleEpisode`) and converted to the pillar's `(db, …)` pattern.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import {
+  type MediaDb,
+  episodes,
+  seasons,
+  tvShowsService,
+  watchHistoryLogService,
+} from '../../../../db/index.js';
+import { hasNearDuplicateWatch } from './sync-helpers.js';
+
+import type { PlexEpisode } from '../types.js';
+
+/** Per-episode mismatch detail for diagnostics. */
+export interface EpisodeMismatch {
+  seasonNumber: number;
+  episodeNumber: number;
+  title: string;
+}
+
+/** Detailed diagnostics returned by {@link syncEpisodeWatches}. */
+export interface EpisodeSyncDiagnostics {
+  plexTotal: number;
+  plexWatched: number;
+  matched: number;
+  alreadyLogged: number;
+  seasonNotFound: number;
+  episodeNotFound: number;
+  missingSeasonsPreview: number[];
+  missingEpisodesPreview: EpisodeMismatch[];
+}
+
+const PREVIEW_LIMIT = 10;
+
+interface ProcessEpisodeContext {
+  showId: number;
+  diagnostics: EpisodeSyncDiagnostics;
+  missingSeasonsSet: Set<number>;
+}
+
+function processSingleEpisode(db: MediaDb, plexEp: PlexEpisode, ctx: ProcessEpisodeContext): void {
+  const { showId, diagnostics, missingSeasonsSet } = ctx;
+  try {
+    const season = db
+      .select()
+      .from(seasons)
+      .where(and(eq(seasons.tvShowId, showId), eq(seasons.seasonNumber, plexEp.seasonIndex)))
+      .get();
+    if (!season) {
+      diagnostics.seasonNotFound++;
+      missingSeasonsSet.add(plexEp.seasonIndex);
+      return;
+    }
+
+    const episode = db
+      .select()
+      .from(episodes)
+      .where(and(eq(episodes.seasonId, season.id), eq(episodes.episodeNumber, plexEp.episodeIndex)))
+      .get();
+    if (!episode) {
+      diagnostics.episodeNotFound++;
+      if (diagnostics.missingEpisodesPreview.length < PREVIEW_LIMIT) {
+        diagnostics.missingEpisodesPreview.push({
+          seasonNumber: plexEp.seasonIndex,
+          episodeNumber: plexEp.episodeIndex,
+          title: plexEp.title,
+        });
+      }
+      return;
+    }
+
+    const episodeWatchedAt = plexEp.lastViewedAt
+      ? new Date(plexEp.lastViewedAt * 1000).toISOString()
+      : new Date().toISOString();
+
+    if (hasNearDuplicateWatch(db, 'episode', episode.id, episodeWatchedAt)) {
+      diagnostics.alreadyLogged++;
+      return;
+    }
+
+    const result = watchHistoryLogService.logWatch(db, {
+      mediaType: 'episode',
+      mediaId: episode.id,
+      watchedAt: episodeWatchedAt,
+      completed: 1,
+      source: 'plex_sync',
+    });
+
+    if (result.created) diagnostics.matched++;
+    else diagnostics.alreadyLogged++;
+  } catch {
+    diagnostics.alreadyLogged++;
+  }
+}
+
+function emptyDiagnostics(plexTotal: number): EpisodeSyncDiagnostics {
+  return {
+    plexTotal,
+    plexWatched: 0,
+    matched: 0,
+    alreadyLogged: 0,
+    seasonNotFound: 0,
+    episodeNotFound: 0,
+    missingSeasonsPreview: [],
+    missingEpisodesPreview: [],
+  };
+}
+
+/**
+ * Match Plex episodes to local DB episodes and log watch history for watched
+ * episodes. Returns diagnostics about what matched, was skipped, and why.
+ */
+export function syncEpisodeWatches(
+  db: MediaDb,
+  tvdbId: number,
+  plexEpisodes: PlexEpisode[]
+): EpisodeSyncDiagnostics {
+  const diagnostics = emptyDiagnostics(plexEpisodes.length);
+  const show = tvShowsService.getTvShowByTvdbId(db, tvdbId);
+  if (!show) return diagnostics;
+
+  const missingSeasonsSet = new Set<number>();
+  const ctx: ProcessEpisodeContext = { showId: show.id, diagnostics, missingSeasonsSet };
+
+  for (const plexEp of plexEpisodes) {
+    if (plexEp.viewCount === 0) continue;
+    diagnostics.plexWatched++;
+    processSingleEpisode(db, plexEp, ctx);
+  }
+
+  diagnostics.missingSeasonsPreview = [...missingSeasonsSet].slice(0, PREVIEW_LIMIT);
+  return diagnostics;
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-helpers.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared Plex-sync primitives — external-ID extraction + movie watch logging.
+ *
+ * Ported from the monolith `media/plex/sync-helpers.ts` and converted to the
+ * pillar's `(db, …)` arg-passing pattern. The near-duplicate window query
+ * reads the `watch_history` table via the passed handle; the insert delegates
+ * to `watchHistoryLogService.logWatch` (idempotent on the unique key).
+ */
+import { and, eq, gte, lte } from 'drizzle-orm';
+
+import { type MediaDb, watchHistory, watchHistoryLogService } from '../../../../db/index.js';
+
+import type { PlexMediaItem } from '../types.js';
+
+/**
+ * Extract an external ID (tmdb, tvdb, imdb) from a Plex item and parse it as
+ * a number. Returns `null` if absent or non-numeric.
+ */
+export function extractExternalIdAsNumber(item: PlexMediaItem, source: string): number | null {
+  const match = item.externalIds.find((id) => id.source === source);
+  if (!match) return null;
+  const parsed = Number(match.id);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** Near-duplicate dedup window for Plex sync: 5 minutes in milliseconds. */
+const NEAR_DUPLICATE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Whether a watch event for the same media already exists within ±5 minutes
+ * of `watchedAt`. Suppresses duplicates when local Plex sync and (future)
+ * Discover cloud sync both process the same playback. Returns `true` when a
+ * near-duplicate exists (caller should skip the insert).
+ */
+export function hasNearDuplicateWatch(
+  db: MediaDb,
+  mediaType: 'movie' | 'episode',
+  mediaId: number,
+  watchedAt: string
+): boolean {
+  try {
+    const ts = new Date(watchedAt).getTime();
+    const windowStart = new Date(ts - NEAR_DUPLICATE_WINDOW_MS).toISOString();
+    const windowEnd = new Date(ts + NEAR_DUPLICATE_WINDOW_MS).toISOString();
+    const existing = db
+      .select({ id: watchHistory.id })
+      .from(watchHistory)
+      .where(
+        and(
+          eq(watchHistory.mediaType, mediaType),
+          eq(watchHistory.mediaId, mediaId),
+          gte(watchHistory.watchedAt, windowStart),
+          lte(watchHistory.watchedAt, windowEnd)
+        )
+      )
+      .get();
+    return existing != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Log a movie watch event from Plex data. Skips exact + near-duplicate
+ * entries (±5 min). Returns `true` when a new entry was created.
+ */
+export function logMovieWatch(
+  db: MediaDb,
+  movieId: number,
+  lastViewedAtUnix: number | null
+): boolean {
+  const watchedAt = lastViewedAtUnix
+    ? new Date(lastViewedAtUnix * 1000).toISOString()
+    : new Date().toISOString();
+
+  if (hasNearDuplicateWatch(db, 'movie', movieId, watchedAt)) return false;
+
+  try {
+    const result = watchHistoryLogService.logWatch(db, {
+      mediaType: 'movie',
+      mediaId: movieId,
+      watchedAt,
+      completed: 1,
+      source: 'plex_sync',
+    });
+    return result.created;
+  } catch {
+    return false;
+  }
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-movies.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-movies.ts
@@ -1,0 +1,146 @@
+/**
+ * Plex movie import — iterate a Plex movie section, match each item to a
+ * TMDB id (via Plex Guid or title+year search), add to the local library,
+ * and log watch history for watched items.
+ *
+ * Ported from the monolith `media/plex/sync-movies.ts`. The monolith wrapped
+ * each movie's writes in an explicit `getDrizzle().transaction(...)`; the
+ * pillar's `createMovie` is a single atomic insert and `logMovieWatch`
+ * self-transacts, so no outer transaction is needed here.
+ */
+import { type MediaDb, moviesService } from '../../../../db/index.js';
+import { logMovieWatch } from './sync-helpers.js';
+
+import type { TmdbClient } from '../../tmdb/client.js';
+import type { PlexClient } from '../client.js';
+import type { PlexMediaItem } from '../types.js';
+
+export interface MovieSyncError {
+  title: string;
+  year: number | null;
+  reason: string;
+}
+
+export interface MovieSyncProgress {
+  total: number;
+  processed: number;
+  synced: number;
+  skipped: number;
+  errors: MovieSyncError[];
+}
+
+export interface MovieSyncOptions {
+  onProgress?: (progress: MovieSyncProgress) => void;
+}
+
+export interface MovieSyncDeps {
+  db: MediaDb;
+  plexClient: PlexClient;
+  tmdbClient: TmdbClient;
+}
+
+async function searchTmdbByTitleYear(
+  title: string,
+  year: number | null,
+  tmdbClient: TmdbClient
+): Promise<number | null> {
+  try {
+    const result = await tmdbClient.searchMovies(title);
+    if (result.results.length === 0) return null;
+    for (const r of result.results) {
+      const titleMatch = r.title.toLowerCase() === title.toLowerCase();
+      const yearMatch =
+        year && r.releaseDate ? new Date(r.releaseDate).getFullYear() === year : true;
+      if (titleMatch && yearMatch) return r.tmdbId;
+    }
+    const first = result.results[0];
+    if (first && first.title.toLowerCase() === title.toLowerCase()) return first.tmdbId;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveTmdbId(item: PlexMediaItem, tmdbClient: TmdbClient): Promise<number | null> {
+  const plexTmdbId = item.externalIds.find((id) => id.source === 'tmdb');
+  if (plexTmdbId) {
+    const parsed = Number(plexTmdbId.id);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return searchTmdbByTitleYear(item.title, item.year, tmdbClient);
+}
+
+async function syncSingleMovie(
+  db: MediaDb,
+  item: PlexMediaItem,
+  tmdbClient: TmdbClient,
+  progress: MovieSyncProgress
+): Promise<void> {
+  const tmdbId = await resolveTmdbId(item, tmdbClient);
+  if (!tmdbId) {
+    progress.skipped++;
+    return;
+  }
+
+  const existing = moviesService.getMovieByTmdbId(db, tmdbId);
+  if (existing) {
+    if (item.viewCount > 0) logMovieWatch(db, existing.id, item.lastViewedAt);
+    progress.synced++;
+    return;
+  }
+
+  const detail = await tmdbClient.getMovie(tmdbId);
+  const movie = moviesService.createMovie(db, {
+    tmdbId: detail.tmdbId,
+    imdbId: detail.imdbId,
+    title: detail.title,
+    originalTitle: detail.originalTitle,
+    overview: detail.overview,
+    tagline: detail.tagline,
+    releaseDate: detail.releaseDate,
+    runtime: detail.runtime,
+    status: detail.status,
+    originalLanguage: detail.originalLanguage,
+    budget: detail.budget,
+    revenue: detail.revenue,
+    posterPath: detail.posterPath,
+    backdropPath: detail.backdropPath,
+    voteAverage: detail.voteAverage,
+    voteCount: detail.voteCount,
+    genres: detail.genres.map((g) => g.name),
+  });
+  if (item.viewCount > 0) logMovieWatch(db, movie.id, item.lastViewedAt);
+  progress.synced++;
+}
+
+/** Import all movies from a Plex library section. */
+export async function importMoviesFromPlex(
+  deps: MovieSyncDeps,
+  sectionId: string,
+  options: MovieSyncOptions = {}
+): Promise<MovieSyncProgress> {
+  const { db, plexClient, tmdbClient } = deps;
+  const items = await plexClient.getAllItems(sectionId);
+  const progress: MovieSyncProgress = {
+    total: items.length,
+    processed: 0,
+    synced: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  for (const item of items) {
+    try {
+      await syncSingleMovie(db, item, tmdbClient, progress);
+    } catch (err) {
+      progress.errors.push({
+        title: item.title,
+        year: item.year,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+    progress.processed++;
+    options.onProgress?.(progress);
+  }
+  return progress;
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-tv.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-tv.ts
@@ -1,0 +1,108 @@
+/**
+ * Plex TV-show import — iterate a Plex TV section, match each show to a TVDB
+ * id (via Plex Guid), add to the local library (show + seasons + episodes),
+ * fetch episodes from Plex, and log watch history for watched episodes.
+ *
+ * Ported from the monolith `media/plex/sync-tv.ts`. Show ingestion delegates
+ * to the pillar's `addTvShow` use-case (which self-transacts); episode watch
+ * matching delegates to `syncEpisodeWatches`.
+ */
+import { type MediaDb } from '../../../../db/index.js';
+import { addTvShow } from '../../../modules/tv-ingest.js';
+import { syncEpisodeWatches } from './sync-episode-match.js';
+import { extractExternalIdAsNumber } from './sync-helpers.js';
+
+import type { TheTvdbClient } from '../../thetvdb/index.js';
+import type { ImageCacheService } from '../../tmdb/image-cache.js';
+import type { PlexClient } from '../client.js';
+import type { PlexMediaItem } from '../types.js';
+
+export interface TvSyncSkip {
+  title: string;
+  year: number | null;
+  reason: string;
+}
+
+export interface TvSyncError {
+  title: string;
+  year: number | null;
+  reason: string;
+}
+
+export interface TvSyncProgress {
+  total: number;
+  processed: number;
+  synced: number;
+  skipped: number;
+  episodesMatched: number;
+  errors: TvSyncError[];
+  skipReasons: TvSyncSkip[];
+}
+
+export interface TvSyncOptions {
+  onProgress?: (progress: TvSyncProgress) => void;
+}
+
+interface TvSyncDeps {
+  db: MediaDb;
+  plexClient: PlexClient;
+  tvdbClient: TheTvdbClient;
+  imageCache: ImageCacheService;
+}
+
+async function syncSingleShow(
+  deps: TvSyncDeps,
+  item: PlexMediaItem,
+  progress: TvSyncProgress
+): Promise<void> {
+  const tvdbId = extractExternalIdAsNumber(item, 'tvdb');
+  if (!tvdbId) {
+    const hasTvdbGuid = item.externalIds.some((id) => id.source === 'tvdb');
+    progress.skipped++;
+    progress.skipReasons.push({
+      title: item.title,
+      year: item.year,
+      reason: hasTvdbGuid ? 'TVDB ID is not a valid number' : 'No TVDB ID in Plex metadata',
+    });
+    return;
+  }
+
+  await addTvShow(deps.db, tvdbId, deps.tvdbClient, deps.imageCache);
+  const plexEpisodes = await deps.plexClient.getEpisodes(item.ratingKey);
+  const diagnostics = syncEpisodeWatches(deps.db, tvdbId, plexEpisodes);
+  progress.episodesMatched += diagnostics.matched;
+  progress.synced++;
+}
+
+/** Import all TV shows from a Plex library section. */
+export async function importTvShowsFromPlex(
+  deps: TvSyncDeps,
+  sectionId: string,
+  options: TvSyncOptions = {}
+): Promise<TvSyncProgress> {
+  const items = await deps.plexClient.getAllItems(sectionId);
+  const progress: TvSyncProgress = {
+    total: items.length,
+    processed: 0,
+    synced: 0,
+    skipped: 0,
+    episodesMatched: 0,
+    errors: [],
+    skipReasons: [],
+  };
+
+  for (const item of items) {
+    try {
+      await syncSingleShow(deps, item, progress);
+    } catch (err) {
+      progress.errors.push({
+        title: item.title,
+        year: item.year,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+    progress.processed++;
+    options.onProgress?.(progress);
+  }
+  return progress;
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-watch-history.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-watch-history.ts
@@ -1,0 +1,135 @@
+/**
+ * Standalone watch-history sync — re-syncs watch data from Plex for movies
+ * and TV shows that are ALREADY in the local library. Unlike the full sync
+ * (sync-movies / sync-tv) it does not import new media.
+ *
+ * Ported from the monolith `media/plex/sync-watch-history.ts`, converted to
+ * the pillar's `(db, …)` services.
+ */
+import { type MediaDb, moviesService } from '../../../../db/index.js';
+import { type EpisodeSyncDiagnostics, syncEpisodeWatches } from './sync-episode-match.js';
+import { extractExternalIdAsNumber, logMovieWatch } from './sync-helpers.js';
+
+import type { PlexClient } from '../client.js';
+import type { PlexMediaItem } from '../types.js';
+
+export interface ShowWatchDiagnostics {
+  title: string;
+  tvdbId: number;
+  plexViewedLeafCount: number | null;
+  diagnostics: EpisodeSyncDiagnostics;
+}
+
+export interface MovieWatchSyncResult {
+  total: number;
+  watched: number;
+  logged: number;
+  alreadyLogged: number;
+  noLocalMatch: number;
+}
+
+export interface WatchHistorySyncResult {
+  movies: MovieWatchSyncResult | null;
+  shows: ShowWatchDiagnostics[];
+  summary: {
+    moviesLogged: number;
+    episodesLogged: number;
+    episodesAlreadyLogged: number;
+    showsProcessed: number;
+    showsWithGaps: number;
+  };
+}
+
+function syncMovieWatches(db: MediaDb, plexItems: PlexMediaItem[]): MovieWatchSyncResult {
+  const result: MovieWatchSyncResult = {
+    total: plexItems.length,
+    watched: 0,
+    logged: 0,
+    alreadyLogged: 0,
+    noLocalMatch: 0,
+  };
+
+  for (const item of plexItems) {
+    if (item.viewCount === 0) continue;
+    result.watched++;
+    const tmdbId = extractExternalIdAsNumber(item, 'tmdb');
+    if (!tmdbId) {
+      result.noLocalMatch++;
+      continue;
+    }
+    const movie = moviesService.getMovieByTmdbId(db, tmdbId);
+    if (!movie) {
+      result.noLocalMatch++;
+      continue;
+    }
+    if (logMovieWatch(db, movie.id, item.lastViewedAt)) result.logged++;
+    else result.alreadyLogged++;
+  }
+  return result;
+}
+
+async function syncTvShowWatches(
+  db: MediaDb,
+  plexClient: PlexClient,
+  tvItems: PlexMediaItem[]
+): Promise<ShowWatchDiagnostics[]> {
+  const showResults: ShowWatchDiagnostics[] = [];
+  for (const item of tvItems) {
+    const tvdbId = extractExternalIdAsNumber(item, 'tvdb');
+    if (!tvdbId) continue;
+    const plexEpisodes = await plexClient.getEpisodes(item.ratingKey);
+    const diagnostics = syncEpisodeWatches(db, tvdbId, plexEpisodes);
+    if (diagnostics.plexWatched > 0) {
+      showResults.push({
+        title: item.title,
+        tvdbId,
+        plexViewedLeafCount: item.viewedLeafCount,
+        diagnostics,
+      });
+    }
+  }
+  return showResults;
+}
+
+function summarise(
+  movieResult: MovieWatchSyncResult | null,
+  showResults: ShowWatchDiagnostics[]
+): WatchHistorySyncResult['summary'] {
+  const episodesLogged = showResults.reduce((sum, s) => sum + s.diagnostics.matched, 0);
+  const episodesAlreadyLogged = showResults.reduce(
+    (sum, s) => sum + s.diagnostics.alreadyLogged,
+    0
+  );
+  const showsWithGaps = showResults.filter((s) => {
+    if (s.plexViewedLeafCount === null) return false;
+    const totalTracked = s.diagnostics.matched + s.diagnostics.alreadyLogged;
+    return totalTracked < s.plexViewedLeafCount;
+  }).length;
+  return {
+    moviesLogged: movieResult?.logged ?? 0,
+    episodesLogged,
+    episodesAlreadyLogged,
+    showsProcessed: showResults.length,
+    showsWithGaps,
+  };
+}
+
+/** Re-sync watch history for already-imported movies + TV shows. */
+export async function syncWatchHistoryFromPlex(
+  db: MediaDb,
+  plexClient: PlexClient,
+  movieSectionId?: string,
+  tvSectionId?: string
+): Promise<WatchHistorySyncResult> {
+  const movieItems = movieSectionId ? await plexClient.getAllItems(movieSectionId) : [];
+  const tvItems = tvSectionId ? await plexClient.getAllItems(tvSectionId) : [];
+
+  const movieResult = movieItems.length > 0 ? syncMovieWatches(db, movieItems) : null;
+  const showResults = await syncTvShowWatches(db, plexClient, tvItems);
+
+  return {
+    movies: movieResult,
+    shows: showResults,
+    summary: summarise(movieResult, showResults),
+  };
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-watchlist-fetch.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-watchlist-fetch.ts
@@ -1,0 +1,118 @@
+/**
+ * Fetch the Plex Universal Watchlist from the Plex Discover cloud API.
+ *
+ * Ported from the monolith `sync-watchlist-fetch.ts`. Standalone (token +
+ * client id) rather than a `PlexClient` method because the watchlist lives on
+ * the Plex cloud, not the local Media Server.
+ */
+import { PlexApiError, type PlexMediaItem } from '../types.js';
+
+const PLEX_DISCOVER_BASE = 'https://discover.provider.plex.tv';
+const WATCHLIST_PAGE_SIZE = 50;
+
+interface PlexWatchlistResponse {
+  MediaContainer: {
+    totalSize?: number;
+    Metadata?: Array<{
+      ratingKey: string;
+      guid: string;
+      type: string;
+      title: string;
+      year?: number;
+      Guid?: Array<{ id: string }>;
+    }>;
+  };
+}
+
+async function fetchPlexWatchlistPage(
+  token: string,
+  clientId: string,
+  start: number,
+  size: number
+): Promise<PlexWatchlistResponse> {
+  const url =
+    `${PLEX_DISCOVER_BASE}/library/sections/watchlist/all` +
+    `?X-Plex-Token=${encodeURIComponent(token)}` +
+    `&X-Plex-Client-Identifier=${encodeURIComponent(clientId)}` +
+    `&X-Plex-Container-Start=${start}` +
+    `&X-Plex-Container-Size=${size}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } });
+  } catch (err) {
+    throw new PlexApiError(
+      0,
+      `Network error fetching Plex watchlist: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!response.ok) {
+    throw new PlexApiError(
+      response.status,
+      `Plex Discover API error: ${response.status} ${response.statusText}`
+    );
+  }
+  return (await response.json()) as PlexWatchlistResponse;
+}
+
+function parseGuids(
+  guids: Array<{ id: string }> | undefined
+): Array<{ source: string; id: string }> {
+  if (!guids) return [];
+  return guids
+    .map((g) => {
+      const match = g.id.match(/^(\w+):\/\/(.+)$/);
+      if (!match) return null;
+      return { source: match[1], id: match[2] };
+    })
+    .filter((id): id is { source: string; id: string } => id !== null);
+}
+
+function toItem(
+  raw: NonNullable<PlexWatchlistResponse['MediaContainer']['Metadata']>[number]
+): PlexMediaItem {
+  return {
+    ratingKey: raw.ratingKey,
+    type: raw.type,
+    title: raw.title,
+    originalTitle: null,
+    summary: null,
+    tagline: null,
+    year: raw.year ?? null,
+    thumbUrl: null,
+    artUrl: null,
+    durationMs: null,
+    addedAt: 0,
+    updatedAt: 0,
+    lastViewedAt: null,
+    viewCount: 0,
+    rating: null,
+    audienceRating: null,
+    contentRating: null,
+    externalIds: parseGuids(raw.Guid),
+    genres: [],
+    directors: [],
+    leafCount: null,
+    viewedLeafCount: null,
+    childCount: null,
+  };
+}
+
+/** Fetch every item from the Plex Universal Watchlist (paginated). */
+export async function fetchPlexWatchlist(
+  token: string,
+  clientId: string
+): Promise<PlexMediaItem[]> {
+  const allItems: PlexMediaItem[] = [];
+  let start = 0;
+  for (;;) {
+    const data = await fetchPlexWatchlistPage(token, clientId, start, WATCHLIST_PAGE_SIZE);
+    const pageItems = data.MediaContainer.Metadata ?? [];
+    for (const item of pageItems) allItems.push(toItem(item));
+    if (pageItems.length < WATCHLIST_PAGE_SIZE) break;
+    start += pageItems.length;
+    const totalSize = data.MediaContainer.totalSize;
+    if (totalSize !== undefined && allItems.length >= totalSize) break;
+  }
+  return allItems;
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-watchlist-resolve.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-watchlist-resolve.ts
@@ -1,0 +1,116 @@
+/**
+ * Resolve a Plex watchlist item to a local media record, importing it into
+ * the library when missing.
+ *
+ * Ported from the monolith `sync-watchlist-resolve.ts`, converted to the
+ * pillar's `(db, …)` services with injected clients.
+ */
+import { type MediaDb, moviesService, tvShowsService } from '../../../../db/index.js';
+import { addTvShow } from '../../../modules/tv-ingest.js';
+import { extractExternalIdAsNumber } from './sync-helpers.js';
+import { searchTmdbByTitleYear, searchTvdbByTitle } from './sync-watchlist-search.js';
+
+import type { TheTvdbClient } from '../../thetvdb/client.js';
+import type { TmdbClient } from '../../tmdb/client.js';
+import type { ImageCacheService } from '../../tmdb/image-cache.js';
+import type { PlexMediaItem } from '../types.js';
+
+export interface ResolvedMedia {
+  mediaType: 'movie' | 'tv_show';
+  mediaId: number;
+}
+
+export interface ResolveResult {
+  resolved: ResolvedMedia | null;
+  skipReason: string | null;
+}
+
+export interface ResolveDeps {
+  db: MediaDb;
+  tmdbClient: TmdbClient;
+  tvdbClient: TheTvdbClient;
+  imageCache: ImageCacheService;
+}
+
+async function resolveMovie(deps: ResolveDeps, item: PlexMediaItem): Promise<ResolveResult> {
+  const { db, tmdbClient } = deps;
+  let tmdbId = extractExternalIdAsNumber(item, 'tmdb');
+  if (!tmdbId) {
+    tmdbId = await searchTmdbByTitleYear(tmdbClient, item.title, item.year);
+    if (!tmdbId) {
+      return {
+        resolved: null,
+        skipReason: 'No TMDB ID in Plex metadata and title search found no match',
+      };
+    }
+  }
+
+  let movie = moviesService.getMovieByTmdbId(db, tmdbId);
+  if (!movie) {
+    try {
+      const detail = await tmdbClient.getMovie(tmdbId);
+      moviesService.createMovie(db, {
+        tmdbId: detail.tmdbId,
+        imdbId: detail.imdbId,
+        title: detail.title,
+        originalTitle: detail.originalTitle,
+        overview: detail.overview,
+        tagline: detail.tagline,
+        releaseDate: detail.releaseDate,
+        runtime: detail.runtime,
+        status: detail.status,
+        originalLanguage: detail.originalLanguage,
+        budget: detail.budget,
+        revenue: detail.revenue,
+        posterPath: detail.posterPath,
+        backdropPath: detail.backdropPath,
+        voteAverage: detail.voteAverage,
+        voteCount: detail.voteCount,
+        genres: detail.genres.map((g) => g.name),
+      });
+      movie = moviesService.getMovieByTmdbId(db, tmdbId);
+    } catch {
+      return { resolved: null, skipReason: 'Failed to fetch movie from TMDB' };
+    }
+  }
+
+  if (!movie) return { resolved: null, skipReason: 'Failed to create movie record' };
+  return { resolved: { mediaType: 'movie', mediaId: movie.id }, skipReason: null };
+}
+
+async function resolveTvShow(deps: ResolveDeps, item: PlexMediaItem): Promise<ResolveResult> {
+  const { db, tvdbClient, imageCache } = deps;
+  let tvdbId = extractExternalIdAsNumber(item, 'tvdb');
+  if (!tvdbId) {
+    tvdbId = await searchTvdbByTitle(tvdbClient, item.title, item.year);
+    if (!tvdbId) {
+      return {
+        resolved: null,
+        skipReason: 'No TVDB ID in Plex metadata and title search found no match',
+      };
+    }
+  }
+
+  let show = tvShowsService.getTvShowByTvdbId(db, tvdbId);
+  if (!show) {
+    try {
+      await addTvShow(db, tvdbId, tvdbClient, imageCache);
+      show = tvShowsService.getTvShowByTvdbId(db, tvdbId);
+    } catch {
+      return { resolved: null, skipReason: 'Failed to fetch TV show from TVDB' };
+    }
+  }
+
+  if (!show) return { resolved: null, skipReason: 'Failed to create TV show record' };
+  return { resolved: { mediaType: 'tv_show', mediaId: show.id }, skipReason: null };
+}
+
+/** Resolve a Plex watchlist item to a local media record (adds if missing). */
+export async function resolveMediaItem(
+  deps: ResolveDeps,
+  item: PlexMediaItem
+): Promise<ResolveResult> {
+  if (item.type === 'movie') return resolveMovie(deps, item);
+  if (item.type === 'show') return resolveTvShow(deps, item);
+  return { resolved: null, skipReason: `Unsupported media type: ${item.type}` };
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-watchlist-search.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-watchlist-search.ts
@@ -1,0 +1,53 @@
+/**
+ * TMDB / TheTVDB title-based search fallbacks for watchlist resolution.
+ *
+ * Ported from the monolith `sync-watchlist-search.ts`; clients are injected
+ * (the pillar resolves the env-configured singletons at the handler boundary).
+ */
+import type { TheTvdbClient } from '../../thetvdb/client.js';
+import type { TmdbClient } from '../../tmdb/client.js';
+
+/** TMDB movie search by title + optional year. Returns the closest TMDB id. */
+export async function searchTmdbByTitleYear(
+  tmdbClient: TmdbClient,
+  title: string,
+  year: number | null
+): Promise<number | null> {
+  try {
+    const result = await tmdbClient.searchMovies(title);
+    if (result.results.length === 0) return null;
+    for (const r of result.results) {
+      const titleMatch = r.title.toLowerCase() === title.toLowerCase();
+      const yearMatch =
+        year && r.releaseDate ? new Date(r.releaseDate).getFullYear() === year : true;
+      if (titleMatch && yearMatch) return r.tmdbId;
+    }
+    const first = result.results[0];
+    if (first && first.title.toLowerCase() === title.toLowerCase()) return first.tmdbId;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** TheTVDB series search by title + optional year. Returns the closest TVDB id. */
+export async function searchTvdbByTitle(
+  tvdbClient: TheTvdbClient,
+  title: string,
+  year: number | null
+): Promise<number | null> {
+  try {
+    const results = await tvdbClient.searchSeries(title);
+    if (results.length === 0) return null;
+    for (const r of results) {
+      const nameMatch = r.name.toLowerCase() === title.toLowerCase();
+      const yearMatch = year && r.year ? Number(r.year) === year : true;
+      if (nameMatch && yearMatch) return r.tvdbId;
+    }
+    const first = results[0];
+    if (first && first.name.toLowerCase() === title.toLowerCase()) return first.tvdbId;
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/pillars/media/src/api/clients/plex/sync/sync-watchlist.ts
+++ b/pillars/media/src/api/clients/plex/sync/sync-watchlist.ts
@@ -1,0 +1,152 @@
+/**
+ * Plex watchlist sync — polls the Plex Discover cloud watchlist and reconciles
+ * it into the pillar's `watchlist` table (insert new, upgrade source, remove
+ * or downgrade entries no longer present upstream).
+ *
+ * Ported from the monolith `media/plex/sync-watchlist.ts`. The monolith's
+ * cross-store migration shim (`getMediaDrizzle` vs `getDrizzle`) is gone — the
+ * pillar owns a single store, so all reads/writes use the one passed handle.
+ */
+import { and, eq, isNotNull } from 'drizzle-orm';
+
+import { type MediaDb, mediaWatchlist } from '../../../../db/index.js';
+import { fetchPlexWatchlist } from './sync-watchlist-fetch.js';
+import { type ResolveDeps, resolveMediaItem } from './sync-watchlist-resolve.js';
+
+import type { PlexMediaItem } from '../types.js';
+
+export interface WatchlistSyncError {
+  title: string;
+  reason: string;
+}
+
+export interface WatchlistSkipReason {
+  title: string;
+  reason: string;
+}
+
+export interface WatchlistSyncProgress {
+  total: number;
+  processed: number;
+  added: number;
+  removed: number;
+  skipped: number;
+  errors: WatchlistSyncError[];
+  skipReasons: WatchlistSkipReason[];
+}
+
+export interface WatchlistSyncDeps extends ResolveDeps {
+  token: string;
+  clientId: string;
+}
+
+async function syncSingleWatchlistItem(
+  deps: WatchlistSyncDeps,
+  item: PlexMediaItem,
+  plexRatingKey: string,
+  progress: WatchlistSyncProgress
+): Promise<void> {
+  const { db } = deps;
+  const { resolved, skipReason } = await resolveMediaItem(deps, item);
+  if (!resolved) {
+    progress.skipped++;
+    progress.skipReasons.push({
+      title: item.title,
+      reason: skipReason ?? 'Could not resolve media item',
+    });
+    return;
+  }
+
+  const { mediaType, mediaId } = resolved;
+  const existing = db
+    .select()
+    .from(mediaWatchlist)
+    .where(and(eq(mediaWatchlist.mediaType, mediaType), eq(mediaWatchlist.mediaId, mediaId)))
+    .get();
+
+  if (existing) {
+    if (existing.source === 'manual') {
+      db.update(mediaWatchlist)
+        .set({ source: 'both', plexRatingKey })
+        .where(eq(mediaWatchlist.id, existing.id))
+        .run();
+    } else if (!existing.source || existing.source === 'plex') {
+      db.update(mediaWatchlist)
+        .set({ source: 'plex', plexRatingKey })
+        .where(eq(mediaWatchlist.id, existing.id))
+        .run();
+    }
+    progress.skipped++;
+    progress.skipReasons.push({ title: item.title, reason: 'Already on watchlist' });
+    return;
+  }
+
+  db.insert(mediaWatchlist).values({ mediaType, mediaId, source: 'plex', plexRatingKey }).run();
+  progress.added++;
+}
+
+/**
+ * Remove or downgrade entries no longer on the Plex watchlist:
+ *  - source="plex" and not seen → delete
+ *  - source="both" and not seen → downgrade to "manual"
+ */
+function handleRemovals(
+  db: MediaDb,
+  seenPlexRatingKeys: Set<string>,
+  progress: WatchlistSyncProgress
+): void {
+  const plexEntries = db
+    .select()
+    .from(mediaWatchlist)
+    .where(isNotNull(mediaWatchlist.plexRatingKey))
+    .all();
+
+  db.transaction((tx) => {
+    for (const entry of plexEntries) {
+      if (!entry.plexRatingKey) continue;
+      if (seenPlexRatingKeys.has(entry.plexRatingKey)) continue;
+      if (entry.source === 'plex') {
+        tx.delete(mediaWatchlist).where(eq(mediaWatchlist.id, entry.id)).run();
+        progress.removed++;
+      } else if (entry.source === 'both') {
+        tx.update(mediaWatchlist)
+          .set({ source: 'manual', plexRatingKey: null })
+          .where(eq(mediaWatchlist.id, entry.id))
+          .run();
+      }
+    }
+  });
+}
+
+/** Sync the Plex Universal Watchlist into the pillar watchlist. */
+export async function syncWatchlistFromPlex(
+  deps: WatchlistSyncDeps
+): Promise<WatchlistSyncProgress> {
+  const plexItems = await fetchPlexWatchlist(deps.token, deps.clientId);
+  const progress: WatchlistSyncProgress = {
+    total: plexItems.length,
+    processed: 0,
+    added: 0,
+    removed: 0,
+    skipped: 0,
+    errors: [],
+    skipReasons: [],
+  };
+
+  const seenPlexRatingKeys = new Set<string>();
+  for (const item of plexItems) {
+    try {
+      seenPlexRatingKeys.add(item.ratingKey);
+      await syncSingleWatchlistItem(deps, item, item.ratingKey, progress);
+    } catch (err) {
+      progress.errors.push({
+        title: item.title,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+    progress.processed++;
+  }
+
+  handleRemovals(deps.db, seenPlexRatingKeys, progress);
+  return progress;
+}

--- a/pillars/media/src/api/clients/plex/sync/types.ts
+++ b/pillars/media/src/api/clients/plex/sync/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared types for the in-process Plex sync ops + job runner (slice 9b).
+ *
+ * The `plexSyncDiscoverWatches` job type is intentionally absent — it needs
+ * the Plex Discover client + the rotation domain, both deferred to wave 3.
+ */
+
+/**
+ * The sync job types this slice runs. `plexSyncDiscoverWatches` is
+ * deliberately excluded (deferred — see module note).
+ */
+export const SYNC_JOB_TYPES = [
+  'plexSyncMovies',
+  'plexSyncTvShows',
+  'plexSyncWatchlist',
+  'plexSyncWatchHistory',
+] as const;
+
+export type SyncJobType = (typeof SYNC_JOB_TYPES)[number];
+
+export function isSyncJobType(value: string): value is SyncJobType {
+  return (SYNC_JOB_TYPES as readonly string[]).includes(value);
+}
+
+/** Start-a-job request shape (mirrors the monolith `startSyncJob` input). */
+export interface StartSyncJobInput {
+  jobType: SyncJobType;
+  sectionId?: string | undefined;
+  movieSectionId?: string | undefined;
+  tvSectionId?: string | undefined;
+}

--- a/pillars/media/src/api/clients/plex/types.ts
+++ b/pillars/media/src/api/clients/plex/types.ts
@@ -1,11 +1,10 @@
 /**
- * Plex API types for the connection + auth slice.
+ * Plex API types — raw API responses and mapped domain types.
  *
- * Only the library-listing shapes the connection surface needs are ported
- * here; the sync-related media/episode types stay in the monolith until the
- * sync slices (9b/9c) land. Plex returns XML by default but supports JSON
- * via the `Accept` header; every response wraps its data in a
- * `MediaContainer`.
+ * Plex returns XML by default but supports JSON via the `Accept` header;
+ * every response wraps its data in a `MediaContainer`. The library-listing
+ * shapes back the connection surface (slice 9a); the media/episode shapes
+ * back the sync surface (slice 9b).
  */
 
 export class PlexApiError extends Error {
@@ -39,6 +38,71 @@ export interface RawPlexLibrariesContainer {
   Directory?: RawPlexLibrary[];
 }
 
+export interface RawPlexGuid {
+  id: string; // e.g. "tmdb://550" or "imdb://tt0137523" or "tvdb://81189"
+}
+
+export interface RawPlexMediaItem {
+  ratingKey: string;
+  key: string;
+  guid: string;
+  type: string;
+  title: string;
+  originalTitle?: string;
+  summary?: string;
+  tagline?: string;
+  year?: number;
+  thumb?: string;
+  art?: string;
+  duration?: number;
+  addedAt: number;
+  updatedAt: number;
+  lastViewedAt?: number;
+  viewCount?: number;
+  rating?: number;
+  audienceRating?: number;
+  contentRating?: string;
+  Guid?: RawPlexGuid[];
+  Genre?: { tag: string }[];
+  Director?: { tag: string }[];
+  Role?: { tag: string; role?: string; thumb?: string }[];
+  leafCount?: number;
+  viewedLeafCount?: number;
+  childCount?: number;
+}
+
+export interface RawPlexItemsContainer {
+  size: number;
+  totalSize?: number;
+  offset?: number;
+  Metadata?: RawPlexMediaItem[];
+}
+
+export interface RawPlexEpisode {
+  ratingKey: string;
+  key: string;
+  parentRatingKey: string;
+  grandparentRatingKey: string;
+  type: string;
+  title: string;
+  index: number;
+  parentIndex: number;
+  summary?: string;
+  thumb?: string;
+  duration?: number;
+  addedAt: number;
+  updatedAt: number;
+  lastViewedAt?: number;
+  viewCount?: number;
+}
+
+export interface RawPlexEpisodesContainer {
+  size: number;
+  totalSize?: number;
+  offset?: number;
+  Metadata?: RawPlexEpisode[];
+}
+
 export interface PlexLibrary {
   key: string;
   title: string;
@@ -49,4 +113,52 @@ export interface PlexLibrary {
   uuid: string;
   updatedAt: number;
   scannedAt: number;
+}
+
+export interface PlexExternalId {
+  source: string; // "tmdb", "imdb", "tvdb"
+  id: string;
+}
+
+export interface PlexMediaItem {
+  ratingKey: string;
+  type: string;
+  title: string;
+  originalTitle: string | null;
+  summary: string | null;
+  tagline: string | null;
+  year: number | null;
+  thumbUrl: string | null;
+  artUrl: string | null;
+  durationMs: number | null;
+  addedAt: number;
+  updatedAt: number;
+  lastViewedAt: number | null;
+  viewCount: number;
+  rating: number | null;
+  audienceRating: number | null;
+  contentRating: string | null;
+  externalIds: PlexExternalId[];
+  genres: string[];
+  directors: string[];
+  /** For TV shows: total episode count */
+  leafCount: number | null;
+  /** For TV shows: watched episode count */
+  viewedLeafCount: number | null;
+  /** For TV shows: season count */
+  childCount: number | null;
+}
+
+export interface PlexEpisode {
+  ratingKey: string;
+  title: string;
+  episodeIndex: number;
+  seasonIndex: number;
+  summary: string | null;
+  thumbUrl: string | null;
+  durationMs: number | null;
+  addedAt: number;
+  updatedAt: number;
+  lastViewedAt: number | null;
+  viewCount: number;
 }

--- a/pillars/media/src/api/rest/plex-handlers.ts
+++ b/pillars/media/src/api/rest/plex-handlers.ts
@@ -24,6 +24,7 @@ import {
 } from '../clients/plex/index.js';
 import { ConflictError } from '../shared/errors.js';
 import { runHttp } from './error-mapping.js';
+import { makePlexSyncHandlers } from './plex-sync-handlers.js';
 
 import type { ServerInferRequest } from '@ts-rest/core';
 
@@ -39,6 +40,7 @@ function requirePlexClient(db: MediaDb): PlexClient {
 
 export function makePlexHandlers(db: MediaDb) {
   return {
+    ...makePlexSyncHandlers(db),
     testConnection: () =>
       runHttp(async () => {
         const client = requirePlexClient(db);

--- a/pillars/media/src/api/rest/plex-sync-handlers.ts
+++ b/pillars/media/src/api/rest/plex-sync-handlers.ts
@@ -1,0 +1,91 @@
+/**
+ * Handlers for the `plex.*` sync routes (slice 9b) — on-demand sync ops over
+ * the in-process job runner.
+ *
+ * `startSyncJob` inserts a `running` row, fires `runSyncJob` ASYNC (NOT
+ * awaited), and returns the `jobId` immediately; the fire-and-forget promise
+ * patches the row to `completed`+result or `failed`+error on settle. The
+ * poll/list/last routes read straight from `sync_job_results`.
+ *
+ * NOTE: `plexSyncDiscoverWatches` is unsupported — the contract enum excludes
+ * it (Plex Discover + rotation domain, deferred to wave 3).
+ */
+import { randomUUID } from 'node:crypto';
+
+import { type MediaDb, syncJobResultsService } from '../../db/index.js';
+import { getPlexClient } from '../clients/plex/index.js';
+import { SYNC_JOB_TYPES, runSyncJob, type StartSyncJobInput } from '../clients/plex/sync/index.js';
+import { ConflictError, NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { mediaPlexContract } from '../../contract/rest-plex.js';
+
+type Req = ServerInferRequest<typeof mediaPlexContract>;
+
+function finalise(db: MediaDb, jobId: string, startedAt: number, result: unknown): void {
+  const completedAt = new Date();
+  syncJobResultsService.updateSyncJobResult(db, jobId, {
+    status: 'completed',
+    completedAt: completedAt.toISOString(),
+    durationMs: completedAt.getTime() - startedAt,
+    result,
+  });
+}
+
+function fail(db: MediaDb, jobId: string, startedAt: number, err: unknown): void {
+  const completedAt = new Date();
+  syncJobResultsService.updateSyncJobResult(db, jobId, {
+    status: 'failed',
+    completedAt: completedAt.toISOString(),
+    durationMs: completedAt.getTime() - startedAt,
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+function launch(db: MediaDb, input: StartSyncJobInput): string {
+  const jobId = randomUUID();
+  const startedAtMs = Date.now();
+  syncJobResultsService.insertSyncJobResult(db, {
+    id: jobId,
+    jobType: input.jobType,
+    status: 'running',
+    startedAt: new Date(startedAtMs).toISOString(),
+    progress: { processed: 0, total: 0 },
+  });
+  void runSyncJob(db, input)
+    .then((result) => finalise(db, jobId, startedAtMs, result))
+    .catch((err: unknown) => fail(db, jobId, startedAtMs, err));
+  return jobId;
+}
+
+export function makePlexSyncHandlers(db: MediaDb) {
+  return {
+    startSyncJob: ({ body }: Req['startSyncJob']) =>
+      runHttp(() => {
+        if (getPlexClient(db) === null) throw new ConflictError('Plex is not configured');
+        const jobId = launch(db, body);
+        return { status: 200 as const, body: { data: { jobId } } };
+      }),
+
+    getActiveSyncJobs: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: syncJobResultsService.listActive(db) },
+      })),
+
+    getLastSyncResults: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: syncJobResultsService.lastByType(db, SYNC_JOB_TYPES) },
+      })),
+
+    getSyncJobStatus: ({ params }: Req['getSyncJobStatus']) =>
+      runHttp(() => {
+        const job = syncJobResultsService.getSyncJobResult(db, params.jobId);
+        if (!job) throw new NotFoundError('Sync job', params.jobId);
+        return { status: 200 as const, body: { data: job } };
+      }),
+  };
+}

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -721,6 +721,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/plex/sync': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Start an on-demand Plex sync job (runs async in-process) */
+    post: operations['plex.startSyncJob'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/plex/sync-status': {
     parameters: {
       query?: never;
@@ -730,6 +747,57 @@ export interface paths {
     };
     /** Connection-config snapshot (configured / hasUrl / hasToken) */
     get: operations['plex.getSyncStatus'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/sync/active': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List currently-running sync jobs */
+    get: operations['plex.getActiveSyncJobs'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/sync/last': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Most recent completed result per sync job type */
+    get: operations['plex.getLastSyncResults'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/sync/{jobId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Poll a sync job by id (404 if unknown) */
+    get: operations['plex.getSyncJobStatus'];
     put?: never;
     post?: never;
     delete?: never;
@@ -4315,6 +4383,84 @@ export interface operations {
       };
     };
   };
+  'plex.startSyncJob': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          jobType:
+            | 'plexSyncMovies'
+            | 'plexSyncTvShows'
+            | 'plexSyncWatchlist'
+            | 'plexSyncWatchHistory';
+          movieSectionId?: string;
+          sectionId?: string;
+          tvSectionId?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              jobId: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'plex.getSyncStatus': {
     parameters: {
       query?: never;
@@ -4337,6 +4483,157 @@ export interface operations {
               hasToken: boolean;
               hasUrl: boolean;
             };
+          };
+        };
+      };
+    };
+  };
+  'plex.getActiveSyncJobs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              completedAt: string | null;
+              durationMs: number | null;
+              error: string | null;
+              id: string;
+              jobType: string;
+              progress: {
+                processed: number;
+                total: number;
+              };
+              result: unknown;
+              startedAt: string;
+              /** @enum {string} */
+              status: 'running' | 'completed' | 'failed';
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'plex.getLastSyncResults': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              [key: string]: {
+                completedAt: string | null;
+                durationMs: number | null;
+                error: string | null;
+                id: string;
+                jobType: string;
+                progress: {
+                  processed: number;
+                  total: number;
+                };
+                result: unknown;
+                startedAt: string;
+                /** @enum {string} */
+                status: 'running' | 'completed' | 'failed';
+              } | null;
+            };
+          };
+        };
+      };
+    };
+  };
+  'plex.getSyncJobStatus': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        jobId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              completedAt: string | null;
+              durationMs: number | null;
+              error: string | null;
+              id: string;
+              jobType: string;
+              progress: {
+                processed: number;
+                total: number;
+              };
+              result: unknown;
+              startedAt: string;
+              /** @enum {string} */
+              status: 'running' | 'completed' | 'failed';
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/media/src/contract/rest-plex-sync.ts
+++ b/pillars/media/src/contract/rest-plex-sync.ts
@@ -1,0 +1,85 @@
+/**
+ * `plex.*` sync routes — on-demand sync ops backed by the in-process job
+ * runner (slice 9b). Merged into `mediaPlexContract` so operation ids stay
+ * `plex.<route>`.
+ *
+ * Re-architecture vs the monolith: the monolith enqueued to a `pops-sync`
+ * BullMQ queue; the pillar runs the sync ASYNC in-process and persists status
+ * to `sync_job_results`. `startSyncJob` returns a `jobId` immediately; callers
+ * poll `getSyncJobStatus`.
+ *
+ * Deferred: the `plexSyncDiscoverWatches` job type (Plex Discover + rotation
+ * domain — wave 3) is deliberately absent from the `jobType` enum.
+ */
+import { z } from 'zod';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+
+export const SYNC_JOB_TYPE_ENUM = [
+  'plexSyncMovies',
+  'plexSyncTvShows',
+  'plexSyncWatchlist',
+  'plexSyncWatchHistory',
+] as const;
+
+const SyncJobTypeSchema = z.enum(SYNC_JOB_TYPE_ENUM);
+
+const SyncJobProgressSchema = z.object({
+  processed: z.number(),
+  total: z.number(),
+});
+
+const SyncJobSchema = z.object({
+  id: z.string(),
+  jobType: z.string(),
+  status: z.enum(['running', 'completed', 'failed']),
+  startedAt: z.string(),
+  completedAt: z.string().nullable(),
+  durationMs: z.number().nullable(),
+  progress: SyncJobProgressSchema,
+  result: z.unknown(),
+  error: z.string().nullable(),
+});
+
+const SectionId = z.string().min(1).optional();
+
+/**
+ * Route map merged into `mediaPlexContract`. The static `/plex/sync/active`
+ * and `/plex/sync/last` paths are declared before the `/plex/sync/:jobId`
+ * param route so Express matches them first.
+ */
+export const plexSyncRoutes = {
+  startSyncJob: {
+    method: 'POST',
+    path: '/plex/sync',
+    body: z.object({
+      jobType: SyncJobTypeSchema,
+      sectionId: SectionId,
+      movieSectionId: SectionId,
+      tvSectionId: SectionId,
+    }),
+    responses: { 200: z.object({ data: z.object({ jobId: z.string() }) }), ...ERR_RESPONSES },
+    summary: 'Start an on-demand Plex sync job (runs async in-process)',
+  },
+  getActiveSyncJobs: {
+    method: 'GET',
+    path: '/plex/sync/active',
+    responses: { 200: z.object({ data: z.array(SyncJobSchema) }) },
+    summary: 'List currently-running sync jobs',
+  },
+  getLastSyncResults: {
+    method: 'GET',
+    path: '/plex/sync/last',
+    responses: {
+      200: z.object({ data: z.record(z.string(), SyncJobSchema.nullable()) }),
+    },
+    summary: 'Most recent completed result per sync job type',
+  },
+  getSyncJobStatus: {
+    method: 'GET',
+    path: '/plex/sync/:jobId',
+    pathParams: z.object({ jobId: z.string().min(1) }),
+    responses: { 200: z.object({ data: SyncJobSchema }), ...ERR_RESPONSES },
+    summary: 'Poll a sync job by id (404 if unknown)',
+  },
+} as const;

--- a/pillars/media/src/contract/rest-plex.ts
+++ b/pillars/media/src/contract/rest-plex.ts
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import { plexSyncRoutes } from './rest-plex-sync.js';
 import { ERR_RESPONSES, MessageSchema } from './rest-schemas.js';
 
 const c = initContract();
@@ -130,4 +131,5 @@ export const mediaPlexContract = c.router({
     responses: { 200: MessageSchema },
     summary: 'Persist the Plex library section ids',
   },
+  ...plexSyncRoutes,
 });

--- a/pillars/media/src/db/index.ts
+++ b/pillars/media/src/db/index.ts
@@ -126,6 +126,17 @@ export type { BatchLogResult, BatchLogWatchInput } from './services/watch-histor
 
 export * as watchHistoryBatchService from './services/watch-history-batch.js';
 
+export type {
+  InsertSyncJobInput,
+  SyncJob,
+  SyncJobProgress,
+  SyncJobResultRow,
+  SyncJobStatus,
+  UpdateSyncJobInput,
+} from './services/sync-job-results.js';
+
+export * as syncJobResultsService from './services/sync-job-results.js';
+
 export * as watchlistService from './services/watchlist.js';
 
 export {

--- a/pillars/media/src/db/services/sync-job-results.ts
+++ b/pillars/media/src/db/services/sync-job-results.ts
@@ -1,0 +1,157 @@
+/**
+ * `sync_job_results` CRUD against the media pillar's SQLite via drizzle.
+ *
+ * Backs the in-process Plex sync job runner (slice 9b). The monolith
+ * persisted job state in BullMQ + a `sync_job_results` mirror table; the
+ * pillar has no Redis/BullMQ, so this table is the single source of truth
+ * for job status. `progress` and `result` are stored as JSON strings; this
+ * service parses/serialises them so callers work with typed values.
+ *
+ * Services take a `MediaDb` handle as their first argument and are
+ * HTTP-free; the calling layer (`src/api/clients/plex/sync/`) resolves the
+ * handle. Mirrors the other media services' `(db, …)` signature.
+ */
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
+
+import { syncJobResults } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** Raw drizzle row shape — the persisted sync_job_results record. */
+export type SyncJobResultRow = typeof syncJobResults.$inferSelect;
+
+export type SyncJobStatus = 'running' | 'completed' | 'failed';
+
+export interface SyncJobProgress {
+  processed: number;
+  total: number;
+}
+
+/** A sync job in the typed shape the handlers + FE consume. */
+export interface SyncJob {
+  id: string;
+  jobType: string;
+  status: SyncJobStatus;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+  progress: SyncJobProgress;
+  result: unknown;
+  error: string | null;
+}
+
+export interface InsertSyncJobInput {
+  id: string;
+  jobType: string;
+  status: SyncJobStatus;
+  startedAt: string;
+  progress?: SyncJobProgress | undefined;
+}
+
+export interface UpdateSyncJobInput {
+  status?: SyncJobStatus;
+  completedAt?: string;
+  durationMs?: number;
+  progress?: SyncJobProgress;
+  result?: unknown;
+  error?: string;
+}
+
+function parseProgress(raw: string | null): SyncJobProgress {
+  if (!raw) return { processed: 0, total: 0 };
+  try {
+    return JSON.parse(raw) as SyncJobProgress;
+  } catch {
+    return { processed: 0, total: 0 };
+  }
+}
+
+function isSyncJobStatus(value: string): value is SyncJobStatus {
+  return value === 'running' || value === 'completed' || value === 'failed';
+}
+
+/** Map a raw row to the typed {@link SyncJob}, JSON-parsing progress + result. */
+export function rowToSyncJob(row: SyncJobResultRow): SyncJob {
+  return {
+    id: row.id,
+    jobType: row.jobType,
+    status: isSyncJobStatus(row.status) ? row.status : 'failed',
+    startedAt: row.startedAt,
+    completedAt: row.completedAt ?? null,
+    durationMs: row.durationMs ?? null,
+    progress: parseProgress(row.progress),
+    result: row.result ? (JSON.parse(row.result) as unknown) : null,
+    error: row.error ?? null,
+  };
+}
+
+/** Insert a new job row. Caller supplies the (uuid) id. */
+export function insertSyncJobResult(db: MediaDb, input: InsertSyncJobInput): void {
+  db.insert(syncJobResults)
+    .values({
+      id: input.id,
+      jobType: input.jobType,
+      status: input.status,
+      startedAt: input.startedAt,
+      progress: input.progress ? JSON.stringify(input.progress) : null,
+    })
+    .run();
+}
+
+/** Patch a job row by id. Only the provided fields are written. */
+export function updateSyncJobResult(db: MediaDb, id: string, input: UpdateSyncJobInput): void {
+  const updates: Partial<typeof syncJobResults.$inferInsert> = {};
+  if (input.status !== undefined) updates.status = input.status;
+  if (input.completedAt !== undefined) updates.completedAt = input.completedAt;
+  if (input.durationMs !== undefined) updates.durationMs = input.durationMs;
+  if (input.progress !== undefined) updates.progress = JSON.stringify(input.progress);
+  if (input.result !== undefined) updates.result = JSON.stringify(input.result);
+  if (input.error !== undefined) updates.error = input.error;
+  if (Object.keys(updates).length === 0) return;
+  db.update(syncJobResults).set(updates).where(eq(syncJobResults.id, id)).run();
+}
+
+/** Read a single job by id, or `null` when absent. */
+export function getSyncJobResult(db: MediaDb, id: string): SyncJob | null {
+  const row = db.select().from(syncJobResults).where(eq(syncJobResults.id, id)).get();
+  return row ? rowToSyncJob(row) : null;
+}
+
+/** Every currently-running job (`status = 'running'`), newest first. */
+export function listActive(db: MediaDb): SyncJob[] {
+  return db
+    .select()
+    .from(syncJobResults)
+    .where(eq(syncJobResults.status, 'running'))
+    .orderBy(desc(syncJobResults.startedAt))
+    .all()
+    .map(rowToSyncJob);
+}
+
+/**
+ * The most recent COMPLETED job for each of `jobTypes` ("last synced"
+ * display). Missing types map to `null`.
+ */
+export function lastByType(
+  db: MediaDb,
+  jobTypes: readonly string[]
+): Record<string, SyncJob | null> {
+  const out: Record<string, SyncJob | null> = {};
+  for (const jobType of jobTypes) {
+    const row = db
+      .select()
+      .from(syncJobResults)
+      .where(
+        and(
+          eq(syncJobResults.jobType, jobType),
+          eq(syncJobResults.status, 'completed'),
+          isNotNull(syncJobResults.completedAt)
+        )
+      )
+      .orderBy(desc(syncJobResults.completedAt), desc(syncJobResults.startedAt))
+      .limit(1)
+      .get();
+    out[jobType] = row ? rowToSyncJob(row) : null;
+  }
+  return out;
+}


### PR DESCRIPTION
Wave 2, part e (Plex, 2 of 3). Ports the on-demand Plex **sync** surface, re-architected off **BullMQ** to an in-process async job runner backed by `sync_job_results`.

- Sync ops in `src/api/clients/plex/sync/` (movies / tv / watch-history / watchlist + helpers + matchers), driving the Plex client (+ new `getAllItems`/`getItemDetail`/`getEpisodes`) and the tmdb/tvdb/movies/tv-shows/watch-history/watchlist services.
- `syncJobResultsService` (db-arg) + migration `0035_sync_job_results_baseline` (the table had a schema but no migration — tests 500'd until added).
- `POST /plex/sync` inserts a `running` row, fires the sync **async (not awaited)**, returns `{jobId}`; the promise patches the row to `completed`+result or `failed`+error. `GET /plex/sync/:jobId` | `/active` | `/last` read the table.
- 8 lifecycle tests (**295 total**).

**Deferred:** `plexSyncDiscoverWatches` + `sync-discover-*` → wave 3 (need the rotation domain; the jobType enum 400s it at the contract boundary). Scheduler is **9c**.

Verified: typecheck ✓ · build ✓ · 295/295 ✓ · format ✓ · lint exit 0 (`.oxlintrc` untouched) ✓ · drift idempotent ✓ · no BullMQ/`core/settings`/`pops-api` leakage ✓. Stacks on #3381.