### PR TITLE
feat(media): mount the /media/images byte route in the pillar

### DIFF
--- a/pillars/media/src/api/__tests__/images.test.ts
+++ b/pillars/media/src/api/__tests__/images.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Integration tests for the `/media/images/:mediaType/:id/:filename` byte
+ * route, driven through the real Express app via supertest.
+ *
+ * The route's tier-2/3 fallbacks (download-and-cache, TMDB poster lookup) are
+ * the only network-touching surface, so the TMDB client + image-cache
+ * factories are mocked at the module boundary; nothing here performs HTTP.
+ * Tier-1 (serve a cached file) is exercised against a real file written into a
+ * temp `MEDIA_IMAGES_DIR`, so the bytes assertion proves the on-disk path
+ * end-to-end.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { moviesService, openMediaDb, tvShowsService, type OpenedMediaDb } from '../../db/index.js';
+import { createMediaApiApp } from '../app.js';
+import { TmdbClient } from '../clients/tmdb/client.js';
+import { ImageCacheService } from '../clients/tmdb/image-cache.js';
+
+import type { TmdbMovieDetail } from '../clients/tmdb/types.js';
+
+const { getTmdbClientMock, getImageCacheMock } = vi.hoisted(() => ({
+  getTmdbClientMock: vi.fn<() => TmdbClient>(),
+  getImageCacheMock: vi.fn<() => ImageCacheService>(),
+}));
+
+vi.mock('../clients/tmdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../clients/tmdb/index.js')>(
+    '../clients/tmdb/index.js'
+  );
+  return { ...actual, getTmdbClient: getTmdbClientMock, getImageCache: getImageCacheMock };
+});
+
+let tmpDir: string;
+let imagesDir: string;
+let mediaDb: OpenedMediaDb;
+let tmdb: TmdbClient;
+let imageCache: ImageCacheService;
+
+function movieDetail(overrides: Partial<TmdbMovieDetail> = {}): TmdbMovieDetail {
+  return {
+    tmdbId: 550,
+    imdbId: 'tt0137523',
+    title: 'Fight Club',
+    originalTitle: 'Fight Club',
+    overview: '',
+    tagline: '',
+    releaseDate: '1999-10-15',
+    runtime: 139,
+    status: 'Released',
+    originalLanguage: 'en',
+    budget: 0,
+    revenue: 0,
+    posterPath: null,
+    backdropPath: null,
+    voteAverage: 8.4,
+    voteCount: 27000,
+    genres: [],
+    productionCompanies: [],
+    spokenLanguages: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-images-test-'));
+  imagesDir = join(tmpDir, 'images');
+  mkdirSync(imagesDir, { recursive: true });
+  vi.stubEnv('MEDIA_IMAGES_DIR', imagesDir);
+
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+
+  tmdb = new TmdbClient('test-key');
+  imageCache = new ImageCacheService(imagesDir);
+  vi.spyOn(imageCache, 'downloadMovieImages').mockResolvedValue();
+  vi.spyOn(imageCache, 'downloadTvShowImages').mockResolvedValue();
+
+  getTmdbClientMock.mockReturnValue(tmdb);
+  getImageCacheMock.mockReturnValue(imageCache);
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function app() {
+  return createMediaApiApp({
+    mediaDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3003',
+  });
+}
+
+function writeCachedImage(mediaDirName: string, id: number, filename: string, bytes: Buffer): void {
+  const dir = join(imagesDir, mediaDirName, String(id));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, filename), bytes);
+}
+
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+
+describe('GET /media/images — tier 1 (cached file)', () => {
+  it('serves a cached poster with its bytes and content-type', async () => {
+    writeCachedImage('movies', 550, 'poster.jpg', JPEG_MAGIC);
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+    expect(Buffer.from(res.body)).toEqual(JPEG_MAGIC);
+    expect(res.headers['cache-control']).toBe('public, max-age=604800');
+    expect(getImageCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers override.jpg over poster.jpg for poster requests', async () => {
+    const override = Buffer.from([0xff, 0xd8, 0xff, 0xe1, 1, 2, 3, 4]);
+    writeCachedImage('movies', 550, 'poster.jpg', JPEG_MAGIC);
+    writeCachedImage('movies', 550, 'override.jpg', override);
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body)).toEqual(override);
+  });
+
+  it('serves tv images from the tv/ directory (not tvs/)', async () => {
+    writeCachedImage('tv', 81189, 'poster.jpg', JPEG_MAGIC);
+
+    const res = await supertest(app()).get('/media/images/tv/81189/poster.jpg');
+
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body)).toEqual(JPEG_MAGIC);
+  });
+
+  it('deletes a corrupted SVG placeholder rather than serving it', async () => {
+    writeCachedImage('movies', 550, 'backdrop.jpg', Buffer.from('<svg xmlns="...">'));
+
+    const res = await supertest(app()).get('/media/images/movie/550/backdrop.jpg');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Image not found');
+  });
+});
+
+describe('GET /media/images — validation', () => {
+  it('returns 400 for an invalid media type', async () => {
+    const res = await supertest(app()).get('/media/images/tvshow/550/poster.jpg');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid media type');
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await supertest(app()).get('/media/images/movie/abc/poster.jpg');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid id');
+  });
+
+  it('returns 400 for an unknown filename', async () => {
+    const res = await supertest(app()).get('/media/images/movie/550/malicious.exe');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid filename');
+  });
+
+  it('accepts season_N.jpg as a valid filename', async () => {
+    writeCachedImage('tv', 81189, 'season_2.jpg', JPEG_MAGIC);
+
+    const res = await supertest(app()).get('/media/images/tv/81189/season_2.jpg');
+
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body)).toEqual(JPEG_MAGIC);
+  });
+});
+
+describe('GET /media/images — tier 3 (404 / CDN fallback, no network)', () => {
+  it('returns 404 when no cached file exists and the DB has no record', async () => {
+    const res = await supertest(app()).get('/media/images/movie/9999/poster.jpg');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Image not found');
+    expect(getTmdbClientMock).not.toHaveBeenCalled();
+    expect(imageCache.downloadMovieImages).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for override.jpg without attempting any download', async () => {
+    const res = await supertest(app()).get('/media/images/movie/550/override.jpg');
+
+    expect(res.status).toBe(404);
+    expect(imageCache.downloadMovieImages).not.toHaveBeenCalled();
+    expect(getTmdbClientMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects to the TMDB CDN when the movie has a stored poster path but no cached file', async () => {
+    moviesService.createMovie(mediaDb.db, {
+      tmdbId: 550,
+      title: 'Fight Club',
+      posterPath: '/stored.jpg',
+    });
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(imageCache.downloadMovieImages).toHaveBeenCalledWith(550, '/stored.jpg', null, null);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://image.tmdb.org/t/p/w780/stored.jpg');
+    expect(res.headers['cache-control']).toBe('private, max-age=300');
+  });
+
+  it('redirects to the stored TheTVDB URL when a tv show has a stored poster path', async () => {
+    tvShowsService.createTvShow(mediaDb.db, {
+      tvdbId: 81189,
+      name: 'Breaking Bad',
+      posterPath: 'https://artworks.thetvdb.com/poster.jpg',
+    });
+
+    const res = await supertest(app()).get('/media/images/tv/81189/poster.jpg');
+
+    expect(imageCache.downloadTvShowImages).toHaveBeenCalledWith({
+      tvdbId: 81189,
+      posterUrl: 'https://artworks.thetvdb.com/poster.jpg',
+      backdropUrl: null,
+      logoUrl: null,
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://artworks.thetvdb.com/poster.jpg');
+  });
+});
+
+describe('GET /media/images — TMDB poster-path lookup (mocked)', () => {
+  it('fetches the poster path from TMDB when the movie record exists but has none', async () => {
+    moviesService.createMovie(mediaDb.db, { tmdbId: 550, title: 'Fight Club', posterPath: null });
+    const getMovie = vi
+      .spyOn(tmdb, 'getMovie')
+      .mockResolvedValue(movieDetail({ posterPath: '/tmdb-fetched.jpg' }));
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(getMovie).toHaveBeenCalledWith(550);
+    expect(imageCache.downloadMovieImages).toHaveBeenCalledWith(
+      550,
+      '/tmdb-fetched.jpg',
+      null,
+      null
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://image.tmdb.org/t/p/w780/tmdb-fetched.jpg');
+  });
+
+  it('returns 404 when neither the DB nor TMDB yields a poster path', async () => {
+    moviesService.createMovie(mediaDb.db, { tmdbId: 550, title: 'Fight Club', posterPath: null });
+    const getMovie = vi
+      .spyOn(tmdb, 'getMovie')
+      .mockResolvedValue(movieDetail({ posterPath: null }));
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(getMovie).toHaveBeenCalledWith(550);
+    expect(imageCache.downloadMovieImages).not.toHaveBeenCalled();
+    expect(res.status).toBe(404);
+  });
+
+  it('does not call TMDB for a backdrop with a null stored path', async () => {
+    moviesService.createMovie(mediaDb.db, { tmdbId: 550, title: 'Fight Club', backdropPath: null });
+    const getMovie = vi.spyOn(tmdb, 'getMovie');
+
+    const res = await supertest(app()).get('/media/images/movie/550/backdrop.jpg');
+
+    expect(getMovie).not.toHaveBeenCalled();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the TMDB lookup throws', async () => {
+    moviesService.createMovie(mediaDb.db, { tmdbId: 550, title: 'Fight Club', posterPath: null });
+    vi.spyOn(tmdb, 'getMovie').mockRejectedValue(new Error('TMDB unavailable'));
+
+    const res = await supertest(app()).get('/media/images/movie/550/poster.jpg');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/pillars/media/src/api/app.ts
+++ b/pillars/media/src/api/app.ts
@@ -11,13 +11,15 @@
  * inventory / finance / food).
  *
  * The `/media/images` byte route (served from `MEDIA_IMAGES_DIR`) is mounted
- * by a later slice; it is intentionally NOT part of the ts-rest contract.
+ * after the contract endpoints; it is intentionally NOT part of the ts-rest
+ * contract, so it contributes no OpenAPI paths.
  */
 import { createExpressEndpoints } from '@ts-rest/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { mediaContract } from '../contract/rest.js';
 import { type MediaApiDeps, makeRequestHandler } from './handlers.js';
+import { createImagesRouter } from './images/router.js';
 import { makeMediaRestHandlers } from './rest/handlers.js';
 
 /**
@@ -43,6 +45,8 @@ export function createMediaApiApp(deps: MediaApiDeps): Express {
   });
 
   createExpressEndpoints(mediaContract, makeMediaRestHandlers(deps), app);
+
+  app.use(createImagesRouter({ mediaDb: deps.mediaDb.db }));
 
   return app;
 }

--- a/pillars/media/src/api/clients/env.ts
+++ b/pillars/media/src/api/clients/env.ts
@@ -34,3 +34,15 @@ export function getEnvInt(name: string, fallback: number): number {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : fallback;
 }
+
+/** Default location for the local media-image cache. */
+const DEFAULT_MEDIA_IMAGES_DIR = './data/media/images';
+
+/**
+ * Root directory the media-image cache reads from and writes to. The byte
+ * route serving `/media/images/...` and the image-cache downloader must agree
+ * on this path, so both resolve it through here.
+ */
+export function getMediaImagesDir(): string {
+  return getEnv('MEDIA_IMAGES_DIR') ?? DEFAULT_MEDIA_IMAGES_DIR;
+}

--- a/pillars/media/src/api/clients/tmdb/index.ts
+++ b/pillars/media/src/api/clients/tmdb/index.ts
@@ -1,4 +1,4 @@
-import { getEnv } from '../env.js';
+import { getEnv, getMediaImagesDir } from '../env.js';
 import { TmdbClient } from './client.js';
 import { ImageCacheService } from './image-cache.js';
 import { TokenBucketRateLimiter } from './rate-limiter.js';
@@ -26,15 +26,12 @@ export function getTmdbClient(): TmdbClient {
   return new TmdbClient(apiToken, tmdbRateLimiter);
 }
 
-const DEFAULT_IMAGES_DIR = './data/media/images';
-
 /** Lazy singleton for the image cache service. */
 let imageCache: ImageCacheService | null = null;
 
 export function getImageCache(): ImageCacheService {
   if (!imageCache) {
-    const dir = getEnv('MEDIA_IMAGES_DIR') ?? DEFAULT_IMAGES_DIR;
-    imageCache = new ImageCacheService(dir, tmdbRateLimiter);
+    imageCache = new ImageCacheService(getMediaImagesDir(), tmdbRateLimiter);
   }
   return imageCache;
 }

--- a/pillars/media/src/api/images/images-fallback.ts
+++ b/pillars/media/src/api/images/images-fallback.ts
@@ -1,0 +1,80 @@
+/**
+ * Tier-2/3 fallbacks for the `/media/images` byte route: on-demand download
+ * from the upstream CDN into the local cache, and the TMDB poster-path
+ * lookup used when the pillar DB has no stored path for a movie. Both go
+ * through the pillar's own TMDB client + image-cache factories.
+ */
+import { getImageCache, getTmdbClient } from '../clients/tmdb/index.js';
+import { tryServeFile } from './images-helpers.js';
+
+import type { Response } from 'express';
+
+/**
+ * Fetch the poster_path for a movie from the TMDB API when the DB has no stored path.
+ */
+export async function fetchPosterPathFromTmdb(tmdbId: number): Promise<string | null> {
+  try {
+    const client = getTmdbClient();
+    const detail = await client.getMovie(tmdbId);
+    return detail.posterPath ?? null;
+  } catch (err) {
+    console.warn(`[Images] TMDB lookup for ${tmdbId} failed:`, err);
+    return null;
+  }
+}
+
+export interface DownloadAndServeOptions {
+  mediaType: string;
+  id: number;
+  originalPath: string;
+  imageType: 'poster' | 'backdrop' | 'logo';
+  filePath: string;
+  res: Response;
+}
+
+async function downloadMovieImage(
+  imageCache: ReturnType<typeof getImageCache>,
+  id: number,
+  imageType: 'poster' | 'backdrop' | 'logo',
+  originalPath: string
+): Promise<void> {
+  await imageCache.downloadMovieImages(
+    id,
+    imageType === 'poster' ? originalPath : null,
+    imageType === 'backdrop' ? originalPath : null,
+    imageType === 'logo' ? originalPath : null
+  );
+}
+
+async function downloadTvImage(
+  imageCache: ReturnType<typeof getImageCache>,
+  id: number,
+  imageType: 'poster' | 'backdrop' | 'logo',
+  originalPath: string
+): Promise<void> {
+  await imageCache.downloadTvShowImages({
+    tvdbId: id,
+    posterUrl: imageType === 'poster' ? originalPath : null,
+    backdropUrl: imageType === 'backdrop' ? originalPath : null,
+    logoUrl: imageType === 'logo' ? originalPath : null,
+  });
+}
+
+/**
+ * Download an image from its original source to local cache and serve.
+ */
+export async function downloadAndServe(opts: DownloadAndServeOptions): Promise<boolean> {
+  const imageCache = getImageCache();
+
+  try {
+    if (opts.mediaType === 'movie') {
+      await downloadMovieImage(imageCache, opts.id, opts.imageType, opts.originalPath);
+    } else if (opts.mediaType === 'tv') {
+      await downloadTvImage(imageCache, opts.id, opts.imageType, opts.originalPath);
+    }
+    return await tryServeFile(opts.filePath, opts.res);
+  } catch (err) {
+    console.warn(`[Images] On-demand download failed for ${opts.mediaType}/${opts.id}:`, err);
+    return false;
+  }
+}

--- a/pillars/media/src/api/images/images-helpers.ts
+++ b/pillars/media/src/api/images/images-helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure helpers for the `/media/images` byte route: content-type mapping,
+ * path-traversal-safe joins, image-type resolution, CDN URL construction,
+ * corrupted-placeholder detection, and the file-serving primitive. These
+ * have no DB or upstream-client dependencies of their own.
+ */
+import { createHash } from 'node:crypto';
+import { open, stat, unlink } from 'node:fs/promises';
+import { basename, extname, resolve } from 'node:path';
+
+import type { Response } from 'express';
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.heic': 'image/heic',
+  '.heif': 'image/heif',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
+};
+
+/** Cache for 7 days, revalidate via ETag after that. */
+const CACHE_CONTROL = 'public, max-age=604800';
+
+const TMDB_CDN_SIZES: Record<string, string> = {
+  poster: 'w780',
+  backdrop: 'w1280',
+  logo: 'original',
+};
+
+/**
+ * Join `filename` to `dir` safely. Strips path traversal and returns null if escape attempted.
+ */
+export function safeJoin(dir: string, filename: string): string | null {
+  const safe = basename(filename);
+  if (!safe || safe === '.' || safe === '..') return null;
+  const resolved = resolve(dir, safe);
+  return resolved.startsWith(dir + '/') || resolved === dir ? resolved : null;
+}
+
+export function resolveImageType(filename: string): 'poster' | 'backdrop' | 'logo' | 'override' {
+  if (filename === 'override.jpg') return 'override';
+  if (filename.startsWith('poster') || filename.startsWith('season_')) return 'poster';
+  if (filename.startsWith('logo')) return 'logo';
+  return 'backdrop';
+}
+
+export function buildCdnFallbackUrl(
+  mediaType: string,
+  path: string,
+  imageType: 'poster' | 'backdrop' | 'logo'
+): string | null {
+  if (mediaType === 'movie' && path.startsWith('/')) {
+    const size = TMDB_CDN_SIZES[imageType] ?? 'w780';
+    return `https://image.tmdb.org/t/p/${size}${path}`;
+  }
+  if (mediaType === 'tv' && path.startsWith('http')) return path;
+  return null;
+}
+
+/** Detect and remove corrupted SVG placeholders (SVG content saved as .jpg). */
+export async function removeCorruptedPlaceholder(filePath: string): Promise<boolean> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(filePath, 'r');
+    const buf = Buffer.alloc(4);
+    const { bytesRead } = await fh.read(buf, 0, 4, 0);
+    if (bytesRead < 4) return false;
+
+    if (buf.toString('ascii', 0, 4) === '<svg') {
+      await fh.close();
+      fh = undefined;
+      await unlink(filePath).catch(() => {});
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    await fh?.close();
+  }
+}
+
+async function sendFileWithErrorHandling(res: Response, filePath: string): Promise<boolean> {
+  return new Promise<boolean>((resolvePromise) => {
+    res.sendFile(resolve(filePath), (err) => {
+      if (err && !res.headersSent) {
+        res.removeHeader('Cache-Control');
+        res.removeHeader('ETag');
+        res.status(500).json({ error: 'Failed to send file' });
+      }
+      resolvePromise(true);
+    });
+  });
+}
+
+/**
+ * Try to serve a file with cache headers. Returns true if the file was served.
+ *
+ * @param filePath absolute path to the file on disk
+ * @param res Express response
+ * @param cacheControl override the default `Cache-Control` header. Defaults to
+ *   `public, max-age=604800` (suitable for immutable media images). Pass a
+ *   stricter value (e.g. `private, max-age=3600`) for user-uploaded content.
+ */
+export async function tryServeFile(
+  filePath: string,
+  res: Response,
+  cacheControl: string = CACHE_CONTROL
+): Promise<boolean> {
+  try {
+    const fileStat = await stat(filePath);
+    const ext = extname(filePath);
+    const contentType = CONTENT_TYPES[ext] ?? 'application/octet-stream';
+    const etag = createHash('md5').update(`${fileStat.mtimeMs}-${fileStat.size}`).digest('hex');
+
+    res.set({
+      'Content-Type': contentType,
+      'Cache-Control': cacheControl,
+      ETag: `"${etag}"`,
+    });
+
+    const ifNoneMatch = res.req.get('If-None-Match');
+    if (ifNoneMatch === `"${etag}"`) {
+      res.status(304).end();
+      return true;
+    }
+
+    return await sendFileWithErrorHandling(res, filePath);
+  } catch {
+    return false;
+  }
+}

--- a/pillars/media/src/api/images/images-validate.ts
+++ b/pillars/media/src/api/images/images-validate.ts
@@ -1,0 +1,63 @@
+/**
+ * Request-parameter validation + cache-directory resolution for the
+ * `/media/images` byte route. Split out of the router so the handler stays
+ * focused on the three-tier fallback flow.
+ */
+import { join, resolve } from 'node:path';
+
+import { getMediaImagesDir } from '../clients/env.js';
+import { MEDIA_DIR_NAMES } from '../clients/tmdb/image-cache.js';
+
+import type { Request } from 'express';
+
+const VALID_MEDIA_TYPES = ['movie', 'tv'] as const;
+const VALID_FILENAMES = ['poster.jpg', 'backdrop.jpg', 'logo.png', 'override.jpg'] as const;
+type ValidFilename = (typeof VALID_FILENAMES)[number];
+
+/** Season poster filenames follow the pattern season_{N}.jpg. */
+const SEASON_POSTER_RE = /^season_\d+\.jpg$/;
+
+export interface ValidationFailure {
+  status: number;
+  body: { error: string };
+}
+
+export interface ValidatedParams {
+  mediaType: string;
+  id: string;
+  filename: string;
+}
+
+export function validateParams(req: Request): ValidatedParams | ValidationFailure {
+  const mediaType = String(req.params['mediaType'] ?? '');
+  const id = String(req.params['id'] ?? '');
+  const filename = String(req.params['filename'] ?? '');
+
+  if (!VALID_MEDIA_TYPES.includes(mediaType as (typeof VALID_MEDIA_TYPES)[number])) {
+    return { status: 400, body: { error: `Invalid media type: ${mediaType}` } };
+  }
+  if (!/^\d+$/.test(id)) return { status: 400, body: { error: `Invalid id: ${id}` } };
+  if (!VALID_FILENAMES.includes(filename as ValidFilename) && !SEASON_POSTER_RE.test(filename)) {
+    return { status: 400, body: { error: `Invalid filename: ${filename}` } };
+  }
+  return { mediaType, id, filename };
+}
+
+export function isValidationFailure(
+  value: ValidatedParams | ValidationFailure
+): value is ValidationFailure {
+  return 'status' in value;
+}
+
+/**
+ * Resolve the on-disk directory holding a media item's cached images, or
+ * `null` if the resolved path escapes `MEDIA_IMAGES_DIR` (defence in depth on
+ * top of the per-param validation).
+ */
+export function getMediaDir(mediaType: string, id: string): string | null {
+  const imagesDir = resolve(getMediaImagesDir());
+  const mediaDirName = MEDIA_DIR_NAMES[mediaType] ?? `${mediaType}s`;
+  const resolvedDir = resolve(join(imagesDir, mediaDirName, id));
+  if (!resolvedDir.startsWith(imagesDir)) return null;
+  return resolvedDir;
+}

--- a/pillars/media/src/api/images/router.ts
+++ b/pillars/media/src/api/images/router.ts
@@ -1,0 +1,161 @@
+/**
+ * Express router for serving cached media images.
+ *
+ * GET /media/images/:mediaType/:id/:filename
+ *
+ * Three-tier fallback strategy: serve cached → download+cache → redirect to
+ * CDN → 404. This is a plain Express router mounted alongside the ts-rest
+ * endpoints; it is intentionally NOT part of the contract, so it adds no
+ * OpenAPI paths.
+ *
+ * Poster-path lookups go through the pillar's drizzle-backed `moviesService`
+ * / `tvShowsService` against the injected DB handle.
+ */
+import { type Router as ExpressRouter, type Request, type Response, Router } from 'express';
+
+import { moviesService, tvShowsService, type MediaDb } from '../../db/index.js';
+import { downloadAndServe, fetchPosterPathFromTmdb } from './images-fallback.js';
+import {
+  buildCdnFallbackUrl,
+  removeCorruptedPlaceholder,
+  resolveImageType,
+  safeJoin,
+  tryServeFile,
+} from './images-helpers.js';
+import { getMediaDir, isValidationFailure, validateParams } from './images-validate.js';
+
+export interface ImagesRouterDeps {
+  /** Open drizzle handle to the media pillar's SQLite. */
+  mediaDb: MediaDb;
+}
+
+async function tryOverrideOrCached(
+  resolvedDir: string,
+  filename: string,
+  res: Response
+): Promise<{ served: true } | { served: false; filePath: string }> {
+  if (filename === 'poster.jpg') {
+    const overridePath = safeJoin(resolvedDir, 'override.jpg');
+    if (overridePath && (await tryServeFile(overridePath, res))) return { served: true };
+  }
+
+  const filePath = safeJoin(resolvedDir, filename);
+  if (!filePath) {
+    res.status(400).json({ error: 'Invalid path' });
+    return { served: true };
+  }
+
+  const wasCorrupted = await removeCorruptedPlaceholder(filePath);
+  if (!wasCorrupted && (await tryServeFile(filePath, res))) return { served: true };
+  return { served: false, filePath };
+}
+
+type StoredImageType = 'poster' | 'backdrop' | 'logo';
+
+function storedPath(
+  record: { posterPath: string | null; backdropPath: string | null; logoPath: string | null },
+  imageType: StoredImageType
+): string | null {
+  if (imageType === 'poster') return record.posterPath;
+  if (imageType === 'logo') return record.logoPath;
+  return record.backdropPath;
+}
+
+async function lookupImagePath(
+  db: MediaDb,
+  mediaType: string,
+  id: string,
+  imageType: StoredImageType
+): Promise<string | null> {
+  const numericId = Number(id);
+  const record =
+    mediaType === 'movie'
+      ? moviesService.getMovieByTmdbId(db, numericId)
+      : tvShowsService.getTvShowByTvdbId(db, numericId);
+  if (!record) return null;
+
+  const resolvedPath = storedPath(record, imageType);
+  if (!resolvedPath && mediaType === 'movie' && imageType === 'poster') {
+    return fetchPosterPathFromTmdb(numericId);
+  }
+  return resolvedPath;
+}
+
+interface FallbackArgs {
+  db: MediaDb;
+  mediaType: string;
+  id: string;
+  filename: string;
+  filePath: string;
+  res: Response;
+}
+
+async function attemptFallbacks(args: FallbackArgs): Promise<void> {
+  const imageType = resolveImageType(args.filename);
+  if (imageType === 'override') {
+    args.res.status(404).json({ error: 'Image not found' });
+    return;
+  }
+
+  try {
+    const resolvedPath = await lookupImagePath(args.db, args.mediaType, args.id, imageType);
+    if (resolvedPath) {
+      const downloaded = await downloadAndServe({
+        mediaType: args.mediaType,
+        id: Number(args.id),
+        originalPath: resolvedPath,
+        imageType,
+        filePath: args.filePath,
+        res: args.res,
+      });
+      if (downloaded) return;
+
+      const cdnUrl = buildCdnFallbackUrl(args.mediaType, resolvedPath, imageType);
+      if (cdnUrl) {
+        args.res.set('Cache-Control', 'private, max-age=300');
+        args.res.redirect(302, cdnUrl);
+        return;
+      }
+    }
+  } catch (err) {
+    console.error('[Images] Fallback failed:', err);
+  }
+
+  args.res.status(404).json({ error: 'Image not found' });
+}
+
+/**
+ * Build the `/media/images` byte router bound to an open media DB handle.
+ * Mounted in `createMediaApiApp` after the ts-rest endpoints.
+ */
+export function createImagesRouter(deps: ImagesRouterDeps): ExpressRouter {
+  const router = Router();
+
+  router.get('/media/images/:mediaType/:id/:filename', async (req: Request, res: Response) => {
+    const params = validateParams(req);
+    if (isValidationFailure(params)) {
+      res.status(params.status).json(params.body);
+      return;
+    }
+
+    const resolvedDir = getMediaDir(params.mediaType, params.id);
+    if (!resolvedDir) {
+      res.status(400).json({ error: 'Invalid path' });
+      return;
+    }
+
+    const cached = await tryOverrideOrCached(resolvedDir, params.filename, res);
+    if (cached.served) return;
+
+    await attemptFallbacks({
+      db: deps.mediaDb,
+      mediaType: params.mediaType,
+      id: params.id,
+      filename: params.filename,
+      filePath: cached.filePath,
+      res,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
Wave-1 infra (orthogonal to the domain slices). Mounts the non-contract `/media/images` Express **byte route** in the pillar so the `to<Entity>` mappers' `/media/images/...` poster/art URLs resolve.

- `src/api/images/` — `createImagesRouter({ mediaDb })`: 3-tier fallback (serve cached → download+cache from TMDB/TVDB CDN → 302 redirect → 404), ported from the monolith `routes/media/images*`. DB poster lookups via `moviesService.getMovieByTmdbId` / `tvShowsService.getTvShowByTvdbId`; download path uses the pillar's `getTmdbClient`/`getImageCache`.
- mounted in `app.ts` alongside `createExpressEndpoints`; `MEDIA_IMAGES_DIR` resolution centralised in `clients/env.ts` (`getMediaImagesDir`).
- **NOT** a ts-rest contract route → **zero new OpenAPI paths**. 16 supertest cases (303 total).

Verified: typecheck ✓ · build ✓ · 303/303 ✓ · format ✓ · lint exit 0 ✓ · openapi unchanged ✓ · no `pops-api`/`as unknown as` leakage ✓. Independent of the Plex slices (disjoint files).