### PR TITLE
feat(cerebrum): REST migration slice — plexus

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -9,6 +9,621 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/plexus/adapters": {
+      "get": {
+        "operationId": "plexus.adapters.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "adapters": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "config": {
+                            "additionalProperties": {},
+                            "nullable": true,
+                            "type": "object"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "emittedCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "ingestedCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "lastError": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "lastHealth": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "name": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": [
+                              "registered",
+                              "initializing",
+                              "healthy",
+                              "degraded",
+                              "error",
+                              "shutdown"
+                            ],
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "status",
+                          "config",
+                          "lastHealth",
+                          "lastError",
+                          "ingestedCount",
+                          "emittedCount",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["adapters"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List every registered plexus adapter.",
+        "tags": ["plexus", "adapters"]
+      }
+    },
+    "/plexus/adapters/{adapterId}": {
+      "get": {
+        "operationId": "plexus.adapters.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "adapter": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "config": {
+                          "additionalProperties": {},
+                          "nullable": true,
+                          "type": "object"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "emittedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "id": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "ingestedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "lastError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastHealth": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "registered",
+                            "initializing",
+                            "healthy",
+                            "degraded",
+                            "error",
+                            "shutdown"
+                          ],
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "status",
+                        "config",
+                        "lastHealth",
+                        "lastError",
+                        "ingestedCount",
+                        "emittedCount",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["adapter"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get a single plexus adapter by id.",
+        "tags": ["plexus", "adapters"]
+      }
+    },
+    "/plexus/adapters/{adapterId}/filters": {
+      "get": {
+        "operationId": "plexus.filters.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "filters": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "adapterId": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "field": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "filterType": {
+                            "enum": ["include", "exclude"],
+                            "type": "string"
+                          },
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "adapterId",
+                          "filterType",
+                          "field",
+                          "pattern",
+                          "enabled"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["filters"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List the ingestion filters for an adapter.",
+        "tags": ["plexus", "filters"]
+      },
+      "post": {
+        "operationId": "plexus.filters.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "filters": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "field": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "filterType": {
+                          "enum": ["include", "exclude"],
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["filterType", "field", "pattern"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["filters"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "filters": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "adapterId": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "field": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "filterType": {
+                            "enum": ["include", "exclude"],
+                            "type": "string"
+                          },
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "adapterId",
+                          "filterType",
+                          "field",
+                          "pattern",
+                          "enabled"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["filters"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Atomically replace the ingestion filters for an adapter.",
+        "tags": ["plexus", "filters"]
+      }
+    },
+    "/plexus/adapters/{adapterId}/health-check": {
+      "post": {
+        "operationId": "plexus.adapters.healthCheck",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "lastCheck": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "registered",
+                        "initializing",
+                        "healthy",
+                        "degraded",
+                        "error",
+                        "shutdown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": ["status", "lastCheck"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Run an on-demand health check against an adapter.",
+        "tags": ["plexus", "adapters"]
+      }
+    },
+    "/plexus/adapters/{adapterId}/sync": {
+      "post": {
+        "operationId": "plexus.adapters.sync",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "filtered": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "ingested": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["ingested", "filtered"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Trigger a manual ingestion cycle for an adapter.",
+        "tags": ["plexus", "adapters"]
+      }
+    },
+    "/plexus/adapters/{adapterId}/unregister": {
+      "post": {
+        "operationId": "plexus.adapters.unregister",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "adapterId",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Shut down and remove an adapter.",
+        "tags": ["plexus", "adapters"]
+      }
+    },
     "/templates": {
       "get": {
         "operationId": "templates.list",

--- a/pillars/cerebrum/src/api/__tests__/plexus.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/plexus.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Integration tests for `cerebrum.plexus.*` over REST.
+ *
+ * Boots the app against a per-test temp cerebrum.db (carrying the plexus
+ * baseline migration 0053) and exercises adapter reads, the filter
+ * set/list round-trip, and the 400 / 404 error paths through supertest.
+ * Adapters are seeded directly via the `plexusService` SQL seam — the
+ * lifecycle/TOML registry isn't part of this slice.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, plexusService, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { makeClient, makeTemplateRegistry } from './test-utils.js';
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-plexus-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+    })
+  );
+}
+
+function seedAdapter(id: string, name: string): void {
+  const now = new Date().toISOString();
+  plexusService.upsertAdapter(cerebrumDb.db, {
+    id,
+    name,
+    config: { foo: 'bar' },
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe('GET /plexus/adapters', () => {
+  it('returns an empty list on a fresh database', async () => {
+    const { adapters } = await client().plexus.listAdapters();
+    expect(adapters).toEqual([]);
+  });
+
+  it('lists seeded adapters ordered by name', async () => {
+    seedAdapter('plx_zeta', 'zeta');
+    seedAdapter('plx_alpha', 'alpha');
+    const { adapters } = await client().plexus.listAdapters();
+    expect(adapters.map((a) => a.name)).toEqual(['alpha', 'zeta']);
+    const alpha = adapters.find((a) => a.name === 'alpha');
+    expect(alpha?.status).toBe('registered');
+    expect(alpha?.config).toEqual({ foo: 'bar' });
+  });
+});
+
+describe('GET /plexus/adapters/:adapterId', () => {
+  it('returns a seeded adapter', async () => {
+    seedAdapter('plx_email', 'email');
+    const { adapter } = await client().plexus.getAdapter('plx_email');
+    expect(adapter.id).toBe('plx_email');
+    expect(adapter.name).toBe('email');
+  });
+
+  it('404s on an unknown adapter', async () => {
+    await expect(client().plexus.getAdapter('plx_missing')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('GET /plexus/adapters/:adapterId/filters', () => {
+  it('returns an empty list for an adapter with no filters', async () => {
+    seedAdapter('plx_github', 'github');
+    const { filters } = await client().plexus.listFilters('plx_github');
+    expect(filters).toEqual([]);
+  });
+});
+
+describe('POST /plexus/adapters/:adapterId/filters', () => {
+  it('404s when the adapter does not exist', async () => {
+    await expect(
+      client().plexus.setFilters('plx_missing', [
+        { filterType: 'include', field: 'title', pattern: '.*' },
+      ])
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('400s on an invalid regex pattern', async () => {
+    seedAdapter('plx_email', 'email');
+    await expect(
+      client().plexus.setFilters('plx_email', [
+        { filterType: 'exclude', field: 'subject', pattern: '[unterminated' },
+      ])
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('replaces and reads back the filter set (round-trip)', async () => {
+    seedAdapter('plx_email', 'email');
+    const written = await client().plexus.setFilters('plx_email', [
+      { filterType: 'include', field: 'subject', pattern: '^\\[urgent\\]' },
+      { filterType: 'exclude', field: 'from', pattern: 'noreply@', enabled: false },
+    ]);
+    expect(written.filters).toHaveLength(2);
+    expect(written.filters[0]).toMatchObject({
+      adapterId: 'plx_email',
+      filterType: 'include',
+      field: 'subject',
+      pattern: '^\\[urgent\\]',
+      enabled: true,
+    });
+    expect(written.filters[1]).toMatchObject({ filterType: 'exclude', enabled: false });
+
+    const { filters: readBack } = await client().plexus.listFilters('plx_email');
+    expect(readBack).toEqual(written.filters);
+
+    const replaced = await client().plexus.setFilters('plx_email', [
+      { filterType: 'include', field: 'subject', pattern: 'newsletter' },
+    ]);
+    expect(replaced.filters).toHaveLength(1);
+    expect(replaced.filters[0]?.pattern).toBe('newsletter');
+  });
+});
+
+describe('POST /plexus/adapters/:adapterId/health-check', () => {
+  it('reports error for an adapter not active in the lifecycle manager', async () => {
+    seedAdapter('plx_email', 'email');
+    const result = await client().plexus.healthCheck('plx_email');
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('not active');
+  });
+});
+
+describe('POST /plexus/adapters/:adapterId/unregister', () => {
+  it('hard-deletes a seeded adapter row even when it is not lifecycle-active', async () => {
+    seedAdapter('plx_email', 'email');
+    const { success } = await client().plexus.unregister('plx_email');
+    expect(success).toBe(true);
+    await expect(client().plexus.getAdapter('plx_email')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns success=false when the adapter is already gone', async () => {
+    const { success } = await client().plexus.unregister('plx_missing');
+    expect(success).toBe(false);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -12,7 +12,15 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 
 import type { Express } from 'express';
 
-import type { TemplateSummaryWire, TemplateWire } from '../../contract/rest-schemas.js';
+import type {
+  PlexusAdapterWire,
+  PlexusFilterDefinitionWire,
+  PlexusFilterWire,
+  PlexusHealthResultWire,
+  PlexusSyncResultWire,
+  TemplateSummaryWire,
+  TemplateWire,
+} from '../../contract/rest-schemas.js';
 
 /** Bundled engram-template fixtures shipped with the pillar. */
 export const TEST_TEMPLATES_DIR = resolve(
@@ -49,11 +57,28 @@ async function send<T>(req: supertest.Test): Promise<T> {
 }
 
 export function makeClient(app: Express) {
-  const r = supertest(app);
+  const r = supertest.agent(app);
   return {
     templates: {
       list: () => send<{ templates: TemplateSummaryWire[] }>(r.get('/templates')),
       get: (name: string) => send<{ template: TemplateWire }>(r.get(`/templates/${name}`)),
+    },
+    plexus: {
+      listAdapters: () => send<{ adapters: PlexusAdapterWire[] }>(r.get('/plexus/adapters')),
+      getAdapter: (adapterId: string) =>
+        send<{ adapter: PlexusAdapterWire }>(r.get(`/plexus/adapters/${adapterId}`)),
+      healthCheck: (adapterId: string) =>
+        send<PlexusHealthResultWire>(r.post(`/plexus/adapters/${adapterId}/health-check`).send({})),
+      sync: (adapterId: string) =>
+        send<PlexusSyncResultWire>(r.post(`/plexus/adapters/${adapterId}/sync`).send({})),
+      unregister: (adapterId: string) =>
+        send<{ success: boolean }>(r.post(`/plexus/adapters/${adapterId}/unregister`).send({})),
+      listFilters: (adapterId: string) =>
+        send<{ filters: PlexusFilterWire[] }>(r.get(`/plexus/adapters/${adapterId}/filters`)),
+      setFilters: (adapterId: string, filters: PlexusFilterDefinitionWire[]) =>
+        send<{ filters: PlexusFilterWire[] }>(
+          r.post(`/plexus/adapters/${adapterId}/filters`).send({ filters })
+        ),
     },
   };
 }

--- a/pillars/cerebrum/src/api/modules/plexus/adapter.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/adapter.ts
@@ -1,0 +1,106 @@
+/**
+ * Plexus adapter interface and base class (PRD-090, US-01).
+ *
+ * Lifted from the pops-api monolith during the cerebrum REST migration.
+ * Every adapter implements `PlexusAdapterInterface`. `BaseAdapter` provides
+ * sensible defaults so simple adapters only need to override `ingest()`.
+ */
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  EmitContent,
+  EmitOptions,
+  EngineData,
+  IngestOptions,
+} from './types.js';
+
+/**
+ * Contract that every Plexus adapter must fulfil.
+ *
+ * Four required methods (`initialize`, `ingest`, `healthCheck`, `shutdown`)
+ * and one optional (`emit`). Adapters that do not support output leave `emit`
+ * undefined — calling it throws a descriptive error via the lifecycle manager.
+ */
+export interface PlexusAdapterInterface<TSettings = Record<string, unknown>> {
+  /** Human-readable adapter name (e.g. `email`, `github`). */
+  readonly name: string;
+  /** Semantic version of the adapter implementation. */
+  readonly version: string;
+
+  /**
+   * Initialise the adapter with resolved configuration. Called once after
+   * registration. Should validate credentials and establish connections.
+   * Throw on failure — the lifecycle manager catches it and transitions the
+   * adapter to `error`.
+   */
+  initialize(config: AdapterConfig<TSettings>): Promise<void>;
+
+  /**
+   * Fetch content from the external system. Returns an array of `EngineData`
+   * items that the ingestion pipeline will process.
+   */
+  ingest(options: IngestOptions): Promise<EngineData[]>;
+
+  /** Check adapter health: connection alive, credentials valid, rate limits OK. */
+  healthCheck(): Promise<AdapterStatus>;
+
+  /** Gracefully shut down the adapter: close connections, flush buffers. */
+  shutdown(): Promise<void>;
+
+  /**
+   * Emit content to the external system. Optional — only adapters that support
+   * output (e.g. email) implement this.
+   */
+  emit?(options: EmitOptions, content: EmitContent): Promise<void>;
+}
+
+/**
+ * Abstract base class reducing boilerplate for simple adapters.
+ *
+ * Provides default implementations:
+ * - `initialize`: stores the config for subclass use
+ * - `healthCheck`: returns `healthy`
+ * - `shutdown`: no-op
+ *
+ * Concrete adapters extend this and override `ingest()` at minimum.
+ */
+export abstract class BaseAdapter<
+  TSettings = Record<string, unknown>,
+> implements PlexusAdapterInterface<TSettings> {
+  abstract readonly name: string;
+  abstract readonly version: string;
+
+  protected config: AdapterConfig<TSettings> | null = null;
+
+  async initialize(config: AdapterConfig<TSettings>): Promise<void> {
+    this.config = config;
+  }
+
+  abstract ingest(options: IngestOptions): Promise<EngineData[]>;
+
+  async healthCheck(): Promise<AdapterStatus> {
+    return {
+      status: 'healthy',
+      lastChecked: new Date().toISOString(),
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    // No-op by default.
+  }
+}
+
+/**
+ * Call `emit` on an adapter, throwing a descriptive error if the adapter does
+ * not implement it.
+ */
+export function callEmit(
+  adapter: PlexusAdapterInterface,
+  options: EmitOptions,
+  content: EmitContent
+): Promise<void> {
+  if (!adapter.emit) {
+    return Promise.reject(new Error(`Adapter '${adapter.name}' does not support emit operations`));
+  }
+  return adapter.emit(options, content);
+}

--- a/pillars/cerebrum/src/api/modules/plexus/filters.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/filters.ts
@@ -1,0 +1,203 @@
+/**
+ * Plexus ingestion filters (PRD-090, US-04).
+ *
+ * Lifted from the pops-api monolith during the cerebrum REST migration.
+ * Per-adapter include/exclude rules evaluated before content enters the
+ * ingestion pipeline. Regex patterns are compiled once at evaluation time
+ * (callers should cache compiled patterns for hot paths).
+ */
+import type { EngineData, FilterRule, FilterType } from './types.js';
+
+interface CompiledFilter {
+  filterType: FilterType;
+  field: string;
+  regex: RegExp;
+}
+
+/**
+ * Compile a filter rule's pattern into a RegExp. Returns `null` if the pattern
+ * is invalid (caller should log a warning and skip).
+ */
+export function compileFilter(rule: FilterRule): CompiledFilter | null {
+  try {
+    return {
+      filterType: rule.filterType,
+      field: rule.field,
+      regex: new RegExp(rule.pattern),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compile all enabled filter rules. Invalid patterns are silently dropped
+ * (caller should log a warning for diagnostics).
+ */
+export function compileFilters(rules: FilterRule[]): {
+  compiled: CompiledFilter[];
+  invalid: FilterRule[];
+} {
+  const compiled: CompiledFilter[] = [];
+  const invalid: FilterRule[] = [];
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const c = compileFilter(rule);
+    if (c) {
+      compiled.push(c);
+    } else {
+      invalid.push(rule);
+    }
+  }
+
+  return { compiled, invalid };
+}
+
+/** Well-known scalar fields on EngineData. */
+const SCALAR_FIELDS: ReadonlySet<string> = new Set([
+  'body',
+  'title',
+  'type',
+  'source',
+  'externalId',
+]);
+
+/** Well-known array fields on EngineData (joined as comma-separated strings). */
+const ARRAY_FIELDS: ReadonlySet<string> = new Set(['tags', 'scopes']);
+
+/**
+ * Extract the value of a named field from an `EngineData` item.
+ *
+ * Adapter-specific fields live in `customFields`; well-known fields (`body`,
+ * `title`, `type`, `source`) are checked first.
+ */
+export function extractField(item: EngineData, field: string): string | undefined {
+  if (SCALAR_FIELDS.has(field)) {
+    return item[field as keyof EngineData] as string | undefined;
+  }
+
+  if (ARRAY_FIELDS.has(field)) {
+    const arr = item[field as 'tags' | 'scopes'];
+    return arr ? arr.join(',') : undefined;
+  }
+
+  const value = item.customFields?.[field];
+  if (value == null) return undefined;
+  return typeof value === 'string' ? value : String(value);
+}
+
+/**
+ * Test a single item against a list of compiled filters for a given type
+ * (include or exclude).
+ */
+function matchesAny(item: EngineData, filters: CompiledFilter[], type: FilterType): boolean {
+  const subset = filters.filter((f) => f.filterType === type);
+  if (subset.length === 0) return false;
+  return subset.some((f) => {
+    const value = extractField(item, f.field);
+    if (value === undefined) return false;
+    return f.regex.test(value);
+  });
+}
+
+/**
+ * Evaluate whether a single item passes the filter rules.
+ *
+ * Evaluation order (per PRD-090):
+ * 1. If include filters exist: item must match at least one include filter.
+ * 2. If exclude filters exist: item must not match any exclude filter.
+ * 3. Items that survive both checks are accepted.
+ */
+export function evaluateItem(item: EngineData, compiled: CompiledFilter[]): boolean {
+  const hasIncludes = compiled.some((f) => f.filterType === 'include');
+  const hasExcludes = compiled.some((f) => f.filterType === 'exclude');
+
+  if (hasIncludes && !matchesAny(item, compiled, 'include')) {
+    return false;
+  }
+
+  if (hasExcludes && matchesAny(item, compiled, 'exclude')) {
+    return false;
+  }
+
+  return true;
+}
+
+export interface FilterResult {
+  /** Items that passed all filters. */
+  accepted: EngineData[];
+  /** Number of items removed by filters. */
+  filtered: number;
+}
+
+/**
+ * Apply filter rules to a batch of `EngineData` items.
+ *
+ * @param items - Raw items from the adapter.
+ * @param rules - Filter rules (from `plexus_filters` table).
+ * @returns Accepted items and the count of filtered items.
+ */
+export function applyFilters(items: EngineData[], rules: FilterRule[]): FilterResult {
+  if (rules.length === 0) {
+    return { accepted: items, filtered: 0 };
+  }
+
+  const { compiled, invalid } = compileFilters(rules);
+  if (invalid.length > 0) {
+    for (const r of invalid) {
+      console.warn(
+        `[plexus] Invalid filter pattern '${r.pattern}' for field '${r.field}' — skipped`
+      );
+    }
+  }
+
+  if (compiled.length === 0) {
+    return { accepted: items, filtered: 0 };
+  }
+
+  const accepted: EngineData[] = [];
+  let filtered = 0;
+
+  for (const item of items) {
+    if (evaluateItem(item, compiled)) {
+      accepted.push(item);
+    } else {
+      filtered++;
+    }
+  }
+
+  return { accepted, filtered };
+}
+
+export interface DryRunResult {
+  /** Items that would be ingested. */
+  wouldIngest: EngineData[];
+  /** Items that would be filtered out. */
+  wouldFilter: EngineData[];
+}
+
+/** Dry-run: show what would be ingested vs filtered without writing anything. */
+export function dryRun(items: EngineData[], rules: FilterRule[]): DryRunResult {
+  if (rules.length === 0) {
+    return { wouldIngest: items, wouldFilter: [] };
+  }
+
+  const { compiled } = compileFilters(rules);
+  if (compiled.length === 0) {
+    return { wouldIngest: items, wouldFilter: [] };
+  }
+
+  const wouldIngest: EngineData[] = [];
+  const wouldFilter: EngineData[] = [];
+
+  for (const item of items) {
+    if (evaluateItem(item, compiled)) {
+      wouldIngest.push(item);
+    } else {
+      wouldFilter.push(item);
+    }
+  }
+
+  return { wouldIngest, wouldFilter };
+}

--- a/pillars/cerebrum/src/api/modules/plexus/instance.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/instance.ts
@@ -1,0 +1,31 @@
+/**
+ * Plexus lifecycle-manager resolution for the cerebrum pillar.
+ *
+ * The monolith kept a process-wide `PlexusLifecycleManager` singleton (the
+ * in-memory map of registered adapters is long-lived — one per process). The
+ * pillar threads its DB handle through `CerebrumApiDeps`, so the manager is
+ * keyed by that handle: the same open `cerebrum.db` reuses one manager (its
+ * registered-adapter map survives across requests), while each test's fresh
+ * temp DB gets its own manager. A `WeakMap` lets a closed handle's manager be
+ * collected with it.
+ *
+ * The TOML registry / file-watcher (`PlexusRegistry`) that populated the
+ * manager at boot in the monolith is intentionally NOT lifted: this slice
+ * exposes the REST surface over an empty registry (zero registered adapters),
+ * mirroring how the monolith tolerates a missing `plexus.toml`. Adapters are
+ * registered out-of-band (or in a later slice), not by this module.
+ */
+import { PlexusLifecycleManager } from './lifecycle.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+
+const managers = new WeakMap<object, PlexusLifecycleManager>();
+
+/** Return the lifecycle manager bound to this DB handle, creating it once. */
+export function getPlexusLifecycle(db: CerebrumDb): PlexusLifecycleManager {
+  const existing = managers.get(db);
+  if (existing) return existing;
+  const created = new PlexusLifecycleManager(db);
+  managers.set(db, created);
+  return created;
+}

--- a/pillars/cerebrum/src/api/modules/plexus/lifecycle-db.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/lifecycle-db.ts
@@ -1,0 +1,72 @@
+/**
+ * Database helpers for the Plexus lifecycle manager (PRD-090, PRD-180 US-03).
+ *
+ * Lifted from the pops-api monolith during the cerebrum REST migration. The
+ * monolith resolved the drizzle handle per-call via `getCerebrumDrizzle()`
+ * (AsyncLocalStorage); the pillar instead threads an explicit `CerebrumDb`
+ * handle through — every helper takes it as its first argument, mirroring the
+ * `plexusService.*` db-arg convention. All access delegates to the in-pillar
+ * `plexusService` namespace.
+ */
+import {
+  plexusService,
+  type CerebrumDb,
+  type PlexusAdapter,
+  type PlexusFilter,
+} from '../../../db/index.js';
+
+import type { AdapterStatusValue, FilterDefinition, FilterRule } from './types.js';
+
+export function updateAdapterStatus(
+  db: CerebrumDb,
+  adapterId: string,
+  status: AdapterStatusValue,
+  error?: string
+): void {
+  plexusService.updateAdapterStatus(db, adapterId, {
+    status,
+    updatedAt: new Date().toISOString(),
+    lastError: error ?? null,
+  });
+}
+
+export function updateAdapterLastHealth(db: CerebrumDb, adapterId: string): void {
+  plexusService.recordAdapterHealth(db, adapterId, new Date().toISOString());
+}
+
+export function getAdapterRow(db: CerebrumDb, adapterId: string): PlexusAdapter {
+  return plexusService.getAdapterOrThrow(db, adapterId);
+}
+
+export function deleteAdapter(db: CerebrumDb, adapterId: string): boolean {
+  return plexusService.deleteAdapter(db, adapterId) > 0;
+}
+
+export function incrementIngestedCount(db: CerebrumDb, adapterId: string, count: number): void {
+  plexusService.incrementAdapterCounter(db, adapterId, {
+    counter: 'ingestedCount',
+    delta: count,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function getEnabledFilterRows(db: CerebrumDb, adapterId: string): FilterRule[] {
+  return plexusService.listEnabledFilters(db, adapterId).map(filterToRule);
+}
+
+export function syncFilterRows(
+  db: CerebrumDb,
+  adapterId: string,
+  filters: FilterDefinition[]
+): void {
+  plexusService.setFilters(db, adapterId, filters);
+}
+
+function filterToRule(filter: PlexusFilter): FilterRule {
+  return {
+    filterType: filter.filterType,
+    field: filter.field,
+    pattern: filter.pattern,
+    enabled: filter.enabled,
+  };
+}

--- a/pillars/cerebrum/src/api/modules/plexus/lifecycle.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/lifecycle.ts
@@ -1,0 +1,238 @@
+/**
+ * Plexus lifecycle manager (PRD-090, US-02).
+ *
+ * Lifted from the pops-api monolith during the cerebrum REST migration.
+ * Manages the full adapter lifecycle: register → initialize → health-check
+ * loop → shutdown. Error isolation ensures one misbehaving adapter never
+ * affects others.
+ *
+ * Two deviations from the monolith copy:
+ *  - The drizzle handle is constructor-injected (`CerebrumDb`) rather than
+ *    resolved per-call via `getCerebrumDrizzle()` — the pillar threads its
+ *    own open handle through `CerebrumApiDeps`.
+ *  - The health-loop tuning knobs (interval / timeout / max failures) read
+ *    from plain constants instead of the pops-api `cerebrum.plexus.*`
+ *    settings, which the pillar does not host. The values match the
+ *    monolith's `getSettingValue` fallbacks.
+ */
+import { plexusService, type CerebrumDb, type PlexusAdapter } from '../../../db/index.js';
+import {
+  deleteAdapter,
+  getAdapterRow,
+  getEnabledFilterRows,
+  incrementIngestedCount,
+  syncFilterRows,
+  updateAdapterLastHealth,
+  updateAdapterStatus,
+} from './lifecycle-db.js';
+
+import type { PlexusAdapterInterface } from './adapter.js';
+import type { AdapterConfig, AdapterStatusValue, EngineData, FilterDefinition } from './types.js';
+
+const DEFAULT_HEALTH_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 3;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+interface RegisteredAdapter {
+  instance: PlexusAdapterInterface;
+  consecutiveFailures: number;
+  healthTimer: ReturnType<typeof setTimeout> | null;
+}
+
+type HealthResult = { status: AdapterStatusValue; lastCheck: string; error?: string };
+
+/** Race a promise against a timeout. */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class PlexusLifecycleManager {
+  private adapters = new Map<string, RegisteredAdapter>();
+  private healthIntervalMs: number;
+  private healthTimeoutMs: number;
+  private maxConsecutiveFailures: number;
+
+  constructor(
+    private readonly db: CerebrumDb,
+    options?: {
+      healthIntervalMs?: number;
+      healthTimeoutMs?: number;
+      maxConsecutiveFailures?: number;
+    }
+  ) {
+    this.healthIntervalMs = options?.healthIntervalMs ?? DEFAULT_HEALTH_INTERVAL_MS;
+    this.healthTimeoutMs = options?.healthTimeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS;
+    this.maxConsecutiveFailures =
+      options?.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
+  }
+
+  /** Register an adapter and immediately attempt initialisation. */
+  async register(
+    adapter: PlexusAdapterInterface,
+    config: AdapterConfig,
+    filters?: FilterDefinition[]
+  ): Promise<PlexusAdapter> {
+    const id = `plx_${adapter.name}`;
+    const now = new Date().toISOString();
+    plexusService.upsertAdapter(this.db, {
+      id,
+      name: adapter.name,
+      config: config.settings,
+      createdAt: now,
+      updatedAt: now,
+    });
+    if (filters) syncFilterRows(this.db, id, filters);
+
+    updateAdapterStatus(this.db, id, 'initializing');
+    try {
+      await withTimeout(
+        adapter.initialize(config),
+        this.healthTimeoutMs,
+        `initialize(${adapter.name})`
+      );
+      updateAdapterStatus(this.db, id, 'healthy');
+      updateAdapterLastHealth(this.db, id);
+    } catch (err) {
+      updateAdapterStatus(this.db, id, 'error', errMsg(err));
+      return getAdapterRow(this.db, id);
+    }
+
+    const entry: RegisteredAdapter = {
+      instance: adapter,
+      consecutiveFailures: 0,
+      healthTimer: null,
+    };
+    this.adapters.set(id, entry);
+    this.scheduleHealthCheck(id, entry);
+    return getAdapterRow(this.db, id);
+  }
+
+  /** Shutdown and remove an adapter. */
+  async unregister(adapterId: string): Promise<boolean> {
+    const entry = this.adapters.get(adapterId);
+    if (entry) {
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      try {
+        await withTimeout(entry.instance.shutdown(), SHUTDOWN_TIMEOUT_MS, `shutdown(${adapterId})`);
+      } catch {
+        /* best-effort */
+      }
+      this.adapters.delete(adapterId);
+    }
+    return deleteAdapter(this.db, adapterId);
+  }
+
+  /** Run a health check for a specific adapter. */
+  async healthCheck(adapterId: string): Promise<HealthResult> {
+    const entry = this.adapters.get(adapterId);
+    if (!entry) {
+      return {
+        status: 'error',
+        lastCheck: new Date().toISOString(),
+        error: `Adapter '${adapterId}' is not active`,
+      };
+    }
+    return this.runHealthCheck(adapterId, entry);
+  }
+
+  /** Trigger an immediate ingestion cycle. */
+  async sync(adapterId: string): Promise<{ ingested: number; filtered: number }> {
+    const entry = this.adapters.get(adapterId);
+    if (!entry) throw new Error(`Adapter '${adapterId}' is not active`);
+    const row = getAdapterRow(this.db, adapterId);
+    if (row.status === 'error')
+      throw new Error(`Adapter '${adapterId}' is in error state — re-initialize first`);
+
+    const { applyFilters } = await import('./filters.js');
+    let items: EngineData[];
+    try {
+      items = await entry.instance.ingest({});
+    } catch (err) {
+      updateAdapterStatus(this.db, adapterId, 'error', errMsg(err));
+      throw err;
+    }
+
+    for (const item of items) item.source = `plexus:${row.name}`;
+    const { accepted, filtered } = applyFilters(items, getEnabledFilterRows(this.db, adapterId));
+    incrementIngestedCount(this.db, adapterId, accepted.length);
+    return { ingested: accepted.length, filtered };
+  }
+
+  /** Gracefully shut down all active adapters. */
+  async shutdownAll(): Promise<void> {
+    const shutdowns = [...this.adapters.entries()].map(async ([id, entry]) => {
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      try {
+        await withTimeout(entry.instance.shutdown(), SHUTDOWN_TIMEOUT_MS, `shutdown(${id})`);
+      } catch {
+        /* abandoned */
+      }
+      updateAdapterStatus(this.db, id, 'shutdown');
+    });
+    await Promise.allSettled(shutdowns);
+    this.adapters.clear();
+  }
+
+  private scheduleHealthCheck(adapterId: string, entry: RegisteredAdapter): void {
+    const jitter = Math.floor(Math.random() * 30_000);
+    entry.healthTimer = setTimeout(() => {
+      void this.runHealthCheck(adapterId, entry).then(() => {
+        if (this.adapters.has(adapterId)) this.scheduleHealthCheck(adapterId, entry);
+      });
+    }, this.healthIntervalMs + jitter);
+  }
+
+  private async runHealthCheck(adapterId: string, entry: RegisteredAdapter): Promise<HealthResult> {
+    const now = new Date().toISOString();
+    try {
+      const result = await withTimeout(
+        entry.instance.healthCheck(),
+        this.healthTimeoutMs,
+        `healthCheck(${adapterId})`
+      );
+      if (result.status === 'healthy') {
+        entry.consecutiveFailures = 0;
+        updateAdapterStatus(this.db, adapterId, 'healthy');
+        updateAdapterLastHealth(this.db, adapterId);
+        return { status: 'healthy', lastCheck: now };
+      }
+      return this.recordFailure(adapterId, entry, result.message ?? 'Unhealthy', now);
+    } catch (err) {
+      return this.recordFailure(adapterId, entry, errMsg(err), now);
+    }
+  }
+
+  private recordFailure(
+    adapterId: string,
+    entry: RegisteredAdapter,
+    message: string,
+    now: string
+  ): HealthResult {
+    entry.consecutiveFailures++;
+    if (entry.consecutiveFailures >= this.maxConsecutiveFailures) {
+      updateAdapterStatus(this.db, adapterId, 'error', message);
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      this.adapters.delete(adapterId);
+      return { status: 'error', lastCheck: now, error: message };
+    }
+    updateAdapterStatus(this.db, adapterId, 'degraded', message);
+    return { status: 'degraded', lastCheck: now, error: message };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/plexus/types.ts
+++ b/pillars/cerebrum/src/api/modules/plexus/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Plexus type definitions (PRD-090).
+ *
+ * Lifted from the pops-api monolith (`apps/pops-api/src/modules/cerebrum/
+ * plexus/types.ts`) during the cerebrum REST migration. Row + API shapes for
+ * adapters and filters live in the pillar DB barrel (`PlexusAdapter`,
+ * `PlexusFilter`, …); this file owns the in-process orchestration types
+ * (engine data, adapter config, filter rules) the lifecycle manager consumes.
+ */
+
+export const ADAPTER_STATUSES = [
+  'registered',
+  'initializing',
+  'healthy',
+  'degraded',
+  'error',
+  'shutdown',
+] as const;
+export type AdapterStatusValue = (typeof ADAPTER_STATUSES)[number];
+
+/**
+ * Content produced by an adapter's `ingest()` method. Passed directly into the
+ * ingestion pipeline (PRD-081). The adapter provides what it knows; the
+ * pipeline fills in classification, entity extraction, and scope inference.
+ */
+export interface EngineData {
+  /** Main content body (Markdown or plain text). */
+  body: string;
+  /** Human-readable title. */
+  title?: string;
+  /** Content type hint (e.g. `email`, `issue`, `event`). */
+  type?: string;
+  /** Explicit scope paths. */
+  scopes?: string[];
+  /** Tag strings. */
+  tags?: string[];
+  /**
+   * Source identifier. Must be `plexus:{adapter_name}` — set automatically by
+   * the lifecycle manager so adapters don't need to hard-code it.
+   */
+  source: string;
+  /** Adapter-specific metadata. */
+  customFields?: Record<string, unknown>;
+  /**
+   * Original ID from the external system. Enables deduplication independent of
+   * content-hash (an email might change formatting on re-fetch but keep the
+   * same external ID).
+   */
+  externalId?: string;
+}
+
+export interface AdapterStatus {
+  status: 'healthy' | 'degraded' | 'error';
+  /** Human-readable detail. */
+  message?: string;
+  /** ISO 8601 timestamp of the check. */
+  lastChecked: string;
+  /** Adapter-specific metrics (connection pool size, rate-limit remaining, etc.). */
+  metrics?: Record<string, unknown>;
+}
+
+/**
+ * Configuration passed to `adapter.initialize()`.
+ * @template TSettings Adapter-specific settings shape.
+ */
+export interface AdapterConfig<TSettings = Record<string, unknown>> {
+  /** Adapter name (matches the key in `plexus.toml`). */
+  name: string;
+  /** Resolved credentials (env var references already replaced with values). */
+  credentials: Record<string, string>;
+  /** Adapter-specific configuration. */
+  settings: TSettings;
+}
+
+export interface IngestOptions {
+  /** Only fetch items newer than this timestamp. */
+  since?: Date;
+  /** Max items to return. */
+  limit?: number;
+  /** Pre-resolved filter rules (evaluated by the plugin system). */
+  filters?: FilterRule[];
+}
+
+export interface EmitOptions {
+  /** Adapter-specific destination identifier. */
+  target: string;
+  /** Output format preference. */
+  format?: string;
+}
+
+export interface EmitContent {
+  title: string;
+  /** Markdown body. */
+  body: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type FilterType = 'include' | 'exclude';
+
+export interface FilterRule {
+  filterType: FilterType;
+  /** Field name to match against (adapter-specific). */
+  field: string;
+  /** Regex pattern (anchored — full match unless `.*` is used). */
+  pattern: string;
+  enabled: boolean;
+}
+
+export interface FilterDefinition {
+  filterType: FilterType;
+  field: string;
+  pattern: string;
+  enabled?: boolean;
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -8,6 +8,7 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
+import { makePlexusHandlers } from './plexus-handlers.js';
 import { makeTemplatesHandlers } from './templates-handlers.js';
 
 import type { CerebrumApiDeps } from '../handlers.js';
@@ -19,5 +20,6 @@ export function makeCerebrumRestHandlers(
 ): ReturnType<typeof server.router<typeof cerebrumContract>> {
   return server.router(cerebrumContract, {
     templates: makeTemplatesHandlers(deps.templateRegistry),
+    plexus: makePlexusHandlers(deps.cerebrumDb.db),
   });
 }

--- a/pillars/cerebrum/src/api/rest/plexus-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/plexus-handlers.ts
@@ -1,0 +1,81 @@
+/**
+ * ts-rest handlers for `cerebrum.plexus.*`.
+ *
+ * Reads (`adapters.list` / `adapters.get` / `filters.list`) and the
+ * `filters.set` write resolve straight through the in-pillar `plexusService`
+ * over the supplied `CerebrumDb` handle. The lifecycle mutations
+ * (`healthCheck` / `sync` / `unregister`) delegate to the per-handle
+ * `PlexusLifecycleManager` singleton.
+ *
+ * Error mapping mirrors the monolith router: a missing adapter on `get`
+ * surfaces as 404; `filters.set` validates every pattern as a regex up front
+ * (400 on a bad one) and translates the service's `PlexusAdapterNotFoundError`
+ * into the pillar `NotFoundError` (404) so a phantom-adapter write never
+ * orphans filter rules.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumPlexusContract } from '../../contract/rest-plexus.js';
+import { plexusService, PlexusAdapterNotFoundError, type CerebrumDb } from '../../db/index.js';
+import { getPlexusLifecycle } from '../modules/plexus/instance.js';
+import { NotFoundError, ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+function assertValidPatterns(filters: ReadonlyArray<{ field: string; pattern: string }>): void {
+  for (const f of filters) {
+    try {
+      new RegExp(f.pattern);
+    } catch {
+      throw new ValidationError(`Invalid regex pattern '${f.pattern}' for field '${f.field}'`);
+    }
+  }
+}
+
+export function makePlexusHandlers(
+  db: CerebrumDb
+): ReturnType<typeof server.router<typeof cerebrumPlexusContract>> {
+  return server.router(cerebrumPlexusContract, {
+    adapters: {
+      list: async () => ({ status: 200, body: { adapters: plexusService.listAdapters(db) } }),
+      get: async ({ params }) =>
+        runHttp(() => {
+          const adapter = plexusService.getAdapter(db, params.adapterId);
+          if (!adapter) throw new NotFoundError('adapter', params.adapterId);
+          return { status: 200, body: { adapter } };
+        }),
+      healthCheck: async ({ params }) => {
+        const result = await getPlexusLifecycle(db).healthCheck(params.adapterId);
+        return { status: 200, body: result };
+      },
+      sync: async ({ params }) => {
+        const result = await getPlexusLifecycle(db).sync(params.adapterId);
+        return { status: 200, body: result };
+      },
+      unregister: async ({ params }) => {
+        const success = await getPlexusLifecycle(db).unregister(params.adapterId);
+        return { status: 200, body: { success } };
+      },
+    },
+    filters: {
+      list: async ({ params }) => ({
+        status: 200,
+        body: { filters: plexusService.listFilters(db, params.adapterId) },
+      }),
+      set: async ({ params, body }) =>
+        runHttp(() => {
+          assertValidPatterns(body.filters);
+          try {
+            const filters = plexusService.setFilters(db, params.adapterId, body.filters);
+            return { status: 200, body: { filters } };
+          } catch (err) {
+            if (err instanceof PlexusAdapterNotFoundError) {
+              throw new NotFoundError('adapter', params.adapterId);
+            }
+            throw err;
+          }
+        }),
+    },
+  });
+}

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -3,6 +3,109 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/cerebrum generate:api-types`.
  */
 export interface paths {
+  '/plexus/adapters': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List every registered plexus adapter. */
+    get: operations['plexus.adapters.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plexus/adapters/{adapterId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single plexus adapter by id. */
+    get: operations['plexus.adapters.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plexus/adapters/{adapterId}/filters': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List the ingestion filters for an adapter. */
+    get: operations['plexus.filters.list'];
+    put?: never;
+    /** Atomically replace the ingestion filters for an adapter. */
+    post: operations['plexus.filters.set'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plexus/adapters/{adapterId}/health-check': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run an on-demand health check against an adapter. */
+    post: operations['plexus.adapters.healthCheck'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plexus/adapters/{adapterId}/sync': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Trigger a manual ingestion cycle for an adapter. */
+    post: operations['plexus.adapters.sync'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plexus/adapters/{adapterId}/unregister': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Shut down and remove an adapter. */
+    post: operations['plexus.adapters.unregister'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/templates': {
     parameters: {
       query?: never;
@@ -49,6 +152,287 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'plexus.adapters.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            adapters: {
+              config: {
+                [key: string]: unknown;
+              } | null;
+              createdAt: string;
+              emittedCount: number;
+              id: string;
+              ingestedCount: number;
+              lastError: string | null;
+              lastHealth: string | null;
+              name: string;
+              /** @enum {string} */
+              status: 'registered' | 'initializing' | 'healthy' | 'degraded' | 'error' | 'shutdown';
+              updatedAt: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'plexus.adapters.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            adapter: {
+              config: {
+                [key: string]: unknown;
+              } | null;
+              createdAt: string;
+              emittedCount: number;
+              id: string;
+              ingestedCount: number;
+              lastError: string | null;
+              lastHealth: string | null;
+              name: string;
+              /** @enum {string} */
+              status: 'registered' | 'initializing' | 'healthy' | 'degraded' | 'error' | 'shutdown';
+              updatedAt: string;
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'plexus.filters.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            filters: {
+              adapterId: string;
+              enabled: boolean;
+              field: string;
+              /** @enum {string} */
+              filterType: 'include' | 'exclude';
+              id: string;
+              pattern: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'plexus.filters.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          filters: {
+            enabled?: boolean;
+            field: string;
+            /** @enum {string} */
+            filterType: 'include' | 'exclude';
+            pattern: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            filters: {
+              adapterId: string;
+              enabled: boolean;
+              field: string;
+              /** @enum {string} */
+              filterType: 'include' | 'exclude';
+              id: string;
+              pattern: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'plexus.adapters.healthCheck': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            error?: string;
+            lastCheck: string;
+            /** @enum {string} */
+            status: 'registered' | 'initializing' | 'healthy' | 'degraded' | 'error' | 'shutdown';
+          };
+        };
+      };
+    };
+  };
+  'plexus.adapters.sync': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            filtered: number;
+            ingested: number;
+          };
+        };
+      };
+    };
+  };
+  'plexus.adapters.unregister': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        adapterId: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            success: boolean;
+          };
+        };
+      };
+    };
+  };
   'templates.list': {
     parameters: {
       query?: never;

--- a/pillars/cerebrum/src/contract/rest-plexus.ts
+++ b/pillars/cerebrum/src/contract/rest-plexus.ts
@@ -1,0 +1,110 @@
+/**
+ * ts-rest contract for `cerebrum.plexus.*`.
+ *
+ * Plexus is the external-adapter registry: adapter CRUD + per-adapter
+ * ingestion-filter management. Non-identity domain — served on the
+ * docker-network trust boundary with no per-request auth (parity with
+ * templates).
+ *
+ * The two queries that take typed input (`adapters.get`, `filters.list`)
+ * carry their input in the path; `filters.set` and the lifecycle mutations
+ * (`healthCheck` / `sync` / `unregister`) are POSTs — typed bodies don't
+ * round-trip cleanly through a query string (mirrors the food precedent).
+ * `unregister` is modelled as a POST sub-action rather than `DELETE` so the
+ * verb stays uniform with the other lifecycle mutations.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  errorBodySchema,
+  plexusAdapterSchema,
+  plexusFilterDefinitionSchema,
+  plexusFilterSchema,
+  plexusHealthResultSchema,
+  plexusSyncResultSchema,
+} from './rest-schemas.js';
+
+const c = initContract();
+
+const adapterIdParams = z.object({ adapterId: z.string().min(1) });
+
+const adaptersContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/plexus/adapters',
+    summary: 'List every registered plexus adapter.',
+    responses: {
+      200: z.object({ adapters: z.array(plexusAdapterSchema) }),
+    },
+  },
+  get: {
+    method: 'GET',
+    path: '/plexus/adapters/:adapterId',
+    summary: 'Get a single plexus adapter by id.',
+    pathParams: adapterIdParams,
+    responses: {
+      200: z.object({ adapter: plexusAdapterSchema }),
+      404: errorBodySchema,
+    },
+  },
+  healthCheck: {
+    method: 'POST',
+    path: '/plexus/adapters/:adapterId/health-check',
+    summary: 'Run an on-demand health check against an adapter.',
+    pathParams: adapterIdParams,
+    body: z.object({}),
+    responses: {
+      200: plexusHealthResultSchema,
+    },
+  },
+  sync: {
+    method: 'POST',
+    path: '/plexus/adapters/:adapterId/sync',
+    summary: 'Trigger a manual ingestion cycle for an adapter.',
+    pathParams: adapterIdParams,
+    body: z.object({}),
+    responses: {
+      200: plexusSyncResultSchema,
+    },
+  },
+  unregister: {
+    method: 'POST',
+    path: '/plexus/adapters/:adapterId/unregister',
+    summary: 'Shut down and remove an adapter.',
+    pathParams: adapterIdParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ success: z.boolean() }),
+    },
+  },
+});
+
+const filtersContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/plexus/adapters/:adapterId/filters',
+    summary: 'List the ingestion filters for an adapter.',
+    pathParams: adapterIdParams,
+    responses: {
+      200: z.object({ filters: z.array(plexusFilterSchema) }),
+    },
+  },
+  set: {
+    method: 'POST',
+    path: '/plexus/adapters/:adapterId/filters',
+    summary: 'Atomically replace the ingestion filters for an adapter.',
+    pathParams: adapterIdParams,
+    body: z.object({ filters: z.array(plexusFilterDefinitionSchema) }),
+    responses: {
+      200: z.object({ filters: z.array(plexusFilterSchema) }),
+      400: errorBodySchema,
+      404: errorBodySchema,
+    },
+  },
+});
+
+export const cerebrumPlexusContract = c.router({
+  adapters: adaptersContract,
+  filters: filtersContract,
+});

--- a/pillars/cerebrum/src/contract/rest-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-schemas.ts
@@ -49,3 +49,64 @@ export const templateSchema = templateSummarySchema.extend({
   body: z.string(),
 });
 export type TemplateWire = z.infer<typeof templateSchema>;
+
+const PLEXUS_ADAPTER_STATUSES = [
+  'registered',
+  'initializing',
+  'healthy',
+  'degraded',
+  'error',
+  'shutdown',
+] as const;
+
+const PLEXUS_FILTER_TYPES = ['include', 'exclude'] as const;
+
+/** A registered plexus adapter row (config envelope passed through opaque). */
+export const plexusAdapterSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  status: z.enum(PLEXUS_ADAPTER_STATUSES),
+  config: z.record(z.string(), z.unknown()).nullable(),
+  lastHealth: z.string().nullable(),
+  lastError: z.string().nullable(),
+  ingestedCount: z.number().int(),
+  emittedCount: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type PlexusAdapterWire = z.infer<typeof plexusAdapterSchema>;
+
+/** A persisted per-adapter ingestion filter. */
+export const plexusFilterSchema = z.object({
+  id: z.string().min(1),
+  adapterId: z.string().min(1),
+  filterType: z.enum(PLEXUS_FILTER_TYPES),
+  field: z.string().min(1),
+  pattern: z.string().min(1),
+  enabled: z.boolean(),
+});
+export type PlexusFilterWire = z.infer<typeof plexusFilterSchema>;
+
+/** A filter definition supplied by the caller (id generated server-side). */
+export const plexusFilterDefinitionSchema = z.object({
+  filterType: z.enum(PLEXUS_FILTER_TYPES),
+  field: z.string().min(1),
+  pattern: z.string().min(1),
+  enabled: z.boolean().optional(),
+});
+export type PlexusFilterDefinitionWire = z.infer<typeof plexusFilterDefinitionSchema>;
+
+/** Result of a manual health-check run against an adapter. */
+export const plexusHealthResultSchema = z.object({
+  status: z.enum(PLEXUS_ADAPTER_STATUSES),
+  lastCheck: z.string(),
+  error: z.string().optional(),
+});
+export type PlexusHealthResultWire = z.infer<typeof plexusHealthResultSchema>;
+
+/** Result of a manual sync run against an adapter. */
+export const plexusSyncResultSchema = z.object({
+  ingested: z.number().int(),
+  filtered: z.number().int(),
+});
+export type PlexusSyncResultWire = z.infer<typeof plexusSyncResultSchema>;

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -12,6 +12,7 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { cerebrumPlexusContract } from './rest-plexus.js';
 import { cerebrumTemplatesContract } from './rest-templates.js';
 
 const c = initContract();
@@ -19,6 +20,7 @@ const c = initContract();
 export const cerebrumContract = c.router(
   {
     templates: cerebrumTemplatesContract,
+    plexus: cerebrumPlexusContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Summary

Migrates the `cerebrum.plexus.*` tRPC domain onto the cerebrum pillar's ts-rest surface (slice following templates / slice 0). Covers the two plexus sub-routers — adapter CRUD and per-adapter ingestion-filter management. Non-identity, docker-net-trust domain: no per-request auth (parity with templates).

### Procedure → route map (7)
| tRPC | REST | notes |
|---|---|---|
| `plexus.adapters.list` | `GET /plexus/adapters` | `{ adapters }` |
| `plexus.adapters.get` | `GET /plexus/adapters/:adapterId` | `{ adapter }`, 404 if missing |
| `plexus.adapters.healthCheck` | `POST /plexus/adapters/:adapterId/health-check` | `{ status, lastCheck, error? }` |
| `plexus.adapters.sync` | `POST /plexus/adapters/:adapterId/sync` | `{ ingested, filtered }` |
| `plexus.adapters.unregister` | `POST /plexus/adapters/:adapterId/unregister` | `{ success }` |
| `plexus.filters.list` | `GET /plexus/adapters/:adapterId/filters` | `{ filters }` |
| `plexus.filters.set` | `POST /plexus/adapters/:adapterId/filters` | `{ filters }`, 400 bad regex / 404 missing adapter |

`operationId`s stay dotted via `concatenated-path` (`plexus.adapters.list`, `plexus.filters.set`, …). `unregister` is a POST sub-action (uniform with the other lifecycle mutations) rather than `DELETE`.

## Changes
- **Contract:** `src/contract/rest-plexus.ts` + plexus schemas in `rest-schemas.ts`, composed into `rest.ts`.
- **Handlers:** `src/api/rest/plexus-handlers.ts`. Reads + `filters.set` go straight through the in-pillar `plexusService` over `deps.cerebrumDb.db`; `healthCheck`/`sync`/`unregister` delegate to a per-DB-handle `PlexusLifecycleManager`. Regex validation (400 `ValidationError`) and `PlexusAdapterNotFoundError` → 404 `NotFoundError` mapping preserved from the monolith router.
- **Lifted module:** `src/api/modules/plexus/` (`types`, `adapter`, `filters`, `lifecycle-db`, `lifecycle`, `instance`).
- **Tests:** `src/api/__tests__/plexus.test.ts` over a temp `cerebrum.db` (plexus baseline migration 0053). `test-utils.makeClient` gains a `plexus` section.

## Deviations from the monolith
- The lifecycle manager's drizzle handle is **constructor-injected** (`CerebrumDb`) rather than resolved per-call via `getCerebrumDrizzle()` (AsyncLocalStorage) — the pillar threads its own open handle through `CerebrumApiDeps`. The manager is keyed to that handle via a `WeakMap` in `instance.ts` (one manager per open DB; survives across requests; collected with the handle).
- Health-loop tuning knobs (interval / timeout / max-failures) read from plain constants matching the monolith's `getSettingValue` fallbacks — the pillar does not host the `cerebrum.plexus.*` settings service.
- The **TOML registry / file-watcher** (`PlexusRegistry`, `toml-parser`, the pops-api `instance.ts`/`getEngramRoot`) is intentionally **not lifted**: this slice serves the REST surface over an empty registry (zero registered adapters), mirroring how the monolith tolerates a missing `plexus.toml`. This keeps `smol-toml` and the engram-root config out of the pillar for this slice. Concrete adapters (email/calendar/github) are likewise not lifted. `CEREBRUM_PLEXUS_CONFIG_DIR` was therefore unnecessary.
- `test-utils.makeClient` switched from `supertest(app)` to a persistent `supertest.agent(app)` — multiple short-lived requests per test triggered transient `ECONNRESET` socket churn under express 5; the persistent agent removes it (no timeout hacks).

## Green-proof (run in worktree)
- `pnpm install --frozen-lockfile` — lockfile up to date (no dep changes).
- `oxfmt --check pillars/cerebrum/` — all files correctly formatted.
- `oxlint pillars/cerebrum/src` — **0 errors** (only the pre-existing `__resetPillarRegistryCache` no-underscore-dangle warning).
- `pnpm --filter @pops/cerebrum typecheck` — passes.
- `pnpm --filter @pops/cerebrum build` — regenerates openapi + api-types successfully.
- `generate:openapi && git diff --exit-code openapi/cerebrum.openapi.json` — **clean** (committed == generated; regeneration is deterministic).
- `pnpm --filter @pops/cerebrum test` — **271 passed (19 files)**; plexus suite run 10× for stability after the agent fix.

No `as any`/`as unknown`, no eslint-disable/ts-ignore/ts-expect-error.