### PR TITLE
feat(cerebrum): REST migration slice — reflex

### DIFF
--- a/pillars/cerebrum/migrations/0056_reflex_executions_baseline.sql
+++ b/pillars/cerebrum/migrations/0056_reflex_executions_baseline.sql
@@ -1,0 +1,25 @@
+-- Cerebrum pillar baseline for the reflex slice (PRD-089 reflex execution
+-- log). The append-only `reflex_executions` table was declared in the
+-- pillar schema (`schema/reflex-executions.ts`) but never had its own
+-- migration in the relocated journal — this baseline creates it.
+--
+-- IF NOT EXISTS throughout so the migration is safe to run against a
+-- database that already received the table from an earlier shared-journal
+-- ancestry.
+CREATE TABLE IF NOT EXISTS `reflex_executions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`reflex_name` text NOT NULL,
+	`trigger_type` text NOT NULL,
+	`trigger_data` text,
+	`action_type` text NOT NULL,
+	`action_verb` text NOT NULL,
+	`status` text NOT NULL,
+	`result` text,
+	`triggered_at` text NOT NULL,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_reflex_exec_name` ON `reflex_executions` (`reflex_name`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_reflex_exec_trigger_type` ON `reflex_executions` (`trigger_type`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_reflex_exec_status` ON `reflex_executions` (`status`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_reflex_exec_triggered_at` ON `reflex_executions` (`triggered_at`);

--- a/pillars/cerebrum/migrations/meta/_journal.json
+++ b/pillars/cerebrum/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782259200000,
       "tag": "0055_debrief_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0056_reflex_executions_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -9,6 +9,840 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/reflex": {
+      "get": {
+        "operationId": "reflex.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "timezone",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reflexes": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "action": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "target": {
+                                "type": "string"
+                              },
+                              "template": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": ["ingest", "emit", "glia"],
+                                "type": "string"
+                              },
+                              "verb": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type", "verb"],
+                            "type": "object"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "executionCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "lastExecutionAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "name": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "nextFireTime": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "trigger": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "conditions": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "source": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "event": {
+                                    "enum": [
+                                      "engram.created",
+                                      "engram.modified",
+                                      "engram.archived",
+                                      "engram.linked"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "enum": ["event"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["type", "event"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "metric": {
+                                    "enum": ["similar_count", "staleness_max", "topic_frequency"],
+                                    "type": "string"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "type": {
+                                    "enum": ["threshold"],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": ["type", "metric", "value"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "cron": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "enum": ["schedule"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["type", "cron"],
+                                "type": "object"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "description",
+                          "enabled",
+                          "trigger",
+                          "action",
+                          "lastExecutionAt",
+                          "nextFireTime",
+                          "executionCount"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["reflexes"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List reflexes enriched with runtime status.",
+        "tags": ["reflex"]
+      }
+    },
+    "/reflex/history": {
+      "post": {
+        "operationId": "reflex.history",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "enum": ["triggered", "executing", "completed", "failed"],
+                    "type": "string"
+                  },
+                  "triggerType": {
+                    "enum": ["event", "threshold", "schedule"],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "executions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["ingest", "emit", "glia"],
+                            "type": "string"
+                          },
+                          "actionVerb": {
+                            "type": "string"
+                          },
+                          "completedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "reflexName": {
+                            "type": "string"
+                          },
+                          "result": {
+                            "additionalProperties": {},
+                            "nullable": true,
+                            "type": "object"
+                          },
+                          "status": {
+                            "enum": ["triggered", "executing", "completed", "failed"],
+                            "type": "string"
+                          },
+                          "triggerData": {
+                            "additionalProperties": {},
+                            "nullable": true,
+                            "type": "object"
+                          },
+                          "triggerType": {
+                            "enum": ["event", "threshold", "schedule"],
+                            "type": "string"
+                          },
+                          "triggeredAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "reflexName",
+                          "triggerType",
+                          "triggerData",
+                          "actionType",
+                          "actionVerb",
+                          "status",
+                          "result",
+                          "triggeredAt",
+                          "completedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["executions", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Query the append-only reflex execution log (filtered + paginated).",
+        "tags": ["reflex"]
+      }
+    },
+    "/reflex/{name}": {
+      "get": {
+        "operationId": "reflex.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "history": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["ingest", "emit", "glia"],
+                            "type": "string"
+                          },
+                          "actionVerb": {
+                            "type": "string"
+                          },
+                          "completedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "reflexName": {
+                            "type": "string"
+                          },
+                          "result": {
+                            "additionalProperties": {},
+                            "nullable": true,
+                            "type": "object"
+                          },
+                          "status": {
+                            "enum": ["triggered", "executing", "completed", "failed"],
+                            "type": "string"
+                          },
+                          "triggerData": {
+                            "additionalProperties": {},
+                            "nullable": true,
+                            "type": "object"
+                          },
+                          "triggerType": {
+                            "enum": ["event", "threshold", "schedule"],
+                            "type": "string"
+                          },
+                          "triggeredAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "reflexName",
+                          "triggerType",
+                          "triggerData",
+                          "actionType",
+                          "actionVerb",
+                          "status",
+                          "result",
+                          "triggeredAt",
+                          "completedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "reflex": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "action": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "target": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "enum": ["ingest", "emit", "glia"],
+                              "type": "string"
+                            },
+                            "verb": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "verb"],
+                          "type": "object"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "executionCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "lastExecutionAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "nextFireTime": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "trigger": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "conditions": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "event": {
+                                  "enum": [
+                                    "engram.created",
+                                    "engram.modified",
+                                    "engram.archived",
+                                    "engram.linked"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "enum": ["event"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "event"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "metric": {
+                                  "enum": ["similar_count", "staleness_max", "topic_frequency"],
+                                  "type": "string"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "type": {
+                                  "enum": ["threshold"],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": ["type", "metric", "value"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "cron": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "enum": ["schedule"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "cron"],
+                              "type": "object"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "description",
+                        "enabled",
+                        "trigger",
+                        "action",
+                        "lastExecutionAt",
+                        "nextFireTime",
+                        "executionCount"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reflex", "history"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get a single reflex with its recent execution history.",
+        "tags": ["reflex"]
+      }
+    },
+    "/reflex/{name}/disable": {
+      "post": {
+        "operationId": "reflex.disable",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Disable a reflex (rewrites the TOML config).",
+        "tags": ["reflex"]
+      }
+    },
+    "/reflex/{name}/enable": {
+      "post": {
+        "operationId": "reflex.enable",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Enable a reflex (rewrites the TOML config).",
+        "tags": ["reflex"]
+      }
+    },
+    "/reflex/{name}/test": {
+      "post": {
+        "operationId": "reflex.test",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "result": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["ingest", "emit", "glia"],
+                          "type": "string"
+                        },
+                        "actionVerb": {
+                          "type": "string"
+                        },
+                        "completedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "reflexName": {
+                          "type": "string"
+                        },
+                        "result": {
+                          "additionalProperties": {},
+                          "nullable": true,
+                          "type": "object"
+                        },
+                        "status": {
+                          "enum": ["triggered", "executing", "completed", "failed"],
+                          "type": "string"
+                        },
+                        "triggerData": {
+                          "additionalProperties": {},
+                          "nullable": true,
+                          "type": "object"
+                        },
+                        "triggerType": {
+                          "enum": ["event", "threshold", "schedule"],
+                          "type": "string"
+                        },
+                        "triggeredAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "reflexName",
+                        "triggerType",
+                        "triggerData",
+                        "actionType",
+                        "actionVerb",
+                        "status",
+                        "result",
+                        "triggeredAt",
+                        "completedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["result"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Dry-run a reflex, logging a completed test execution.",
+        "tags": ["reflex"]
+      }
+    },
     "/templates": {
       "get": {
         "operationId": "templates.list",

--- a/pillars/cerebrum/package.json
+++ b/pillars/cerebrum/package.json
@@ -46,10 +46,13 @@
     "@ts-rest/express": "3.53.0-rc.1",
     "@ts-rest/open-api": "3.53.0-rc.1",
     "better-sqlite3": "^12.10.0",
+    "chokidar": "^5.0.0",
+    "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "express": "^5.1.0",
     "gray-matter": "^4.0.3",
+    "smol-toml": "^1.6.1",
     "sqlite-vec": "^0.1.7",
     "zod": "^4.4.3"
   },

--- a/pillars/cerebrum/src/api/__tests__/health.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/health.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeTemplateRegistry } from './test-utils.js';
+import { makeReflexService, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -33,6 +33,7 @@ function makeApp(): ReturnType<typeof createCerebrumApiApp> {
   return createCerebrumApiApp({
     cerebrumDb,
     templateRegistry: makeTemplateRegistry(),
+    reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
     version: '0.0.1-test',
     selfBaseUrl: 'http://localhost:3007',
   });

--- a/pillars/cerebrum/src/api/__tests__/pillars.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/pillars.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
 import { __resetPillarRegistryCache } from '../pillars/registry.js';
-import { makeTemplateRegistry } from './test-utils.js';
+import { makeReflexService, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -40,6 +40,7 @@ function makeApp(): ReturnType<typeof createCerebrumApiApp> {
   return createCerebrumApiApp({
     cerebrumDb,
     templateRegistry: makeTemplateRegistry(),
+    reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
     version: '0.0.1-test',
     selfBaseUrl: 'http://cerebrum-api:3007',
   });

--- a/pillars/cerebrum/src/api/__tests__/reflex.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/reflex.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration tests for `cerebrum.reflex.*` over REST (PRD-089).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` plus a temp
+ * `reflexes.toml` fixture, exercising list/get/enable/disable/test/history.
+ * One suite uses the no-config (missing-file) path to prove the pillar boots
+ * to an empty reflex set.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, reflexExecutions, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+
+const FIXTURE_TOML = `
+[[reflex]]
+name = "prune-stale"
+description = "Prune stale work notes"
+enabled = true
+[reflex.trigger]
+type = "threshold"
+metric = "staleness_max"
+value = 30
+[reflex.action]
+type = "glia"
+verb = "prune"
+
+[[reflex]]
+name = "classify-on-create"
+description = "Classify new captures"
+enabled = false
+[reflex.trigger]
+type = "event"
+event = "engram.created"
+[reflex.action]
+type = "ingest"
+verb = "classify"
+`;
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+let configPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-reflex-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+  configPath = join(tmpDir, 'reflexes.toml');
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function clientWith(toml: string | null) {
+  if (toml !== null) writeFileSync(configPath, toml, 'utf8');
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      reflexService: makeReflexService(cerebrumDb.db, configPath),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+    })
+  );
+}
+
+function seedExecution(reflexName: string, triggeredAt: string): void {
+  cerebrumDb.db
+    .insert(reflexExecutions)
+    .values({
+      id: `rex_${reflexName}_${triggeredAt}`,
+      reflexName,
+      triggerType: 'threshold',
+      triggerData: JSON.stringify({ metric: 'staleness_max', value: 31 }),
+      actionType: 'glia',
+      actionVerb: 'prune',
+      status: 'completed',
+      result: null,
+      triggeredAt,
+      completedAt: triggeredAt,
+    })
+    .run();
+}
+
+describe('GET /reflex', () => {
+  it('boots to an empty set when no TOML is present', async () => {
+    const { reflexes } = await clientWith(null).reflex.list();
+    expect(reflexes).toEqual([]);
+  });
+
+  it('lists reflexes from the fixture with enriched runtime status', async () => {
+    const { reflexes } = await clientWith(FIXTURE_TOML).reflex.list();
+    const names = reflexes.map((r) => r.name).toSorted();
+    expect(names).toEqual(['classify-on-create', 'prune-stale']);
+    for (const r of reflexes) {
+      expect(r).toHaveProperty('executionCount', 0);
+      expect(r).toHaveProperty('lastExecutionAt', null);
+    }
+  });
+});
+
+describe('GET /reflex/:name', () => {
+  it('returns a reflex with its execution history', async () => {
+    seedExecution('prune-stale', '2026-01-01T00:00:00.000Z');
+    const { reflex, history } = await clientWith(FIXTURE_TOML).reflex.get('prune-stale');
+    expect(reflex.name).toBe('prune-stale');
+    expect(reflex.executionCount).toBe(1);
+    expect(reflex.lastExecutionAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(history).toHaveLength(1);
+    expect(history[0]?.status).toBe('completed');
+  });
+
+  it('404s on an unknown reflex', async () => {
+    await expect(clientWith(FIXTURE_TOML).reflex.get('nope')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('POST /reflex/:name/{enable,disable}', () => {
+  it('round-trips the enabled flag through the TOML', async () => {
+    const client = clientWith(FIXTURE_TOML);
+
+    const disabled = await client.reflex.disable('prune-stale');
+    expect(disabled.success).toBe(true);
+    const afterDisable = await client.reflex.list();
+    expect(afterDisable.reflexes.find((r) => r.name === 'prune-stale')?.enabled).toBe(false);
+
+    const enabled = await client.reflex.enable('classify-on-create');
+    expect(enabled.success).toBe(true);
+    const afterEnable = await client.reflex.list();
+    expect(afterEnable.reflexes.find((r) => r.name === 'classify-on-create')?.enabled).toBe(true);
+  });
+
+  it('404s when toggling an unknown reflex', async () => {
+    await expect(clientWith(FIXTURE_TOML).reflex.enable('nope')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('POST /reflex/:name/test', () => {
+  it('logs a completed dry-run execution', async () => {
+    const client = clientWith(FIXTURE_TOML);
+    const { result } = await client.reflex.test('prune-stale');
+    expect(result?.status).toBe('completed');
+    expect(result?.result).toMatchObject({ dryRun: true, wouldExecute: 'glia:prune' });
+
+    const { total } = await client.reflex.history({ name: 'prune-stale' });
+    expect(total).toBe(1);
+  });
+});
+
+describe('POST /reflex/history', () => {
+  it('paginates the execution log newest-first', async () => {
+    seedExecution('prune-stale', '2026-01-01T00:00:00.000Z');
+    seedExecution('prune-stale', '2026-01-02T00:00:00.000Z');
+    seedExecution('prune-stale', '2026-01-03T00:00:00.000Z');
+    const client = clientWith(FIXTURE_TOML);
+
+    const page1 = await client.reflex.history({ limit: 2, offset: 0 });
+    expect(page1.total).toBe(3);
+    expect(page1.executions).toHaveLength(2);
+    expect(page1.executions[0]?.triggeredAt).toBe('2026-01-03T00:00:00.000Z');
+    expect(page1.executions[1]?.triggeredAt).toBe('2026-01-02T00:00:00.000Z');
+
+    const page2 = await client.reflex.history({ limit: 2, offset: 2 });
+    expect(page2.executions).toHaveLength(1);
+    expect(page2.executions[0]?.triggeredAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('filters by status', async () => {
+    seedExecution('prune-stale', '2026-01-01T00:00:00.000Z');
+    const client = clientWith(FIXTURE_TOML);
+    const completed = await client.reflex.history({ status: 'completed' });
+    expect(completed.total).toBe(1);
+    const failed = await client.reflex.history({ status: 'failed' });
+    expect(failed.total).toBe(0);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/templates.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/templates.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeTemplateRegistry } from './test-utils.js';
+import { makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -32,6 +32,7 @@ function client() {
     createCerebrumApiApp({
       cerebrumDb,
       templateRegistry: makeTemplateRegistry(),
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
     })

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -8,11 +8,21 @@ import { fileURLToPath } from 'node:url';
 
 import supertest from 'supertest';
 
+import { buildReflexService } from '../modules/reflex/instance.js';
 import { TemplateRegistry } from '../modules/templates/registry.js';
 
 import type { Express } from 'express';
 
-import type { TemplateSummaryWire, TemplateWire } from '../../contract/rest-schemas.js';
+import type {
+  ReflexExecutionStatusWire,
+  ReflexExecutionWire,
+  ReflexTriggerTypeWire,
+  ReflexWithStatusWire,
+  TemplateSummaryWire,
+  TemplateWire,
+} from '../../contract/rest-schemas.js';
+import type { CerebrumDb } from '../../db/index.js';
+import type { ReflexService } from '../modules/reflex/reflex-service.js';
 
 /** Bundled engram-template fixtures shipped with the pillar. */
 export const TEST_TEMPLATES_DIR = resolve(
@@ -25,6 +35,15 @@ export const TEST_TEMPLATES_DIR = resolve(
 
 export function makeTemplateRegistry(): TemplateRegistry {
   return new TemplateRegistry(TEST_TEMPLATES_DIR);
+}
+
+/**
+ * Build a {@link ReflexService} pointed at a test-controlled TOML path with
+ * the chokidar watcher disabled. Pass a path to a fixture, or a path to a
+ * non-existent file to exercise the empty-reflex-set boot.
+ */
+export function makeReflexService(db: CerebrumDb, configPath: string): ReflexService {
+  return buildReflexService({ db, configPath, watch: false });
 }
 
 export class HttpError extends Error {
@@ -48,12 +67,40 @@ async function send<T>(req: supertest.Test): Promise<T> {
   throw new HttpError(res.status, res.body);
 }
 
+export interface ReflexHistoryFilters {
+  name?: string;
+  triggerType?: ReflexTriggerTypeWire;
+  status?: ReflexExecutionStatusWire;
+  limit?: number;
+  offset?: number;
+}
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
     templates: {
       list: () => send<{ templates: TemplateSummaryWire[] }>(r.get('/templates')),
       get: (name: string) => send<{ template: TemplateWire }>(r.get(`/templates/${name}`)),
+    },
+    reflex: {
+      list: (timezone?: string) =>
+        send<{ reflexes: ReflexWithStatusWire[] }>(
+          r.get('/reflex').query(timezone ? { timezone } : {})
+        ),
+      get: (name: string) =>
+        send<{ reflex: ReflexWithStatusWire; history: ReflexExecutionWire[] }>(
+          r.get(`/reflex/${name}`)
+        ),
+      test: (name: string) =>
+        send<{ result: ReflexExecutionWire | null }>(r.post(`/reflex/${name}/test`).send({})),
+      enable: (name: string) =>
+        send<{ success: boolean }>(r.post(`/reflex/${name}/enable`).send({})),
+      disable: (name: string) =>
+        send<{ success: boolean }>(r.post(`/reflex/${name}/disable`).send({})),
+      history: (filters: ReflexHistoryFilters = {}) =>
+        send<{ executions: ReflexExecutionWire[]; total: number }>(
+          r.post('/reflex/history').send(filters)
+        ),
     },
   };
 }

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -10,6 +10,7 @@ import { getPillarRegistry } from './pillars/registry.js';
 import type { PillarRegistryEntry } from '@pops/types';
 
 import type { OpenedCerebrumDb } from '../db/index.js';
+import type { ReflexService } from './modules/reflex/reflex-service.js';
 import type { TemplateRegistry } from './modules/templates/registry.js';
 
 export interface CerebrumApiDeps {
@@ -17,6 +18,8 @@ export interface CerebrumApiDeps {
   cerebrumDb: OpenedCerebrumDb;
   /** In-memory registry of on-disk engram templates. */
   templateRegistry: TemplateRegistry;
+  /** TOML-driven reflex registry + execution-log accessor (PRD-089). */
+  reflexService: ReflexService;
   /** Semver of the build, surfaced on the health response. */
   version: string;
   /**

--- a/pillars/cerebrum/src/api/modules/reflex/instance.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/instance.ts
@@ -1,0 +1,60 @@
+/**
+ * Reflex service accessor for the cerebrum pillar (PRD-089).
+ *
+ * The {@link ReflexService} is config-dependent (reads `reflexes.toml`) and
+ * holds in-memory threshold state, so it is cached per DB handle rather than
+ * rebuilt on each request. The config path is env-configurable and a missing
+ * file is tolerated (empty reflex set) so the pillar boots without any TOML.
+ *
+ * Resolution order for the config file:
+ *   1. `CEREBRUM_REFLEX_CONFIG` — an explicit path to `reflexes.toml`.
+ *   2. `CEREBRUM_REFLEX_CONFIG_DIR` (or `ENGRAM_ROOT`) — a directory whose
+ *      `.config/reflexes.toml` is used (parity with the monolith's engram
+ *      root layout).
+ *   3. A safe default under the cwd that almost certainly does not exist,
+ *      yielding an empty reflex set.
+ */
+import { join } from 'node:path';
+
+import { ReflexService } from './reflex-service.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+
+/** Resolve the absolute path to `reflexes.toml` from the environment. */
+export function resolveReflexConfigPath(): string {
+  const explicit = process.env['CEREBRUM_REFLEX_CONFIG'];
+  if (explicit && explicit.length > 0) return explicit;
+
+  const dir = process.env['CEREBRUM_REFLEX_CONFIG_DIR'] ?? process.env['ENGRAM_ROOT'];
+  if (dir && dir.length > 0) return join(dir, '.config', 'reflexes.toml');
+
+  return join(process.cwd(), 'engrams', '.config', 'reflexes.toml');
+}
+
+const cache = new WeakMap<CerebrumDb, ReflexService>();
+
+/**
+ * Return a started {@link ReflexService} bound to `db`, constructing (and
+ * caching) it on first access. The hot-reload watcher is enabled by default
+ * so an operator editing the TOML at runtime is picked up; pass `watch: false`
+ * to opt out (tests do this implicitly via {@link buildReflexService}).
+ */
+export function getReflexService(db: CerebrumDb): ReflexService {
+  const cached = cache.get(db);
+  if (cached) return cached;
+
+  const service = buildReflexService({ db, configPath: resolveReflexConfigPath(), watch: true });
+  cache.set(db, service);
+  return service;
+}
+
+/** Construct and start a {@link ReflexService} without touching the cache. */
+export function buildReflexService(options: {
+  db: CerebrumDb;
+  configPath: string;
+  watch?: boolean;
+}): ReflexService {
+  const service = new ReflexService(options);
+  service.start();
+  return service;
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-helpers.ts
@@ -1,0 +1,148 @@
+/**
+ * Reflex service helpers (PRD-089).
+ *
+ * Extracted from reflex-service.ts to keep file sizes manageable.
+ */
+import {
+  ACTION_TYPES,
+  type ActionType,
+  type ExecutionStatus,
+  type ReflexDefinition,
+  type ReflexExecution,
+  type TriggerType,
+} from './types.js';
+
+const TRIGGER_TYPES: readonly TriggerType[] = ['event', 'threshold', 'schedule'];
+const EXECUTION_STATUSES: readonly ExecutionStatus[] = [
+  'triggered',
+  'executing',
+  'completed',
+  'failed',
+];
+
+function toTriggerType(value: string): TriggerType {
+  const match = TRIGGER_TYPES.find((t) => t === value);
+  if (!match) throw new Error(`reflex execution row has unknown trigger_type "${value}"`);
+  return match;
+}
+
+function toActionType(value: string): ActionType {
+  const match = ACTION_TYPES.find((t) => t === value);
+  if (!match) throw new Error(`reflex execution row has unknown action_type "${value}"`);
+  return match;
+}
+
+function toExecutionStatus(value: string): ExecutionStatus {
+  const match = EXECUTION_STATUSES.find((s) => s === value);
+  if (!match) throw new Error(`reflex execution row has unknown status "${value}"`);
+  return match;
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> | null {
+  if (value === null) return null;
+  const parsed: unknown = JSON.parse(value);
+  if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+    return { ...parsed };
+  }
+  return null;
+}
+
+/** Shape of a `reflex_executions` row as read from the DB. */
+export interface ReflexExecutionRowLike {
+  id: string;
+  reflexName: string;
+  triggerType: string;
+  triggerData: string | null;
+  actionType: string;
+  actionVerb: string;
+  status: string;
+  result: string | null;
+  triggeredAt: string;
+  completedAt: string | null;
+}
+
+/** Convert a DB row into a typed ReflexExecution. */
+export function toReflexExecution(row: ReflexExecutionRowLike): ReflexExecution {
+  return {
+    id: row.id,
+    reflexName: row.reflexName,
+    triggerType: toTriggerType(row.triggerType),
+    triggerData: parseJsonRecord(row.triggerData),
+    actionType: toActionType(row.actionType),
+    actionVerb: row.actionVerb,
+    status: toExecutionStatus(row.status),
+    result: parseJsonRecord(row.result),
+    triggeredAt: row.triggeredAt,
+    completedAt: row.completedAt,
+  };
+}
+
+/**
+ * Update the `enabled` field for a named reflex in raw TOML text.
+ *
+ * Uses a targeted line-by-line replacement to preserve comments and formatting.
+ * Returns null if the reflex is not found.
+ */
+export function updateEnabledInToml(
+  toml: string,
+  reflexName: string,
+  enabled: boolean
+): string | null {
+  const lines = toml.split('\n');
+  let inTargetBlock = false;
+  let foundName = false;
+  let modified = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
+
+    if (trimmed === '[[reflex]]') {
+      inTargetBlock = false;
+      foundName = false;
+    }
+
+    if (trimmed === `name = "${reflexName}"` || trimmed === `name = '${reflexName}'`) {
+      inTargetBlock = true;
+      foundName = true;
+    }
+
+    if (inTargetBlock && foundName && /^\s*enabled\s*=\s*(true|false)/.test(trimmed)) {
+      const indent = line.match(/^(\s*)/)?.[1] ?? '';
+      lines[i] = `${indent}enabled = ${String(enabled)}`;
+      modified = true;
+      inTargetBlock = false;
+    }
+  }
+
+  return modified ? lines.join('\n') : null;
+}
+
+/** Build synthetic trigger data for a dry-run test execution. */
+export function buildTestTriggerData(reflex: ReflexDefinition): Record<string, unknown> {
+  switch (reflex.trigger.type) {
+    case 'event':
+      return {
+        event: reflex.trigger.event,
+        engramId: 'test-engram-id',
+        engramType: reflex.trigger.conditions?.type ?? 'note',
+        scopes: reflex.trigger.conditions?.scopes ?? ['test'],
+        source: reflex.trigger.conditions?.source ?? 'test',
+        dryRun: true,
+      };
+    case 'threshold':
+      return {
+        metric: reflex.trigger.metric,
+        value: reflex.trigger.value,
+        threshold: reflex.trigger.value,
+        dryRun: true,
+      };
+    case 'schedule':
+      return {
+        cron: reflex.trigger.cron,
+        firedAt: new Date().toISOString(),
+        dryRun: true,
+      };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-io.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-io.ts
@@ -1,0 +1,177 @@
+/**
+ * Reflex I/O helpers (PRD-089).
+ *
+ * Extracted from ReflexService to keep file sizes within the max-lines lint
+ * limit. Contains disk I/O (load, watch, TOML toggle) and execution logging.
+ *
+ * Unlike the monolith original this module takes the cerebrum drizzle handle
+ * explicitly (`CerebrumDb`) rather than reaching for a process-wide singleton —
+ * the pillar owns its own `cerebrum.db` connection.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+import { watch as chokidarWatch, type FSWatcher } from 'chokidar';
+import { eq } from 'drizzle-orm';
+
+import { reflexExecutions } from '../../../db/index.js';
+import { updateEnabledInToml } from './reflex-helpers.js';
+import { parseReflexesToml } from './reflex-parser.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type { ParseError } from './reflex-parser.js';
+import type { ThresholdState } from './triggers/threshold-trigger.js';
+import type { ActionType, ExecutionStatus, ReflexDefinition, TriggerType } from './types.js';
+
+/** Mutable state bag owned by ReflexService, shared with I/O helpers. */
+export interface ReflexState {
+  reflexes: ReflexDefinition[];
+  parseErrors: ParseError[];
+  thresholdStates: Map<string, ThresholdState>;
+}
+
+/**
+ * Read and parse `reflexes.toml`, updating `state` in-place.
+ *
+ * A missing file is tolerated (empty reflex set) so the pillar boots and the
+ * test suite runs with no TOML present.
+ */
+export function loadFromDisk(configPath: string, state: ReflexState): void {
+  if (!existsSync(configPath)) {
+    state.reflexes = [];
+    state.parseErrors = [];
+    return;
+  }
+
+  let text: string;
+  try {
+    text = readFileSync(configPath, 'utf8');
+  } catch (err) {
+    console.error(`[reflex] Failed to read: ${(err as Error).message}`);
+    state.reflexes = [];
+    state.parseErrors = [{ reflexName: null, message: (err as Error).message }];
+    return;
+  }
+
+  const result = parseReflexesToml(text);
+  state.reflexes = result.reflexes;
+  state.parseErrors = result.errors;
+
+  for (const e of result.errors) {
+    console.warn(`[reflex] ${e.reflexName ? `"${e.reflexName}": ` : ''}${e.message}`);
+  }
+
+  for (const key of state.thresholdStates.keys()) {
+    if (!state.reflexes.some((r) => r.name === key)) state.thresholdStates.delete(key);
+  }
+}
+
+/**
+ * Start a chokidar file watcher on `configPath`.
+ *
+ * Returns the new {@link FSWatcher} or `null` if setup fails. When the file
+ * changes, `onReload` is invoked so the caller can refresh state.
+ */
+export function startWatcher(configPath: string, onReload: () => void): FSWatcher | null {
+  try {
+    const watcher = chokidarWatch(configPath, {
+      persistent: true,
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
+    });
+    watcher.on('change', () => {
+      console.warn('[reflex] reflexes.toml changed — reloading');
+      onReload();
+    });
+    watcher.on('error', (err: unknown) => {
+      console.error(`[reflex] Watcher error: ${(err as Error).message}`);
+    });
+    return watcher;
+  } catch (err) {
+    console.error(`[reflex] Watcher start failed: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Toggle the `enabled` flag for a named reflex in the TOML config on disk.
+ *
+ * Rewrites the TOML file then reloads state. Returns `true` on success.
+ */
+export function setReflexEnabled(
+  configPath: string,
+  state: ReflexState,
+  name: string,
+  enabled: boolean
+): boolean {
+  if (!state.reflexes.find((r) => r.name === name)) return false;
+  try {
+    const updated = updateEnabledInToml(readFileSync(configPath, 'utf8'), name, enabled);
+    if (!updated) return false;
+    writeFileSync(configPath, updated, 'utf8');
+    loadFromDisk(configPath, state);
+    return true;
+  } catch (err) {
+    console.error(`[reflex] TOML update failed: ${(err as Error).message}`);
+    return false;
+  }
+}
+
+/** Insert a reflex execution record and return its ID. */
+export function logExecution(
+  db: CerebrumDb,
+  entry: {
+    reflexName: string;
+    triggerType: TriggerType;
+    triggerData: Record<string, unknown> | null;
+    actionType: ActionType;
+    actionVerb: string;
+    status: ExecutionStatus;
+    result: Record<string, unknown> | null;
+  }
+): string {
+  const now = new Date().toISOString();
+  const id = `rex_${entry.reflexName}_${Date.now()}`;
+  db.insert(reflexExecutions)
+    .values({
+      id,
+      reflexName: entry.reflexName,
+      triggerType: entry.triggerType,
+      triggerData: entry.triggerData ? JSON.stringify(entry.triggerData) : null,
+      actionType: entry.actionType,
+      actionVerb: entry.actionVerb,
+      status: entry.status,
+      result: entry.result ? JSON.stringify(entry.result) : null,
+      triggeredAt: now,
+      completedAt: entry.status === 'completed' || entry.status === 'failed' ? now : null,
+    })
+    .run();
+  return id;
+}
+
+/**
+ * Mark an execution as completed/failed in the DB.
+ *
+ * Returns the reflex name associated with the execution so the caller can
+ * update its running-set, or `null` if the row was not found.
+ */
+export function completeExecution(
+  db: CerebrumDb,
+  executionId: string,
+  status: ExecutionStatus,
+  result: Record<string, unknown> | null
+): string | null {
+  db.update(reflexExecutions)
+    .set({
+      status,
+      result: result ? JSON.stringify(result) : null,
+      completedAt: new Date().toISOString(),
+    })
+    .where(eq(reflexExecutions.id, executionId))
+    .run();
+  const row = db
+    .select({ reflexName: reflexExecutions.reflexName })
+    .from(reflexExecutions)
+    .where(eq(reflexExecutions.id, executionId))
+    .get();
+  return row?.reflexName ?? null;
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-parser.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-parser.ts
@@ -1,0 +1,147 @@
+/**
+ * Reflex TOML parser and validator (PRD-089 US-01).
+ *
+ * Parses `reflexes.toml` into validated `ReflexDefinition[]`. Invalid
+ * individual reflexes are skipped (with warnings); a TOML syntax error
+ * disables the entire file.
+ */
+import { parse as parseToml } from 'smol-toml';
+
+import { validateAction, validateTrigger } from './reflex-validators.js';
+
+import type { ReflexDefinition } from './types.js';
+
+export interface ParseResult {
+  reflexes: ReflexDefinition[];
+  errors: ParseError[];
+}
+
+export interface ParseError {
+  reflexName: string | null;
+  message: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse raw TOML text into validated reflex definitions.
+ *
+ * - TOML syntax errors -> zero reflexes + one error entry.
+ * - Per-reflex validation errors -> that reflex skipped, others kept.
+ * - Template variable warnings are surfaced as errors (non-fatal: reflex loads).
+ */
+export function parseReflexesToml(tomlText: string): ParseResult {
+  let parsed: unknown;
+  try {
+    parsed = parseToml(tomlText);
+  } catch (err) {
+    return {
+      reflexes: [],
+      errors: [{ reflexName: null, message: `TOML parse error: ${(err as Error).message}` }],
+    };
+  }
+
+  if (!isRecord(parsed)) return { reflexes: [], errors: [] };
+
+  const rawReflexes = parsed['reflex'];
+  if (!Array.isArray(rawReflexes)) {
+    return { reflexes: [], errors: [] };
+  }
+
+  const reflexes: ReflexDefinition[] = [];
+  const errors: ParseError[] = [];
+  const seenNames = new Set<string>();
+
+  for (const raw of rawReflexes) {
+    const result = validateReflex(raw, seenNames);
+    if (result.error) errors.push(result.error);
+    if (result.warnings) errors.push(...result.warnings);
+    if (result.reflex) {
+      reflexes.push(result.reflex);
+      seenNames.add(result.reflex.name);
+    }
+  }
+
+  return { reflexes, errors };
+}
+
+interface ValidateResult {
+  reflex: ReflexDefinition | null;
+  error: ParseError | null;
+  warnings: ParseError[] | null;
+}
+
+function fail(reflexName: string | null, message: string): ValidateResult {
+  return { reflex: null, error: { reflexName, message }, warnings: null };
+}
+
+function validateReflexFields(
+  entry: Record<string, unknown>,
+  seenNames: Set<string>
+): { name: string; description: string; enabled: boolean } | ParseError {
+  const name = entry['name'];
+  if (typeof name !== 'string' || name.length === 0) {
+    return { reflexName: null, message: 'Reflex missing required "name" field' };
+  }
+  if (seenNames.has(name)) {
+    return { reflexName: name, message: `Duplicate reflex name: "${name}"` };
+  }
+  const description = entry['description'];
+  if (typeof description !== 'string' || description.length === 0) {
+    return { reflexName: name, message: `Reflex "${name}": missing required "description" field` };
+  }
+  const enabled = entry['enabled'];
+  if (typeof enabled !== 'boolean') {
+    return { reflexName: name, message: `Reflex "${name}": "enabled" must be a boolean` };
+  }
+  return { name, description, enabled };
+}
+
+function checkTemplateWarnings(
+  name: string,
+  trigger: { type: string },
+  action: { target?: string; template?: string }
+): ParseError[] {
+  if (trigger.type === 'event') return [];
+  const combined = `${action.target ?? ''} ${action.template ?? ''}`;
+  if (/\{\{[^}]+\}\}/.test(combined)) {
+    return [
+      {
+        reflexName: name,
+        message: `Reflex "${name}": template variables (e.g. {{engram_id}}) are only valid for event triggers — variables will resolve to empty strings`,
+      },
+    ];
+  }
+  return [];
+}
+
+function validateReflex(raw: unknown, seenNames: Set<string>): ValidateResult {
+  if (!isRecord(raw)) {
+    return fail(null, 'Reflex entry is not an object');
+  }
+
+  const fields = validateReflexFields(raw, seenNames);
+  if ('reflexName' in fields) return fail(fields.reflexName, fields.message);
+
+  const { name, description, enabled } = fields;
+
+  const triggerResult = validateTrigger(raw['trigger'], name);
+  if (triggerResult.error) return { reflex: null, error: triggerResult.error, warnings: null };
+
+  const actionResult = validateAction(raw['action'], name);
+  if (actionResult.error) return { reflex: null, error: actionResult.error, warnings: null };
+
+  const trigger = triggerResult.trigger;
+  const action = actionResult.action;
+  if (!trigger || !action) return fail(name, `Reflex "${name}": internal validation error`);
+
+  const warnings = checkTemplateWarnings(name, trigger, action);
+
+  return {
+    reflex: { name, description, enabled, trigger, action },
+    error: null,
+    warnings: warnings.length > 0 ? warnings : null,
+  };
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-queries.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-queries.ts
@@ -1,0 +1,102 @@
+/**
+ * Reflex execution history queries (PRD-089 US-05).
+ *
+ * Extracted from ReflexService to keep file sizes manageable. Each query takes
+ * the cerebrum drizzle handle explicitly so the pillar owns its connection.
+ */
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { reflexExecutions } from '../../../db/index.js';
+import { toReflexExecution } from './reflex-helpers.js';
+import { getNextFireTime } from './triggers/scheduled-trigger.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type {
+  ExecutionStatus,
+  ReflexDefinition,
+  ReflexExecution,
+  ReflexWithStatus,
+  TriggerType,
+} from './types.js';
+
+function getReflexStats(
+  db: CerebrumDb,
+  name: string
+): { lastTriggeredAt: string | null; executionCount: number } | undefined {
+  return db
+    .select({
+      lastTriggeredAt: sql<string | null>`MAX(${reflexExecutions.triggeredAt})`,
+      executionCount: sql<number>`COUNT(*)`,
+    })
+    .from(reflexExecutions)
+    .where(eq(reflexExecutions.reflexName, name))
+    .get();
+}
+
+/** Enrich a reflex definition with runtime status. */
+export function enrichWithStatus(
+  db: CerebrumDb,
+  reflex: ReflexDefinition,
+  timezone?: string
+): ReflexWithStatus {
+  const stats = getReflexStats(db, reflex.name);
+  return {
+    ...reflex,
+    lastExecutionAt: stats?.lastTriggeredAt ?? null,
+    nextFireTime: getNextFireTime(reflex, timezone),
+    executionCount: stats?.executionCount ?? 0,
+  };
+}
+
+/** Get a single reflex with recent execution history. */
+export function getReflexHistory(
+  db: CerebrumDb,
+  reflex: ReflexDefinition,
+  limit = 20
+): { reflex: ReflexWithStatus; history: ReflexExecution[] } {
+  const enriched = enrichWithStatus(db, reflex);
+  const history = db
+    .select()
+    .from(reflexExecutions)
+    .where(eq(reflexExecutions.reflexName, reflex.name))
+    .orderBy(desc(reflexExecutions.triggeredAt))
+    .limit(limit)
+    .all()
+    .map(toReflexExecution);
+
+  return { reflex: enriched, history };
+}
+
+/** Paginated execution history query. */
+export function queryExecutionHistory(
+  db: CerebrumDb,
+  opts: {
+    name?: string;
+    triggerType?: TriggerType;
+    status?: ExecutionStatus;
+    limit?: number;
+    offset?: number;
+  }
+): { executions: ReflexExecution[]; total: number } {
+  const conditions = [];
+  if (opts.name) conditions.push(eq(reflexExecutions.reflexName, opts.name));
+  if (opts.triggerType) conditions.push(eq(reflexExecutions.triggerType, opts.triggerType));
+  if (opts.status) conditions.push(eq(reflexExecutions.status, opts.status));
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const totalResult = db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(reflexExecutions)
+    .where(whereClause)
+    .get();
+  const rows = db
+    .select()
+    .from(reflexExecutions)
+    .where(whereClause)
+    .orderBy(desc(reflexExecutions.triggeredAt))
+    .limit(opts.limit ?? 50)
+    .offset(opts.offset ?? 0)
+    .all();
+
+  return { executions: rows.map(toReflexExecution), total: totalResult?.count ?? 0 };
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-service.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-service.ts
@@ -1,0 +1,232 @@
+/**
+ * ReflexService — core orchestrator for the reflex system (PRD-089).
+ *
+ * Loads (and optionally watches) `reflexes.toml`, maintains an in-memory
+ * registry, matches events/thresholds/schedules, and logs execution history
+ * to the cerebrum pillar DB.
+ *
+ * The pillar owns its own `cerebrum.db` connection, so the drizzle handle is
+ * injected at construction rather than resolved from a process singleton. The
+ * config path is supplied explicitly (env-configured in production, a temp
+ * fixture in tests) and a missing file is tolerated as an empty reflex set.
+ * The chokidar watcher is opt-in (`watch: true`) so tests never spin one up.
+ */
+import { eq } from 'drizzle-orm';
+
+import { reflexExecutions } from '../../../db/index.js';
+import { buildTestTriggerData, toReflexExecution } from './reflex-helpers.js';
+import {
+  completeExecution,
+  loadFromDisk,
+  logExecution,
+  setReflexEnabled,
+  startWatcher,
+  type ReflexState,
+} from './reflex-io.js';
+import { enrichWithStatus, getReflexHistory, queryExecutionHistory } from './reflex-queries.js';
+import { matchesEventTrigger, resolveTemplateVariables } from './triggers/event-trigger.js';
+import { createInitialThresholdState, evaluateThreshold } from './triggers/threshold-trigger.js';
+
+import type { FSWatcher } from 'chokidar';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type { ParseError } from './reflex-parser.js';
+import type { ThresholdState } from './triggers/threshold-trigger.js';
+import type {
+  EngramEventPayload,
+  ExecutionStatus,
+  ReflexDefinition,
+  ReflexExecution,
+  ReflexWithStatus,
+  TriggerType,
+} from './types.js';
+
+export interface ReflexServiceOptions {
+  /** Drizzle handle for the cerebrum pillar DB (execution log lives here). */
+  db: CerebrumDb;
+  /** Absolute path to `reflexes.toml`. A missing file yields an empty set. */
+  configPath: string;
+  /** When true, start a chokidar hot-reload watcher on the config file. */
+  watch?: boolean;
+}
+
+export class ReflexService {
+  private watcher: FSWatcher | null = null;
+  private readonly db: CerebrumDb;
+  private readonly configPath: string;
+  private readonly watch: boolean;
+  private readonly thresholdStates = new Map<string, ThresholdState>();
+  private readonly runningReflexes = new Set<string>();
+  private readonly state: ReflexState;
+
+  constructor(options: ReflexServiceOptions) {
+    this.db = options.db;
+    this.configPath = options.configPath;
+    this.watch = options.watch ?? false;
+    this.state = { reflexes: [], parseErrors: [], thresholdStates: this.thresholdStates };
+  }
+
+  start(): void {
+    loadFromDisk(this.configPath, this.state);
+    if (this.watch && !this.watcher) {
+      this.watcher =
+        startWatcher(this.configPath, () => loadFromDisk(this.configPath, this.state)) ?? null;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.state.reflexes = [];
+    this.state.parseErrors = [];
+    this.thresholdStates.clear();
+    this.runningReflexes.clear();
+  }
+
+  getAll(): ReflexDefinition[] {
+    return this.state.reflexes;
+  }
+  getByName(name: string): ReflexDefinition | undefined {
+    return this.state.reflexes.find((r) => r.name === name);
+  }
+  getEnabled(): ReflexDefinition[] {
+    return this.state.reflexes.filter((r) => r.enabled);
+  }
+  getByTriggerType(type: TriggerType): ReflexDefinition[] {
+    return this.state.reflexes.filter((r) => r.trigger.type === type);
+  }
+  getParseErrors(): ParseError[] {
+    return this.state.parseErrors;
+  }
+
+  processEvent(payload: EngramEventPayload): string[] {
+    return this.getEnabled()
+      .filter((r) => matchesEventTrigger(r, payload))
+      .map((reflex) => {
+        const resolvedTarget = reflex.action.target
+          ? resolveTemplateVariables(reflex.action.target, payload)
+          : undefined;
+        return logExecution(this.db, {
+          reflexName: reflex.name,
+          triggerType: 'event',
+          triggerData: {
+            event: payload.event,
+            engramId: payload.engramId,
+            engramType: payload.engramType,
+            scopes: payload.scopes,
+            source: payload.source,
+            changes: payload.changes,
+          },
+          actionType: reflex.action.type,
+          actionVerb: reflex.action.verb,
+          status: 'triggered',
+          result: resolvedTarget ? { resolvedTarget } : null,
+        });
+      });
+  }
+
+  evaluateThresholds(metrics: Record<string, number>): string[] {
+    const ids: string[] = [];
+    for (const reflex of this.getEnabled().filter((r) => r.trigger.type === 'threshold')) {
+      if (reflex.trigger.type !== 'threshold') continue;
+      const val = metrics[reflex.trigger.metric];
+      if (val === undefined) continue;
+      const prev = this.thresholdStates.get(reflex.name) ?? createInitialThresholdState();
+      const { shouldFire, newState } = evaluateThreshold(reflex, val, prev);
+      this.thresholdStates.set(reflex.name, newState);
+      if (shouldFire) {
+        ids.push(
+          logExecution(this.db, {
+            reflexName: reflex.name,
+            triggerType: 'threshold',
+            triggerData: {
+              metric: reflex.trigger.metric,
+              value: val,
+              threshold: reflex.trigger.value,
+            },
+            actionType: reflex.action.type,
+            actionVerb: reflex.action.verb,
+            status: 'triggered',
+            result: null,
+          })
+        );
+      }
+    }
+    return ids;
+  }
+
+  fireScheduled(reflexName: string): string | null {
+    const reflex = this.getByName(reflexName);
+    if (!reflex || !reflex.enabled || reflex.trigger.type !== 'schedule') return null;
+    if (this.runningReflexes.has(reflexName)) {
+      console.warn(`[reflex] Skipping scheduled "${reflexName}" — previous still running`);
+      return null;
+    }
+    this.runningReflexes.add(reflexName);
+    return logExecution(this.db, {
+      reflexName: reflex.name,
+      triggerType: 'schedule',
+      triggerData: { cron: reflex.trigger.cron, firedAt: new Date().toISOString() },
+      actionType: reflex.action.type,
+      actionVerb: reflex.action.verb,
+      status: 'triggered',
+      result: null,
+    });
+  }
+
+  completeExecution(
+    executionId: string,
+    status: ExecutionStatus,
+    result: Record<string, unknown> | null
+  ): void {
+    const name = completeExecution(this.db, executionId, status, result);
+    if (name) this.runningReflexes.delete(name);
+  }
+
+  listWithStatus(timezone?: string): ReflexWithStatus[] {
+    return this.state.reflexes.map((r) => enrichWithStatus(this.db, r, timezone));
+  }
+
+  getWithHistory(
+    name: string,
+    limit = 20
+  ): { reflex: ReflexWithStatus; history: ReflexExecution[] } | null {
+    const reflex = this.getByName(name);
+    return reflex ? getReflexHistory(this.db, reflex, limit) : null;
+  }
+
+  testReflex(name: string): ReflexExecution | null {
+    const reflex = this.getByName(name);
+    if (!reflex) return null;
+    const id = logExecution(this.db, {
+      reflexName: reflex.name,
+      triggerType: reflex.trigger.type,
+      triggerData: buildTestTriggerData(reflex),
+      actionType: reflex.action.type,
+      actionVerb: reflex.action.verb,
+      status: 'completed',
+      result: { dryRun: true, wouldExecute: `${reflex.action.type}:${reflex.action.verb}` },
+    });
+    const row = this.db.select().from(reflexExecutions).where(eq(reflexExecutions.id, id)).get();
+    return row ? toReflexExecution(row) : null;
+  }
+
+  enableReflex(name: string): boolean {
+    return setReflexEnabled(this.configPath, this.state, name, true);
+  }
+  disableReflex(name: string): boolean {
+    return setReflexEnabled(this.configPath, this.state, name, false);
+  }
+
+  getHistory(opts: {
+    name?: string;
+    triggerType?: TriggerType;
+    status?: ExecutionStatus;
+    limit?: number;
+    offset?: number;
+  }): { executions: ReflexExecution[]; total: number } {
+    return queryExecutionHistory(this.db, opts);
+  }
+}

--- a/pillars/cerebrum/src/api/modules/reflex/reflex-validators.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/reflex-validators.ts
@@ -1,0 +1,207 @@
+/**
+ * Reflex trigger and action validators (PRD-089 US-01).
+ */
+import { CronExpressionParser } from 'cron-parser';
+
+import {
+  ACTION_TYPES,
+  ENGRAM_EVENTS,
+  KNOWN_VERBS,
+  THRESHOLD_METRICS,
+  type ActionConfig,
+  type ActionType,
+  type EngramEvent,
+  type EventTriggerConditions,
+  type ThresholdMetric,
+  type TriggerConfig,
+} from './types.js';
+
+import type { ParseError } from './reflex-parser.js';
+
+interface TriggerResult {
+  trigger: TriggerConfig | null;
+  error: ParseError | null;
+}
+interface ActionResult {
+  action: ActionConfig | null;
+  error: ParseError | null;
+}
+
+function isEngramEvent(value: unknown): value is EngramEvent {
+  return typeof value === 'string' && (ENGRAM_EVENTS as readonly string[]).includes(value);
+}
+
+function isThresholdMetric(value: unknown): value is ThresholdMetric {
+  return typeof value === 'string' && (THRESHOLD_METRICS as readonly string[]).includes(value);
+}
+
+function isActionType(value: unknown): value is ActionType {
+  return typeof value === 'string' && (ACTION_TYPES as readonly string[]).includes(value);
+}
+
+function asStringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  return raw.filter((s): s is string => typeof s === 'string');
+}
+
+export function validateTrigger(raw: unknown, reflexName: string): TriggerResult {
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      trigger: null,
+      error: { reflexName, message: `Reflex "${reflexName}": missing required "trigger" object` },
+    };
+  }
+  const obj: Record<string, unknown> = { ...raw };
+  const type = obj['type'];
+  if (type === 'event') return validateEventTrigger(obj, reflexName);
+  if (type === 'threshold') return validateThresholdTrigger(obj, reflexName);
+  if (type === 'schedule') return validateScheduleTrigger(obj, reflexName);
+  return {
+    trigger: null,
+    error: {
+      reflexName,
+      message: `Reflex "${reflexName}": trigger type must be one of event, threshold, schedule — got "${String(type)}"`,
+    },
+  };
+}
+
+function validateEventTrigger(obj: Record<string, unknown>, reflexName: string): TriggerResult {
+  const event = obj['event'];
+  if (!isEngramEvent(event)) {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": event trigger "event" must be one of ${ENGRAM_EVENTS.join(', ')} — got "${String(event)}"`,
+      },
+    };
+  }
+  const conditions = parseEventConditions(obj['conditions']);
+  if (conditions === 'error') {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": event trigger "conditions" must be an object`,
+      },
+    };
+  }
+  return {
+    trigger: { type: 'event', event, conditions: conditions ?? undefined },
+    error: null,
+  };
+}
+
+function parseEventConditions(raw: unknown): EventTriggerConditions | null | 'error' {
+  if (raw === undefined) return null;
+  if (typeof raw !== 'object' || raw === null) return 'error';
+  const conds: Record<string, unknown> = { ...raw };
+  const result: EventTriggerConditions = {};
+  if (typeof conds['type'] === 'string') result.type = conds['type'];
+  const scopes = asStringArray(conds['scopes']);
+  if (scopes) result.scopes = scopes;
+  if (typeof conds['source'] === 'string') result.source = conds['source'];
+  return result;
+}
+
+function validateThresholdTrigger(obj: Record<string, unknown>, reflexName: string): TriggerResult {
+  const metric = obj['metric'];
+  if (!isThresholdMetric(metric)) {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": threshold trigger "metric" must be one of ${THRESHOLD_METRICS.join(', ')} — got "${String(metric)}"`,
+      },
+    };
+  }
+  const value = obj['value'];
+  if (typeof value !== 'number' || value <= 0) {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": threshold trigger "value" must be a positive number — got "${String(value)}"`,
+      },
+    };
+  }
+  return {
+    trigger: { type: 'threshold', metric, value, scopes: asStringArray(obj['scopes']) },
+    error: null,
+  };
+}
+
+function validateScheduleTrigger(obj: Record<string, unknown>, reflexName: string): TriggerResult {
+  const cron = obj['cron'];
+  if (typeof cron !== 'string') {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": schedule trigger "cron" must be a string`,
+      },
+    };
+  }
+  const trimmed = cron.trim();
+  if (!trimmed || trimmed.split(/\s+/).length !== 5) {
+    return {
+      trigger: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": invalid cron expression "${cron}" — must be a 5-field cron`,
+      },
+    };
+  }
+  try {
+    CronExpressionParser.parse(cron);
+  } catch {
+    return {
+      trigger: null,
+      error: { reflexName, message: `Reflex "${reflexName}": invalid cron expression "${cron}"` },
+    };
+  }
+  return { trigger: { type: 'schedule', cron }, error: null };
+}
+
+export function validateAction(raw: unknown, reflexName: string): ActionResult {
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      action: null,
+      error: { reflexName, message: `Reflex "${reflexName}": missing required "action" object` },
+    };
+  }
+  const obj: Record<string, unknown> = { ...raw };
+  const type = obj['type'];
+  if (!isActionType(type)) {
+    return {
+      action: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": action type must be one of ${ACTION_TYPES.join(', ')} — got "${String(type)}"`,
+      },
+    };
+  }
+  const verb = obj['verb'];
+  if (typeof verb !== 'string' || verb.length === 0) {
+    return {
+      action: null,
+      error: { reflexName, message: `Reflex "${reflexName}": action "verb" is required` },
+    };
+  }
+  const knownVerbs = KNOWN_VERBS[type];
+  if (!knownVerbs.includes(verb)) {
+    return {
+      action: null,
+      error: {
+        reflexName,
+        message: `Reflex "${reflexName}": unknown verb "${verb}" for action type "${type}" — expected one of ${knownVerbs.join(', ')}`,
+      },
+    };
+  }
+  const action: ActionConfig = { type, verb };
+  if (typeof obj['template'] === 'string') action.template = obj['template'];
+  if (typeof obj['target'] === 'string') action.target = obj['target'];
+  const scopes = asStringArray(obj['scopes']);
+  if (scopes) action.scopes = scopes;
+  return { action, error: null };
+}

--- a/pillars/cerebrum/src/api/modules/reflex/triggers/event-trigger.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/triggers/event-trigger.ts
@@ -1,0 +1,66 @@
+/**
+ * Event trigger — matches engram lifecycle events against reflex conditions
+ * and dispatches matching actions (PRD-089 US-02).
+ *
+ * The event trigger is a pure matching function. The actual event bus
+ * subscription and action dispatch are handled by the ReflexService.
+ */
+import type { EngramEventPayload, EventTriggerConfig, ReflexDefinition } from '../types.js';
+
+/**
+ * Check whether an event payload matches a reflex's event trigger conditions.
+ *
+ * Returns `true` when:
+ * 1. The reflex is enabled and has an event trigger.
+ * 2. The event type matches the trigger's configured event.
+ * 3. All optional conditions are satisfied (type, scopes prefix, source).
+ */
+export function matchesEventTrigger(
+  reflex: ReflexDefinition,
+  payload: EngramEventPayload
+): boolean {
+  if (!reflex.enabled) return false;
+  if (reflex.trigger.type !== 'event') return false;
+
+  const trigger: EventTriggerConfig = reflex.trigger;
+  if (trigger.event !== payload.event) return false;
+
+  const conditions = trigger.conditions;
+  if (!conditions) return true;
+
+  if (conditions.type !== undefined && conditions.type !== payload.engramType) {
+    return false;
+  }
+
+  if (conditions.source !== undefined && conditions.source !== payload.source) {
+    return false;
+  }
+
+  if (conditions.scopes !== undefined && conditions.scopes.length > 0) {
+    const matches = conditions.scopes.some((pattern) => {
+      if (pattern.endsWith('.*')) {
+        const prefix = pattern.slice(0, -2);
+        return payload.scopes.some((s) => s === prefix || s.startsWith(`${prefix}.`));
+      }
+      return payload.scopes.includes(pattern);
+    });
+    if (!matches) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Resolve template variables in action config strings using the event payload.
+ *
+ * Supported variables:
+ * - `{{engram_id}}` → payload.engramId
+ * - `{{engram_type}}` → payload.engramType
+ * - `{{engram_scopes}}` → comma-separated scopes
+ */
+export function resolveTemplateVariables(template: string, payload: EngramEventPayload): string {
+  return template
+    .replace(/\{\{engram_id\}\}/g, payload.engramId)
+    .replace(/\{\{engram_type\}\}/g, payload.engramType)
+    .replace(/\{\{engram_scopes\}\}/g, payload.scopes.join(','));
+}

--- a/pillars/cerebrum/src/api/modules/reflex/triggers/scheduled-trigger.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/triggers/scheduled-trigger.ts
@@ -1,0 +1,57 @@
+/**
+ * Scheduled trigger — cron-based firing via BullMQ repeatable jobs
+ * (PRD-089 US-04).
+ *
+ * Provides helpers for managing repeatable jobs: registering, removing,
+ * and computing the next fire time for display. The pillar reflex surface
+ * only needs the pure cron + job-name helpers; the live queue lives outside
+ * the request path.
+ */
+import { CronExpressionParser } from 'cron-parser';
+
+import type { ReflexDefinition, ScheduleTriggerConfig } from '../types.js';
+
+/**
+ * Compute the next fire time for a scheduled reflex.
+ * Returns an ISO 8601 string or null if the reflex is not a schedule trigger.
+ */
+export function getNextFireTime(reflex: ReflexDefinition, timezone?: string): string | null {
+  if (reflex.trigger.type !== 'schedule') return null;
+  const trigger: ScheduleTriggerConfig = reflex.trigger;
+
+  try {
+    const interval = CronExpressionParser.parse(trigger.cron, { tz: timezone });
+    return interval.next().toISOString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate that a cron expression is a valid 5-field expression.
+ * Returns true if valid, false otherwise.
+ */
+export function isValidCron(cron: string): boolean {
+  if (!cron.trim()) return false;
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  try {
+    CronExpressionParser.parse(cron);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Job name for a scheduled reflex's BullMQ repeatable job. */
+export function scheduledJobName(reflexName: string): string {
+  return `reflex:scheduled:${reflexName}`;
+}
+
+/**
+ * Generate a unique repeatable job key for deduplication.
+ * BullMQ uses jobId + cron pattern for repeatable job dedup.
+ */
+export function scheduledJobId(reflexName: string): string {
+  return `reflex-sched-${reflexName}`;
+}

--- a/pillars/cerebrum/src/api/modules/reflex/triggers/threshold-trigger.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/triggers/threshold-trigger.ts
@@ -1,0 +1,75 @@
+/**
+ * Threshold trigger — evaluates Thalamus metrics and fires reflexes when
+ * values cross configured thresholds (PRD-089 US-03).
+ *
+ * Implements edge detection (hysteresis): a threshold fires once when crossed,
+ * then is suppressed until the metric drops below the threshold and crosses
+ * again. This prevents the same reflex from firing every evaluation cycle
+ * while the metric stays above threshold.
+ */
+import type { ReflexDefinition, ThresholdTriggerConfig } from '../types.js';
+
+/**
+ * Per-reflex state tracking for edge detection.
+ * When `wasAbove` is true, the threshold was crossed on the last evaluation
+ * and will not fire again until the metric drops below the threshold.
+ */
+export interface ThresholdState {
+  wasAbove: boolean;
+  lastValue: number | null;
+  lastTriggeredAt: string | null;
+}
+
+/**
+ * Evaluate a threshold reflex against the current metric value.
+ *
+ * Returns `true` (should fire) only on a rising-edge crossing: the metric was
+ * previously at or below the threshold and is now above it.
+ */
+export function evaluateThreshold(
+  reflex: ReflexDefinition,
+  currentValue: number,
+  state: ThresholdState
+): { shouldFire: boolean; newState: ThresholdState } {
+  if (!reflex.enabled || reflex.trigger.type !== 'threshold') {
+    return { shouldFire: false, newState: state };
+  }
+
+  const trigger: ThresholdTriggerConfig = reflex.trigger;
+  const isAbove = currentValue >= trigger.value;
+
+  const shouldFire = isAbove && !state.wasAbove;
+
+  return {
+    shouldFire,
+    newState: {
+      wasAbove: isAbove,
+      lastValue: currentValue,
+      lastTriggeredAt: shouldFire ? new Date().toISOString() : state.lastTriggeredAt,
+    },
+  };
+}
+
+/**
+ * Check whether a reflex's threshold scopes match the given engram scopes.
+ * If the threshold trigger has no scopes restriction, always matches.
+ */
+export function matchesThresholdScopes(reflex: ReflexDefinition, engramScopes: string[]): boolean {
+  if (reflex.trigger.type !== 'threshold') return false;
+  const trigger: ThresholdTriggerConfig = reflex.trigger;
+
+  if (!trigger.scopes || trigger.scopes.length === 0) return true;
+
+  return trigger.scopes.some((pattern) => {
+    if (pattern.endsWith('.*')) {
+      const prefix = pattern.slice(0, -2);
+      return engramScopes.some((s) => s === prefix || s.startsWith(`${prefix}.`));
+    }
+    return engramScopes.includes(pattern);
+  });
+}
+
+/** Create initial state for a threshold-tracked reflex. */
+export function createInitialThresholdState(): ThresholdState {
+  return { wasAbove: false, lastValue: null, lastTriggeredAt: null };
+}

--- a/pillars/cerebrum/src/api/modules/reflex/types.ts
+++ b/pillars/cerebrum/src/api/modules/reflex/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Reflex system types (PRD-089).
+ *
+ * Reflexes are declarative trigger-action rules defined in `reflexes.toml`.
+ * Three trigger types (event, threshold, schedule) fire actions dispatched
+ * to existing subsystems (Ingest, Emit, Glia).
+ */
+
+export const ENGRAM_EVENTS = [
+  'engram.created',
+  'engram.modified',
+  'engram.archived',
+  'engram.linked',
+] as const;
+export type EngramEvent = (typeof ENGRAM_EVENTS)[number];
+
+export const THRESHOLD_METRICS = ['similar_count', 'staleness_max', 'topic_frequency'] as const;
+export type ThresholdMetric = (typeof THRESHOLD_METRICS)[number];
+
+export interface EventTriggerConditions {
+  type?: string;
+  scopes?: string[];
+  source?: string;
+}
+
+export interface EventTriggerConfig {
+  type: 'event';
+  event: EngramEvent;
+  conditions?: EventTriggerConditions;
+}
+
+export interface ThresholdTriggerConfig {
+  type: 'threshold';
+  metric: ThresholdMetric;
+  value: number;
+  scopes?: string[];
+}
+
+export interface ScheduleTriggerConfig {
+  type: 'schedule';
+  cron: string;
+}
+
+export type TriggerConfig = EventTriggerConfig | ThresholdTriggerConfig | ScheduleTriggerConfig;
+export type TriggerType = TriggerConfig['type'];
+
+export const ACTION_TYPES = ['ingest', 'emit', 'glia'] as const;
+export type ActionType = (typeof ACTION_TYPES)[number];
+
+export const GLIA_VERBS = ['prune', 'consolidate', 'link', 'audit'] as const;
+export const EMIT_VERBS = ['generate'] as const;
+export const INGEST_VERBS = ['classify', 'ingest'] as const;
+
+export type GliaVerb = (typeof GLIA_VERBS)[number];
+export type EmitVerb = (typeof EMIT_VERBS)[number];
+export type IngestVerb = (typeof INGEST_VERBS)[number];
+
+export interface ActionConfig {
+  type: ActionType;
+  verb: string;
+  template?: string;
+  scopes?: string[];
+  target?: string;
+}
+
+export interface ReflexDefinition {
+  name: string;
+  description: string;
+  enabled: boolean;
+  trigger: TriggerConfig;
+  action: ActionConfig;
+}
+
+export type ExecutionStatus = 'triggered' | 'executing' | 'completed' | 'failed';
+
+export interface ReflexExecution {
+  id: string;
+  reflexName: string;
+  triggerType: TriggerType;
+  triggerData: Record<string, unknown> | null;
+  actionType: ActionType;
+  actionVerb: string;
+  status: ExecutionStatus;
+  result: Record<string, unknown> | null;
+  triggeredAt: string;
+  completedAt: string | null;
+}
+
+/** Runtime-enriched reflex returned by the list/get API. */
+export interface ReflexWithStatus extends ReflexDefinition {
+  lastExecutionAt: string | null;
+  nextFireTime: string | null;
+  executionCount: number;
+}
+
+export interface EngramEventPayload {
+  event: EngramEvent;
+  engramId: string;
+  engramType: string;
+  scopes: string[];
+  source: string;
+  changes?: Record<string, unknown>;
+}
+
+/** Map from action type to its known verbs. */
+export const KNOWN_VERBS: Record<ActionType, readonly string[]> = {
+  glia: GLIA_VERBS,
+  emit: EMIT_VERBS,
+  ingest: INGEST_VERBS,
+};

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -8,6 +8,7 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
+import { makeReflexHandlers } from './reflex-handlers.js';
 import { makeTemplatesHandlers } from './templates-handlers.js';
 
 import type { CerebrumApiDeps } from '../handlers.js';
@@ -19,5 +20,6 @@ export function makeCerebrumRestHandlers(
 ): ReturnType<typeof server.router<typeof cerebrumContract>> {
   return server.router(cerebrumContract, {
     templates: makeTemplatesHandlers(deps.templateRegistry),
+    reflex: makeReflexHandlers(deps.reflexService),
   });
 }

--- a/pillars/cerebrum/src/api/rest/reflex-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/reflex-handlers.ts
@@ -1,0 +1,57 @@
+/**
+ * ts-rest handlers for `cerebrum.reflex.*` (PRD-089).
+ *
+ * Thin adapter over {@link ReflexService}: reads the in-memory registry
+ * (loaded from `reflexes.toml`) and the append-only execution log in the
+ * cerebrum DB. `get`/`test`/`enable`/`disable` 404 on an unknown reflex name.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumReflexContract } from '../../contract/rest-reflex.js';
+import { NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ReflexService } from '../modules/reflex/reflex-service.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export function makeReflexHandlers(
+  service: ReflexService
+): ReturnType<typeof server.router<typeof cerebrumReflexContract>> {
+  return server.router(cerebrumReflexContract, {
+    list: async ({ query }) => ({
+      status: 200,
+      body: { reflexes: service.listWithStatus(query.timezone) },
+    }),
+
+    get: async ({ params }) =>
+      runHttp(() => {
+        const result = service.getWithHistory(params.name);
+        if (!result) throw new NotFoundError('reflex', params.name);
+        return { status: 200, body: result };
+      }),
+
+    test: async ({ params }) =>
+      runHttp(() => {
+        if (!service.getByName(params.name)) throw new NotFoundError('reflex', params.name);
+        return { status: 200, body: { result: service.testReflex(params.name) } };
+      }),
+
+    enable: async ({ params }) =>
+      runHttp(() => {
+        if (!service.getByName(params.name)) throw new NotFoundError('reflex', params.name);
+        return { status: 200, body: { success: service.enableReflex(params.name) } };
+      }),
+
+    disable: async ({ params }) =>
+      runHttp(() => {
+        if (!service.getByName(params.name)) throw new NotFoundError('reflex', params.name);
+        return { status: 200, body: { success: service.disableReflex(params.name) } };
+      }),
+
+    history: async ({ body }) => ({
+      status: 200,
+      body: service.getHistory(body),
+    }),
+  });
+}

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -20,6 +20,7 @@ import { openCerebrumDb } from '../db/index.js';
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { buildCerebrumManifest } from './manifest.js';
+import { getReflexService } from './modules/reflex/instance.js';
 import { TemplateRegistry } from './modules/templates/registry.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -57,7 +58,14 @@ function resolveTemplatesDir(): string {
 
 const cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
 const templateRegistry = new TemplateRegistry(resolveTemplatesDir());
-const app = createCerebrumApiApp({ cerebrumDb, templateRegistry, version, selfBaseUrl });
+const reflexService = getReflexService(cerebrumDb.db);
+const app = createCerebrumApiApp({
+  cerebrumDb,
+  templateRegistry,
+  reflexService,
+  version,
+  selfBaseUrl,
+});
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -3,6 +3,108 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/cerebrum generate:api-types`.
  */
 export interface paths {
+  '/reflex': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List reflexes enriched with runtime status. */
+    get: operations['reflex.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/reflex/history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query the append-only reflex execution log (filtered + paginated). */
+    post: operations['reflex.history'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/reflex/{name}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single reflex with its recent execution history. */
+    get: operations['reflex.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/reflex/{name}/disable': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Disable a reflex (rewrites the TOML config). */
+    post: operations['reflex.disable'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/reflex/{name}/enable': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Enable a reflex (rewrites the TOML config). */
+    post: operations['reflex.enable'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/reflex/{name}/test': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dry-run a reflex, logging a completed test execution. */
+    post: operations['reflex.test'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/templates': {
     parameters: {
       query?: never;
@@ -49,6 +151,372 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'reflex.list': {
+    parameters: {
+      query?: {
+        timezone?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reflexes: {
+              action: {
+                scopes?: string[];
+                target?: string;
+                template?: string;
+                /** @enum {string} */
+                type: 'ingest' | 'emit' | 'glia';
+                verb: string;
+              };
+              description: string;
+              enabled: boolean;
+              executionCount: number;
+              lastExecutionAt: string | null;
+              name: string;
+              nextFireTime: string | null;
+              trigger:
+                | {
+                    conditions?: {
+                      scopes?: string[];
+                      source?: string;
+                      type?: string;
+                    };
+                    /** @enum {string} */
+                    event:
+                      | 'engram.created'
+                      | 'engram.modified'
+                      | 'engram.archived'
+                      | 'engram.linked';
+                    /** @enum {string} */
+                    type: 'event';
+                  }
+                | {
+                    /** @enum {string} */
+                    metric: 'similar_count' | 'staleness_max' | 'topic_frequency';
+                    scopes?: string[];
+                    /** @enum {string} */
+                    type: 'threshold';
+                    value: number;
+                  }
+                | {
+                    cron: string;
+                    /** @enum {string} */
+                    type: 'schedule';
+                  };
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'reflex.history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          name?: string;
+          offset?: number;
+          /** @enum {string} */
+          status?: 'triggered' | 'executing' | 'completed' | 'failed';
+          /** @enum {string} */
+          triggerType?: 'event' | 'threshold' | 'schedule';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            executions: {
+              /** @enum {string} */
+              actionType: 'ingest' | 'emit' | 'glia';
+              actionVerb: string;
+              completedAt: string | null;
+              id: string;
+              reflexName: string;
+              result: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              status: 'triggered' | 'executing' | 'completed' | 'failed';
+              triggerData: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              triggerType: 'event' | 'threshold' | 'schedule';
+              triggeredAt: string;
+            }[];
+            total: number;
+          };
+        };
+      };
+    };
+  };
+  'reflex.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            history: {
+              /** @enum {string} */
+              actionType: 'ingest' | 'emit' | 'glia';
+              actionVerb: string;
+              completedAt: string | null;
+              id: string;
+              reflexName: string;
+              result: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              status: 'triggered' | 'executing' | 'completed' | 'failed';
+              triggerData: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              triggerType: 'event' | 'threshold' | 'schedule';
+              triggeredAt: string;
+            }[];
+            reflex: {
+              action: {
+                scopes?: string[];
+                target?: string;
+                template?: string;
+                /** @enum {string} */
+                type: 'ingest' | 'emit' | 'glia';
+                verb: string;
+              };
+              description: string;
+              enabled: boolean;
+              executionCount: number;
+              lastExecutionAt: string | null;
+              name: string;
+              nextFireTime: string | null;
+              trigger:
+                | {
+                    conditions?: {
+                      scopes?: string[];
+                      source?: string;
+                      type?: string;
+                    };
+                    /** @enum {string} */
+                    event:
+                      | 'engram.created'
+                      | 'engram.modified'
+                      | 'engram.archived'
+                      | 'engram.linked';
+                    /** @enum {string} */
+                    type: 'event';
+                  }
+                | {
+                    /** @enum {string} */
+                    metric: 'similar_count' | 'staleness_max' | 'topic_frequency';
+                    scopes?: string[];
+                    /** @enum {string} */
+                    type: 'threshold';
+                    value: number;
+                  }
+                | {
+                    cron: string;
+                    /** @enum {string} */
+                    type: 'schedule';
+                  };
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'reflex.disable': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        name: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            success: boolean;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'reflex.enable': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        name: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            success: boolean;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'reflex.test': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        name: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            result: {
+              /** @enum {string} */
+              actionType: 'ingest' | 'emit' | 'glia';
+              actionVerb: string;
+              completedAt: string | null;
+              id: string;
+              reflexName: string;
+              result: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              status: 'triggered' | 'executing' | 'completed' | 'failed';
+              triggerData: {
+                [key: string]: unknown;
+              } | null;
+              /** @enum {string} */
+              triggerType: 'event' | 'threshold' | 'schedule';
+              triggeredAt: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'templates.list': {
     parameters: {
       query?: never;

--- a/pillars/cerebrum/src/contract/rest-reflex.ts
+++ b/pillars/cerebrum/src/contract/rest-reflex.ts
@@ -1,0 +1,103 @@
+/**
+ * ts-rest contract for `cerebrum.reflex.*` (PRD-089).
+ *
+ * Reflexes are declarative trigger/action rules the operator authors in
+ * `reflexes.toml`; the pillar exposes management reads, enable/disable toggles
+ * (which rewrite the TOML), a dry-run test, and the append-only execution
+ * history. Non-identity domain: served on the docker-network trust boundary,
+ * no per-request auth (parity with templates).
+ *
+ * `history` is POST-with-body rather than GET because its typed enum filters
+ * (`triggerType` / `status`) don't round-trip cleanly through a query string —
+ * mirrors the food pillar's `inbox.list` precedent.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  errorBodySchema,
+  reflexExecutionSchema,
+  reflexExecutionStatusSchema,
+  reflexTriggerTypeSchema,
+  reflexWithStatusSchema,
+} from './rest-schemas.js';
+
+const c = initContract();
+
+const nameParams = z.object({ name: z.string().min(1) });
+
+export const cerebrumReflexContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/reflex',
+    summary: 'List reflexes enriched with runtime status.',
+    query: z.object({ timezone: z.string().optional() }),
+    responses: {
+      200: z.object({ reflexes: z.array(reflexWithStatusSchema) }),
+    },
+  },
+  get: {
+    method: 'GET',
+    path: '/reflex/:name',
+    summary: 'Get a single reflex with its recent execution history.',
+    pathParams: nameParams,
+    responses: {
+      200: z.object({
+        reflex: reflexWithStatusSchema,
+        history: z.array(reflexExecutionSchema),
+      }),
+      404: errorBodySchema,
+    },
+  },
+  test: {
+    method: 'POST',
+    path: '/reflex/:name/test',
+    summary: 'Dry-run a reflex, logging a completed test execution.',
+    pathParams: nameParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ result: reflexExecutionSchema.nullable() }),
+      404: errorBodySchema,
+    },
+  },
+  enable: {
+    method: 'POST',
+    path: '/reflex/:name/enable',
+    summary: 'Enable a reflex (rewrites the TOML config).',
+    pathParams: nameParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ success: z.boolean() }),
+      404: errorBodySchema,
+    },
+  },
+  disable: {
+    method: 'POST',
+    path: '/reflex/:name/disable',
+    summary: 'Disable a reflex (rewrites the TOML config).',
+    pathParams: nameParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ success: z.boolean() }),
+      404: errorBodySchema,
+    },
+  },
+  history: {
+    method: 'POST',
+    path: '/reflex/history',
+    summary: 'Query the append-only reflex execution log (filtered + paginated).',
+    body: z.object({
+      name: z.string().optional(),
+      triggerType: reflexTriggerTypeSchema.optional(),
+      status: reflexExecutionStatusSchema.optional(),
+      limit: z.number().int().positive().max(200).optional(),
+      offset: z.number().int().nonnegative().optional(),
+    }),
+    responses: {
+      200: z.object({
+        executions: z.array(reflexExecutionSchema),
+        total: z.number().int(),
+      }),
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-schemas.ts
@@ -49,3 +49,88 @@ export const templateSchema = templateSummarySchema.extend({
   body: z.string(),
 });
 export type TemplateWire = z.infer<typeof templateSchema>;
+
+/**
+ * Reflex wire schemas (PRD-089). Reflexes are declarative trigger/action rules
+ * defined in `reflexes.toml`; the pillar exposes management reads + toggles +
+ * a dry-run test + an append-only execution history.
+ */
+export const reflexTriggerTypeSchema = z.enum(['event', 'threshold', 'schedule']);
+export type ReflexTriggerTypeWire = z.infer<typeof reflexTriggerTypeSchema>;
+
+export const reflexExecutionStatusSchema = z.enum([
+  'triggered',
+  'executing',
+  'completed',
+  'failed',
+]);
+export type ReflexExecutionStatusWire = z.infer<typeof reflexExecutionStatusSchema>;
+
+const reflexEventTriggerSchema = z.object({
+  type: z.literal('event'),
+  event: z.enum(['engram.created', 'engram.modified', 'engram.archived', 'engram.linked']),
+  conditions: z
+    .object({
+      type: z.string().optional(),
+      scopes: z.array(z.string()).optional(),
+      source: z.string().optional(),
+    })
+    .optional(),
+});
+
+const reflexThresholdTriggerSchema = z.object({
+  type: z.literal('threshold'),
+  metric: z.enum(['similar_count', 'staleness_max', 'topic_frequency']),
+  value: z.number(),
+  scopes: z.array(z.string()).optional(),
+});
+
+const reflexScheduleTriggerSchema = z.object({
+  type: z.literal('schedule'),
+  cron: z.string(),
+});
+
+export const reflexTriggerSchema = z.discriminatedUnion('type', [
+  reflexEventTriggerSchema,
+  reflexThresholdTriggerSchema,
+  reflexScheduleTriggerSchema,
+]);
+
+export const reflexActionSchema = z.object({
+  type: z.enum(['ingest', 'emit', 'glia']),
+  verb: z.string(),
+  template: z.string().optional(),
+  scopes: z.array(z.string()).optional(),
+  target: z.string().optional(),
+});
+
+export const reflexDefinitionSchema = z.object({
+  name: z.string().min(1),
+  description: z.string(),
+  enabled: z.boolean(),
+  trigger: reflexTriggerSchema,
+  action: reflexActionSchema,
+});
+
+/** A reflex enriched with runtime status (last fire, next fire, count). */
+export const reflexWithStatusSchema = reflexDefinitionSchema.extend({
+  lastExecutionAt: z.string().nullable(),
+  nextFireTime: z.string().nullable(),
+  executionCount: z.number().int(),
+});
+export type ReflexWithStatusWire = z.infer<typeof reflexWithStatusSchema>;
+
+/** One row of the append-only reflex execution log. */
+export const reflexExecutionSchema = z.object({
+  id: z.string(),
+  reflexName: z.string(),
+  triggerType: reflexTriggerTypeSchema,
+  triggerData: z.record(z.string(), z.unknown()).nullable(),
+  actionType: z.enum(['ingest', 'emit', 'glia']),
+  actionVerb: z.string(),
+  status: reflexExecutionStatusSchema,
+  result: z.record(z.string(), z.unknown()).nullable(),
+  triggeredAt: z.string(),
+  completedAt: z.string().nullable(),
+});
+export type ReflexExecutionWire = z.infer<typeof reflexExecutionSchema>;

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -12,6 +12,7 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { cerebrumReflexContract } from './rest-reflex.js';
 import { cerebrumTemplatesContract } from './rest-templates.js';
 
 const c = initContract();
@@ -19,6 +20,7 @@ const c = initContract();
 export const cerebrumContract = c.router(
   {
     templates: cerebrumTemplatesContract,
+    reflex: cerebrumReflexContract,
   },
   {
     pathPrefix: '',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2037,6 +2037,12 @@ importers:
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
@@ -2049,6 +2055,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       sqlite-vec:
         specifier: ^0.1.7
         version: 0.1.9


### PR DESCRIPTION
## Summary

REST migration slice for the **reflex** domain (PRD-089), lifting it from the `apps/pops-api` monolith onto the `@pops/cerebrum` pillar's ts-rest surface. Copies the templates slice (slice 0) pattern exactly.

Six procedures, all on the docker-network trust boundary (non-identity, no per-request auth, parity with templates):

| Procedure | Route |
|---|---|
| `reflex.list` | `GET /reflex` (`?timezone`) |
| `reflex.get` | `GET /reflex/:name` -> `{ reflex, history }`, 404 if missing |
| `reflex.test` | `POST /reflex/:name/test` -> `{ result }` (dry-run) |
| `reflex.enable` | `POST /reflex/:name/enable` -> `{ success }` |
| `reflex.disable` | `POST /reflex/:name/disable` -> `{ success }` |
| `reflex.history` | `POST /reflex/history` -> `{ executions, total }` |

`history` is POST-with-body because its typed enum filters (`triggerType`/`status`) don't round-trip cleanly through a query string — mirrors the food pillar's `inbox.list` precedent. operationIds render dotted (`reflex.list`, ...). No literal-vs-`:param` GET collisions (`/reflex/history` is a single segment under POST).

## What changed

- **Contract**: `rest-reflex.ts` + reflex wire schemas in `rest-schemas.ts`, composed into `rest.ts`.
- **Handlers**: `rest/reflex-handlers.ts` over a `ReflexService` injected via `CerebrumApiDeps`; 404 on unknown reflex via `NotFoundError` + `runHttp`.
- **Lifted module** (`src/api/modules/reflex/`): `reflex-service`, `reflex-io`, `reflex-queries`, `reflex-helpers`, `reflex-validators`, `reflex-parser`, `types`, `triggers/*`, `instance`. DB access threads the pillar drizzle handle (`deps.cerebrumDb.db`) — the `getDrizzle()` singleton and `@pops/cerebrum-db` imports are gone; everything imports from `../../../db/index.js`.
- **File/TOML driven**: config path is env-configurable (`CEREBRUM_REFLEX_CONFIG` -> `CEREBRUM_REFLEX_CONFIG_DIR`/`ENGRAM_ROOT` -> safe default) and tolerates a **missing file** (empty reflex set). The chokidar hot-reload watcher is **opt-in** (`watch: true` in prod via `instance.ts`; tests never start one and point the service at a temp fixture).
- **DB**: added `0056_reflex_executions_baseline.sql` (+ journal entry). The `reflex_executions` table had a schema in the pillar but no migration in the relocated journal, so a fresh `cerebrum.db` never created it.
- **Deps**: added `smol-toml`, `cron-parser`, `chokidar` (same versions the monolith uses).
- **Tests**: `reflex.test.ts` — empty/no-config boot, list from fixture, get unknown -> 404, enable/disable round-trip through the TOML, dry-run test, history pagination + status filter. `test-utils.ts` gains a `reflex` client section + `makeReflexService` helper.

All `as`/`as unknown as` casts from the monolith originals were replaced with type guards (per repo type-safety rules).

## Green proof (run in the worktree)

- `oxfmt --check pillars/cerebrum/` -> clean
- `oxlint pillars/cerebrum/src` -> 0 errors (only the pre-existing `__resetPillarRegistryCache` warning)
- `pnpm -C pillars/cerebrum typecheck` -> pass
- `pnpm -C pillars/cerebrum build` -> pass
- `generate:openapi` -> deterministic (regenerate yields no diff); 8 routes, dotted operationIds
- `pnpm -C pillars/cerebrum test` -> **269 passed** (19 files), reflex.test.ts = 9 passed
- `pnpm install --frozen-lockfile --filter @pops/cerebrum...` -> consistent
