### PR TITLE
feat(media): REST migration slice 9c — Plex sync scheduler (BullMQ → in-process setInterval)

### DIFF
--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -6810,6 +6810,447 @@
         "tags": ["plex"]
       }
     },
+    "/plex/scheduler/start": {
+      "post": {
+        "operationId": "plex.startScheduler",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "intervalMs": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "movieSectionId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "tvSectionId": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "intervalMs": {
+                          "type": "number"
+                        },
+                        "isRunning": {
+                          "type": "boolean"
+                        },
+                        "lastSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastSyncError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "moviesSynced": {
+                          "type": "number"
+                        },
+                        "nextSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "tvShowsSynced": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "isRunning",
+                        "intervalMs",
+                        "lastSyncAt",
+                        "lastSyncError",
+                        "nextSyncAt",
+                        "moviesSynced",
+                        "tvShowsSynced"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Arm the periodic Plex sync scheduler (fires one tick immediately)",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/scheduler/status": {
+      "get": {
+        "operationId": "plex.getSchedulerStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "intervalMs": {
+                          "type": "number"
+                        },
+                        "isRunning": {
+                          "type": "boolean"
+                        },
+                        "lastSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastSyncError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "moviesSynced": {
+                          "type": "number"
+                        },
+                        "nextSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "tvShowsSynced": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "isRunning",
+                        "intervalMs",
+                        "lastSyncAt",
+                        "lastSyncError",
+                        "nextSyncAt",
+                        "moviesSynced",
+                        "tvShowsSynced"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Read the scheduler run state + last-sync stats",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/scheduler/stop": {
+      "post": {
+        "operationId": "plex.stopScheduler",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "intervalMs": {
+                          "type": "number"
+                        },
+                        "isRunning": {
+                          "type": "boolean"
+                        },
+                        "lastSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastSyncError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "moviesSynced": {
+                          "type": "number"
+                        },
+                        "nextSyncAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "tvShowsSynced": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "isRunning",
+                        "intervalMs",
+                        "lastSyncAt",
+                        "lastSyncError",
+                        "nextSyncAt",
+                        "moviesSynced",
+                        "tvShowsSynced"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Stop the periodic Plex sync scheduler",
+        "tags": ["plex"]
+      }
+    },
+    "/plex/scheduler/sync-logs": {
+      "get": {
+        "operationId": "plex.getSyncLogs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "durationMs": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "errors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "nullable": true,
+                            "type": "array"
+                          },
+                          "id": {
+                            "type": "number"
+                          },
+                          "moviesSynced": {
+                            "type": "number"
+                          },
+                          "syncedAt": {
+                            "type": "string"
+                          },
+                          "tvShowsSynced": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "syncedAt",
+                          "moviesSynced",
+                          "tvShowsSynced",
+                          "errors",
+                          "durationMs"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List recent periodic-sync log entries (newest first)",
+        "tags": ["plex"]
+      }
+    },
     "/plex/section-ids": {
       "get": {
         "operationId": "plex.getSectionIds",

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -10,7 +10,8 @@ import supertest from 'supertest';
 
 import type { Express } from 'express';
 
-import type { SyncJob } from '../../db/index.js';
+import type { SyncJob, SyncLogEntry } from '../../db/index.js';
+import type { PlexSchedulerStatus as SchedulerStatus } from '../cron/plex-scheduler.js';
 import type { LibraryItem } from '../modules/library-types.js';
 import type { Movie } from '../modules/movie-types.js';
 import type { Episode, Season, TvShow } from '../modules/tv-show-types.js';
@@ -326,6 +327,13 @@ export function makeClient(app: Express) {
       getActiveSyncJobs: () => send<{ data: SyncJob[] }>(r.get('/plex/sync/active')),
       getLastSyncResults: () =>
         send<{ data: Record<string, SyncJob | null> }>(r.get('/plex/sync/last')),
+      startScheduler: (
+        body: { intervalMs?: number; movieSectionId?: string; tvSectionId?: string } = {}
+      ) => send<{ data: SchedulerStatus }>(r.post('/plex/scheduler/start').send(body)),
+      stopScheduler: () => send<{ data: SchedulerStatus }>(r.post('/plex/scheduler/stop').send({})),
+      getSchedulerStatus: () => send<{ data: SchedulerStatus }>(r.get('/plex/scheduler/status')),
+      getSyncLogs: (query: { limit?: number } = {}) =>
+        send<{ data: SyncLogEntry[] }>(r.get('/plex/scheduler/sync-logs').query(query)),
     },
   };
 }

--- a/pillars/media/src/api/clients/plex/keys.ts
+++ b/pillars/media/src/api/clients/plex/keys.ts
@@ -12,4 +12,6 @@ export const PLEX_KEYS = {
   clientIdentifier: 'plex_client_identifier',
   movieSectionId: 'plex_movie_section_id',
   tvSectionId: 'plex_tv_section_id',
+  schedulerEnabled: 'plex_scheduler_enabled',
+  schedulerIntervalMs: 'plex_scheduler_interval_ms',
 } as const;

--- a/pillars/media/src/api/clients/plex/sync/index.ts
+++ b/pillars/media/src/api/clients/plex/sync/index.ts
@@ -11,3 +11,7 @@ export {
   type StartSyncJobInput,
   type SyncJobType,
 } from './types.js';
+
+export { importMoviesFromPlex, type MovieSyncProgress } from './sync-movies.js';
+export { importTvShowsFromPlex, type TvSyncProgress } from './sync-tv.js';
+export { syncWatchlistFromPlex, type WatchlistSyncProgress } from './sync-watchlist.js';

--- a/pillars/media/src/api/cron/__tests__/plex-scheduler-tick.test.ts
+++ b/pillars/media/src/api/cron/__tests__/plex-scheduler-tick.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the periodic-sync tick (`runPlexSyncTick`, slice 9c).
+ *
+ * The Plex/TMDB/TheTVDB client factories and the three 9b sync ops are
+ * mocked at the module boundary so the tick runs with zero network and the
+ * assertions focus on what the tick is responsible for: resolving the
+ * client once, summing per-op counts, collecting error strings, and writing
+ * exactly one `sync_logs` row per tick. No real timers are used.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb, syncLogsService, type OpenedMediaDb } from '../../../db/index.js';
+import { runPlexSyncTick } from '../plex-scheduler-tick.js';
+
+import type { PlexClient } from '../../clients/plex/client.js';
+import type { MovieSyncProgress, TvSyncProgress } from '../../clients/plex/sync/index.js';
+import type { WatchlistSyncProgress } from '../../clients/plex/sync/index.js';
+
+const hoisted = vi.hoisted(() => ({
+  getPlexClientMock: vi.fn<() => PlexClient | null>(),
+  getPlexSectionIdsMock:
+    vi.fn<() => { movieSectionId: string | null; tvSectionId: string | null }>(),
+  getPlexTokenMock: vi.fn<() => string | null>(),
+  getPlexClientIdMock: vi.fn<() => string>(),
+  importMoviesMock: vi.fn<() => Promise<MovieSyncProgress>>(),
+  importTvShowsMock: vi.fn<() => Promise<TvSyncProgress>>(),
+  syncWatchlistMock: vi.fn<() => Promise<WatchlistSyncProgress>>(),
+}));
+
+vi.mock('../../clients/plex/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../clients/plex/index.js')>(
+    '../../clients/plex/index.js'
+  );
+  return {
+    ...actual,
+    getPlexClient: hoisted.getPlexClientMock,
+    getPlexSectionIds: hoisted.getPlexSectionIdsMock,
+    getPlexToken: hoisted.getPlexTokenMock,
+    getPlexClientId: hoisted.getPlexClientIdMock,
+  };
+});
+
+vi.mock('../../clients/plex/sync/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../clients/plex/sync/index.js')>(
+    '../../clients/plex/sync/index.js'
+  );
+  return {
+    ...actual,
+    importMoviesFromPlex: hoisted.importMoviesMock,
+    importTvShowsFromPlex: hoisted.importTvShowsMock,
+    syncWatchlistFromPlex: hoisted.syncWatchlistMock,
+  };
+});
+
+vi.mock('../../clients/tmdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../clients/tmdb/index.js')>(
+    '../../clients/tmdb/index.js'
+  );
+  return { ...actual, getTmdbClient: vi.fn(), getImageCache: vi.fn() };
+});
+
+vi.mock('../../clients/thetvdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../clients/thetvdb/index.js')>(
+    '../../clients/thetvdb/index.js'
+  );
+  return { ...actual, getTvdbClient: vi.fn() };
+});
+
+function movieProgress(over: Partial<MovieSyncProgress> = {}): MovieSyncProgress {
+  return { total: 0, processed: 0, synced: 0, skipped: 0, errors: [], ...over };
+}
+
+function tvProgress(over: Partial<TvSyncProgress> = {}): TvSyncProgress {
+  return {
+    total: 0,
+    processed: 0,
+    synced: 0,
+    skipped: 0,
+    episodesMatched: 0,
+    errors: [],
+    skipReasons: [],
+    ...over,
+  };
+}
+
+function watchlistProgress(over: Partial<WatchlistSyncProgress> = {}): WatchlistSyncProgress {
+  return {
+    total: 0,
+    processed: 0,
+    added: 0,
+    removed: 0,
+    skipped: 0,
+    errors: [],
+    skipReasons: [],
+    ...over,
+  };
+}
+
+const FAKE_CLIENT = {} as PlexClient;
+
+let tmpDir: string;
+let opened: OpenedMediaDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-scheduler-tick-'));
+  opened = openMediaDb(join(tmpDir, 'media.db'));
+
+  hoisted.getPlexClientMock.mockReturnValue(FAKE_CLIENT);
+  hoisted.getPlexSectionIdsMock.mockReturnValue({ movieSectionId: '1', tvSectionId: '2' });
+  hoisted.getPlexTokenMock.mockReturnValue('token');
+  hoisted.getPlexClientIdMock.mockReturnValue('client-id');
+  hoisted.importMoviesMock.mockResolvedValue(movieProgress({ synced: 3 }));
+  hoisted.importTvShowsMock.mockResolvedValue(tvProgress({ synced: 2 }));
+  hoisted.syncWatchlistMock.mockResolvedValue(watchlistProgress());
+});
+
+afterEach(() => {
+  opened.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe('runPlexSyncTick', () => {
+  it('runs movies + tv + watchlist and writes a sync log with the summed counts', async () => {
+    const result = await runPlexSyncTick(opened.db);
+
+    expect(result.moviesSynced).toBe(3);
+    expect(result.tvShowsSynced).toBe(2);
+    expect(result.errors).toEqual([]);
+    expect(hoisted.importMoviesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ plexClient: FAKE_CLIENT }),
+      '1'
+    );
+    expect(hoisted.importTvShowsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ plexClient: FAKE_CLIENT }),
+      '2'
+    );
+    expect(hoisted.syncWatchlistMock).toHaveBeenCalledOnce();
+
+    const logs = syncLogsService.listSyncLogs(opened.db);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({ moviesSynced: 3, tvShowsSynced: 2, errors: null });
+    expect(logs[0]?.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('writes a single error log and runs nothing when the client is null', async () => {
+    hoisted.getPlexClientMock.mockReturnValue(null);
+
+    const result = await runPlexSyncTick(opened.db);
+
+    expect(result.errors).toEqual(['Plex is not configured']);
+    expect(hoisted.importMoviesMock).not.toHaveBeenCalled();
+    expect(hoisted.syncWatchlistMock).not.toHaveBeenCalled();
+
+    const logs = syncLogsService.listSyncLogs(opened.db);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({ moviesSynced: 0, tvShowsSynced: 0 });
+    expect(logs[0]?.errors).toEqual(['Plex is not configured']);
+  });
+
+  it('skips a section-less op without erroring the whole tick', async () => {
+    hoisted.getPlexSectionIdsMock.mockReturnValue({ movieSectionId: null, tvSectionId: '2' });
+
+    const result = await runPlexSyncTick(opened.db);
+
+    expect(hoisted.importMoviesMock).not.toHaveBeenCalled();
+    expect(hoisted.importTvShowsMock).toHaveBeenCalledWith(expect.anything(), '2');
+    expect(result.moviesSynced).toBe(0);
+    expect(result.tvShowsSynced).toBe(2);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('collects per-op errors without aborting later ops', async () => {
+    hoisted.importMoviesMock.mockRejectedValue(new Error('movies upstream 500'));
+    hoisted.importTvShowsMock.mockResolvedValue(tvProgress({ synced: 1 }));
+    hoisted.syncWatchlistMock.mockResolvedValue(
+      watchlistProgress({ errors: [{ title: 'Dune', reason: 'no tmdb id' }] })
+    );
+
+    const result = await runPlexSyncTick(opened.db);
+
+    expect(result.tvShowsSynced).toBe(1);
+    expect(result.errors).toContain('movies: movies upstream 500');
+    expect(result.errors).toContain('watchlist:Dune: no tmdb id');
+
+    const logs = syncLogsService.listSyncLogs(opened.db);
+    expect(logs[0]?.errors).toEqual(result.errors);
+  });
+
+  it('honours explicit section-id overrides over the persisted settings', async () => {
+    await runPlexSyncTick(opened.db, { movieSectionId: '99', tvSectionId: '88' });
+
+    expect(hoisted.importMoviesMock).toHaveBeenCalledWith(expect.anything(), '99');
+    expect(hoisted.importTvShowsMock).toHaveBeenCalledWith(expect.anything(), '88');
+  });
+});

--- a/pillars/media/src/api/cron/__tests__/plex-scheduler.test.ts
+++ b/pillars/media/src/api/cron/__tests__/plex-scheduler.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the singleton scheduler controller + the `getSyncLogs` REST
+ * route (slice 9c).
+ *
+ * The tick runner is mocked at the module boundary so the controller is
+ * exercised without a real Plex client. The recursive timer is driven with
+ * `vi.useFakeTimers()` (restored in `afterEach`) so no real interval leaks
+ * between tests. `plexScheduler._reset()` clears the module-level singleton
+ * state after every test.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb, syncLogsService, type OpenedMediaDb } from '../../../db/index.js';
+import { plexSettingsService } from '../../../db/index.js';
+import { makeClient } from '../../__tests__/test-utils.js';
+import { createMediaApiApp } from '../../app.js';
+import { PLEX_KEYS } from '../../clients/plex/keys.js';
+import { plexScheduler } from '../plex-scheduler.js';
+
+import type { Express } from 'express';
+
+const runTickMock = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
+
+vi.mock('../plex-scheduler-tick.js', () => ({
+  runPlexSyncTick: runTickMock,
+}));
+
+let tmpDir: string;
+let opened: OpenedMediaDb;
+
+function app(): Express {
+  return createMediaApiApp({
+    mediaDb: opened,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3003',
+  });
+}
+
+function seedLog(over: Partial<Parameters<typeof syncLogsService.writeSyncLog>[1]> = {}): void {
+  syncLogsService.writeSyncLog(opened.db, {
+    syncedAt: new Date().toISOString(),
+    moviesSynced: 5,
+    tvShowsSynced: 2,
+    errors: null,
+    durationMs: 42,
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-scheduler-'));
+  opened = openMediaDb(join(tmpDir, 'media.db'));
+  runTickMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  plexScheduler._reset();
+  opened.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe('plexScheduler controller', () => {
+  it('start → isRunning true, fires one immediate tick, then stop → isRunning false', async () => {
+    vi.useFakeTimers();
+    try {
+      const status = plexScheduler.start({ db: opened.db, intervalMs: 1_000 });
+      expect(status.isRunning).toBe(true);
+      expect(status.intervalMs).toBe(1_000);
+
+      await vi.runOnlyPendingTimersAsync();
+      expect(runTickMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(plexScheduler.status(opened.db).isRunning).toBe(true);
+
+      plexScheduler.stop();
+      expect(plexScheduler.status(opened.db).isRunning).toBe(false);
+
+      const callsAfterStop = runTickMock.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(runTickMock.mock.calls.length).toBe(callsAfterStop);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('persists enabled+interval on start and disabled on stop', () => {
+    vi.useFakeTimers();
+    try {
+      plexScheduler.start({ db: opened.db, intervalMs: 7_000 });
+      expect(plexSettingsService.getSetting(opened.db, PLEX_KEYS.schedulerEnabled)).toBe('true');
+      expect(plexSettingsService.getSetting(opened.db, PLEX_KEYS.schedulerIntervalMs)).toBe('7000');
+
+      plexScheduler.stop();
+      expect(plexSettingsService.getSetting(opened.db, PLEX_KEYS.schedulerEnabled)).toBe('false');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-arms recursively (next tick only after the current one finishes)', async () => {
+    vi.useFakeTimers();
+    try {
+      plexScheduler.start({ db: opened.db, intervalMs: 1_000 });
+      await vi.runOnlyPendingTimersAsync();
+      const afterImmediate = runTickMock.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(runTickMock.mock.calls.length).toBeGreaterThan(afterImmediate);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('runOnce drives a single tick without arming a timer', async () => {
+    await plexScheduler.runOnce(opened.db);
+    expect(runTickMock).toHaveBeenCalledOnce();
+    expect(plexScheduler.status(opened.db).isRunning).toBe(false);
+  });
+
+  it('status surfaces the last sync-log counts + error from the db', () => {
+    seedLog({ moviesSynced: 9, tvShowsSynced: 4, errors: ['boom'] });
+    const status = plexScheduler.status(opened.db);
+    expect(status.moviesSynced).toBe(9);
+    expect(status.tvShowsSynced).toBe(4);
+    expect(status.lastSyncError).toBe('boom');
+    expect(status.lastSyncAt).not.toBeNull();
+  });
+
+  it('resumeIfEnabled starts with the persisted interval', () => {
+    vi.useFakeTimers();
+    try {
+      plexSettingsService.setSetting(opened.db, PLEX_KEYS.schedulerEnabled, 'true');
+      plexSettingsService.setSetting(opened.db, PLEX_KEYS.schedulerIntervalMs, '12345');
+
+      const status = plexScheduler.resumeIfEnabled(opened.db);
+      expect(status?.isRunning).toBe(true);
+      expect(status?.intervalMs).toBe(12_345);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resumeIfEnabled is a no-op when the persisted flag is not "true"', () => {
+    plexSettingsService.setSetting(opened.db, PLEX_KEYS.schedulerEnabled, 'false');
+    expect(plexScheduler.resumeIfEnabled(opened.db)).toBeNull();
+    expect(plexScheduler.status(opened.db).isRunning).toBe(false);
+  });
+});
+
+describe('plex scheduler — REST', () => {
+  it('GET /plex/scheduler/sync-logs returns rows newest-first', async () => {
+    seedLog({ syncedAt: '2026-01-01T00:00:00.000Z', moviesSynced: 1, tvShowsSynced: 0 });
+    seedLog({ syncedAt: '2026-02-01T00:00:00.000Z', moviesSynced: 2, tvShowsSynced: 1 });
+
+    const { data } = await makeClient(app()).plex.getSyncLogs();
+    expect(data).toHaveLength(2);
+    expect(data[0]?.syncedAt).toBe('2026-02-01T00:00:00.000Z');
+    expect(data[0]?.moviesSynced).toBe(2);
+  });
+
+  it('GET /plex/scheduler/sync-logs honours the limit query param', async () => {
+    seedLog({ syncedAt: '2026-01-01T00:00:00.000Z' });
+    seedLog({ syncedAt: '2026-02-01T00:00:00.000Z' });
+    seedLog({ syncedAt: '2026-03-01T00:00:00.000Z' });
+
+    const { data } = await makeClient(app()).plex.getSyncLogs({ limit: 2 });
+    expect(data).toHaveLength(2);
+    expect(data[0]?.syncedAt).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('GET /plex/scheduler/status reports stopped by default', async () => {
+    const { data } = await makeClient(app()).plex.getSchedulerStatus();
+    expect(data.isRunning).toBe(false);
+    expect(data.nextSyncAt).toBeNull();
+  });
+});

--- a/pillars/media/src/api/cron/plex-scheduler-tick.ts
+++ b/pillars/media/src/api/cron/plex-scheduler-tick.ts
@@ -1,0 +1,150 @@
+/**
+ * One periodic-sync tick for the Plex scheduler (slice 9c).
+ *
+ * Resolves the Plex client + section ids once, runs the movies / tv /
+ * watchlist 9b sync ops, collects per-op counts and error strings, and
+ * persists a single `sync_logs` row with the tick duration. Returns the
+ * tick summary so the controller can refresh its in-memory status.
+ *
+ * Gate: this runs ONLY movies / tv / watchlist. The Plex Discover watch
+ * sync is deferred to wave 3 (it needs the Discover client + rotation
+ * domain) and is intentionally absent here.
+ *
+ * Section-id resolution is `arg ?? plex_settings`. A missing section id
+ * skips that op (no movies/tv to import) rather than erroring the tick —
+ * watchlist sync needs no section id and still runs.
+ */
+import { type MediaDb, syncLogsService } from '../../db/index.js';
+import {
+  type PlexClient,
+  getPlexClient,
+  getPlexClientId,
+  getPlexSectionIds,
+  getPlexToken,
+} from '../clients/plex/index.js';
+import {
+  importMoviesFromPlex,
+  importTvShowsFromPlex,
+  syncWatchlistFromPlex,
+} from '../clients/plex/sync/index.js';
+import { getTvdbClient } from '../clients/thetvdb/index.js';
+import { getImageCache, getTmdbClient } from '../clients/tmdb/index.js';
+
+export interface PlexTickResult {
+  syncedAt: string;
+  moviesSynced: number;
+  tvShowsSynced: number;
+  errors: string[];
+  durationMs: number;
+}
+
+export interface PlexTickOptions {
+  movieSectionId?: string;
+  tvSectionId?: string;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function runMovies(
+  db: MediaDb,
+  plexClient: PlexClient,
+  sectionId: string | null,
+  errors: string[]
+): Promise<number> {
+  if (sectionId === null) return 0;
+  try {
+    const progress = await importMoviesFromPlex(
+      { db, plexClient, tmdbClient: getTmdbClient() },
+      sectionId
+    );
+    for (const e of progress.errors) errors.push(`movie:${e.title}: ${e.reason}`);
+    return progress.synced;
+  } catch (err) {
+    errors.push(`movies: ${errorMessage(err)}`);
+    return 0;
+  }
+}
+
+async function runTvShows(
+  db: MediaDb,
+  plexClient: PlexClient,
+  sectionId: string | null,
+  errors: string[]
+): Promise<number> {
+  if (sectionId === null) return 0;
+  try {
+    const progress = await importTvShowsFromPlex(
+      { db, plexClient, tvdbClient: getTvdbClient(), imageCache: getImageCache() },
+      sectionId
+    );
+    for (const e of progress.errors) errors.push(`tv:${e.title}: ${e.reason}`);
+    return progress.synced;
+  } catch (err) {
+    errors.push(`tvShows: ${errorMessage(err)}`);
+    return 0;
+  }
+}
+
+async function runWatchlist(db: MediaDb, errors: string[]): Promise<void> {
+  const token = getPlexToken(db);
+  if (token === null) return;
+  try {
+    const progress = await syncWatchlistFromPlex({
+      db,
+      token,
+      clientId: getPlexClientId(db),
+      tmdbClient: getTmdbClient(),
+      tvdbClient: getTvdbClient(),
+      imageCache: getImageCache(),
+    });
+    for (const e of progress.errors) errors.push(`watchlist:${e.title}: ${e.reason}`);
+  } catch (err) {
+    errors.push(`watchlist: ${errorMessage(err)}`);
+  }
+}
+
+/**
+ * Run a single sync tick and persist a `sync_logs` row. A `null` Plex
+ * client (not configured) writes an error log and returns immediately.
+ */
+export async function runPlexSyncTick(
+  db: MediaDb,
+  options: PlexTickOptions = {}
+): Promise<PlexTickResult> {
+  const startedAt = Date.now();
+  const syncedAt = new Date(startedAt).toISOString();
+  const plexClient = getPlexClient(db);
+
+  if (plexClient === null) {
+    const result: PlexTickResult = {
+      syncedAt,
+      moviesSynced: 0,
+      tvShowsSynced: 0,
+      errors: ['Plex is not configured'],
+      durationMs: Date.now() - startedAt,
+    };
+    syncLogsService.writeSyncLog(db, result);
+    return result;
+  }
+
+  const saved = getPlexSectionIds(db);
+  const movieSectionId = options.movieSectionId ?? saved.movieSectionId;
+  const tvSectionId = options.tvSectionId ?? saved.tvSectionId;
+  const errors: string[] = [];
+
+  const moviesSynced = await runMovies(db, plexClient, movieSectionId, errors);
+  const tvShowsSynced = await runTvShows(db, plexClient, tvSectionId, errors);
+  await runWatchlist(db, errors);
+
+  const result: PlexTickResult = {
+    syncedAt,
+    moviesSynced,
+    tvShowsSynced,
+    errors,
+    durationMs: Date.now() - startedAt,
+  };
+  syncLogsService.writeSyncLog(db, result);
+  return result;
+}

--- a/pillars/media/src/api/cron/plex-scheduler.ts
+++ b/pillars/media/src/api/cron/plex-scheduler.ts
@@ -1,0 +1,162 @@
+/**
+ * In-process periodic Plex sync scheduler (slice 9c).
+ *
+ * Re-architected from the monolith's BullMQ repeatable job to a recursive
+ * `setTimeout` driven by a MODULE-LEVEL singleton controller, so the
+ * `server.ts` boot path and the `POST /plex/scheduler/{start,stop}` REST
+ * handlers all drive the SAME timer. Mirrors the finance pillar's
+ * `startReconcileCrossPillarWorker` recursive-arm pattern (the next tick is
+ * armed only AFTER the current one resolves — no pile-up), and fires one
+ * tick immediately on start.
+ *
+ * Persisted state lives in `plex_settings` (`plex_scheduler_enabled` +
+ * `plex_scheduler_interval_ms`); `resumeIfEnabled` reads it on boot.
+ *
+ * Gate: a tick runs ONLY movies / tv / watchlist sync. The Plex Discover
+ * watch sync is deferred to wave 3 — see `plex-scheduler-tick.ts`.
+ */
+import { type MediaDb, plexSettingsService } from '../../db/index.js';
+import { getLastSyncAt, getLastSyncCounts, getLastSyncError } from '../../db/services/sync-logs.js';
+import { PLEX_KEYS } from '../clients/plex/keys.js';
+import { runPlexSyncTick } from './plex-scheduler-tick.js';
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface PlexSchedulerStatus {
+  isRunning: boolean;
+  intervalMs: number;
+  lastSyncAt: string | null;
+  lastSyncError: string | null;
+  nextSyncAt: string | null;
+  moviesSynced: number;
+  tvShowsSynced: number;
+}
+
+export interface PlexSchedulerStartOptions {
+  db: MediaDb;
+  intervalMs?: number;
+  movieSectionId?: string;
+  tvSectionId?: string;
+}
+
+interface SchedulerState {
+  db: MediaDb;
+  intervalMs: number;
+  movieSectionId?: string;
+  tvSectionId?: string;
+  timer: NodeJS.Timeout | undefined;
+}
+
+let state: SchedulerState | null = null;
+let nextSyncAt: string | null = null;
+
+function persistEnabled(db: MediaDb, intervalMs: number): void {
+  plexSettingsService.setSetting(db, PLEX_KEYS.schedulerEnabled, 'true');
+  plexSettingsService.setSetting(db, PLEX_KEYS.schedulerIntervalMs, String(intervalMs));
+}
+
+function persistDisabled(db: MediaDb): void {
+  plexSettingsService.setSetting(db, PLEX_KEYS.schedulerEnabled, 'false');
+}
+
+interface TickArgs {
+  movieSectionId?: string;
+  tvSectionId?: string;
+}
+
+async function runOnce(db: MediaDb, args: TickArgs): Promise<void> {
+  await runPlexSyncTick(db, {
+    movieSectionId: args.movieSectionId,
+    tvSectionId: args.tvSectionId,
+  });
+}
+
+function arm(): void {
+  if (state === null) return;
+  const current = state;
+  nextSyncAt = new Date(Date.now() + current.intervalMs).toISOString();
+  current.timer = setTimeout(() => {
+    void tick();
+  }, current.intervalMs);
+}
+
+async function tick(): Promise<void> {
+  if (state === null) return;
+  const current = state;
+  try {
+    await runOnce(current.db, {
+      movieSectionId: current.movieSectionId,
+      tvSectionId: current.tvSectionId,
+    });
+  } catch (err) {
+    console.warn('[media-api] plex scheduler tick failed', err);
+  }
+  arm();
+}
+
+export const plexScheduler = {
+  /**
+   * Arm the recursive timer and fire one tick immediately. Idempotent: a
+   * second `start` while running clears the prior timer and re-arms with the
+   * new options. Persists the enabled flag + interval to `plex_settings`.
+   */
+  start(options: PlexSchedulerStartOptions): PlexSchedulerStatus {
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    state = {
+      db: options.db,
+      intervalMs,
+      movieSectionId: options.movieSectionId,
+      tvSectionId: options.tvSectionId,
+      timer: undefined,
+    };
+    persistEnabled(options.db, intervalMs);
+    void tick();
+    return plexScheduler.status(options.db);
+  },
+
+  /** Clear the timer and persist the disabled flag. No-op if not running. */
+  stop(): void {
+    if (state === null) return;
+    const { db, timer } = state;
+    if (timer !== undefined) clearTimeout(timer);
+    persistDisabled(db);
+    state = null;
+    nextSyncAt = null;
+  },
+
+  /** Run a single sync tick directly (no timer). Persists a sync log. */
+  async runOnce(db: MediaDb): Promise<void> {
+    await runOnce(db, {});
+  },
+
+  /** Read persisted state; start with the persisted interval if enabled. */
+  resumeIfEnabled(db: MediaDb): PlexSchedulerStatus | null {
+    const enabled = plexSettingsService.getSetting(db, PLEX_KEYS.schedulerEnabled);
+    if (enabled !== 'true') return null;
+    const raw = plexSettingsService.getSetting(db, PLEX_KEYS.schedulerIntervalMs);
+    const parsed = raw === null ? NaN : Number(raw);
+    const intervalMs = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MS;
+    return plexScheduler.start({ db, intervalMs });
+  },
+
+  status(db: MediaDb): PlexSchedulerStatus {
+    const counts = getLastSyncCounts(db);
+    return {
+      isRunning: state !== null,
+      intervalMs: state?.intervalMs ?? DEFAULT_INTERVAL_MS,
+      lastSyncAt: getLastSyncAt(db),
+      lastSyncError: getLastSyncError(db),
+      nextSyncAt,
+      moviesSynced: counts.moviesSynced,
+      tvShowsSynced: counts.tvShowsSynced,
+    };
+  },
+
+  /** Reset all in-memory state — for tests only. */
+  _reset(): void {
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    state = null;
+    nextSyncAt = null;
+  },
+};

--- a/pillars/media/src/api/manifest.ts
+++ b/pillars/media/src/api/manifest.ts
@@ -98,6 +98,8 @@ const MEDIA_ROUTES: ManifestPayload['routes'] = {
     'media.plex.getPlexUsername',
     'media.plex.getSyncStatus',
     'media.plex.getSectionIds',
+    'media.plex.getSchedulerStatus',
+    'media.plex.getSyncLogs',
   ],
   mutations: [
     'media.movies.create',
@@ -141,6 +143,8 @@ const MEDIA_ROUTES: ManifestPayload['routes'] = {
     'media.plex.checkAuthPin',
     'media.plex.disconnect',
     'media.plex.saveSectionIds',
+    'media.plex.startScheduler',
+    'media.plex.stopScheduler',
   ],
   subscriptions: [],
 };

--- a/pillars/media/src/api/rest/plex-handlers.ts
+++ b/pillars/media/src/api/rest/plex-handlers.ts
@@ -24,6 +24,7 @@ import {
 } from '../clients/plex/index.js';
 import { ConflictError } from '../shared/errors.js';
 import { runHttp } from './error-mapping.js';
+import { makePlexSchedulerHandlers } from './plex-scheduler-handlers.js';
 import { makePlexSyncHandlers } from './plex-sync-handlers.js';
 
 import type { ServerInferRequest } from '@ts-rest/core';
@@ -41,6 +42,7 @@ function requirePlexClient(db: MediaDb): PlexClient {
 export function makePlexHandlers(db: MediaDb) {
   return {
     ...makePlexSyncHandlers(db),
+    ...makePlexSchedulerHandlers(db),
     testConnection: () =>
       runHttp(async () => {
         const client = requirePlexClient(db);

--- a/pillars/media/src/api/rest/plex-scheduler-handlers.ts
+++ b/pillars/media/src/api/rest/plex-scheduler-handlers.ts
@@ -1,0 +1,45 @@
+/**
+ * Handlers for the `plex.*` scheduler routes (slice 9c) — drive the
+ * module-level singleton `plexScheduler` controller. `start`/`stop`/`status`
+ * all touch the SAME timer the `server.ts` boot path uses, so a scheduler
+ * resumed on boot can be observed + stopped over REST and vice-versa.
+ */
+import { type MediaDb, syncLogsService } from '../../db/index.js';
+import { plexScheduler } from '../cron/plex-scheduler.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { mediaPlexContract } from '../../contract/rest-plex.js';
+
+type Req = ServerInferRequest<typeof mediaPlexContract>;
+
+export function makePlexSchedulerHandlers(db: MediaDb) {
+  return {
+    startScheduler: ({ body }: Req['startScheduler']) =>
+      runHttp(() => {
+        const data = plexScheduler.start({
+          db,
+          intervalMs: body.intervalMs,
+          movieSectionId: body.movieSectionId,
+          tvSectionId: body.tvSectionId,
+        });
+        return { status: 200 as const, body: { data } };
+      }),
+
+    stopScheduler: () =>
+      runHttp(() => {
+        plexScheduler.stop();
+        return { status: 200 as const, body: { data: plexScheduler.status(db) } };
+      }),
+
+    getSchedulerStatus: () =>
+      runHttp(() => ({ status: 200 as const, body: { data: plexScheduler.status(db) } })),
+
+    getSyncLogs: ({ query }: Req['getSyncLogs']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: syncLogsService.listSyncLogs(db, query.limit ?? 20) },
+      })),
+  };
+}

--- a/pillars/media/src/api/server.ts
+++ b/pillars/media/src/api/server.ts
@@ -15,6 +15,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 
 import { openMediaDb } from '../db/index.js';
 import { createMediaApiApp } from './app.js';
+import { plexScheduler } from './cron/plex-scheduler.js';
 import { buildMediaManifest } from './manifest.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
@@ -51,6 +52,24 @@ const selfBaseUrl = resolveSelfBaseUrl();
 const mediaDb = openMediaDb(resolveMediaSqlitePath());
 const app = createMediaApiApp({ mediaDb, version, selfBaseUrl });
 
+// Periodic Plex sync scheduler (slice 9c). When PLEX_SCHEDULER_ENABLED is
+// set, force-start with the PLEX_SCHEDULER_INTERVAL_MS interval; otherwise
+// auto-resume from the persisted `plex_scheduler_enabled` flag in
+// plex_settings. The controller is a module-level singleton so the REST
+// start/stop handlers drive the same timer.
+function resolveSchedulerIntervalMs(): number | undefined {
+  const raw = process.env['PLEX_SCHEDULER_INTERVAL_MS'];
+  if (raw === undefined || raw === '') return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+if (process.env['PLEX_SCHEDULER_ENABLED'] === 'true') {
+  plexScheduler.start({ db: mediaDb.db, intervalMs: resolveSchedulerIntervalMs() });
+} else {
+  plexScheduler.resumeIfEnabled(mediaDb.db);
+}
+
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
@@ -68,6 +87,7 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[media-api] Shutting down (${signal})`);
+  plexScheduler.stop();
   void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
     server.close(() => {
       mediaDb.raw.close();

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -703,6 +703,74 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/plex/scheduler/start': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Arm the periodic Plex sync scheduler (fires one tick immediately) */
+    post: operations['plex.startScheduler'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/scheduler/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read the scheduler run state + last-sync stats */
+    get: operations['plex.getSchedulerStatus'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/scheduler/stop': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Stop the periodic Plex sync scheduler */
+    post: operations['plex.stopScheduler'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plex/scheduler/sync-logs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List recent periodic-sync log entries (newest first) */
+    get: operations['plex.getSyncLogs'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/plex/section-ids': {
     parameters: {
       query?: never;
@@ -4323,6 +4391,219 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'plex.startScheduler': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          intervalMs?: number;
+          movieSectionId?: string;
+          tvSectionId?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              intervalMs: number;
+              isRunning: boolean;
+              lastSyncAt: string | null;
+              lastSyncError: string | null;
+              moviesSynced: number;
+              nextSyncAt: string | null;
+              tvShowsSynced: number;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'plex.getSchedulerStatus': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              intervalMs: number;
+              isRunning: boolean;
+              lastSyncAt: string | null;
+              lastSyncError: string | null;
+              moviesSynced: number;
+              nextSyncAt: string | null;
+              tvShowsSynced: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'plex.stopScheduler': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              intervalMs: number;
+              isRunning: boolean;
+              lastSyncAt: string | null;
+              lastSyncError: string | null;
+              moviesSynced: number;
+              nextSyncAt: string | null;
+              tvShowsSynced: number;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'plex.getSyncLogs': {
+    parameters: {
+      query?: {
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              durationMs: number | null;
+              errors: string[] | null;
+              id: number;
+              moviesSynced: number;
+              syncedAt: string;
+              tvShowsSynced: number;
+            }[];
           };
         };
       };

--- a/pillars/media/src/contract/rest-plex-scheduler.ts
+++ b/pillars/media/src/contract/rest-plex-scheduler.ts
@@ -1,0 +1,72 @@
+/**
+ * `plex.*` scheduler routes — control + observe the in-process periodic
+ * sync scheduler (slice 9c). Merged into `mediaPlexContract` so operation
+ * ids stay `plex.<route>`.
+ *
+ * Re-architecture vs the monolith: the monolith armed a BullMQ repeatable
+ * job; the pillar drives a recursive `setTimeout` via a module-level
+ * singleton controller (`src/api/cron/plex-scheduler.ts`). The wire shapes
+ * mirror the legacy `startScheduler` / `stopScheduler` / `getSchedulerStatus`
+ * / `getSyncLogs` procedures.
+ *
+ * Gate: a tick runs ONLY movies / tv / watchlist sync. The Plex Discover
+ * watch sync is deferred to wave 3.
+ */
+import { z } from 'zod';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+
+const SchedulerStatusSchema = z.object({
+  isRunning: z.boolean(),
+  intervalMs: z.number(),
+  lastSyncAt: z.string().nullable(),
+  lastSyncError: z.string().nullable(),
+  nextSyncAt: z.string().nullable(),
+  moviesSynced: z.number(),
+  tvShowsSynced: z.number(),
+});
+
+const SyncLogSchema = z.object({
+  id: z.number(),
+  syncedAt: z.string(),
+  moviesSynced: z.number(),
+  tvShowsSynced: z.number(),
+  errors: z.array(z.string()).nullable(),
+  durationMs: z.number().nullable(),
+});
+
+const SectionId = z.string().min(1).optional();
+
+export const plexSchedulerRoutes = {
+  startScheduler: {
+    method: 'POST',
+    path: '/plex/scheduler/start',
+    body: z.object({
+      intervalMs: z.number().int().positive().optional(),
+      movieSectionId: SectionId,
+      tvSectionId: SectionId,
+    }),
+    responses: { 200: z.object({ data: SchedulerStatusSchema }), ...ERR_RESPONSES },
+    summary: 'Arm the periodic Plex sync scheduler (fires one tick immediately)',
+  },
+  stopScheduler: {
+    method: 'POST',
+    path: '/plex/scheduler/stop',
+    body: z.object({}).optional(),
+    responses: { 200: z.object({ data: SchedulerStatusSchema }), ...ERR_RESPONSES },
+    summary: 'Stop the periodic Plex sync scheduler',
+  },
+  getSchedulerStatus: {
+    method: 'GET',
+    path: '/plex/scheduler/status',
+    responses: { 200: z.object({ data: SchedulerStatusSchema }) },
+    summary: 'Read the scheduler run state + last-sync stats',
+  },
+  getSyncLogs: {
+    method: 'GET',
+    path: '/plex/scheduler/sync-logs',
+    query: z.object({ limit: z.coerce.number().int().positive().max(100).optional() }),
+    responses: { 200: z.object({ data: z.array(SyncLogSchema) }) },
+    summary: 'List recent periodic-sync log entries (newest first)',
+  },
+} as const;

--- a/pillars/media/src/contract/rest-plex.ts
+++ b/pillars/media/src/contract/rest-plex.ts
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import { plexSchedulerRoutes } from './rest-plex-scheduler.js';
 import { plexSyncRoutes } from './rest-plex-sync.js';
 import { ERR_RESPONSES, MessageSchema } from './rest-schemas.js';
 
@@ -131,5 +132,6 @@ export const mediaPlexContract = c.router({
     responses: { 200: MessageSchema },
     summary: 'Persist the Plex library section ids',
   },
+  ...plexSchedulerRoutes,
   ...plexSyncRoutes,
 });

--- a/pillars/media/src/db/index.ts
+++ b/pillars/media/src/db/index.ts
@@ -137,6 +137,10 @@ export type {
 
 export * as syncJobResultsService from './services/sync-job-results.js';
 
+export type { SyncLogEntry, WriteSyncLogInput } from './services/sync-logs.js';
+
+export * as syncLogsService from './services/sync-logs.js';
+
 export * as watchlistService from './services/watchlist.js';
 
 export {

--- a/pillars/media/src/db/services/sync-logs.ts
+++ b/pillars/media/src/db/services/sync-logs.ts
@@ -1,0 +1,89 @@
+/**
+ * `sync_logs` persistence for the periodic Plex sync scheduler (slice 9c).
+ *
+ * One row is written per scheduler tick: the counts of movies/tv shows
+ * synced, an optional JSON-encoded array of error strings, and the tick
+ * duration. The scheduler controller (`src/api/cron/plex-scheduler.ts`)
+ * reads the last row to surface `getSchedulerStatus`.
+ *
+ * Services take a `MediaDb` handle as their first argument and are
+ * HTTP-free; the api layer resolves the handle. Mirrors the other media
+ * services' `(db, …)` signature.
+ */
+import { desc } from 'drizzle-orm';
+
+import { syncLogs } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** A persisted sync-log row in the typed shape handlers + status consume. */
+export interface SyncLogEntry {
+  id: number;
+  syncedAt: string;
+  moviesSynced: number;
+  tvShowsSynced: number;
+  errors: string[] | null;
+  durationMs: number | null;
+}
+
+export interface WriteSyncLogInput {
+  syncedAt: string;
+  moviesSynced: number;
+  tvShowsSynced: number;
+  errors: string[] | null;
+  durationMs: number | null;
+}
+
+function parseErrors(raw: string | null): string[] | null {
+  if (raw === null) return null;
+  const parsed: unknown = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed.map(String) : null;
+}
+
+export function writeSyncLog(db: MediaDb, input: WriteSyncLogInput): void {
+  const { syncedAt, moviesSynced, tvShowsSynced, errors, durationMs } = input;
+  db.insert(syncLogs)
+    .values({
+      syncedAt,
+      moviesSynced,
+      tvShowsSynced,
+      errors: errors && errors.length > 0 ? JSON.stringify(errors) : null,
+      durationMs,
+    })
+    .run();
+}
+
+export function listSyncLogs(db: MediaDb, limit = 20): SyncLogEntry[] {
+  const rows = db.select().from(syncLogs).orderBy(desc(syncLogs.syncedAt)).limit(limit).all();
+  return rows.map((row) => ({
+    id: row.id,
+    syncedAt: row.syncedAt,
+    moviesSynced: row.moviesSynced,
+    tvShowsSynced: row.tvShowsSynced,
+    errors: parseErrors(row.errors),
+    durationMs: row.durationMs,
+  }));
+}
+
+function lastRow(db: MediaDb): SyncLogEntry | null {
+  const rows = listSyncLogs(db, 1);
+  return rows[0] ?? null;
+}
+
+export function getLastSyncAt(db: MediaDb): string | null {
+  return lastRow(db)?.syncedAt ?? null;
+}
+
+export function getLastSyncCounts(db: MediaDb): { moviesSynced: number; tvShowsSynced: number } {
+  const row = lastRow(db);
+  return {
+    moviesSynced: row?.moviesSynced ?? 0,
+    tvShowsSynced: row?.tvShowsSynced ?? 0,
+  };
+}
+
+export function getLastSyncError(db: MediaDb): string | null {
+  const errors = lastRow(db)?.errors;
+  if (!errors || errors.length === 0) return null;
+  return errors[0] ?? null;
+}


### PR DESCRIPTION
Wave 2, part f (Plex, 3 of 3 — **completes Wave 2**). Re-architects the periodic Plex sync off **BullMQ** to an in-process `setInterval` scheduler wired into the pillar server (mirrors finance's reconcile cron).

- **module-level controller** (`src/api/cron/plex-scheduler.ts`): `start/stop/runOnce/resumeIfEnabled/status`; recursive `setTimeout` (next tick armed only after the current finishes — no pile-up); enabled+interval persisted to `plex_settings`.
- a **tick** (`plex-scheduler-tick.ts`) runs the movies/tv/watchlist 9b sync ops and writes one `sync_logs` row via the new `syncLogsService` (db-arg, HTTP-free).
- `/plex/scheduler/{start,stop,status,sync-logs}` routes drive the same singleton controller; `server.ts` **resumes on boot** (`PLEX_SCHEDULER_ENABLED` / `PLEX_SCHEDULER_INTERVAL_MS` or the persisted flag) and **stops on SIGTERM**.
- 15 new tests (**310 total**).

**Deferred:** Plex Discover sync → wave 3 (needs the rotation domain).

Verified: typecheck ✓ · build ✓ · 310/310 ✓ (×3 clean runs) · format ✓ · lint exit 0 (`.oxlintrc` untouched) ✓ · drift idempotent ✓ · no BullMQ/`core/settings`/`pops-api` leakage ✓. Stacks on #3382.