### PR TITLE
feat(cerebrum): REST migration slice — nudges read surface

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -1411,6 +1411,489 @@
         "tags": ["engrams"]
       }
     },
+    "/nudges/contradictions": {
+      "post": {
+        "operationId": "nudges.contradictions",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "enum": ["pending", "dismissed", "acted", "expired"],
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "contradictions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "conflict": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "engramA": {
+                            "type": "string"
+                          },
+                          "engramB": {
+                            "type": "string"
+                          },
+                          "excerptA": {
+                            "type": "string"
+                          },
+                          "excerptB": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "priority": {
+                            "enum": ["low", "medium", "high"],
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["pending", "dismissed", "acted", "expired"],
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "createdAt",
+                          "status",
+                          "priority",
+                          "title",
+                          "engramA",
+                          "engramB",
+                          "excerptA",
+                          "excerptB",
+                          "conflict"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["contradictions", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List contradiction-pattern nudges with structured evidence.",
+        "tags": ["nudges"]
+      }
+    },
+    "/nudges/search": {
+      "post": {
+        "operationId": "nudges.list",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "priority": {
+                    "enum": ["low", "medium", "high"],
+                    "type": "string"
+                  },
+                  "status": {
+                    "enum": ["pending", "dismissed", "acted", "expired"],
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": ["consolidation", "staleness", "pattern", "insight"],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nudges": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "action": {
+                            "additionalProperties": false,
+                            "nullable": true,
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "params": {
+                                "additionalProperties": {},
+                                "type": "object"
+                              },
+                              "type": {
+                                "enum": ["consolidate", "archive", "review", "link"],
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type", "label", "params"],
+                            "type": "object"
+                          },
+                          "body": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "engramIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "expiresAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "priority": {
+                            "enum": ["low", "medium", "high"],
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["pending", "dismissed", "acted", "expired"],
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "enum": ["consolidation", "staleness", "pattern", "insight"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "title",
+                          "body",
+                          "engramIds",
+                          "priority",
+                          "status",
+                          "createdAt",
+                          "expiresAt",
+                          "actedAt",
+                          "action"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["nudges", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List nudges matching the supplied filters, with a total count.",
+        "tags": ["nudges"]
+      }
+    },
+    "/nudges/{id}": {
+      "get": {
+        "operationId": "nudges.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nudge": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "action": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "params": {
+                              "additionalProperties": {},
+                              "type": "object"
+                            },
+                            "type": {
+                              "enum": ["consolidate", "archive", "review", "link"],
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "label", "params"],
+                          "type": "object"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "engramIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "expiresAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "enum": ["low", "medium", "high"],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "dismissed", "acted", "expired"],
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": ["consolidation", "staleness", "pattern", "insight"],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "title",
+                        "body",
+                        "engramIds",
+                        "priority",
+                        "status",
+                        "createdAt",
+                        "expiresAt",
+                        "actedAt",
+                        "action"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["nudge"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get a single nudge by ID.",
+        "tags": ["nudges"]
+      }
+    },
+    "/nudges/{id}/dismiss": {
+      "post": {
+        "operationId": "nudges.dismiss",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Dismiss a pending nudge.",
+        "tags": ["nudges"]
+      }
+    },
     "/plexus/adapters": {
       "get": {
         "operationId": "plexus.adapters.list",

--- a/pillars/cerebrum/src/api/__tests__/nudges.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/nudges.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Integration tests for `cerebrum.nudges.*` over REST (PRD-084).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` (nudge_log present via
+ * migrations 0039/0044) and seeds `nudge_log` rows directly through the
+ * drizzle handle. Covers the read/dismiss surface only — `scan`/`act`/
+ * `configure` are deferred to a post-retrieval slice.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type CerebrumDb,
+  type NudgePriority,
+  type NudgeStatus,
+  type NudgeType,
+  nudgeLog,
+  openCerebrumDb,
+  type OpenedCerebrumDb,
+} from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { HttpError, makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+
+interface SeedNudge {
+  id: string;
+  type?: NudgeType;
+  title?: string;
+  body?: string;
+  engramIds?: string[];
+  priority?: NudgePriority;
+  status?: NudgeStatus;
+  createdAt: string;
+  action?: { type: string; label: string; params: Record<string, unknown> } | null;
+}
+
+function seedNudge(db: CerebrumDb, n: SeedNudge): void {
+  const action = n.action ?? null;
+  db.insert(nudgeLog)
+    .values({
+      id: n.id,
+      type: n.type ?? 'insight',
+      title: n.title ?? n.id,
+      body: n.body ?? '',
+      engramIds: JSON.stringify(n.engramIds ?? []),
+      priority: n.priority ?? 'medium',
+      status: n.status ?? 'pending',
+      createdAt: n.createdAt,
+      expiresAt: null,
+      actedAt: null,
+      actionType: action?.type ?? null,
+      actionLabel: action?.label ?? null,
+      actionParams: action ? JSON.stringify(action.params) : null,
+    })
+    .run();
+}
+
+function contradictionAction(over: Partial<Record<string, string>> = {}): {
+  type: string;
+  label: string;
+  params: Record<string, unknown>;
+} {
+  return {
+    type: 'review',
+    label: 'Resolve contradiction',
+    params: {
+      contradiction: {
+        engramA: over.engramA ?? 'eng_a',
+        engramB: over.engramB ?? 'eng_b',
+        excerptA: over.excerptA ?? 'A says yes',
+        excerptB: over.excerptB ?? 'B says no',
+        conflict: over.conflict ?? 'They disagree',
+      },
+    },
+  };
+}
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-nudges-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+    })
+  );
+}
+
+describe('cerebrum.nudges.list', () => {
+  it('returns an empty page when nudge_log is empty', async () => {
+    const { nudges, total } = await client().nudges.list();
+    expect(nudges).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  it('lists newest-first and round-trips the full nudge shape', async () => {
+    const db = cerebrumDb.db;
+    seedNudge(db, {
+      id: 'nudge_a',
+      type: 'consolidation',
+      title: 'Older',
+      body: 'first',
+      engramIds: ['eng_1', 'eng_2'],
+      priority: 'low',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    seedNudge(db, {
+      id: 'nudge_b',
+      type: 'staleness',
+      title: 'Newer',
+      priority: 'high',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    const { nudges, total } = await client().nudges.list();
+    expect(total).toBe(2);
+    expect(nudges.map((n) => n.id)).toEqual(['nudge_b', 'nudge_a']);
+    expect(nudges[1]).toMatchObject({
+      id: 'nudge_a',
+      type: 'consolidation',
+      title: 'Older',
+      body: 'first',
+      engramIds: ['eng_1', 'eng_2'],
+      priority: 'low',
+      status: 'pending',
+      action: null,
+    });
+  });
+
+  it('filters by type, status and priority', async () => {
+    const db = cerebrumDb.db;
+    seedNudge(db, {
+      id: 'n_pattern_pending',
+      type: 'pattern',
+      status: 'pending',
+      priority: 'high',
+      createdAt: '2026-03-01T00:00:00.000Z',
+    });
+    seedNudge(db, {
+      id: 'n_pattern_dismissed',
+      type: 'pattern',
+      status: 'dismissed',
+      priority: 'high',
+      createdAt: '2026-03-02T00:00:00.000Z',
+    });
+    seedNudge(db, {
+      id: 'n_insight_pending',
+      type: 'insight',
+      status: 'pending',
+      priority: 'low',
+      createdAt: '2026-03-03T00:00:00.000Z',
+    });
+
+    const c = client();
+
+    const byType = await c.nudges.list({ type: 'pattern' });
+    expect(byType.total).toBe(2);
+    expect(byType.nudges.map((n) => n.id).toSorted()).toEqual([
+      'n_pattern_dismissed',
+      'n_pattern_pending',
+    ]);
+
+    const byStatus = await c.nudges.list({ status: 'pending' });
+    expect(byStatus.total).toBe(2);
+
+    const byPriority = await c.nudges.list({
+      type: 'pattern',
+      priority: 'high',
+      status: 'pending',
+    });
+    expect(byPriority.total).toBe(1);
+    expect(byPriority.nudges[0]?.id).toBe('n_pattern_pending');
+  });
+
+  it('paginates with limit/offset while reporting the unpaged total', async () => {
+    const db = cerebrumDb.db;
+    for (let i = 0; i < 5; i++) {
+      seedNudge(db, {
+        id: `n_${i}`,
+        createdAt: `2026-04-0${i + 1}T00:00:00.000Z`,
+      });
+    }
+    const page = await client().nudges.list({ limit: 2, offset: 1 });
+    expect(page.total).toBe(5);
+    expect(page.nudges.map((n) => n.id)).toEqual(['n_3', 'n_2']);
+  });
+});
+
+describe('cerebrum.nudges.get', () => {
+  it('returns the nudge by id', async () => {
+    seedNudge(cerebrumDb.db, {
+      id: 'nudge_get',
+      title: 'Findable',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const { nudge } = await client().nudges.get('nudge_get');
+    expect(nudge).toMatchObject({ id: 'nudge_get', title: 'Findable' });
+  });
+
+  it('404s on an unknown id', async () => {
+    await expect(client().nudges.get('does_not_exist')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('cerebrum.nudges.dismiss', () => {
+  it('dismisses a pending nudge', async () => {
+    seedNudge(cerebrumDb.db, {
+      id: 'nudge_pending',
+      status: 'pending',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const c = client();
+    const result = await c.nudges.dismiss('nudge_pending');
+    expect(result).toEqual({ success: true });
+
+    const { nudge } = await c.nudges.get('nudge_pending');
+    expect(nudge.status).toBe('dismissed');
+  });
+
+  it('404s when the nudge is missing', async () => {
+    await expect(client().nudges.dismiss('ghost')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('409s when the nudge is not pending', async () => {
+    seedNudge(cerebrumDb.db, {
+      id: 'nudge_done',
+      status: 'dismissed',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const err = await client()
+      .nudges.dismiss('nudge_done')
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    if (!(err instanceof HttpError)) throw new Error('expected HttpError');
+    expect(err.status).toBe(409);
+    expect(err.body).toMatchObject({ code: 'ConflictError' });
+  });
+});
+
+describe('cerebrum.nudges.contradictions', () => {
+  it('projects contradiction-pattern nudges to structured evidence', async () => {
+    const db = cerebrumDb.db;
+    seedNudge(db, {
+      id: 'n_contradiction',
+      type: 'pattern',
+      status: 'pending',
+      priority: 'high',
+      title: 'Contradiction found',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      action: contradictionAction({ conflict: 'X vs Y' }),
+    });
+    // A non-contradiction pattern nudge must not leak into the projection.
+    seedNudge(db, {
+      id: 'n_recurring',
+      type: 'pattern',
+      status: 'pending',
+      createdAt: '2026-05-02T00:00:00.000Z',
+      action: { type: 'review', label: 'Review', params: { recurring: { topic: 'x' } } },
+    });
+
+    const { contradictions, total } = await client().nudges.contradictions();
+    expect(total).toBe(1);
+    expect(contradictions).toHaveLength(1);
+    expect(contradictions[0]).toEqual({
+      id: 'n_contradiction',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      status: 'pending',
+      priority: 'high',
+      title: 'Contradiction found',
+      engramA: 'eng_a',
+      engramB: 'eng_b',
+      excerptA: 'A says yes',
+      excerptB: 'B says no',
+      conflict: 'X vs Y',
+    });
+  });
+
+  it('defaults to pending and excludes dismissed contradictions', async () => {
+    const db = cerebrumDb.db;
+    seedNudge(db, {
+      id: 'n_pending',
+      type: 'pattern',
+      status: 'pending',
+      createdAt: '2026-06-01T00:00:00.000Z',
+      action: contradictionAction({ engramA: 'eng_p1', engramB: 'eng_p2' }),
+    });
+    seedNudge(db, {
+      id: 'n_dismissed',
+      type: 'pattern',
+      status: 'dismissed',
+      createdAt: '2026-06-02T00:00:00.000Z',
+      action: contradictionAction({ engramA: 'eng_d1', engramB: 'eng_d2' }),
+    });
+
+    const c = client();
+
+    const defaulted = await c.nudges.contradictions();
+    expect(defaulted.total).toBe(1);
+    expect(defaulted.contradictions[0]?.id).toBe('n_pending');
+
+    const all = await c.nudges.contradictions({ status: null });
+    expect(all.total).toBe(2);
+  });
+
+  it('returns an empty projection when there are no contradictions', async () => {
+    const { contradictions, total } = await client().nudges.contradictions();
+    expect(contradictions).toEqual([]);
+    expect(total).toBe(0);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -14,6 +14,13 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 import type { Express } from 'express';
 
 import type {
+  NudgeContradictionWire,
+  NudgePriorityWire,
+  NudgeStatusWire,
+  NudgeTypeWire,
+  NudgeWire,
+} from '../../contract/rest-nudges.js';
+import type {
   EngramWire,
   PlexusAdapterWire,
   PlexusFilterDefinitionWire,
@@ -118,6 +125,20 @@ export interface ReflexHistoryFilters {
   offset?: number;
 }
 
+export interface ListNudgesFilters {
+  type?: NudgeTypeWire;
+  status?: NudgeStatusWire;
+  priority?: NudgePriorityWire;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListContradictionsFilters {
+  status?: NudgeStatusWire | null;
+  limit?: number;
+  offset?: number;
+}
+
 export function makeClient(app: Express) {
   const r = supertest.agent(app);
   return {
@@ -185,6 +206,16 @@ export function makeClient(app: Express) {
       history: (filters: ReflexHistoryFilters = {}) =>
         send<{ executions: ReflexExecutionWire[]; total: number }>(
           r.post('/reflex/history').send(filters)
+        ),
+    },
+    nudges: {
+      list: (filters: ListNudgesFilters = {}) =>
+        send<{ nudges: NudgeWire[]; total: number }>(r.post('/nudges/search').send(filters)),
+      get: (id: string) => send<{ nudge: NudgeWire }>(r.get(`/nudges/${id}`)),
+      dismiss: (id: string) => send<{ success: boolean }>(r.post(`/nudges/${id}/dismiss`).send({})),
+      contradictions: (filters: ListContradictionsFilters = {}) =>
+        send<{ contradictions: NudgeContradictionWire[]; total: number }>(
+          r.post('/nudges/contradictions').send(filters)
         ),
     },
     plexus: {

--- a/pillars/cerebrum/src/api/modules/nudges/contradiction.ts
+++ b/pillars/cerebrum/src/api/modules/nudges/contradiction.ts
@@ -1,0 +1,33 @@
+/**
+ * Contradiction-evidence extraction for `cerebrum.nudges.contradictions`.
+ *
+ * Contradiction evidence is stored on `Nudge.action.params.contradiction`
+ * when the underlying pattern is a contradiction. Other pattern nudges
+ * (recurring / emerging) carry no contradiction field, so this returns null
+ * for them — the caller drops those rows from the projection.
+ */
+export interface ContradictionEvidence {
+  engramA: string;
+  engramB: string;
+  excerptA: string;
+  excerptB: string;
+  conflict: string;
+}
+
+const EVIDENCE_FIELDS = ['engramA', 'engramB', 'excerptA', 'excerptB', 'conflict'] as const;
+
+export function extractContradiction(
+  params: Record<string, unknown> | undefined
+): ContradictionEvidence | null {
+  if (!params) return null;
+  const raw = params['contradiction'];
+  if (!raw || typeof raw !== 'object') return null;
+  const evidence = raw as Record<string, unknown>;
+  const result: Partial<ContradictionEvidence> = {};
+  for (const field of EVIDENCE_FIELDS) {
+    const value = evidence[field];
+    if (typeof value !== 'string' || value.length === 0) return null;
+    result[field] = value;
+  }
+  return result as ContradictionEvidence;
+}

--- a/pillars/cerebrum/src/api/modules/nudges/service.ts
+++ b/pillars/cerebrum/src/api/modules/nudges/service.ts
@@ -1,0 +1,90 @@
+/**
+ * nudge_log read/dismiss service for the cerebrum pillar (PRD-084).
+ *
+ * Lifted from `apps/pops-cerebrum-api/src/modules/nudges/service.ts`, rebound
+ * onto the pillar's own db package (`../../../db/index.js`) rather than
+ * `@pops/cerebrum-db`. Covers only the read + dismiss surface — the procedures
+ * that touch nothing but the `nudge_log` table. `scan` / `act` / `configure`
+ * (detectors + retrieval + LLM analyzer) follow a later slice.
+ */
+import { and, count, eq, sql } from 'drizzle-orm';
+
+import {
+  type CerebrumDb,
+  type Nudge,
+  type NudgePriority,
+  type NudgeStatus,
+  type NudgeType,
+  nudgeLog,
+  nudgeLogService,
+  rowToNudge,
+} from '../../../db/index.js';
+
+export interface ListNudgesOptions {
+  type?: NudgeType;
+  status?: NudgeStatus;
+  priority?: NudgePriority;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListContradictionsOptions {
+  status?: NudgeStatus | null;
+  limit?: number;
+  offset?: number;
+}
+
+export interface NudgeReadService {
+  list(opts: ListNudgesOptions): { nudges: Nudge[]; total: number };
+  get(id: string): Nudge | null;
+  dismiss(id: string): { success: boolean };
+  listContradictions(opts: ListContradictionsOptions): { nudges: Nudge[]; total: number };
+}
+
+export function createNudgeReadService(db: CerebrumDb): NudgeReadService {
+  return {
+    list(opts: ListNudgesOptions): { nudges: Nudge[]; total: number } {
+      const conditions = [];
+      if (opts.type) conditions.push(eq(nudgeLog.type, opts.type));
+      if (opts.status) conditions.push(eq(nudgeLog.status, opts.status));
+      if (opts.priority) conditions.push(eq(nudgeLog.priority, opts.priority));
+
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+      const limit = opts.limit ?? 50;
+      const offset = opts.offset ?? 0;
+
+      const baseQuery = db.select().from(nudgeLog);
+      const rows = (where ? baseQuery.where(where) : baseQuery)
+        .orderBy(sql`${nudgeLog.createdAt} desc`)
+        .limit(limit)
+        .offset(offset)
+        .all();
+
+      const countQuery = db.select({ total: count() }).from(nudgeLog);
+      const [totalRow] = (where ? countQuery.where(where) : countQuery).all();
+
+      return {
+        nudges: rows.map((r) => rowToNudge(r)),
+        total: totalRow?.total ?? 0,
+      };
+    },
+
+    get(id: string): Nudge | null {
+      const [row] = db.select().from(nudgeLog).where(eq(nudgeLog.id, id)).all();
+      return row ? rowToNudge(row) : null;
+    },
+
+    dismiss(id: string): { success: boolean } {
+      const result = db
+        .update(nudgeLog)
+        .set({ status: 'dismissed' })
+        .where(and(eq(nudgeLog.id, id), eq(nudgeLog.status, 'pending')))
+        .run();
+      return { success: result.changes > 0 };
+    },
+
+    listContradictions(opts: ListContradictionsOptions): { nudges: Nudge[]; total: number } {
+      return nudgeLogService.listContradictions(db, opts);
+    },
+  };
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -9,6 +9,7 @@ import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
+import { makeNudgesHandlers } from './nudges-handlers.js';
 import { makePlexusHandlers } from './plexus-handlers.js';
 import { makeReflexHandlers } from './reflex-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
@@ -34,5 +35,6 @@ export function makeCerebrumRestHandlers(
     engrams: makeEngramsHandlers(engramDeps),
     scopes: makeScopesHandlers(engramDeps),
     tags: makeTagsHandlers(deps.cerebrumDb.db),
+    nudges: makeNudgesHandlers(deps.cerebrumDb.db),
   });
 }

--- a/pillars/cerebrum/src/api/rest/nudges-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/nudges-handlers.ts
@@ -1,0 +1,83 @@
+/**
+ * ts-rest handlers for `cerebrum.nudges.*` (PRD-084).
+ *
+ * Thin adapter over {@link createNudgeReadService} bound to the pillar db
+ * handle. Reads the `nudge_log` table; `dismiss` distinguishes a missing
+ * nudge (404) from a non-pending nudge (409) — `runHttp` maps the pillar
+ * `NotFoundError` → 404 and `ConflictError` → 409.
+ *
+ * The legacy monolith collapsed missing-vs-already-dismissed into one
+ * `BAD_REQUEST`; the migrated surface keeps the tighter split so consumers
+ * can tell a stale UI cache apart from a no-op double-click (parity with the
+ * pops-cerebrum-api shadow router).
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumNudgesContract } from '../../contract/rest-nudges.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { extractContradiction } from '../modules/nudges/contradiction.js';
+import { createNudgeReadService } from '../modules/nudges/service.js';
+import { ConflictError, NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export function makeNudgesHandlers(
+  db: CerebrumDb
+): ReturnType<typeof server.router<typeof cerebrumNudgesContract>> {
+  const service = createNudgeReadService(db);
+
+  return server.router(cerebrumNudgesContract, {
+    list: async ({ body }) => ({
+      status: 200,
+      body: service.list(body),
+    }),
+
+    get: async ({ params }) =>
+      runHttp(() => {
+        const nudge = service.get(params.id);
+        if (!nudge) throw new NotFoundError('Nudge', params.id);
+        return { status: 200, body: { nudge } };
+      }),
+
+    dismiss: async ({ params }) =>
+      runHttp(() => {
+        const existing = service.get(params.id);
+        if (!existing) throw new NotFoundError('Nudge', params.id);
+        if (existing.status !== 'pending') {
+          throw new ConflictError(
+            `Nudge '${params.id}' is not pending (status=${existing.status}).`
+          );
+        }
+        const result = service.dismiss(params.id);
+        if (!result.success) {
+          throw new ConflictError(`Nudge '${params.id}' could not be dismissed.`);
+        }
+        return { status: 200, body: result };
+      }),
+
+    contradictions: async ({ body }) => {
+      const status = body.status === undefined ? 'pending' : body.status;
+      const result = service.listContradictions({
+        status,
+        limit: body.limit ?? 50,
+        offset: body.offset ?? 0,
+      });
+      const contradictions = result.nudges
+        .map((nudge) => {
+          const evidence = extractContradiction(nudge.action?.params);
+          if (!evidence) return null;
+          return {
+            id: nudge.id,
+            createdAt: nudge.createdAt,
+            status: nudge.status,
+            priority: nudge.priority,
+            title: nudge.title,
+            ...evidence,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => row !== null);
+      return { status: 200, body: { contradictions, total: result.total } };
+    },
+  });
+}

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -124,6 +124,74 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/nudges/contradictions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List contradiction-pattern nudges with structured evidence. */
+    post: operations['nudges.contradictions'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nudges/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List nudges matching the supplied filters, with a total count. */
+    post: operations['nudges.list'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nudges/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single nudge by ID. */
+    get: operations['nudges.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nudges/{id}/dismiss': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dismiss a pending nudge. */
+    post: operations['nudges.dismiss'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/plexus/adapters': {
     parameters: {
       query?: never;
@@ -1063,6 +1131,225 @@ export interface operations {
       };
       /** @description 404 */
       404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'nudges.contradictions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          offset?: number;
+          /** @enum {string|null} */
+          status?: 'pending' | 'dismissed' | 'acted' | 'expired' | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            contradictions: {
+              conflict: string;
+              createdAt: string;
+              engramA: string;
+              engramB: string;
+              excerptA: string;
+              excerptB: string;
+              id: string;
+              /** @enum {string} */
+              priority: 'low' | 'medium' | 'high';
+              /** @enum {string} */
+              status: 'pending' | 'dismissed' | 'acted' | 'expired';
+              title: string;
+            }[];
+            total: number;
+          };
+        };
+      };
+    };
+  };
+  'nudges.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          offset?: number;
+          /** @enum {string} */
+          priority?: 'low' | 'medium' | 'high';
+          /** @enum {string} */
+          status?: 'pending' | 'dismissed' | 'acted' | 'expired';
+          /** @enum {string} */
+          type?: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            nudges: {
+              actedAt: string | null;
+              action: {
+                label: string;
+                params: {
+                  [key: string]: unknown;
+                };
+                /** @enum {string} */
+                type: 'consolidate' | 'archive' | 'review' | 'link';
+              } | null;
+              body: string;
+              createdAt: string;
+              engramIds: string[];
+              expiresAt: string | null;
+              id: string;
+              /** @enum {string} */
+              priority: 'low' | 'medium' | 'high';
+              /** @enum {string} */
+              status: 'pending' | 'dismissed' | 'acted' | 'expired';
+              title: string;
+              /** @enum {string} */
+              type: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+            }[];
+            total: number;
+          };
+        };
+      };
+    };
+  };
+  'nudges.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            nudge: {
+              actedAt: string | null;
+              action: {
+                label: string;
+                params: {
+                  [key: string]: unknown;
+                };
+                /** @enum {string} */
+                type: 'consolidate' | 'archive' | 'review' | 'link';
+              } | null;
+              body: string;
+              createdAt: string;
+              engramIds: string[];
+              expiresAt: string | null;
+              id: string;
+              /** @enum {string} */
+              priority: 'low' | 'medium' | 'high';
+              /** @enum {string} */
+              status: 'pending' | 'dismissed' | 'acted' | 'expired';
+              title: string;
+              /** @enum {string} */
+              type: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'nudges.dismiss': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            success: boolean;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
         headers: {
           [name: string]: unknown;
         };

--- a/pillars/cerebrum/src/contract/rest-nudges.ts
+++ b/pillars/cerebrum/src/contract/rest-nudges.ts
@@ -1,0 +1,139 @@
+/**
+ * ts-rest contract for `cerebrum.nudges.*` (PRD-084).
+ *
+ * Nudges are detector-produced suggestions persisted in `nudge_log`. This
+ * slice migrates ONLY the clean read/dismiss surface — the four procedures
+ * that touch nothing but the `nudge_log` table:
+ *
+ *   - `list`           → POST /nudges/search (typed enum filters)
+ *   - `get`            → GET  /nudges/:id
+ *   - `dismiss`        → POST /nudges/:id/dismiss
+ *   - `contradictions` → POST /nudges/contradictions
+ *
+ * `scan` / `act` / `configure` stay in the legacy router: they pull in the
+ * detectors, the HybridSearchService, the EngramService and an LLM
+ * contradiction analyzer — none of which have migrated. They follow a later
+ * slice once retrieval lands.
+ *
+ * Non-identity domain — served on the docker-network trust boundary with no
+ * per-request auth (parity with templates / engrams). `list` /
+ * `contradictions` are POST-with-body rather than GET because their typed
+ * enum filters don't round-trip cleanly through a query string (mirrors the
+ * reflex `history` + engrams `search` precedent).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+/**
+ * Nudge wire schemas. The pillar contract is self-contained, so the Nudge
+ * shape is defined here rather than imported from the db package. They live
+ * with the nudges contract (rather than in shared `rest-schemas.ts`) because
+ * no other domain consumes them.
+ */
+export const nudgeTypeSchema = z.enum(['consolidation', 'staleness', 'pattern', 'insight']);
+export type NudgeTypeWire = z.infer<typeof nudgeTypeSchema>;
+
+export const nudgeStatusSchema = z.enum(['pending', 'dismissed', 'acted', 'expired']);
+export type NudgeStatusWire = z.infer<typeof nudgeStatusSchema>;
+
+export const nudgePrioritySchema = z.enum(['low', 'medium', 'high']);
+export type NudgePriorityWire = z.infer<typeof nudgePrioritySchema>;
+
+export const nudgeActionSchema = z.object({
+  type: z.enum(['consolidate', 'archive', 'review', 'link']),
+  label: z.string(),
+  params: z.record(z.string(), z.unknown()),
+});
+
+/** A persisted nudge — the core data model of PRD-084. */
+export const nudgeSchema = z.object({
+  id: z.string(),
+  type: nudgeTypeSchema,
+  title: z.string(),
+  body: z.string(),
+  engramIds: z.array(z.string()),
+  priority: nudgePrioritySchema,
+  status: nudgeStatusSchema,
+  createdAt: z.string(),
+  expiresAt: z.string().nullable(),
+  actedAt: z.string().nullable(),
+  action: nudgeActionSchema.nullable(),
+});
+export type NudgeWire = z.infer<typeof nudgeSchema>;
+
+/** A contradiction-pattern nudge projected to its structured evidence. */
+export const nudgeContradictionSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  status: nudgeStatusSchema,
+  priority: nudgePrioritySchema,
+  title: z.string(),
+  engramA: z.string(),
+  engramB: z.string(),
+  excerptA: z.string(),
+  excerptB: z.string(),
+  conflict: z.string(),
+});
+export type NudgeContradictionWire = z.infer<typeof nudgeContradictionSchema>;
+
+const idParams = z.object({ id: z.string().min(1) });
+
+export const cerebrumNudgesContract = c.router({
+  list: {
+    method: 'POST',
+    path: '/nudges/search',
+    summary: 'List nudges matching the supplied filters, with a total count.',
+    body: z.object({
+      type: nudgeTypeSchema.optional(),
+      status: nudgeStatusSchema.optional(),
+      priority: nudgePrioritySchema.optional(),
+      limit: z.number().int().positive().max(100).optional(),
+      offset: z.number().int().nonnegative().optional(),
+    }),
+    responses: {
+      200: z.object({ nudges: z.array(nudgeSchema), total: z.number().int() }),
+    },
+  },
+  get: {
+    method: 'GET',
+    path: '/nudges/:id',
+    summary: 'Get a single nudge by ID.',
+    pathParams: idParams,
+    responses: {
+      200: z.object({ nudge: nudgeSchema }),
+      404: errorBodySchema,
+    },
+  },
+  dismiss: {
+    method: 'POST',
+    path: '/nudges/:id/dismiss',
+    summary: 'Dismiss a pending nudge.',
+    pathParams: idParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ success: z.boolean() }),
+      404: errorBodySchema,
+      409: errorBodySchema,
+    },
+  },
+  contradictions: {
+    method: 'POST',
+    path: '/nudges/contradictions',
+    summary: 'List contradiction-pattern nudges with structured evidence.',
+    body: z.object({
+      status: nudgeStatusSchema.nullable().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+      offset: z.number().int().nonnegative().optional(),
+    }),
+    responses: {
+      200: z.object({
+        contradictions: z.array(nudgeContradictionSchema),
+        total: z.number().int(),
+      }),
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 
 import { cerebrumEngramsContract } from './rest-engrams.js';
+import { cerebrumNudgesContract } from './rest-nudges.js';
 import { cerebrumPlexusContract } from './rest-plexus.js';
 import { cerebrumReflexContract } from './rest-reflex.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
@@ -29,6 +30,7 @@ export const cerebrumContract = c.router(
     engrams: cerebrumEngramsContract,
     scopes: cerebrumScopesContract,
     tags: cerebrumTagsContract,
+    nudges: cerebrumNudgesContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Summary

Migrates the four clean read/dismiss nudge procedures off tRPC onto the cerebrum pillar's ts-rest contract, following the established slice pattern (templates / plexus / reflex / engrams / scopes / tags).

| tRPC proc | REST | notes |
|---|---|---|
| `cerebrum.nudges.list` | `POST /nudges/search` | typed enum filters in body → `{nudges, total}` |
| `cerebrum.nudges.get` | `GET /nudges/:id` | `{nudge}`, 404 if missing |
| `cerebrum.nudges.dismiss` | `POST /nudges/:id/dismiss` | `{success}`, 404 if missing / 409 if non-pending |
| `cerebrum.nudges.contradictions` | `POST /nudges/contradictions` | `{contradictions[], total}` |

Dotted operationIds (`nudges.list`, `nudges.get`, `nudges.dismiss`, `nudges.contradictions`) via the contract's `concatenated-path` setting.

## What changed
- `src/contract/rest-nudges.ts` — per-domain contract + the Nudge wire schemas (defined locally so the pillar contract stays self-contained; they live with the nudges contract because no other domain consumes them).
- `src/api/modules/nudges/service.ts` — the read service lifted from `apps/pops-cerebrum-api`, rebound onto the pillar db package (`../../../db`) instead of `@pops/cerebrum-db`. Reads `nudge_log`, reuses `nudgeLogService.listContradictions()`.
- `src/api/modules/nudges/contradiction.ts` — the contradiction-evidence extractor (no casts).
- `src/api/rest/nudges-handlers.ts` — handlers over `deps.cerebrumDb.db`; errors flow through the pillar `HttpError` subclasses + `runHttp` (`NotFoundError`→404, `ConflictError`→409), preserving the missing-vs-non-pending split the cerebrum-api shadow router introduced over the monolith's single `BAD_REQUEST`.
- Wired `nudges` into `rest.ts` + `rest/handlers.ts` alongside the existing domains.
- `src/api/__tests__/nudges.test.ts` + a `nudges` section in `test-utils.ts makeClient`.
- Regenerated `openapi/cerebrum.openapi.json` + `src/contract/api-types.generated.ts`.

## Deferred
`scan` / `act` / `configure` are **not** migrated. They depend on the detectors, `HybridSearchService`, `EngramService` and an LLM contradiction analyzer — none of which have migrated. They follow a **post-retrieval slice**.

## Green proof (worktree, against lake-migration head)
- `oxfmt --check pillars/cerebrum/` — all files correctly formatted
- `oxlint pillars/cerebrum/src` — 0 errors (only the pre-existing `__resetPillarRegistryCache` warning)
- `pnpm --filter @pops/cerebrum typecheck` — clean
- `pnpm --filter @pops/cerebrum build` — clean
- `generate:openapi` + `git diff --exit-code` — clean (deterministic, committed)
- `pnpm --filter @pops/cerebrum test` — **426 passed** (12 new in `nudges.test.ts`): search empty + filters (type/status/priority) + pagination, get unknown→404, dismiss pending→success, dismiss missing→404, dismiss already-dismissed→409, contradictions projection + pending-default + status:null + empty.

No `as any` / casts / suppressions.
