### PR TITLE
feat(cerebrum): REST migration slice — glia

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -1411,6 +1411,1440 @@
         "tags": ["engrams"]
       }
     },
+    "/glia/actions/history": {
+      "post": {
+        "operationId": "glia.actions.history",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "actionType": {
+                    "enum": ["prune", "consolidate", "link", "audit"],
+                    "type": "string"
+                  },
+                  "dateFrom": {
+                    "type": "string"
+                  },
+                  "dateTo": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "executedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "payload": {
+                            "nullable": true
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "revertedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                            "type": "string"
+                          },
+                          "userDecision": {
+                            "enum": ["approve", "reject", "modify"],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "userNote": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "userDecision",
+                          "userNote",
+                          "executedAt",
+                          "decidedAt",
+                          "revertedAt",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Query the action audit trail (filtered + paginated).",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/actions/search": {
+      "post": {
+        "operationId": "glia.actions.list",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "actionType": {
+                    "enum": ["prune", "consolidate", "link", "audit"],
+                    "type": "string"
+                  },
+                  "dateFrom": {
+                    "type": "string"
+                  },
+                  "dateTo": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "executedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "payload": {
+                            "nullable": true
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "revertedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                            "type": "string"
+                          },
+                          "userDecision": {
+                            "enum": ["approve", "reject", "modify"],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "userNote": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "userDecision",
+                          "userNote",
+                          "executedAt",
+                          "decidedAt",
+                          "revertedAt",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List glia actions matching the supplied filters (proposal queue + audit trail).",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/actions/{id}": {
+      "get": {
+        "operationId": "glia.actions.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "affectedIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "decidedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "executedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "payload": {
+                          "nullable": true
+                        },
+                        "phase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "revertedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                          "type": "string"
+                        },
+                        "userDecision": {
+                          "enum": ["approve", "reject", "modify"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "userNote": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "actionType",
+                        "affectedIds",
+                        "rationale",
+                        "payload",
+                        "phase",
+                        "status",
+                        "userDecision",
+                        "userNote",
+                        "executedAt",
+                        "decidedAt",
+                        "revertedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["action"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get a single glia action by id.",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/actions/{id}/decide": {
+      "post": {
+        "operationId": "glia.actions.decide",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "decision": {
+                    "enum": ["approve", "reject", "modify"],
+                    "type": "string"
+                  },
+                  "note": {
+                    "type": "string"
+                  }
+                },
+                "required": ["decision"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "affectedIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "decidedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "executedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "payload": {
+                          "nullable": true
+                        },
+                        "phase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "revertedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                          "type": "string"
+                        },
+                        "userDecision": {
+                          "enum": ["approve", "reject", "modify"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "userNote": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "actionType",
+                        "affectedIds",
+                        "rationale",
+                        "payload",
+                        "phase",
+                        "status",
+                        "userDecision",
+                        "userNote",
+                        "executedAt",
+                        "decidedAt",
+                        "revertedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "transition": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "newPhase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "oldPhase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "transitioned": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["transitioned", "actionType", "oldPhase", "newPhase", "reason"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["action", "transition"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Record a user decision on a pending action; eagerly re-evaluate graduation.",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/actions/{id}/execute": {
+      "post": {
+        "operationId": "glia.actions.execute",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "affectedIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "decidedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "executedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "payload": {
+                          "nullable": true
+                        },
+                        "phase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "revertedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                          "type": "string"
+                        },
+                        "userDecision": {
+                          "enum": ["approve", "reject", "modify"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "userNote": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "actionType",
+                        "affectedIds",
+                        "rationale",
+                        "payload",
+                        "phase",
+                        "status",
+                        "userDecision",
+                        "userNote",
+                        "executedAt",
+                        "decidedAt",
+                        "revertedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["action"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Execute an approved action.",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/actions/{id}/revert": {
+      "post": {
+        "operationId": "glia.actions.revert",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "affectedIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "decidedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "executedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "payload": {
+                          "nullable": true
+                        },
+                        "phase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "revertedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "approved", "rejected", "executed", "reverted"],
+                          "type": "string"
+                        },
+                        "userDecision": {
+                          "enum": ["approve", "reject", "modify"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "userNote": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "actionType",
+                        "affectedIds",
+                        "rationale",
+                        "payload",
+                        "phase",
+                        "status",
+                        "userDecision",
+                        "userNote",
+                        "executedAt",
+                        "decidedAt",
+                        "revertedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "revertResult": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errors": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "restoredIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["success", "restoredIds", "errors"],
+                      "type": "object"
+                    },
+                    "transition": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "newPhase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "oldPhase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "transitioned": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["transitioned", "actionType", "oldPhase", "newPhase", "reason"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["action", "transition", "revertResult"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Revert an executed action (DB-state flip + file-level undo).",
+        "tags": ["glia", "actions"]
+      }
+    },
+    "/glia/digest": {
+      "post": {
+        "operationId": "glia.digest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "actionType": {
+                    "enum": ["prune", "consolidate", "link", "audit"],
+                    "type": "string"
+                  },
+                  "deliver": {
+                    "type": "boolean"
+                  },
+                  "period": {
+                    "enum": ["daily", "weekly"],
+                    "type": "string"
+                  },
+                  "rejectionRateThreshold": {
+                    "exclusiveMinimum": true,
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "delivery": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "attempted": {
+                          "type": "boolean"
+                        },
+                        "channels": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "channel": {
+                                "enum": ["shell", "moltbot"],
+                                "type": "string"
+                              },
+                              "delivered": {
+                                "type": "boolean"
+                              },
+                              "reason": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": ["channel", "delivered", "reason"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "suppressedReason": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["attempted", "suppressedReason", "channels"],
+                      "type": "object"
+                    },
+                    "report": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "anomalies": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "actionType": {
+                                "enum": ["prune", "consolidate", "link", "audit"],
+                                "type": "string"
+                              },
+                              "autonomousSince": {
+                                "type": "string"
+                              },
+                              "executedCount": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "rejectionRatePostGraduation": {
+                                "type": "number"
+                              },
+                              "revertedCount": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "threshold": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "actionType",
+                              "rejectionRatePostGraduation",
+                              "threshold",
+                              "autonomousSince",
+                              "executedCount",
+                              "revertedCount"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "endDate": {
+                          "type": "string"
+                        },
+                        "groups": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "actionType": {
+                                "enum": ["prune", "consolidate", "link", "audit"],
+                                "type": "string"
+                              },
+                              "actions": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "affectedIds": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "executedAt": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "rationale": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["id", "affectedIds", "rationale", "executedAt"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "count": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["actionType", "count", "actions"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "period": {
+                          "enum": ["daily", "weekly"],
+                          "type": "string"
+                        },
+                        "startDate": {
+                          "type": "string"
+                        },
+                        "totalAutonomousActions": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "period",
+                        "startDate",
+                        "endDate",
+                        "totalAutonomousActions",
+                        "groups",
+                        "anomalies"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["report", "delivery"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Generate (and optionally deliver) the autonomous-action digest.",
+        "tags": ["glia"]
+      }
+    },
+    "/glia/trust-state": {
+      "get": {
+        "operationId": "glia.trustState.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "states": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "approvedCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "autonomousSince": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "currentPhase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "graduatedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "lastRevertAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "rejectedCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "revertedCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "actionType",
+                          "currentPhase",
+                          "approvedCount",
+                          "rejectedCount",
+                          "revertedCount",
+                          "autonomousSince",
+                          "lastRevertAt",
+                          "graduatedAt",
+                          "updatedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["states"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List trust state for every action type.",
+        "tags": ["glia", "trustState"]
+      }
+    },
+    "/glia/trust-state/{actionType}": {
+      "get": {
+        "operationId": "glia.trustState.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "actionType",
+            "required": true,
+            "schema": {
+              "enum": ["prune", "consolidate", "link", "audit"],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "state": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actionType": {
+                          "enum": ["prune", "consolidate", "link", "audit"],
+                          "type": "string"
+                        },
+                        "approvedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "autonomousSince": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "currentPhase": {
+                          "enum": ["propose", "act_report", "silent"],
+                          "type": "string"
+                        },
+                        "graduatedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastRevertAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "rejectedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "revertedCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "actionType",
+                        "currentPhase",
+                        "approvedCount",
+                        "rejectedCount",
+                        "revertedCount",
+                        "autonomousSince",
+                        "lastRevertAt",
+                        "graduatedAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["state"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get trust state for a single action type.",
+        "tags": ["glia", "trustState"]
+      }
+    },
     "/plexus/adapters": {
       "get": {
         "operationId": "plexus.adapters.list",

--- a/pillars/cerebrum/src/api/__tests__/glia.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/glia.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration tests for `cerebrum.glia.*` over REST (PRD-086 / PRD-181).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` (glia baseline migration
+ * 0051 applied by `openCerebrumDb`). Glia rows are seeded directly through the
+ * `gliaService` data-access namespace, then the wire surface is exercised via
+ * the supertest client. The digest cases use `deliver: false` plus seeded
+ * trust phases to prove the three suppression rules without touching Telegram.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  gliaService,
+  openCerebrumDb,
+  type ActionType,
+  type GliaAction,
+  type OpenedCerebrumDb,
+  type TrustPhase,
+} from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { makeClient, makeTemplateRegistry, makeReflexService } from './test-utils.js';
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-glia-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      // Point glia.toml at a non-existent file so the hardcoded ADR-021
+      // defaults apply deterministically.
+      gliaConfigPath: join(tmpDir, '.config', 'glia.toml'),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+    })
+  );
+}
+
+function seedTrustState(
+  actionType: ActionType,
+  phase: TrustPhase,
+  overrides: Partial<{
+    approvedCount: number;
+    rejectedCount: number;
+    revertedCount: number;
+    autonomousSince: string | null;
+  }> = {}
+): void {
+  gliaService.seedTrustState(cerebrumDb.db, {
+    actionType,
+    currentPhase: phase,
+    approvedCount: 0,
+    rejectedCount: 0,
+    revertedCount: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  });
+  gliaService.updateTrustState(cerebrumDb.db, actionType, {
+    currentPhase: phase,
+    approvedCount: overrides.approvedCount ?? 0,
+    rejectedCount: overrides.rejectedCount ?? 0,
+    revertedCount: overrides.revertedCount ?? 0,
+    autonomousSince: overrides.autonomousSince ?? null,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  });
+}
+
+function seedPendingAction(id: string, actionType: ActionType = 'link'): GliaAction {
+  return gliaService.insertAction(cerebrumDb.db, {
+    id,
+    actionType,
+    affectedIds: ['eng_20260101_0900_a', 'eng_20260101_0900_b'],
+    rationale: `proposal ${id}`,
+    payload: null,
+    phase: 'propose',
+    status: 'pending',
+    executedAt: null,
+    createdAt: '2026-01-05T00:00:00.000Z',
+  });
+}
+
+/** Seed an autonomous executed action inside the daily digest window. */
+function seedAutonomousExecuted(
+  id: string,
+  actionType: ActionType,
+  phase: TrustPhase,
+  executedAt: string
+): void {
+  gliaService.insertAction(cerebrumDb.db, {
+    id,
+    actionType,
+    affectedIds: ['eng_20260601_0900_x'],
+    rationale: `autonomous ${id}`,
+    payload: null,
+    phase,
+    status: 'executed',
+    executedAt,
+    createdAt: executedAt,
+  });
+}
+
+describe('POST /glia/actions/search', () => {
+  it('returns an empty result on a fresh DB', async () => {
+    const { actions, total } = await client().glia.list();
+    expect(actions).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  it('filters by status', async () => {
+    seedTrustState('link', 'propose');
+    seedPendingAction('glia_link_1');
+    seedPendingAction('glia_link_2');
+
+    const pending = await client().glia.list({ status: 'pending' });
+    expect(pending.total).toBe(2);
+
+    const executed = await client().glia.list({ status: 'executed' });
+    expect(executed.total).toBe(0);
+  });
+});
+
+describe('GET /glia/actions/:id', () => {
+  it('404s on an unknown action', async () => {
+    await expect(client().glia.get('nope')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns a seeded action', async () => {
+    seedTrustState('link', 'propose');
+    seedPendingAction('glia_link_get');
+    const { action } = await client().glia.get('glia_link_get');
+    expect(action.id).toBe('glia_link_get');
+    expect(action.status).toBe('pending');
+    expect(action.affectedIds).toHaveLength(2);
+  });
+});
+
+describe('POST /glia/actions/:id/decide', () => {
+  it('approves a pending action and increments the trust-state counter atomically', async () => {
+    seedTrustState('link', 'propose');
+    seedPendingAction('glia_link_decide');
+
+    const { action, transition } = await client().glia.decide('glia_link_decide', 'approve');
+    expect(action.status).toBe('approved');
+    expect(action.userDecision).toBe('approve');
+    expect(transition.transitioned).toBe(false);
+
+    const { state } = await client().glia.trustStateGet('link');
+    expect(state.approvedCount).toBe(1);
+    expect(state.rejectedCount).toBe(0);
+  });
+
+  it('increments the rejected counter on a reject', async () => {
+    seedTrustState('prune', 'propose');
+    seedPendingAction('glia_prune_decide', 'prune');
+
+    await client().glia.decide('glia_prune_decide', 'reject', 'too aggressive');
+    const { state } = await client().glia.trustStateGet('prune');
+    expect(state.rejectedCount).toBe(1);
+    expect(state.approvedCount).toBe(0);
+  });
+
+  it('409s when deciding on an already-decided action', async () => {
+    seedTrustState('link', 'propose');
+    seedPendingAction('glia_link_twice');
+    await client().glia.decide('glia_link_twice', 'approve');
+    await expect(client().glia.decide('glia_link_twice', 'approve')).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it('404s deciding on an unknown action', async () => {
+    seedTrustState('link', 'propose');
+    await expect(client().glia.decide('ghost', 'approve')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('GET /glia/trust-state', () => {
+  it('lists every seeded trust state', async () => {
+    seedTrustState('prune', 'propose');
+    seedTrustState('link', 'act_report', { autonomousSince: '2026-01-01T00:00:00.000Z' });
+
+    const { states } = await client().glia.trustStateList();
+    const byType = new Map(states.map((s) => [s.actionType, s]));
+    expect(byType.get('prune')?.currentPhase).toBe('propose');
+    expect(byType.get('link')?.currentPhase).toBe('act_report');
+  });
+
+  it('404s on a trust state that was never seeded', async () => {
+    await expect(client().glia.trustStateGet('audit')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('POST /glia/digest (deliver:false + suppression rules)', () => {
+  it('suppresses delivery when the caller disables it', async () => {
+    seedTrustState('link', 'act_report', { autonomousSince: '2026-06-01T00:00:00.000Z' });
+    seedAutonomousExecuted('glia_link_auto', 'link', 'act_report', isoYesterday());
+
+    const { report, delivery } = await client().glia.digest({ deliver: false });
+    expect(report.totalAutonomousActions).toBe(1);
+    expect(delivery.attempted).toBe(false);
+    expect(delivery.suppressedReason).toBe('Delivery disabled by caller');
+    expect(delivery.channels).toEqual([]);
+  });
+
+  it('suppresses delivery when there are zero autonomous actions in the period', async () => {
+    seedTrustState('link', 'act_report', { autonomousSince: '2026-06-01T00:00:00.000Z' });
+    const { report, delivery } = await client().glia.digest({});
+    expect(report.totalAutonomousActions).toBe(0);
+    expect(delivery.attempted).toBe(false);
+    expect(delivery.suppressedReason).toBe('No autonomous actions in period');
+  });
+
+  it('suppresses delivery when every type in the digest is in the silent phase', async () => {
+    seedTrustState('prune', 'silent', { autonomousSince: '2026-06-01T00:00:00.000Z' });
+    seedAutonomousExecuted('glia_prune_silent', 'prune', 'silent', isoYesterday());
+
+    const { report, delivery } = await client().glia.digest({});
+    expect(report.totalAutonomousActions).toBe(1);
+    expect(delivery.attempted).toBe(false);
+    expect(delivery.suppressedReason).toBe('All action types in digest are in silent phase');
+  });
+});
+
+/**
+ * An ISO timestamp inside the previous-day daily-digest window. The digest
+ * range is `[startOfYesterday, startOfToday)`, so mid-yesterday is always in
+ * range regardless of when the test runs.
+ */
+function isoYesterday(): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - 1);
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+}

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -14,6 +14,17 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 import type { Express } from 'express';
 
 import type {
+  GliaActionTypeWire,
+  GliaActionStatusWire,
+  GliaActionWire,
+  GliaDigestDeliveryWire,
+  GliaDigestReportWire,
+  GliaRevertResultWire,
+  GliaTransitionResultWire,
+  GliaTrustStateWire,
+  GliaUserDecisionWire,
+} from '../../contract/rest-glia-schemas.js';
+import type {
   EngramWire,
   PlexusAdapterWire,
   PlexusFilterDefinitionWire,
@@ -118,6 +129,22 @@ export interface ReflexHistoryFilters {
   offset?: number;
 }
 
+export interface GliaActionFilters {
+  actionType?: GliaActionTypeWire;
+  status?: GliaActionStatusWire;
+  dateFrom?: string;
+  dateTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GliaDigestInput {
+  period?: 'daily' | 'weekly';
+  actionType?: GliaActionTypeWire;
+  rejectionRateThreshold?: number;
+  deliver?: boolean;
+}
+
 export function makeClient(app: Express) {
   const r = supertest.agent(app);
   return {
@@ -202,6 +229,36 @@ export function makeClient(app: Express) {
       setFilters: (adapterId: string, filters: PlexusFilterDefinitionWire[]) =>
         send<{ filters: PlexusFilterWire[] }>(
           r.post(`/plexus/adapters/${adapterId}/filters`).send({ filters })
+        ),
+    },
+    glia: {
+      list: (filters: GliaActionFilters = {}) =>
+        send<{ actions: GliaActionWire[]; total: number }>(
+          r.post('/glia/actions/search').send(filters)
+        ),
+      get: (id: string) => send<{ action: GliaActionWire }>(r.get(`/glia/actions/${id}`)),
+      decide: (id: string, decision: GliaUserDecisionWire, note?: string) =>
+        send<{ action: GliaActionWire; transition: GliaTransitionResultWire }>(
+          r.post(`/glia/actions/${id}/decide`).send({ decision, ...(note ? { note } : {}) })
+        ),
+      execute: (id: string) =>
+        send<{ action: GliaActionWire }>(r.post(`/glia/actions/${id}/execute`).send({})),
+      revert: (id: string) =>
+        send<{
+          action: GliaActionWire;
+          transition: GliaTransitionResultWire;
+          revertResult: GliaRevertResultWire;
+        }>(r.post(`/glia/actions/${id}/revert`).send({})),
+      history: (filters: GliaActionFilters = {}) =>
+        send<{ actions: GliaActionWire[]; total: number }>(
+          r.post('/glia/actions/history').send(filters)
+        ),
+      trustStateGet: (actionType: GliaActionTypeWire) =>
+        send<{ state: GliaTrustStateWire }>(r.get(`/glia/trust-state/${actionType}`)),
+      trustStateList: () => send<{ states: GliaTrustStateWire[] }>(r.get('/glia/trust-state')),
+      digest: (input: GliaDigestInput = {}) =>
+        send<{ report: GliaDigestReportWire; delivery: GliaDigestDeliveryWire }>(
+          r.post('/glia/digest').send(input)
         ),
     },
   };

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -25,6 +25,12 @@ export interface CerebrumApiDeps {
   engramRoot: string;
   /** TOML-driven reflex registry + execution-log accessor (PRD-089). */
   reflexService: ReflexService;
+  /**
+   * Absolute path to the glia graduation-threshold TOML (`glia.toml`).
+   * Optional — defaults to `resolveGliaConfigPath()` (env-driven, tolerant of
+   * a missing file → hardcoded ADR-021 defaults). Tests pin it to a fixture.
+   */
+  gliaConfigPath?: string;
   /** Semver of the build, surfaced on the health response. */
   version: string;
   /**

--- a/pillars/cerebrum/src/api/modules/glia/action-service.ts
+++ b/pillars/cerebrum/src/api/modules/glia/action-service.ts
@@ -1,0 +1,197 @@
+/**
+ * GliaActionService — CRUD over `glia_actions` + `glia_trust_state`.
+ *
+ * The constructor takes a `CerebrumDb` handle (the injected pillar handle, or
+ * a transaction handle for the atomic decide/revert paths). All write
+ * operations that mutate trust-state counters wrap the action update and the
+ * counter increment in a single `db.transaction(...)` so a partial failure
+ * never leaves the counters out of step with the action rows.
+ *
+ * Reads + writes route through the `gliaService` data-access namespace in the
+ * pillar db package — the SQL seam stays pure data-access; the trust-machine
+ * orchestration lives in `./trust-machine.ts`.
+ */
+import { gliaService, type CerebrumDb } from '../../../db/index.js';
+import { ConflictError, NotFoundError, ValidationError } from '../../shared/errors.js';
+import { generateActionId } from './helpers.js';
+import { ACTION_TYPES } from './types.js';
+
+import type {
+  ActionListFilters,
+  ActionType,
+  CreateActionInput,
+  GliaAction,
+  GliaTrustState,
+  UserDecision,
+} from './types.js';
+
+export class GliaActionService {
+  private readonly db: CerebrumDb;
+  private readonly now: () => Date;
+
+  constructor(db: CerebrumDb, now: () => Date = () => new Date()) {
+    this.db = db;
+    this.now = now;
+  }
+
+  /** Seed initial trust states for all four action types. Idempotent. */
+  seedTrustStates(): void {
+    const timestamp = this.now().toISOString();
+    for (const actionType of ACTION_TYPES) {
+      gliaService.seedTrustState(this.db, {
+        actionType,
+        currentPhase: 'propose',
+        approvedCount: 0,
+        rejectedCount: 0,
+        revertedCount: 0,
+        updatedAt: timestamp,
+      });
+    }
+  }
+
+  /** Create a new Glia action (proposal or autonomous). */
+  createAction(input: CreateActionInput): GliaAction {
+    if (!ACTION_TYPES.includes(input.actionType)) {
+      throw new ValidationError(`Unknown action type: ${input.actionType}`);
+    }
+    if (!input.affectedIds.length) {
+      throw new ValidationError('affectedIds must contain at least one engram ID');
+    }
+
+    const timestamp = this.now().toISOString();
+    const trustState = gliaService.getTrustState(this.db, input.actionType);
+    if (!trustState) {
+      throw new ValidationError(`Trust state not initialized for: ${input.actionType}`);
+    }
+
+    const id = generateActionId(input.actionType, timestamp);
+    const phase = trustState.currentPhase;
+    const isAutonomous = phase === 'act_report' || phase === 'silent';
+
+    return gliaService.insertAction(this.db, {
+      id,
+      actionType: input.actionType,
+      affectedIds: input.affectedIds,
+      rationale: input.rationale,
+      payload: input.payload ?? null,
+      phase,
+      status: isAutonomous ? 'executed' : 'pending',
+      executedAt: isAutonomous ? timestamp : null,
+      createdAt: timestamp,
+    });
+  }
+
+  /** Record a user decision on a pending action (transactional). */
+  decideAction(id: string, decision: UserDecision, note?: string): GliaAction {
+    const action = this.requireAction(id);
+    if (action.status !== 'pending') {
+      throw new ConflictError(
+        `Cannot decide on action '${id}' — current status is '${action.status}', expected 'pending'`
+      );
+    }
+
+    const timestamp = this.now().toISOString();
+    const isApproval = decision === 'approve' || decision === 'modify';
+    const counterField = isApproval ? 'approvedCount' : 'rejectedCount';
+
+    this.db.transaction((tx) => {
+      gliaService.updateAction(tx, id, {
+        status: isApproval ? 'approved' : 'rejected',
+        userDecision: decision,
+        userNote: note ?? null,
+        decidedAt: timestamp,
+      });
+      gliaService.incrementTrustStateCounter(tx, action.actionType, counterField, timestamp);
+    });
+
+    return this.requireAction(id);
+  }
+
+  /** Execute an approved action. */
+  executeAction(id: string): GliaAction {
+    const action = this.requireAction(id);
+    if (action.status !== 'approved') {
+      throw new ConflictError(
+        `Cannot execute action '${id}' — current status is '${action.status}', expected 'approved'`
+      );
+    }
+    gliaService.updateAction(this.db, id, {
+      status: 'executed',
+      executedAt: this.now().toISOString(),
+    });
+    return this.requireAction(id);
+  }
+
+  /** Revert an executed action (idempotent for already-reverted; transactional). */
+  revertAction(id: string): GliaAction {
+    const action = this.requireAction(id);
+    if (action.status === 'reverted') return action;
+    if (action.actionType === 'audit') {
+      throw new ValidationError('Audit actions are informational and cannot be reverted');
+    }
+    if (action.status !== 'executed') {
+      throw new ConflictError(
+        `Cannot revert action '${id}' — current status is '${action.status}', expected 'executed'`
+      );
+    }
+
+    const timestamp = this.now().toISOString();
+    this.db.transaction((tx) => {
+      gliaService.updateAction(tx, id, { status: 'reverted', revertedAt: timestamp });
+      gliaService.incrementTrustStateCounter(tx, action.actionType, 'revertedCount', timestamp);
+      gliaService.updateTrustState(tx, action.actionType, {
+        lastRevertAt: timestamp,
+        updatedAt: timestamp,
+      });
+    });
+    return this.requireAction(id);
+  }
+
+  getAction(id: string): GliaAction | null {
+    return gliaService.getAction(this.db, id);
+  }
+  listActions(filters: ActionListFilters = {}): { actions: GliaAction[]; total: number } {
+    return gliaService.listActions(this.db, filters);
+  }
+  getTrustState(actionType: ActionType): GliaTrustState | null {
+    return gliaService.getTrustState(this.db, actionType);
+  }
+  listTrustStates(): GliaTrustState[] {
+    return gliaService.listTrustStates(this.db);
+  }
+  countRevertsInWindow(actionType: ActionType, windowStart: string): number {
+    return gliaService.countRevertsInWindow(this.db, actionType, windowStart);
+  }
+
+  /** Autonomous actions executed in a window (used by the digest). */
+  listAutonomousActionsInWindow(startDate: string, endDate: string): GliaAction[] {
+    return gliaService.listAutonomousActionsInWindow(this.db, startDate, endDate);
+  }
+
+  /** Count autonomous executions for a type since a given timestamp. */
+  countAutonomousExecutionsSince(actionType: ActionType, sinceIso: string): number {
+    return gliaService.countAutonomousExecutionsSince(this.db, actionType, sinceIso);
+  }
+
+  /** Count autonomous reverts for a type since a given timestamp. */
+  countAutonomousRevertsSince(actionType: ActionType, sinceIso: string): number {
+    return gliaService.countAutonomousRevertsSince(this.db, actionType, sinceIso);
+  }
+
+  /** Update trust state directly (used by the trust machine). */
+  updateTrustState(
+    actionType: ActionType,
+    updates: Partial<Omit<GliaTrustState, 'actionType'>>
+  ): void {
+    gliaService.updateTrustState(this.db, actionType, {
+      ...updates,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  private requireAction(id: string): GliaAction {
+    const action = gliaService.getAction(this.db, id);
+    if (!action) throw new NotFoundError('GliaAction', id);
+    return action;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/glia/autonomous-digest.test.ts
+++ b/pillars/cerebrum/src/api/modules/glia/autonomous-digest.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for the autonomous-action digest builder (#2577).
+ *
+ * Pure-function checks: grouping, ordering, anomaly detection, renderer output.
+ * No DB access.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD,
+  buildAutonomousDigest,
+  renderAutonomousDigestText,
+} from './autonomous-digest.js';
+
+import type { ActionType, GliaAction, GliaTrustState, TrustPhase } from './types.js';
+
+function autonomousAction(overrides: Partial<GliaAction> = {}): GliaAction {
+  return {
+    id: 'glia_prune_20260510_a',
+    actionType: 'prune',
+    affectedIds: ['eng_1'],
+    rationale: 'Stale engram archived',
+    payload: null,
+    phase: 'act_report',
+    status: 'executed',
+    userDecision: null,
+    userNote: null,
+    executedAt: '2026-05-10T10:00:00Z',
+    decidedAt: null,
+    revertedAt: null,
+    createdAt: '2026-05-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function trustState(
+  actionType: ActionType,
+  currentPhase: TrustPhase,
+  overrides: Partial<GliaTrustState> = {}
+): GliaTrustState {
+  return {
+    actionType,
+    currentPhase,
+    approvedCount: 0,
+    rejectedCount: 0,
+    revertedCount: 0,
+    autonomousSince: currentPhase === 'propose' ? null : '2026-04-01T00:00:00Z',
+    lastRevertAt: null,
+    graduatedAt: currentPhase === 'propose' ? null : '2026-04-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildAutonomousDigest', () => {
+  it('groups actions by type and lists affected engrams with rationale', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({
+        id: 'a1',
+        actionType: 'prune',
+        affectedIds: ['eng_1'],
+        rationale: 'Stale 1',
+        executedAt: '2026-05-10T10:00:00Z',
+      }),
+      autonomousAction({
+        id: 'a2',
+        actionType: 'prune',
+        affectedIds: ['eng_2'],
+        rationale: 'Stale 2',
+        executedAt: '2026-05-10T11:00:00Z',
+      }),
+      autonomousAction({
+        id: 'a3',
+        actionType: 'link',
+        affectedIds: ['eng_3', 'eng_4'],
+        rationale: 'Cross reference',
+        executedAt: '2026-05-10T12:00:00Z',
+      }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report'), trustState('link', 'act_report')],
+      postGraduationExecutedByType: { prune: 2, link: 1 },
+      postGraduationRevertedByType: { prune: 0, link: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.totalAutonomousActions).toBe(3);
+    expect(report.groups).toHaveLength(2);
+
+    expect(report.groups[0]?.actionType).toBe('prune');
+    expect(report.groups[0]?.count).toBe(2);
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['a1', 'a2']);
+    expect(report.groups[0]?.actions[0]?.affectedIds).toEqual(['eng_1']);
+    expect(report.groups[0]?.actions[0]?.rationale).toBe('Stale 1');
+
+    expect(report.groups[1]?.actionType).toBe('link');
+    expect(report.groups[1]?.count).toBe(1);
+    expect(report.groups[1]?.actions[0]?.affectedIds).toEqual(['eng_3', 'eng_4']);
+  });
+
+  it('sorts entries inside a group chronologically', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({ id: 'late', executedAt: '2026-05-10T12:00:00Z' }),
+      autonomousAction({ id: 'early', executedAt: '2026-05-10T08:00:00Z' }),
+      autonomousAction({ id: 'mid', executedAt: '2026-05-10T10:00:00Z' }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 3 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('skips rows that are not actually autonomous', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({ id: 'autonomous' }),
+      autonomousAction({ id: 'user-driven', decidedAt: '2026-05-10T09:30:00Z' }),
+      autonomousAction({ id: 'pending', status: 'pending', executedAt: null }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 1 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['autonomous']);
+  });
+
+  it('returns an empty report when there are no actions', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: {},
+      postGraduationRevertedByType: {},
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.totalAutonomousActions).toBe(0);
+    expect(report.groups).toEqual([]);
+    expect(report.anomalies).toEqual([]);
+  });
+});
+
+describe('buildAutonomousDigest anomalies', () => {
+  it('flags an action type whose post-graduation rejection rate exceeds the default threshold', () => {
+    const report = buildAutonomousDigest({
+      actions: [autonomousAction()],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 6 },
+      postGraduationRevertedByType: { prune: 4 },
+      period: 'weekly',
+      startDate: '2026-05-04T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.anomalies).toHaveLength(1);
+    const anomaly = report.anomalies[0];
+    expect(anomaly?.actionType).toBe('prune');
+    expect(anomaly?.rejectionRatePostGraduation).toBeCloseTo(0.4);
+    expect(anomaly?.threshold).toBe(DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD);
+    expect(anomaly?.executedCount).toBe(6);
+    expect(anomaly?.revertedCount).toBe(4);
+  });
+
+  it('does not flag types in propose phase', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'propose', { autonomousSince: null })],
+      postGraduationExecutedByType: { prune: 1 },
+      postGraduationRevertedByType: { prune: 10 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+    expect(report.anomalies).toEqual([]);
+  });
+
+  it('respects a custom threshold', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 8 },
+      postGraduationRevertedByType: { prune: 2 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+      rejectionRateThreshold: 0.15,
+    });
+
+    expect(report.anomalies).toHaveLength(1);
+    expect(report.anomalies[0]?.rejectionRatePostGraduation).toBeCloseTo(0.2);
+    expect(report.anomalies[0]?.threshold).toBe(0.15);
+  });
+
+  it('does not flag when total post-graduation activity is zero', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('link', 'act_report')],
+      postGraduationExecutedByType: { link: 0 },
+      postGraduationRevertedByType: { link: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+    expect(report.anomalies).toEqual([]);
+  });
+});
+
+describe('renderAutonomousDigestText', () => {
+  it('renders groups, affected engrams, and anomalies in plain text', () => {
+    const report = buildAutonomousDigest({
+      actions: [
+        autonomousAction({
+          id: 'a1',
+          actionType: 'prune',
+          affectedIds: ['eng_1'],
+          rationale: 'Stale',
+        }),
+        autonomousAction({
+          id: 'a2',
+          actionType: 'link',
+          affectedIds: ['eng_a', 'eng_b'],
+          rationale: 'Linked',
+        }),
+      ],
+      trustStates: [trustState('prune', 'act_report'), trustState('link', 'act_report')],
+      postGraduationExecutedByType: { prune: 1, link: 6 },
+      postGraduationRevertedByType: { prune: 0, link: 4 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    const text = renderAutonomousDigestText(report);
+    expect(text).toContain('Daily Glia digest — 2 autonomous actions');
+    expect(text).toContain('prune (1)');
+    expect(text).toContain('link (1)');
+    expect(text).toContain('[eng_1] Stale');
+    expect(text).toContain('[eng_a, eng_b] Linked');
+    expect(text).toContain('Anomalies');
+    expect(text).toContain('link: 40.0% post-graduation rejection rate (4/10)');
+  });
+
+  it('truncates per-group previews above 5 entries', () => {
+    const actions: GliaAction[] = Array.from({ length: 7 }, (_, i) =>
+      autonomousAction({
+        id: `a${i}`,
+        executedAt: `2026-05-10T10:0${i}:00Z`,
+      })
+    );
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 7 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    const text = renderAutonomousDigestText(report);
+    expect(text).toContain('+2 more');
+  });
+});

--- a/pillars/cerebrum/src/api/modules/glia/autonomous-digest.ts
+++ b/pillars/cerebrum/src/api/modules/glia/autonomous-digest.ts
@@ -1,0 +1,237 @@
+/**
+ * Autonomous-action digest for `cerebrum.glia.digest` (#2248, #2577).
+ *
+ * Pure functions — no DB access. The caller (`GliaDigestService`) assembles the
+ * inputs from the action service, so this stays trivially testable.
+ */
+import type { ActionType, GliaAction, GliaTrustState } from './types.js';
+
+/**
+ * Default rejection-rate threshold above which the post-graduation anomaly
+ * fires. Picked at 30% — the propose→act_report gate is 10%, so 30% is the
+ * smallest multiple that unambiguously indicates the worker has regressed
+ * since being trusted. Configurable per-call through `buildAutonomousDigest`.
+ */
+export const DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD = 0.3;
+
+/** A single autonomous action surfaced in the digest. */
+export interface DigestActionEntry {
+  id: string;
+  affectedIds: string[];
+  rationale: string;
+  executedAt: string;
+}
+
+/** Per action-type grouping in the digest. */
+export interface DigestActionGroup {
+  actionType: ActionType;
+  count: number;
+  actions: DigestActionEntry[];
+}
+
+/**
+ * Anomaly: action type whose post-graduation revert rate exceeds the
+ * configured threshold.
+ *
+ * `rejectionRatePostGraduation` is computed as
+ * `revertedCount / (executedAutonomous + revertedCount)` since the trust
+ * state's `autonomousSince` timestamp — once an action type graduates to
+ * `act_report`, the user can no longer reject pre-execution, so reverts are
+ * the only signal of dissatisfaction.
+ */
+export interface DigestAnomaly {
+  actionType: ActionType;
+  rejectionRatePostGraduation: number;
+  threshold: number;
+  autonomousSince: string;
+  executedCount: number;
+  revertedCount: number;
+}
+
+/** The full autonomous digest payload returned by `cerebrum.glia.digest`. */
+export interface AutonomousDigestReport {
+  period: 'daily' | 'weekly';
+  startDate: string;
+  endDate: string;
+  totalAutonomousActions: number;
+  groups: DigestActionGroup[];
+  anomalies: DigestAnomaly[];
+}
+
+export interface AutonomousDigestInput {
+  /** Autonomous (status=executed, decided_at IS NULL) actions in window. */
+  actions: GliaAction[];
+  /** Current trust state for every action type — used for anomaly detection. */
+  trustStates: GliaTrustState[];
+  /**
+   * Counts of executed autonomous actions by action type since each type's
+   * `autonomousSince` timestamp. Used to compute the post-graduation rate.
+   */
+  postGraduationExecutedByType: Partial<Record<ActionType, number>>;
+  /**
+   * Counts of reverted autonomous actions by action type since each type's
+   * `autonomousSince` timestamp.
+   */
+  postGraduationRevertedByType: Partial<Record<ActionType, number>>;
+  period: 'daily' | 'weekly';
+  startDate: string;
+  endDate: string;
+  rejectionRateThreshold?: number;
+}
+
+/**
+ * Build the autonomous-action digest. The caller is responsible for filtering
+ * to autonomous executions (`status='executed'` AND `decided_at IS NULL`);
+ * defensive checks here skip anything that slips through.
+ */
+export function buildAutonomousDigest(input: AutonomousDigestInput): AutonomousDigestReport {
+  const threshold = input.rejectionRateThreshold ?? DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD;
+  const groups = groupAutonomousActions(input.actions);
+  const anomalies = detectRejectionAnomalies(
+    input.trustStates,
+    input.postGraduationExecutedByType,
+    input.postGraduationRevertedByType,
+    threshold
+  );
+
+  // Sum from groups so the total reflects rows that survived the defensive
+  // filter in `groupAutonomousActions` — `input.actions.length` would overcount
+  // anything the caller passed in that wasn't a clean autonomous execution.
+  const totalAutonomousActions = groups.reduce((sum, group) => sum + group.count, 0);
+
+  return {
+    period: input.period,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    totalAutonomousActions,
+    groups,
+    anomalies,
+  };
+}
+
+function groupAutonomousActions(actions: GliaAction[]): DigestActionGroup[] {
+  const buckets = new Map<ActionType, DigestActionEntry[]>();
+  for (const action of actions) {
+    if (action.decidedAt !== null || action.status !== 'executed') continue;
+    if (action.executedAt === null) continue;
+
+    const entry: DigestActionEntry = {
+      id: action.id,
+      affectedIds: action.affectedIds,
+      rationale: action.rationale,
+      executedAt: action.executedAt,
+    };
+    const existing = buckets.get(action.actionType);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      buckets.set(action.actionType, [entry]);
+    }
+  }
+
+  const groups: DigestActionGroup[] = [];
+  for (const [actionType, entries] of buckets) {
+    entries.sort((a, b) => a.executedAt.localeCompare(b.executedAt));
+    groups.push({ actionType, count: entries.length, actions: entries });
+  }
+  groups.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.actionType.localeCompare(b.actionType);
+  });
+
+  return groups;
+}
+
+function detectRejectionAnomalies(
+  trustStates: GliaTrustState[],
+  executedByType: Partial<Record<ActionType, number>>,
+  revertedByType: Partial<Record<ActionType, number>>,
+  threshold: number
+): DigestAnomaly[] {
+  const anomalies: DigestAnomaly[] = [];
+  for (const state of trustStates) {
+    if (!state.autonomousSince) continue;
+    if (state.currentPhase === 'propose') continue;
+
+    const executed = executedByType[state.actionType] ?? 0;
+    const reverted = revertedByType[state.actionType] ?? 0;
+    const total = executed + reverted;
+    if (total === 0) continue;
+
+    const rate = reverted / total;
+    if (rate > threshold) {
+      anomalies.push({
+        actionType: state.actionType,
+        rejectionRatePostGraduation: rate,
+        threshold,
+        autonomousSince: state.autonomousSince,
+        executedCount: executed,
+        revertedCount: reverted,
+      });
+    }
+  }
+  return anomalies;
+}
+
+/**
+ * Render the autonomous digest as a concise plain-text summary suitable for
+ * the shell nudge body and the Telegram message body. Markdown is avoided —
+ * the Telegram dispatcher escapes the body when it forwards, and the shell
+ * notification surface renders it as plain text.
+ */
+export function renderAutonomousDigestText(report: AutonomousDigestReport): string {
+  const lines: string[] = [];
+  const periodLabel = report.period === 'daily' ? 'Daily' : 'Weekly';
+  lines.push(`${periodLabel} Glia digest — ${report.totalAutonomousActions} autonomous actions`);
+
+  for (const group of report.groups) {
+    lines.push('');
+    lines.push(`${group.actionType} (${group.count}):`);
+    const previewLimit = 5;
+    for (const entry of group.actions.slice(0, previewLimit)) {
+      const affected = entry.affectedIds.join(', ');
+      lines.push(`  - [${affected}] ${entry.rationale}`);
+    }
+    if (group.actions.length > previewLimit) {
+      lines.push(`  - +${group.actions.length - previewLimit} more`);
+    }
+  }
+
+  if (report.anomalies.length > 0) {
+    lines.push('');
+    lines.push('Anomalies:');
+    for (const anomaly of report.anomalies) {
+      const pct = (anomaly.rejectionRatePostGraduation * 100).toFixed(1);
+      const total = anomaly.executedCount + anomaly.revertedCount;
+      lines.push(
+        `  - ${anomaly.actionType}: ${pct}% post-graduation rejection rate (${anomaly.revertedCount}/${total})`
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Compute date range for a daily digest (previous day). Returns ISO date
+ * strings for start and end of the previous day.
+ */
+export function dailyDigestRange(now: Date): { startDate: string; endDate: string } {
+  const end = new Date(now);
+  end.setHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setDate(start.getDate() - 1);
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+/**
+ * Compute date range for a weekly digest (previous 7 days). Returns ISO date
+ * strings for start and end of the week.
+ */
+export function weeklyDigestRange(now: Date): { startDate: string; endDate: string } {
+  const end = new Date(now);
+  end.setHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setDate(start.getDate() - 7);
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}

--- a/pillars/cerebrum/src/api/modules/glia/digest-channels.ts
+++ b/pillars/cerebrum/src/api/modules/glia/digest-channels.ts
@@ -1,0 +1,193 @@
+/**
+ * Digest delivery channels for `cerebrum.glia.digest`.
+ *
+ * Two channels:
+ *
+ *   - shell:  persists the digest as a `nudge_log` row in the pillar DB so the
+ *     existing nudge UI can surface it. Always available.
+ *   - telegram: forwards the body to a Telegram chat (Moltbot). Cross-module in
+ *     the monolith (`core/ai-alerts/dispatchers/telegram`); the pillar has no
+ *     ai-alerts module, so a minimal env-gated sender is inlined here. When the
+ *     bot token / chat id env vars are unset it is a silent no-op (returns
+ *     false), exactly as the monolith behaved when Moltbot was unconfigured.
+ *
+ * The `deliver: false` path and the shell channel both work without any
+ * Telegram configuration.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { nudgeLog, type CerebrumDb } from '../../../db/index.js';
+
+import type { AutonomousDigestReport } from './autonomous-digest.js';
+
+/** A single delivery channel's outcome. */
+export interface DeliveryChannelResult {
+  channel: 'shell' | 'moltbot';
+  delivered: boolean;
+  /** Reason for non-delivery — populated when `delivered=false`. */
+  reason: string | null;
+}
+
+/** Channels invoked by the digest delivery step. */
+export interface DigestDeliveryChannels {
+  /** Persist a shell notification. Returns true when accepted. */
+  shell: (report: AutonomousDigestReport, body: string) => Promise<boolean> | boolean;
+  /** Forward to Moltbot/Telegram. Returns true when sent, false when unconfigured. */
+  moltbot: (report: AutonomousDigestReport, body: string) => Promise<boolean>;
+}
+
+/** Map digest urgency to nudge priority — anomalies bump severity. */
+function priorityFor(report: AutonomousDigestReport): 'low' | 'medium' | 'high' {
+  if (report.anomalies.length > 0) return 'high';
+  if (report.totalAutonomousActions >= 10) return 'medium';
+  return 'low';
+}
+
+function buildShellNudgeId(now: Date): string {
+  const pad = (n: number, len: number): string => String(n).padStart(len, '0');
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
+  const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}${pad(now.getSeconds(), 2)}`;
+  const ms = pad(now.getMilliseconds(), 3);
+  // Append a UUID slice so parallel triggers within the same millisecond still
+  // produce distinct IDs — second-level precision alone collides under load.
+  const nonce = randomUUID().slice(0, 8);
+  return `nudge_${date}_${time}${ms}_${nonce}_gliaDigest`;
+}
+
+function collectEngramIds(report: AutonomousDigestReport): string[] {
+  const set = new Set<string>();
+  for (const group of report.groups) {
+    for (const entry of group.actions) {
+      for (const id of entry.affectedIds) set.add(id);
+    }
+  }
+  return [...set];
+}
+
+/**
+ * Persist the digest as a shell notification row in `nudge_log`. Engram IDs are
+ * union'd across all groups so the existing nudge UI can deep-link back to the
+ * affected engrams without a dedicated digest viewer.
+ */
+export function deliverShellDigest(
+  db: CerebrumDb,
+  report: AutonomousDigestReport,
+  body: string,
+  now: Date = new Date()
+): boolean {
+  const id = buildShellNudgeId(now);
+  const title = `Glia ${report.period} digest — ${report.totalAutonomousActions} autonomous actions`;
+  const engramIds = collectEngramIds(report);
+
+  db.insert(nudgeLog)
+    .values({
+      id,
+      type: 'insight',
+      title,
+      body,
+      engramIds: JSON.stringify(engramIds),
+      priority: priorityFor(report),
+      status: 'pending',
+      createdAt: now.toISOString(),
+      expiresAt: null,
+      actionType: null,
+      actionLabel: null,
+      actionParams: JSON.stringify({
+        source: 'glia-digest',
+        period: report.period,
+        startDate: report.startDate,
+        endDate: report.endDate,
+        totalAutonomousActions: report.totalAutonomousActions,
+        anomalyCount: report.anomalies.length,
+      }),
+    })
+    .run();
+
+  return true;
+}
+
+interface TelegramConfig {
+  botToken: string;
+  chatId: string;
+}
+
+/** Read Telegram config from env. Returns null when either var is unset. */
+export function readTelegramConfig(env: NodeJS.ProcessEnv = process.env): TelegramConfig | null {
+  const botToken = env['POPS_ALERTS_TELEGRAM_BOT_TOKEN'];
+  const chatId = env['POPS_ALERTS_TELEGRAM_CHAT_ID'];
+  if (!botToken || !chatId) return null;
+  return { botToken, chatId };
+}
+
+/** Escape every Telegram MarkdownV2 reserved character. */
+function escapeTelegramMarkdownV2(value: string): string {
+  return value.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+}
+
+const TELEGRAM_REQUEST_TIMEOUT_MS = 10_000;
+
+async function sendTelegram(config: TelegramConfig, text: string): Promise<void> {
+  const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TELEGRAM_REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        chat_id: config.chatId,
+        text,
+        parse_mode: 'MarkdownV2',
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`Telegram sendMessage timed out after ${TELEGRAM_REQUEST_TIMEOUT_MS}ms`, {
+        cause: err,
+      });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '<no body>');
+    throw new Error(`Telegram sendMessage failed: ${res.status} ${body}`);
+  }
+}
+
+/**
+ * Forward the digest body to Moltbot/Telegram. Returns `false` when no Telegram
+ * config is present (silent no-op); throws on transport errors so the caller
+ * records the failure against the channel.
+ */
+export async function deliverMoltbotDigest(
+  report: AutonomousDigestReport,
+  body: string
+): Promise<boolean> {
+  const config = readTelegramConfig();
+  if (!config) return false;
+
+  const header = `🧠 *Glia ${report.period} digest*`;
+  // `report.period` is a union literal so the header carries no reserved chars;
+  // only the dynamic body needs escaping for MarkdownV2.
+  const text = `${header}\n\n${escapeTelegramMarkdownV2(body)}`;
+
+  await sendTelegram(config, text);
+  return true;
+}
+
+/**
+ * Build the default channel pair bound to a pillar DB handle. The shell channel
+ * writes `nudge_log`; the Telegram channel is env-gated and a no-op when
+ * unconfigured.
+ */
+export function buildDefaultDigestChannels(db: CerebrumDb): DigestDeliveryChannels {
+  return {
+    shell: (report, body) => deliverShellDigest(db, report, body),
+    moltbot: deliverMoltbotDigest,
+  };
+}

--- a/pillars/cerebrum/src/api/modules/glia/digest-service.ts
+++ b/pillars/cerebrum/src/api/modules/glia/digest-service.ts
@@ -1,0 +1,205 @@
+/**
+ * GliaDigestService — assembles + (optionally) delivers the autonomous-action
+ * digest (PRD-086 US-04).
+ *
+ * Three suppression rules govern delivery (preserved from the monolith):
+ *   1. zero autonomous actions in the window → suppress.
+ *   2. every action type in the digest is in the silent phase → suppress.
+ *   3. no delivery channels configured → suppress.
+ *
+ * The `deliver: false` caller flag short-circuits delivery entirely.
+ */
+import {
+  buildAutonomousDigest,
+  dailyDigestRange,
+  renderAutonomousDigestText,
+  weeklyDigestRange,
+} from './autonomous-digest.js';
+
+import type { GliaActionService } from './action-service.js';
+import type { AutonomousDigestReport } from './autonomous-digest.js';
+import type { DeliveryChannelResult, DigestDeliveryChannels } from './digest-channels.js';
+import type { ActionType, GliaTrustState, TrustPhase } from './types.js';
+
+export interface DigestDeliveryResult {
+  /** Whether delivery was attempted at all (false when suppressed). */
+  attempted: boolean;
+  /** Reason for suppression — null when `attempted=true`. */
+  suppressedReason: string | null;
+  channels: DeliveryChannelResult[];
+}
+
+export interface DigestResult {
+  report: AutonomousDigestReport;
+  delivery: DigestDeliveryResult;
+}
+
+export interface GenerateDigestInput {
+  period?: 'daily' | 'weekly';
+  /** Restrict the digest to a single action type. */
+  actionType?: ActionType;
+  /** Override the anomaly threshold (default 30%). */
+  rejectionRateThreshold?: number;
+  /** When false, the digest is computed but not delivered. Default true. */
+  deliver?: boolean;
+}
+
+export interface DigestServiceOptions {
+  now?: () => Date;
+  channels?: DigestDeliveryChannels;
+}
+
+export class GliaDigestService {
+  private readonly now: () => Date;
+  private readonly channels: DigestDeliveryChannels | null;
+
+  constructor(
+    private readonly actionService: GliaActionService,
+    options: DigestServiceOptions = {}
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.channels = options.channels ?? null;
+  }
+
+  async generate(input: GenerateDigestInput = {}): Promise<DigestResult> {
+    const period = input.period ?? 'daily';
+    const { startDate, endDate } =
+      period === 'daily' ? dailyDigestRange(this.now()) : weeklyDigestRange(this.now());
+
+    let actions = this.actionService.listAutonomousActionsInWindow(startDate, endDate);
+    if (input.actionType) {
+      actions = actions.filter((a) => a.actionType === input.actionType);
+    }
+
+    const trustStates = this.actionService.listTrustStates();
+    const filteredTrustStates = input.actionType
+      ? trustStates.filter((s) => s.actionType === input.actionType)
+      : trustStates;
+
+    const { executedByType, revertedByType } = this.gatherPostGraduationCounts(filteredTrustStates);
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: filteredTrustStates,
+      postGraduationExecutedByType: executedByType,
+      postGraduationRevertedByType: revertedByType,
+      period,
+      startDate,
+      endDate,
+      rejectionRateThreshold: input.rejectionRateThreshold,
+    });
+
+    const deliver = input.deliver ?? true;
+    const delivery = deliver
+      ? await this.maybeDeliver(report, trustStates)
+      : { attempted: false, suppressedReason: 'Delivery disabled by caller', channels: [] };
+
+    return { report, delivery };
+  }
+
+  private gatherPostGraduationCounts(trustStates: GliaTrustState[]): {
+    executedByType: Partial<Record<ActionType, number>>;
+    revertedByType: Partial<Record<ActionType, number>>;
+  } {
+    const executedByType: Partial<Record<ActionType, number>> = {};
+    const revertedByType: Partial<Record<ActionType, number>> = {};
+
+    for (const state of trustStates) {
+      if (!state.autonomousSince) continue;
+      executedByType[state.actionType] = this.actionService.countAutonomousExecutionsSince(
+        state.actionType,
+        state.autonomousSince
+      );
+      revertedByType[state.actionType] = this.actionService.countAutonomousRevertsSince(
+        state.actionType,
+        state.autonomousSince
+      );
+    }
+
+    return { executedByType, revertedByType };
+  }
+
+  private async maybeDeliver(
+    report: AutonomousDigestReport,
+    allTrustStates: GliaTrustState[]
+  ): Promise<DigestDeliveryResult> {
+    if (report.totalAutonomousActions === 0) {
+      return {
+        attempted: false,
+        suppressedReason: 'No autonomous actions in period',
+        channels: [],
+      };
+    }
+
+    const phasesInReport = collectPhasesInReport(report, allTrustStates);
+    if (!phasesInReport.has('act_report')) {
+      // Every type in the digest is silent (or somehow propose, which would
+      // mean no autonomous actions — handled above). Silent phase intentionally
+      // suppresses delivery per PRD-086 US-04 AC #6.
+      return {
+        attempted: false,
+        suppressedReason: 'All action types in digest are in silent phase',
+        channels: [],
+      };
+    }
+
+    const channels = this.channels;
+    if (!channels) {
+      return {
+        attempted: false,
+        suppressedReason: 'No delivery channels configured',
+        channels: [],
+      };
+    }
+
+    const body = renderAutonomousDigestText(report);
+    const channelResults: DeliveryChannelResult[] = [];
+
+    const shellResult = await this.invokeChannel(() => channels.shell(report, body));
+    channelResults.push({ channel: 'shell', ...shellResult });
+
+    const moltbotResult = await this.invokeChannel(() => channels.moltbot(report, body));
+    channelResults.push({ channel: 'moltbot', ...moltbotResult });
+
+    return { attempted: true, suppressedReason: null, channels: channelResults };
+  }
+
+  private async invokeChannel(
+    fn: () => Promise<boolean> | boolean
+  ): Promise<{ delivered: boolean; reason: string | null }> {
+    try {
+      const delivered = await fn();
+      return delivered
+        ? { delivered: true, reason: null }
+        : { delivered: false, reason: 'Channel returned false (not configured)' };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { delivered: false, reason };
+    }
+  }
+}
+
+function collectPhasesInReport(
+  report: AutonomousDigestReport,
+  trustStates: GliaTrustState[]
+): Set<TrustPhase> {
+  const phaseByType = new Map<ActionType, TrustPhase>();
+  for (const state of trustStates) {
+    phaseByType.set(state.actionType, state.currentPhase);
+  }
+
+  const phases = new Set<TrustPhase>();
+  const typesInReport = new Set<ActionType>();
+  for (const group of report.groups) {
+    typesInReport.add(group.actionType);
+  }
+  for (const anomaly of report.anomalies) {
+    typesInReport.add(anomaly.actionType);
+  }
+
+  for (const type of typesInReport) {
+    const phase = phaseByType.get(type);
+    if (phase) phases.add(phase);
+  }
+  return phases;
+}

--- a/pillars/cerebrum/src/api/modules/glia/helpers.ts
+++ b/pillars/cerebrum/src/api/modules/glia/helpers.ts
@@ -1,0 +1,15 @@
+/**
+ * Glia shared helpers — action ID generation.
+ *
+ * Owns the public ID shape (`glia_{type}_{timestamp}_{hash}`) and has no DB
+ * dependency, so it stays in the orchestration module rather than the
+ * data-access package.
+ */
+import type { ActionType } from './types.js';
+
+/** Generate a unique action ID. */
+export function generateActionId(actionType: ActionType, timestamp: string): string {
+  const hash = Math.random().toString(36).substring(2, 10);
+  const ts = timestamp.replace(/[^0-9]/g, '').substring(0, 14);
+  return `glia_${actionType}_${ts}_${hash}`;
+}

--- a/pillars/cerebrum/src/api/modules/glia/instance.ts
+++ b/pillars/cerebrum/src/api/modules/glia/instance.ts
@@ -1,0 +1,80 @@
+/**
+ * Glia runtime wiring for the cerebrum pillar.
+ *
+ * Builds the action service, trust machine, and digest service bound to a
+ * `CerebrumDb` handle. Unlike the monolith (which resolved an
+ * AsyncLocalStorage-scoped Drizzle handle per request), the pillar threads the
+ * injected handle straight through — the handlers build a per-request bundle so
+ * a `now` clock can be injected in tests.
+ *
+ * Config-path resolution for `glia.toml` (graduation thresholds) mirrors the
+ * reflex slice's TOML resolution and is tolerant of a missing file (falls back
+ * to the hardcoded ADR-021 defaults).
+ */
+import { join } from 'node:path';
+
+import { GliaActionService } from './action-service.js';
+import { buildDefaultDigestChannels } from './digest-channels.js';
+import { GliaDigestService } from './digest-service.js';
+import { makeGliaThresholdReader } from './thresholds.js';
+import { GliaTrustMachine } from './trust-machine.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type { DigestDeliveryChannels } from './digest-channels.js';
+
+/**
+ * Resolve the absolute path to `glia.toml`.
+ *
+ * Resolution order:
+ *   1. `CEREBRUM_GLIA_CONFIG` — explicit path to `glia.toml`.
+ *   2. `CEREBRUM_GLIA_CONFIG_DIR` (or `CEREBRUM_ENGRAMS_DIR`) — a directory
+ *      whose `.config/glia.toml` is used (parity with the monolith's engram
+ *      root layout).
+ *   3. A default under the cwd that almost certainly does not exist, yielding
+ *      the hardcoded ADR-021 defaults.
+ */
+export function resolveGliaConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env['CEREBRUM_GLIA_CONFIG'];
+  if (explicit && explicit.length > 0) return explicit;
+
+  const dir = env['CEREBRUM_GLIA_CONFIG_DIR'] ?? env['CEREBRUM_ENGRAMS_DIR'];
+  if (dir && dir.length > 0) return join(dir, '.config', 'glia.toml');
+
+  return join(process.cwd(), 'data', 'engrams', '.config', 'glia.toml');
+}
+
+export interface GliaServices {
+  actionService: GliaActionService;
+  trustMachine: GliaTrustMachine;
+  digestService: GliaDigestService;
+}
+
+export interface BuildGliaServicesOptions {
+  db: CerebrumDb;
+  /** Absolute path to `glia.toml` (graduation thresholds). */
+  configPath: string;
+  /** Injectable clock — tests pin this for deterministic transitions. */
+  now?: () => Date;
+  /**
+   * Delivery channels for the digest. Defaults to the shell (`nudge_log`) +
+   * env-gated Telegram pair bound to `db`. Pass explicit channels in tests.
+   */
+  channels?: DigestDeliveryChannels;
+}
+
+/** Build the glia services bundle bound to `db`. */
+export function buildGliaServices(options: BuildGliaServicesOptions): GliaServices {
+  const now = options.now ?? (() => new Date());
+  const actionService = new GliaActionService(options.db, now);
+  const trustMachine = new GliaTrustMachine(
+    actionService,
+    makeGliaThresholdReader(options.configPath),
+    now
+  );
+  const digestService = new GliaDigestService(actionService, {
+    now,
+    channels: options.channels ?? buildDefaultDigestChannels(options.db),
+  });
+
+  return { actionService, trustMachine, digestService };
+}

--- a/pillars/cerebrum/src/api/modules/glia/revert-operations.test.ts
+++ b/pillars/cerebrum/src/api/modules/glia/revert-operations.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for revert operations (PRD-086 US-04, #2576).
+ *
+ * Each path runs against a real {@link EngramService} over a temp engram root
+ * and a temp `cerebrum.db` (opened through `openCerebrumDb`). Idempotency is
+ * exercised per action type. The action payloads are plain objects shaped to
+ * the fields revert reads (`mergedEngramId`, `sourceId`/`targetId`).
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../../db/index.js';
+import { EngramService } from '../engrams/service.js';
+import { TemplateRegistry } from '../templates/registry.js';
+import { executeRevert } from './revert-operations.js';
+
+import type { GliaAction } from './types.js';
+
+const TEMPLATES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'templates', 'defaults');
+
+function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+function makeAction(overrides: Partial<GliaAction> = {}): GliaAction {
+  return {
+    id: 'glia_prune_20260512_aaaaaaaa',
+    actionType: 'prune',
+    affectedIds: [],
+    rationale: 'test',
+    payload: null,
+    phase: 'act_report',
+    status: 'executed',
+    userDecision: null,
+    userNote: null,
+    executedAt: '2026-05-12T10:00:00Z',
+    decidedAt: null,
+    revertedAt: null,
+    createdAt: '2026-05-12T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('executeRevert (filesystem)', () => {
+  let opened: OpenedCerebrumDb;
+  let dbDir: string;
+  let root: string;
+  let service: EngramService;
+
+  beforeEach(() => {
+    dbDir = mkdtempSync(join(tmpdir(), 'glia-revert-db-'));
+    root = mkdtempSync(join(tmpdir(), 'glia-revert-root-'));
+    opened = openCerebrumDb(join(dbDir, 'cerebrum.db'), { loadVec: false });
+    service = new EngramService({
+      root,
+      db: opened.db,
+      templates: new TemplateRegistry(TEMPLATES_DIR),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+    rmSync(root, { recursive: true, force: true });
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  describe('prune revert', () => {
+    it('moves archived engrams back to their original type folder', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      const aPath = a.filePath;
+      const bPath = b.filePath;
+
+      service.archive(a.id);
+      service.archive(b.id);
+      expect(existsSync(join(root, aPath))).toBe(false);
+      expect(existsSync(join(root, bPath))).toBe(false);
+
+      const action = makeAction({ actionType: 'prune', affectedIds: [a.id, b.id] });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.restoredIds.toSorted()).toEqual([a.id, b.id].toSorted());
+      expect(existsSync(join(root, aPath))).toBe(true);
+      expect(existsSync(join(root, bPath))).toBe(true);
+      expect(service.read(a.id).engram.status).toBe('active');
+      expect(service.read(b.id).engram.status).toBe('active');
+    });
+
+    it('is idempotent — re-reverting a restored prune is a no-op', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      service.archive(a.id);
+
+      const action = makeAction({ actionType: 'prune', affectedIds: [a.id] });
+      executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      expect(second.success).toBe(true);
+      expect(service.read(a.id).engram.status).toBe('active');
+    });
+
+    it('skips missing ids and restores existing archived engrams', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      service.archive(a.id);
+
+      const action = makeAction({
+        actionType: 'prune',
+        affectedIds: [a.id, 'eng_20260101_0000_missing'],
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.restoredIds).toEqual([a.id]);
+    });
+  });
+
+  describe('consolidate revert', () => {
+    function setupConsolidatedScenario(): {
+      sources: { id: string; path: string }[];
+      mergedId: string;
+      externalLinkTarget: string;
+    } {
+      const s1 = service.create({ type: 'note', title: 'S1', body: '# S1', scopes: ['x'] });
+      const s2 = service.create({ type: 'note', title: 'S2', body: '# S2', scopes: ['x'] });
+      const s3 = service.create({ type: 'note', title: 'S3', body: '# S3', scopes: ['x'] });
+      const external = service.create({ type: 'note', title: 'Ext', body: '# Ext', scopes: ['x'] });
+      const sources = [s1, s2, s3].map((e) => ({ id: e.id, path: e.filePath }));
+
+      const merged = service.create({
+        type: 'note',
+        title: 'Consolidated: S1',
+        body: '# Consolidated\n\n...',
+        scopes: ['x'],
+        source: 'agent',
+      });
+      service.link(merged.id, external.id);
+      for (const s of [s1, s2, s3]) service.archive(s.id);
+
+      return { sources, mergedId: merged.id, externalLinkTarget: external.id };
+    }
+
+    it('deletes the merged engram and restores all source engrams', () => {
+      const { sources, mergedId, externalLinkTarget } = setupConsolidatedScenario();
+      const mergedPath = service.read(mergedId).engram.filePath;
+
+      const action = makeAction({
+        actionType: 'consolidate',
+        affectedIds: sources.map((s) => s.id),
+        payload: { type: 'merge', mergedEngramId: mergedId },
+      });
+
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.restoredIds.toSorted()).toEqual(sources.map((s) => s.id).toSorted());
+      expect(existsSync(join(root, mergedPath))).toBe(false);
+      expect(service.exists(mergedId)).toBe(false);
+      for (const s of sources) {
+        expect(existsSync(join(root, s.path))).toBe(true);
+        expect(service.read(s.id).engram.status).toBe('active');
+      }
+      expect(service.read(externalLinkTarget).engram.links).not.toContain(mergedId);
+    });
+
+    it('is idempotent — re-reverting an already-reverted consolidate is a no-op', () => {
+      const { sources, mergedId } = setupConsolidatedScenario();
+      const action = makeAction({
+        actionType: 'consolidate',
+        affectedIds: sources.map((s) => s.id),
+        payload: { type: 'merge', mergedEngramId: mergedId },
+      });
+
+      const first = executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(second.restoredIds).toEqual([]);
+      expect(service.exists(mergedId)).toBe(false);
+      for (const s of sources) expect(service.read(s.id).engram.status).toBe('active');
+    });
+
+    it('still restores sources when the merged engram is missing from the payload', () => {
+      const { sources } = setupConsolidatedScenario();
+
+      const action = makeAction({
+        actionType: 'consolidate',
+        affectedIds: sources.map((s) => s.id),
+        payload: null,
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.restoredIds.toSorted()).toEqual(sources.map((s) => s.id).toSorted());
+    });
+  });
+
+  describe('link revert', () => {
+    it('unlinks using payload sourceId/targetId in both directions', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: { type: 'link', sourceId: a.id, targetId: b.id },
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(service.read(a.id).engram.links).not.toContain(b.id);
+      expect(service.read(b.id).engram.links).not.toContain(a.id);
+    });
+
+    it('falls back to the first two affectedIds when the payload is null', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: null,
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
+      expect(service.read(b.id).engram.links ?? []).not.toContain(a.id);
+    });
+
+    it('is idempotent when the target engram has been deleted', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      service.hardDelete(b.id);
+      expect(service.exists(b.id)).toBe(false);
+      expect(service.exists(a.id)).toBe(true);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: { type: 'link', sourceId: a.id, targetId: b.id },
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('is idempotent — re-reverting an already-unlinked pair succeeds', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: { type: 'link', sourceId: a.id, targetId: b.id },
+      });
+      const first = executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
+    });
+
+    it('returns failure when no pair can be resolved', () => {
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: ['eng_20260101_0000_only'],
+        payload: null,
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toMatch(/sourceId\/targetId or two affectedIds/);
+    });
+  });
+
+  describe('audit revert', () => {
+    it('returns success without touching engrams', () => {
+      const action = makeAction({ actionType: 'audit', affectedIds: ['e1'] });
+      const result = executeRevert(action, service);
+      expect(result.success).toBe(true);
+      expect(result.restoredIds).toEqual([]);
+    });
+  });
+});

--- a/pillars/cerebrum/src/api/modules/glia/revert-operations.ts
+++ b/pillars/cerebrum/src/api/modules/glia/revert-operations.ts
@@ -1,0 +1,176 @@
+/**
+ * Revert operations for glia actions (PRD-086 US-04, #2576).
+ *
+ * Implements file-level revert for prune/consolidate/link action types over
+ * the in-pillar {@link EngramService}:
+ *
+ *   - prune: restore every archived engram (`.archive/{type}/{id}.md` →
+ *     `{type}/{id}.md`).
+ *   - consolidate: delete the merged engram, then restore every source engram.
+ *   - link: remove the bidirectional link recorded in the action payload.
+ *   - audit: informational — no-op.
+ *
+ * Every operation is idempotent — re-reverting an already-reverted action
+ * succeeds as a no-op.
+ *
+ * The minimal payload shapes are declared locally rather than importing the
+ * worker payload types from pops-api: revert only reads `mergedEngramId` (for
+ * consolidate) and `sourceId`/`targetId` (for link), and the worker module is
+ * not part of this pillar slice.
+ */
+import type { EngramService } from '../engrams/service.js';
+import type { GliaAction } from './types.js';
+
+/** Result of a revert operation. */
+export interface RevertResult {
+  success: boolean;
+  restoredIds: string[];
+  errors: string[];
+}
+
+/** Fields revert reads from a consolidate action's payload. */
+interface ConsolidateRevertPayload {
+  mergedEngramId?: string;
+}
+
+/** Fields revert reads from a link action's payload. */
+interface LinkRevertPayload {
+  sourceId?: string;
+  targetId?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Execute the domain-specific revert logic for a glia action. Called after the
+ * action has been marked as reverted in the DB.
+ */
+export function executeRevert(action: GliaAction, engramService: EngramService): RevertResult {
+  switch (action.actionType) {
+    case 'prune':
+      return revertPrune(action, engramService);
+    case 'consolidate':
+      return revertConsolidate(action, engramService);
+    case 'link':
+      return revertLink(action, engramService);
+    case 'audit':
+      return { success: true, restoredIds: [], errors: [] };
+  }
+}
+
+/** Revert a prune action: move every archived engram back to its type folder. */
+function revertPrune(action: GliaAction, engramService: EngramService): RevertResult {
+  const restoredIds: string[] = [];
+  const errors: string[] = [];
+
+  for (const id of action.affectedIds) {
+    try {
+      if (!engramService.exists(id)) continue;
+      const { result } = engramService.restore(id);
+      if (result.moved) restoredIds.push(id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Failed to restore ${id}: ${msg}`);
+      console.warn(`[glia/revert] Prune revert failed for ${id}: ${msg}`);
+    }
+  }
+
+  return { success: errors.length === 0, restoredIds, errors };
+}
+
+/**
+ * Revert a consolidate action: delete the merged engram and restore all
+ * archived source engrams. The merged engram ID is read from
+ * `payload.mergedEngramId`, recorded by the consolidator at execution time.
+ */
+function revertConsolidate(action: GliaAction, engramService: EngramService): RevertResult {
+  const restoredIds: string[] = [];
+  const errors: string[] = [];
+  const payload: ConsolidateRevertPayload | null = isRecord(action.payload)
+    ? { mergedEngramId: readString(action.payload, 'mergedEngramId') }
+    : null;
+
+  const mergedId = payload?.mergedEngramId;
+  if (mergedId) {
+    try {
+      engramService.hardDelete(mergedId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Failed to delete merged engram ${mergedId}: ${msg}`);
+      console.warn(
+        `[glia/revert] Consolidate revert: merged delete failed for ${mergedId}: ${msg}`
+      );
+    }
+  }
+
+  for (const id of action.affectedIds) {
+    try {
+      if (!engramService.exists(id)) continue;
+      const { result } = engramService.restore(id);
+      if (result.moved) restoredIds.push(id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Failed to restore ${id}: ${msg}`);
+      console.warn(`[glia/revert] Consolidate revert: restore failed for ${id}: ${msg}`);
+    }
+  }
+
+  return { success: errors.length === 0, restoredIds, errors };
+}
+
+/**
+ * Revert a link action: remove the bidirectional link recorded in the payload.
+ * Falls back to the first two `affectedIds` when the payload lacks the pair
+ * (older proposals before the link payload was wired up). Idempotent.
+ */
+function revertLink(action: GliaAction, engramService: EngramService): RevertResult {
+  const errors: string[] = [];
+  const payload: LinkRevertPayload | null = isRecord(action.payload)
+    ? {
+        sourceId: readString(action.payload, 'sourceId'),
+        targetId: readString(action.payload, 'targetId'),
+      }
+    : null;
+  const pair = resolveLinkPair(action, payload);
+  if (!pair) {
+    return {
+      success: false,
+      restoredIds: [],
+      errors: ['Link revert requires payload.sourceId/targetId or two affectedIds'],
+    };
+  }
+
+  try {
+    // Idempotency: either side missing means the link can no longer exist.
+    if (!engramService.exists(pair.sourceId) || !engramService.exists(pair.targetId)) {
+      return { success: true, restoredIds: [], errors: [] };
+    }
+    engramService.unlink(pair.sourceId, pair.targetId);
+    return { success: true, restoredIds: [], errors: [] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Failed to unlink: ${msg}`);
+    console.warn(`[glia/revert] Link revert failed: ${msg}`);
+  }
+
+  return { success: false, restoredIds: [], errors };
+}
+
+function resolveLinkPair(
+  action: GliaAction,
+  payload: LinkRevertPayload | null
+): { sourceId: string; targetId: string } | null {
+  if (payload?.sourceId && payload?.targetId) {
+    return { sourceId: payload.sourceId, targetId: payload.targetId };
+  }
+  const [first, second] = action.affectedIds;
+  if (first && second) return { sourceId: first, targetId: second };
+  return null;
+}

--- a/pillars/cerebrum/src/api/modules/glia/thresholds.ts
+++ b/pillars/cerebrum/src/api/modules/glia/thresholds.ts
@@ -1,0 +1,49 @@
+/**
+ * Graduation-threshold resolution for the glia trust machine.
+ *
+ * Precedence (PRD-086 US-03 AC #7): `glia.toml` is the source of truth — it is
+ * re-read on every call (mtime-cached) so operator edits take effect on the
+ * next evaluation without a restart. Any key the toml file does not set falls
+ * back to the hardcoded ADR-021 defaults.
+ *
+ * DEVIATION FROM THE MONOLITH: the monolith inserted a settings-DB tier
+ * (`getSettingValue('cerebrum.glia.*', …)`) between the toml file and the
+ * hardcoded defaults. The cerebrum pillar has no settings service, so that
+ * middle tier is dropped: toml → hardcoded defaults. The toml file remains the
+ * documented user-facing knob, so behaviour is unchanged for any deployment
+ * that configured thresholds through it rather than the (internal) settings DB.
+ */
+import { loadGliaToml } from './toml-config.js';
+
+import type { GraduationThresholds } from './types.js';
+
+/** Hardcoded graduation thresholds per ADR-021 — the last-resort defaults. */
+export const FALLBACK_THRESHOLDS: GraduationThresholds = {
+  proposeToActReportMinApproved: 20,
+  proposeToActReportMaxRejectionRate: 0.1,
+  actReportToSilentMinDays: 60,
+  demotionRevertThreshold: 2,
+  demotionWindowDays: 7,
+};
+
+/**
+ * Build a `getThresholds` accessor bound to a glia config path. Each call
+ * re-reads the toml (mtime-cached) and overlays it onto the ADR-021 defaults.
+ */
+export function makeGliaThresholdReader(configPath: string): () => GraduationThresholds {
+  return () => {
+    const toml = loadGliaToml(configPath);
+    return {
+      proposeToActReportMinApproved:
+        toml.proposeToActReportMinApproved ?? FALLBACK_THRESHOLDS.proposeToActReportMinApproved,
+      proposeToActReportMaxRejectionRate:
+        toml.proposeToActReportMaxRejectionRate ??
+        FALLBACK_THRESHOLDS.proposeToActReportMaxRejectionRate,
+      actReportToSilentMinDays:
+        toml.actReportToSilentMinDays ?? FALLBACK_THRESHOLDS.actReportToSilentMinDays,
+      demotionRevertThreshold:
+        toml.demotionRevertThreshold ?? FALLBACK_THRESHOLDS.demotionRevertThreshold,
+      demotionWindowDays: toml.demotionWindowDays ?? FALLBACK_THRESHOLDS.demotionWindowDays,
+    };
+  };
+}

--- a/pillars/cerebrum/src/api/modules/glia/toml-config.ts
+++ b/pillars/cerebrum/src/api/modules/glia/toml-config.ts
@@ -1,0 +1,146 @@
+/**
+ * Glia threshold loader for `<gliaConfigPath>/glia.toml` (PRD-086 US-03 AC #7).
+ *
+ * Reads `[trust.graduation]` from the toml file and exposes a partial
+ * {@link GraduationThresholds} object containing only the keys the user set.
+ *
+ * Hot-reload semantics: the parsed result is cached and re-validated against
+ * the file's mtime on every call. Edits to `glia.toml` are picked up on the
+ * next evaluation without restart. If the file is absent or unreadable the
+ * loader returns an empty object so callers can fall back to the hardcoded
+ * defaults.
+ */
+import { readFileSync, statSync } from 'node:fs';
+
+import { parse as parseToml } from 'smol-toml';
+import { z } from 'zod';
+
+import type { GraduationThresholds } from './types.js';
+
+/** Subset of {@link GraduationThresholds} expressible in `glia.toml`. */
+export type PartialGraduationThresholds = Partial<GraduationThresholds>;
+
+interface CacheEntry {
+  mtimeMs: number;
+  thresholds: PartialGraduationThresholds;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+const nonNegativeInt = z.number().int().nonnegative();
+const rejectionRate = z.number().min(0).max(1);
+
+// Zod v4 strips unknown keys from object schemas by default — no explicit
+// `.strip()` is required (and `z.strictObject` would be too aggressive here
+// since users may add commented-out keys or future fields the parser hasn't
+// learned yet).
+const graduationSchema = z.object({
+  propose_to_act_report_min_approved: nonNegativeInt.optional(),
+  propose_to_act_report_max_rejection_rate: rejectionRate.optional(),
+  act_report_to_silent_min_days: nonNegativeInt.optional(),
+  demotion_revert_threshold: nonNegativeInt.optional(),
+  demotion_window_days: nonNegativeInt.optional(),
+});
+
+const gliaTomlSchema = z.object({
+  trust: z
+    .object({
+      graduation: graduationSchema.optional(),
+    })
+    .optional(),
+});
+
+/** Parse the `[trust.graduation]` block into a partial thresholds object. */
+export function parseGliaToml(content: string): PartialGraduationThresholds {
+  let raw: unknown;
+  try {
+    raw = parseToml(content);
+  } catch (err) {
+    console.warn(`[cerebrum] glia.toml parse failed: ${(err as Error).message}`);
+    return {};
+  }
+
+  const parsed = gliaTomlSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn(
+      `[cerebrum] glia.toml validation failed: ${parsed.error.issues
+        .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+        .join('; ')}`
+    );
+    return {};
+  }
+
+  const section = parsed.data.trust?.graduation;
+  if (!section) return {};
+
+  const result: PartialGraduationThresholds = {};
+  if (section.propose_to_act_report_min_approved !== undefined) {
+    result.proposeToActReportMinApproved = section.propose_to_act_report_min_approved;
+  }
+  if (section.propose_to_act_report_max_rejection_rate !== undefined) {
+    result.proposeToActReportMaxRejectionRate = section.propose_to_act_report_max_rejection_rate;
+  }
+  if (section.act_report_to_silent_min_days !== undefined) {
+    result.actReportToSilentMinDays = section.act_report_to_silent_min_days;
+  }
+  if (section.demotion_revert_threshold !== undefined) {
+    result.demotionRevertThreshold = section.demotion_revert_threshold;
+  }
+  if (section.demotion_window_days !== undefined) {
+    result.demotionWindowDays = section.demotion_window_days;
+  }
+  return result;
+}
+
+/**
+ * Load partial thresholds from `path`.
+ *
+ * Returns an empty object when the file is missing or unreadable. Uses an
+ * mtime-keyed cache so repeated calls within the same process do not re-read
+ * the disk unless the file has changed.
+ */
+export function loadGliaToml(path: string): PartialGraduationThresholds {
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`[cerebrum] glia.toml stat failed at ${path}: ${(err as Error).message}`);
+    }
+    cache.delete(path);
+    return {};
+  }
+
+  const cached = cache.get(path);
+  if (cached && cached.mtimeMs === mtimeMs) {
+    // Defensive copy — never hand callers the cached reference, otherwise
+    // a downstream mutation poisons every subsequent read until the file's
+    // mtime changes.
+    return { ...cached.thresholds };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (err) {
+    // If the file was removed between statSync and readFileSync, ENOENT is
+    // an expected race and should stay quiet — same policy as the stat path.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`[cerebrum] glia.toml read failed at ${path}: ${(err as Error).message}`);
+    }
+    cache.delete(path);
+    return {};
+  }
+
+  const thresholds = parseGliaToml(content);
+  cache.set(path, { mtimeMs, thresholds });
+  // Return a copy so mutation by the caller can't corrupt the cache entry.
+  return { ...thresholds };
+}
+
+/** Test hook — clear the mtime cache. */
+export function resetGliaTomlCache(): void {
+  cache.clear();
+}

--- a/pillars/cerebrum/src/api/modules/glia/trust-machine.test.ts
+++ b/pillars/cerebrum/src/api/modules/glia/trust-machine.test.ts
@@ -1,0 +1,443 @@
+/**
+ * GliaTrustMachine unit tests (PRD-086 US-03).
+ *
+ * Graduation thresholds, demotion logic, counter resets, and phase-transition
+ * edge cases. Runs against a real temp `cerebrum.db` (glia baseline migration
+ * 0051) so the transactional decide/revert counter writes are exercised end to
+ * end, with a controllable clock for the time-window logic.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../../db/index.js';
+import { GliaActionService } from './action-service.js';
+import { FALLBACK_THRESHOLDS } from './thresholds.js';
+import { GliaTrustMachine } from './trust-machine.js';
+
+import type { GraduationThresholds } from './types.js';
+
+/** Fixed clock that advances one second per call. */
+function makeControllableClock(start = new Date('2026-04-27T10:00:00Z')): {
+  now: () => Date;
+  setTime: (d: Date) => void;
+} {
+  let t = start.getTime();
+  return {
+    now: () => {
+      const d = new Date(t);
+      t += 1_000;
+      return d;
+    },
+    setTime: (d: Date) => {
+      t = d.getTime();
+    },
+  };
+}
+
+describe('GliaTrustMachine', () => {
+  let tmpDir: string;
+  let opened: OpenedCerebrumDb;
+  let svc: GliaActionService;
+  let machine: GliaTrustMachine;
+  let clock: ReturnType<typeof makeControllableClock>;
+  let thresholds: GraduationThresholds;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-glia-trust-'));
+    opened = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    clock = makeControllableClock();
+    thresholds = { ...FALLBACK_THRESHOLDS };
+    svc = new GliaActionService(opened.db, clock.now);
+    machine = new GliaTrustMachine(svc, () => thresholds, clock.now);
+    svc.seedTrustStates();
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('propose → act_report', () => {
+    it('does not graduate with fewer than 20 approvals', () => {
+      for (let i = 0; i < 19; i++) {
+        const a = svc.createAction({ actionType: 'link', affectedIds: ['e1'], rationale: `r${i}` });
+        svc.decideAction(a.id, 'approve');
+      }
+
+      const result = machine.checkGraduation('link');
+      expect(result.transitioned).toBe(false);
+      expect(result.reason).toContain('Need 20 approvals');
+    });
+
+    it('graduates with 20+ approvals and <10% rejection rate', () => {
+      for (let i = 0; i < 20; i++) {
+        const a = svc.createAction({ actionType: 'link', affectedIds: ['e1'], rationale: `r${i}` });
+        svc.decideAction(a.id, 'approve');
+      }
+      const rejected = svc.createAction({
+        actionType: 'link',
+        affectedIds: ['e1'],
+        rationale: 'bad',
+      });
+      svc.decideAction(rejected.id, 'reject');
+
+      const result = machine.checkGraduation('link');
+      expect(result.transitioned).toBe(true);
+      expect(result.oldPhase).toBe('propose');
+      expect(result.newPhase).toBe('act_report');
+      expect(result.reason).toContain('Graduated');
+
+      const state = svc.getTrustState('link');
+      expect(state?.currentPhase).toBe('act_report');
+      expect(state?.autonomousSince).not.toBeNull();
+      expect(state?.graduatedAt).not.toBeNull();
+    });
+
+    it('does not graduate when rejection rate is >= 10%', () => {
+      for (let i = 0; i < 20; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `r${i}`,
+        });
+        svc.decideAction(a.id, 'approve');
+      }
+      for (let i = 0; i < 3; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `bad${i}`,
+        });
+        svc.decideAction(a.id, 'reject');
+      }
+
+      const result = machine.checkGraduation('prune');
+      expect(result.transitioned).toBe(false);
+      expect(result.reason).toContain('Rejection rate');
+    });
+
+    it('graduates at exactly the 10% rejection-rate threshold', () => {
+      for (let i = 0; i < 20; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `r${i}`,
+        });
+        svc.decideAction(a.id, 'approve');
+      }
+      for (let i = 0; i < 2; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `bad${i}`,
+        });
+        svc.decideAction(a.id, 'reject');
+      }
+
+      const result = machine.checkGraduation('prune');
+      expect(result.transitioned).toBe(true);
+    });
+
+    it('respects custom thresholds', () => {
+      thresholds.proposeToActReportMinApproved = 5;
+
+      for (let i = 0; i < 5; i++) {
+        const a = svc.createAction({ actionType: 'link', affectedIds: ['e1'], rationale: `r${i}` });
+        svc.decideAction(a.id, 'approve');
+      }
+
+      const result = machine.checkGraduation('link');
+      expect(result.transitioned).toBe(true);
+    });
+  });
+
+  describe('act_report → silent', () => {
+    beforeEach(() => {
+      svc.updateTrustState('audit', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-25T10:00:00.000Z',
+      });
+    });
+
+    it('graduates after 60+ days with 0 reverts', () => {
+      const result = machine.checkGraduation('audit');
+
+      expect(result.transitioned).toBe(true);
+      expect(result.oldPhase).toBe('act_report');
+      expect(result.newPhase).toBe('silent');
+      expect(result.reason).toContain('days in act_report with 0 reverts');
+    });
+
+    it('does not graduate before 60 days', () => {
+      svc.updateTrustState('audit', { autonomousSince: '2026-04-01T10:00:00.000Z' });
+
+      const result = machine.checkGraduation('audit');
+
+      expect(result.transitioned).toBe(false);
+      expect(result.reason).toContain('Need 60 days');
+    });
+
+    it('does not graduate with reverts in the period', () => {
+      svc.updateTrustState('prune', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-25T10:00:00.000Z',
+        revertedCount: 1,
+      });
+
+      const result = machine.checkGraduation('prune');
+
+      expect(result.transitioned).toBe(false);
+      expect(result.reason).toContain('reverts during act_report phase');
+    });
+
+    it('respects a custom day threshold', () => {
+      thresholds.actReportToSilentMinDays = 30;
+      svc.updateTrustState('audit', { autonomousSince: '2026-03-27T10:00:00.000Z' });
+
+      const result = machine.checkGraduation('audit');
+      expect(result.transitioned).toBe(true);
+    });
+  });
+
+  describe('silent phase', () => {
+    it('returns no transition when already in silent', () => {
+      svc.updateTrustState('link', { currentPhase: 'silent' });
+
+      const result = machine.checkGraduation('link');
+
+      expect(result.transitioned).toBe(false);
+      expect(result.oldPhase).toBe('silent');
+      expect(result.newPhase).toBe('silent');
+    });
+  });
+
+  describe('automatic demotion', () => {
+    it('demotes from act_report to propose on 2+ reverts in the window', () => {
+      svc.updateTrustState('consolidate', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-01T10:00:00.000Z',
+        approvedCount: 25,
+      });
+
+      const a1 = svc.createAction({
+        actionType: 'consolidate',
+        affectedIds: ['e1', 'e2'],
+        rationale: 'merge 1',
+      });
+      svc.revertAction(a1.id);
+
+      const a2 = svc.createAction({
+        actionType: 'consolidate',
+        affectedIds: ['e3', 'e4'],
+        rationale: 'merge 2',
+      });
+      svc.revertAction(a2.id);
+
+      const result = machine.checkGraduation('consolidate');
+
+      expect(result.transitioned).toBe(true);
+      expect(result.oldPhase).toBe('act_report');
+      expect(result.newPhase).toBe('propose');
+      expect(result.reason).toContain('Demoted');
+      expect(result.reason).toContain('2 reverts');
+    });
+
+    it('resets all counters on demotion', () => {
+      svc.updateTrustState('prune', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-01T10:00:00.000Z',
+        approvedCount: 30,
+        rejectedCount: 2,
+      });
+
+      const a1 = svc.createAction({ actionType: 'prune', affectedIds: ['e1'], rationale: 'r1' });
+      svc.revertAction(a1.id);
+      const a2 = svc.createAction({ actionType: 'prune', affectedIds: ['e2'], rationale: 'r2' });
+      svc.revertAction(a2.id);
+
+      machine.checkGraduation('prune');
+
+      const state = svc.getTrustState('prune');
+      expect(state?.currentPhase).toBe('propose');
+      expect(state?.approvedCount).toBe(0);
+      expect(state?.rejectedCount).toBe(0);
+      expect(state?.revertedCount).toBe(0);
+      expect(state?.autonomousSince).toBeNull();
+    });
+
+    it('demotes from silent to propose', () => {
+      svc.updateTrustState('link', {
+        currentPhase: 'silent',
+        autonomousSince: '2025-01-01T00:00:00.000Z',
+      });
+
+      const a1 = svc.createAction({
+        actionType: 'link',
+        affectedIds: ['e1', 'e2'],
+        rationale: 'r1',
+      });
+      svc.revertAction(a1.id);
+      const a2 = svc.createAction({
+        actionType: 'link',
+        affectedIds: ['e3', 'e4'],
+        rationale: 'r2',
+      });
+      svc.revertAction(a2.id);
+
+      const result = machine.checkGraduation('link');
+
+      expect(result.transitioned).toBe(true);
+      expect(result.oldPhase).toBe('silent');
+      expect(result.newPhase).toBe('propose');
+    });
+
+    it('does not demote from propose (already lowest)', () => {
+      const a1 = svc.createAction({ actionType: 'prune', affectedIds: ['e1'], rationale: 'r1' });
+      svc.decideAction(a1.id, 'approve');
+      svc.executeAction(a1.id);
+      svc.revertAction(a1.id);
+
+      const a2 = svc.createAction({ actionType: 'prune', affectedIds: ['e2'], rationale: 'r2' });
+      svc.decideAction(a2.id, 'approve');
+      svc.executeAction(a2.id);
+      svc.revertAction(a2.id);
+
+      const result = machine.checkGraduation('prune');
+
+      expect(result.transitioned).toBe(false);
+      expect(result.oldPhase).toBe('propose');
+    });
+
+    it('only counts reverts within the rolling window', () => {
+      svc.updateTrustState('prune', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-01T10:00:00.000Z',
+      });
+
+      const a1 = svc.createAction({ actionType: 'prune', affectedIds: ['e1'], rationale: 'r1' });
+      svc.revertAction(a1.id);
+
+      clock.setTime(new Date('2026-05-05T10:00:00Z'));
+
+      const a2 = svc.createAction({ actionType: 'prune', affectedIds: ['e2'], rationale: 'r2' });
+      svc.revertAction(a2.id);
+
+      const result = machine.checkGraduation('prune');
+      expect(result.transitioned).toBe(false);
+    });
+
+    it('demotion takes precedence over graduation', () => {
+      svc.updateTrustState('link', {
+        currentPhase: 'act_report',
+        autonomousSince: '2026-02-01T10:00:00.000Z',
+        revertedCount: 0,
+      });
+
+      const a1 = svc.createAction({
+        actionType: 'link',
+        affectedIds: ['e1', 'e2'],
+        rationale: 'r1',
+      });
+      svc.revertAction(a1.id);
+      const a2 = svc.createAction({
+        actionType: 'link',
+        affectedIds: ['e3', 'e4'],
+        rationale: 'r2',
+      });
+      svc.revertAction(a2.id);
+
+      const result = machine.checkGraduation('link');
+
+      expect(result.transitioned).toBe(true);
+      expect(result.newPhase).toBe('propose');
+      expect(result.reason).toContain('Demoted');
+    });
+  });
+
+  describe('full lifecycle with graduation', () => {
+    it('propose → approve 20 → graduate → act_report → revert 2 → demote → propose', () => {
+      for (let i = 0; i < 20; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `prune ${i}`,
+        });
+        svc.decideAction(a.id, 'approve');
+        svc.executeAction(a.id);
+      }
+
+      const grad1 = machine.checkGraduation('prune');
+      expect(grad1.transitioned).toBe(true);
+      expect(grad1.newPhase).toBe('act_report');
+
+      const auto1 = svc.createAction({
+        actionType: 'prune',
+        affectedIds: ['e10'],
+        rationale: 'auto prune 1',
+      });
+      expect(auto1.status).toBe('executed');
+
+      svc.revertAction(auto1.id);
+      const auto2 = svc.createAction({
+        actionType: 'prune',
+        affectedIds: ['e11'],
+        rationale: 'auto prune 2',
+      });
+      svc.revertAction(auto2.id);
+
+      const demote = machine.checkGraduation('prune');
+      expect(demote.transitioned).toBe(true);
+      expect(demote.newPhase).toBe('propose');
+
+      const finalState = svc.getTrustState('prune');
+      expect(finalState?.currentPhase).toBe('propose');
+      expect(finalState?.approvedCount).toBe(0);
+      expect(finalState?.rejectedCount).toBe(0);
+      expect(finalState?.revertedCount).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles uninitialized trust state gracefully', () => {
+      opened.raw.prepare("DELETE FROM glia_trust_state WHERE action_type = 'prune'").run();
+
+      const result = machine.checkGraduation('prune');
+
+      expect(result.transitioned).toBe(false);
+      expect(result.reason).toContain('not initialized');
+    });
+
+    it('graduation fires on the next check after lowering thresholds, not retroactively', () => {
+      for (let i = 0; i < 10; i++) {
+        const a = svc.createAction({ actionType: 'link', affectedIds: ['e1'], rationale: `r${i}` });
+        svc.decideAction(a.id, 'approve');
+      }
+
+      thresholds.proposeToActReportMinApproved = 5;
+
+      const result = machine.checkGraduation('link');
+      expect(result.transitioned).toBe(true);
+    });
+
+    it('all rejections keeps an action type in propose permanently', () => {
+      for (let i = 0; i < 25; i++) {
+        const a = svc.createAction({
+          actionType: 'prune',
+          affectedIds: ['e1'],
+          rationale: `r${i}`,
+        });
+        svc.decideAction(a.id, 'reject');
+      }
+
+      const result = machine.checkGraduation('prune');
+      expect(result.transitioned).toBe(false);
+
+      const state = svc.getTrustState('prune');
+      expect(state?.currentPhase).toBe('propose');
+      expect(state?.rejectedCount).toBe(25);
+    });
+  });
+});

--- a/pillars/cerebrum/src/api/modules/glia/trust-machine.ts
+++ b/pillars/cerebrum/src/api/modules/glia/trust-machine.ts
@@ -1,0 +1,228 @@
+/**
+ * GliaTrustMachine — phase transitions and automatic demotion (PRD-086 US-03).
+ *
+ * Evaluates graduation/demotion for each action type after every decide or
+ * revert. Transitions are checked eagerly, not on a schedule. Demotion is
+ * checked first (safety net), then graduation.
+ *
+ * Thresholds are read through the injected `getThresholds` accessor (built by
+ * `makeGliaThresholdReader` so toml edits hot-reload); the machine never reads
+ * config or the DB directly.
+ */
+import type { GliaActionService } from './action-service.js';
+import type { ActionType, GliaTrustState, GraduationThresholds, TrustPhase } from './types.js';
+
+/** Result of a graduation check. */
+export interface TransitionResult {
+  transitioned: boolean;
+  actionType: ActionType;
+  oldPhase: TrustPhase;
+  newPhase: TrustPhase;
+  reason: string;
+}
+
+export class GliaTrustMachine {
+  constructor(
+    private readonly actionService: GliaActionService,
+    private readonly getThresholds: () => GraduationThresholds,
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  /**
+   * Check whether an action type should graduate or be demoted.
+   * Called after every decide or revert operation.
+   */
+  checkGraduation(actionType: ActionType): TransitionResult {
+    const state = this.actionService.getTrustState(actionType);
+    if (!state) {
+      return {
+        transitioned: false,
+        actionType,
+        oldPhase: 'propose',
+        newPhase: 'propose',
+        reason: 'Trust state not initialized',
+      };
+    }
+
+    const demotionResult = this.checkDemotion(actionType, state);
+    if (demotionResult.transitioned) {
+      return demotionResult;
+    }
+
+    return this.checkPromotion(actionType, state);
+  }
+
+  /**
+   * Evaluate demotion: N+ reverts in a rolling window → reset to propose.
+   * Applies to any phase except propose (already at lowest).
+   */
+  private checkDemotion(actionType: ActionType, state: GliaTrustState): TransitionResult {
+    const noTransition: TransitionResult = {
+      transitioned: false,
+      actionType,
+      oldPhase: state.currentPhase,
+      newPhase: state.currentPhase,
+      reason: 'No demotion triggered',
+    };
+
+    if (state.currentPhase === 'propose') {
+      return noTransition;
+    }
+
+    const thresholds = this.getThresholds();
+    const windowMs = thresholds.demotionWindowDays * 24 * 60 * 60 * 1000;
+    const windowStart = new Date(this.now().getTime() - windowMs).toISOString();
+
+    const recentReverts = this.actionService.countRevertsInWindow(actionType, windowStart);
+
+    if (recentReverts >= thresholds.demotionRevertThreshold) {
+      const timestamp = this.now().toISOString();
+      const oldPhase = state.currentPhase;
+
+      this.actionService.updateTrustState(actionType, {
+        currentPhase: 'propose',
+        approvedCount: 0,
+        rejectedCount: 0,
+        revertedCount: 0,
+        autonomousSince: null,
+        graduatedAt: timestamp,
+      });
+
+      return {
+        transitioned: true,
+        actionType,
+        oldPhase,
+        newPhase: 'propose',
+        reason: `Demoted: ${recentReverts} reverts in ${thresholds.demotionWindowDays}-day window (threshold: ${thresholds.demotionRevertThreshold})`,
+      };
+    }
+
+    return noTransition;
+  }
+
+  /**
+   * Evaluate graduation:
+   *   propose → act_report: enough approvals, low rejection rate
+   *   act_report → silent: enough days in act_report, 0 reverts
+   */
+  private checkPromotion(actionType: ActionType, state: GliaTrustState): TransitionResult {
+    const noTransition: TransitionResult = {
+      transitioned: false,
+      actionType,
+      oldPhase: state.currentPhase,
+      newPhase: state.currentPhase,
+      reason: 'Graduation criteria not met',
+    };
+
+    const thresholds = this.getThresholds();
+
+    if (state.currentPhase === 'propose') {
+      return this.checkProposeToActReport(actionType, state, thresholds);
+    }
+
+    if (state.currentPhase === 'act_report') {
+      return this.checkActReportToSilent(actionType, state, thresholds);
+    }
+
+    return noTransition;
+  }
+
+  private checkProposeToActReport(
+    actionType: ActionType,
+    state: GliaTrustState,
+    thresholds: GraduationThresholds
+  ): TransitionResult {
+    const noTransition: TransitionResult = {
+      transitioned: false,
+      actionType,
+      oldPhase: 'propose',
+      newPhase: 'propose',
+      reason: 'Graduation criteria not met',
+    };
+
+    if (state.approvedCount < thresholds.proposeToActReportMinApproved) {
+      return {
+        ...noTransition,
+        reason: `Need ${thresholds.proposeToActReportMinApproved} approvals, have ${state.approvedCount}`,
+      };
+    }
+
+    const totalDecisions = state.approvedCount + state.rejectedCount;
+    const rejectionRate = totalDecisions > 0 ? state.rejectedCount / totalDecisions : 0;
+
+    if (rejectionRate >= thresholds.proposeToActReportMaxRejectionRate) {
+      return {
+        ...noTransition,
+        reason: `Rejection rate ${(rejectionRate * 100).toFixed(1)}% exceeds threshold ${(thresholds.proposeToActReportMaxRejectionRate * 100).toFixed(1)}%`,
+      };
+    }
+
+    const timestamp = this.now().toISOString();
+    this.actionService.updateTrustState(actionType, {
+      currentPhase: 'act_report',
+      autonomousSince: timestamp,
+      graduatedAt: timestamp,
+    });
+
+    return {
+      transitioned: true,
+      actionType,
+      oldPhase: 'propose',
+      newPhase: 'act_report',
+      reason: `Graduated: ${state.approvedCount} approvals, ${(rejectionRate * 100).toFixed(1)}% rejection rate`,
+    };
+  }
+
+  private checkActReportToSilent(
+    actionType: ActionType,
+    state: GliaTrustState,
+    thresholds: GraduationThresholds
+  ): TransitionResult {
+    const noTransition: TransitionResult = {
+      transitioned: false,
+      actionType,
+      oldPhase: 'act_report',
+      newPhase: 'act_report',
+      reason: 'Graduation criteria not met',
+    };
+
+    if (!state.autonomousSince) {
+      return {
+        ...noTransition,
+        reason: 'No autonomous_since timestamp',
+      };
+    }
+
+    const autonomousSinceMs = new Date(state.autonomousSince).getTime();
+    const nowMs = this.now().getTime();
+    const daysInPhase = (nowMs - autonomousSinceMs) / (24 * 60 * 60 * 1000);
+
+    if (daysInPhase < thresholds.actReportToSilentMinDays) {
+      return {
+        ...noTransition,
+        reason: `Need ${thresholds.actReportToSilentMinDays} days in act_report, have ${Math.floor(daysInPhase)}`,
+      };
+    }
+
+    if (state.revertedCount > 0) {
+      return {
+        ...noTransition,
+        reason: `Cannot graduate with ${state.revertedCount} reverts during act_report phase`,
+      };
+    }
+
+    const timestamp = this.now().toISOString();
+    this.actionService.updateTrustState(actionType, {
+      currentPhase: 'silent',
+      graduatedAt: timestamp,
+    });
+
+    return {
+      transitioned: true,
+      actionType,
+      oldPhase: 'act_report',
+      newPhase: 'silent',
+      reason: `Graduated: ${Math.floor(daysInPhase)} days in act_report with 0 reverts`,
+    };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/glia/types.ts
+++ b/pillars/cerebrum/src/api/modules/glia/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Glia trust-graduation domain types for the cerebrum pillar.
+ *
+ * The action / trust-state / enum shapes are owned by the pillar data-access
+ * layer (`../../../db/index.js`) and re-exported here so the glia module's
+ * orchestration code (action service, trust machine, digest) imports a single
+ * surface. The graduation-threshold + transition types are pure domain
+ * orchestration concerns that never touch the wire or the DB, so they live
+ * here rather than in the data package.
+ */
+export {
+  ACTION_STATUSES,
+  ACTION_TYPES,
+  TRUST_PHASES,
+  USER_DECISIONS,
+  type ActionListFilters,
+  type ActionStatus,
+  type ActionType,
+  type GliaAction,
+  type GliaTrustState,
+  type TrustPhase,
+  type UserDecision,
+} from '../../../db/index.js';
+
+import type { ActionType } from '../../../db/index.js';
+
+/** Input for creating a new action. */
+export interface CreateActionInput {
+  actionType: ActionType;
+  affectedIds: string[];
+  rationale: string;
+  payload?: unknown;
+}
+
+/** Configurable graduation thresholds (ADR-021). */
+export interface GraduationThresholds {
+  /** Minimum approved actions to graduate from propose to act_report. */
+  proposeToActReportMinApproved: number;
+  /** Maximum rejection rate (0.0-1.0) to graduate from propose to act_report. */
+  proposeToActReportMaxRejectionRate: number;
+  /** Minimum days in act_report phase to graduate to silent. */
+  actReportToSilentMinDays: number;
+  /** Maximum reverts in demotion window before demoting to propose. */
+  demotionRevertThreshold: number;
+  /** Rolling window in days for counting reverts for demotion. */
+  demotionWindowDays: number;
+}

--- a/pillars/cerebrum/src/api/rest/glia-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/glia-handlers.ts
@@ -1,0 +1,109 @@
+/**
+ * ts-rest handlers for `cerebrum.glia.*` (PRD-086 / PRD-181).
+ *
+ * Builds a per-request glia services bundle bound to the pillar DB handle, then
+ * delegates to it. The services throw the pillar `HttpError` subclasses;
+ * `runHttp` maps `NotFoundError` → 404, `ConflictError` → 409, and
+ * `ValidationError` → 400.
+ *
+ * `decide` and `revert` eagerly re-evaluate graduation via the trust machine
+ * after the (transactional) state change. `revert` additionally performs the
+ * file-level undo through the in-pillar {@link EngramService} — wired here from
+ * the same db + engram root + template registry the engrams slice uses, so a
+ * prune/consolidate/link revert restores or unlinks the affected engrams.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumGliaContract } from '../../contract/rest-glia.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { EngramService } from '../modules/engrams/service.js';
+import { buildGliaServices } from '../modules/glia/instance.js';
+import { executeRevert } from '../modules/glia/revert-operations.js';
+import { NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface GliaHandlerDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  /** Absolute path to `glia.toml` (graduation thresholds). */
+  configPath: string;
+}
+
+export function makeGliaHandlers(
+  deps: GliaHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumGliaContract>> {
+  const services = () => buildGliaServices({ db: deps.db, configPath: deps.configPath });
+  const engramService = (): EngramService =>
+    new EngramService({ root: deps.engramRoot, db: deps.db, templates: deps.templates });
+
+  return server.router(cerebrumGliaContract, {
+    actions: {
+      list: async ({ body }) => {
+        const { actionService } = services();
+        return { status: 200, body: actionService.listActions(body) };
+      },
+
+      get: async ({ params }) =>
+        runHttp(() => {
+          const { actionService } = services();
+          const action = actionService.getAction(params.id);
+          if (!action) throw new NotFoundError('GliaAction', params.id);
+          return { status: 200, body: { action } };
+        }),
+
+      decide: async ({ params, body }) =>
+        runHttp(() => {
+          const { actionService, trustMachine } = services();
+          const action = actionService.decideAction(params.id, body.decision, body.note);
+          const transition = trustMachine.checkGraduation(action.actionType);
+          return { status: 200, body: { action, transition } };
+        }),
+
+      execute: async ({ params }) =>
+        runHttp(() => {
+          const { actionService } = services();
+          return { status: 200, body: { action: actionService.executeAction(params.id) } };
+        }),
+
+      revert: async ({ params }) =>
+        runHttp(() => {
+          const { actionService, trustMachine } = services();
+          const action = actionService.revertAction(params.id);
+          const revertResult = executeRevert(action, engramService());
+          const transition = trustMachine.checkGraduation(action.actionType);
+          return { status: 200, body: { action, transition, revertResult } };
+        }),
+
+      history: async ({ body }) => {
+        const { actionService } = services();
+        return { status: 200, body: actionService.listActions(body) };
+      },
+    },
+
+    trustState: {
+      get: async ({ params }) =>
+        runHttp(() => {
+          const { actionService } = services();
+          const state = actionService.getTrustState(params.actionType);
+          if (!state) throw new NotFoundError('GliaTrustState', params.actionType);
+          return { status: 200, body: { state } };
+        }),
+
+      list: async () => {
+        const { actionService } = services();
+        return { status: 200, body: { states: actionService.listTrustStates() } };
+      },
+    },
+
+    digest: async ({ body }) =>
+      runHttp(async () => {
+        const { digestService } = services();
+        return { status: 200, body: await digestService.generate(body) };
+      }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -8,7 +8,9 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
+import { resolveGliaConfigPath } from '../modules/glia/instance.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
+import { makeGliaHandlers } from './glia-handlers.js';
 import { makePlexusHandlers } from './plexus-handlers.js';
 import { makeReflexHandlers } from './reflex-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
@@ -34,5 +36,11 @@ export function makeCerebrumRestHandlers(
     engrams: makeEngramsHandlers(engramDeps),
     scopes: makeScopesHandlers(engramDeps),
     tags: makeTagsHandlers(deps.cerebrumDb.db),
+    glia: makeGliaHandlers({
+      db: deps.cerebrumDb.db,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      configPath: deps.gliaConfigPath ?? resolveGliaConfigPath(),
+    }),
   });
 }

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -124,6 +124,159 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/glia/actions/history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query the action audit trail (filtered + paginated). */
+    post: operations['glia.actions.history'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/actions/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List glia actions matching the supplied filters (proposal queue + audit trail). */
+    post: operations['glia.actions.list'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/actions/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single glia action by id. */
+    get: operations['glia.actions.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/actions/{id}/decide': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Record a user decision on a pending action; eagerly re-evaluate graduation. */
+    post: operations['glia.actions.decide'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/actions/{id}/execute': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Execute an approved action. */
+    post: operations['glia.actions.execute'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/actions/{id}/revert': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Revert an executed action (DB-state flip + file-level undo). */
+    post: operations['glia.actions.revert'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/digest': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate (and optionally deliver) the autonomous-action digest. */
+    post: operations['glia.digest'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/trust-state': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List trust state for every action type. */
+    get: operations['glia.trustState.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/trust-state/{actionType}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get trust state for a single action type. */
+    get: operations['glia.trustState.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/plexus/adapters': {
     parameters: {
       query?: never;
@@ -1058,6 +1211,598 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          actionType?: 'prune' | 'consolidate' | 'link' | 'audit';
+          dateFrom?: string;
+          dateTo?: string;
+          limit?: number;
+          offset?: number;
+          /** @enum {string} */
+          status?: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            }[];
+            total: number;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          actionType?: 'prune' | 'consolidate' | 'link' | 'audit';
+          dateFrom?: string;
+          dateTo?: string;
+          limit?: number;
+          offset?: number;
+          /** @enum {string} */
+          status?: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            }[];
+            total: number;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            action: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.decide': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          decision: 'approve' | 'reject' | 'modify';
+          note?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            action: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            };
+            transition: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              /** @enum {string} */
+              newPhase: 'propose' | 'act_report' | 'silent';
+              /** @enum {string} */
+              oldPhase: 'propose' | 'act_report' | 'silent';
+              reason: string;
+              transitioned: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.execute': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            action: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'glia.actions.revert': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            action: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              decidedAt: string | null;
+              executedAt: string | null;
+              id: string;
+              payload: unknown;
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              revertedAt: string | null;
+              /** @enum {string} */
+              status: 'pending' | 'approved' | 'rejected' | 'executed' | 'reverted';
+              /** @enum {string|null} */
+              userDecision: 'approve' | 'reject' | 'modify' | null;
+              userNote: string | null;
+            };
+            revertResult: {
+              errors: string[];
+              restoredIds: string[];
+              success: boolean;
+            };
+            transition: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              /** @enum {string} */
+              newPhase: 'propose' | 'act_report' | 'silent';
+              /** @enum {string} */
+              oldPhase: 'propose' | 'act_report' | 'silent';
+              reason: string;
+              transitioned: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'glia.digest': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          actionType?: 'prune' | 'consolidate' | 'link' | 'audit';
+          deliver?: boolean;
+          /** @enum {string} */
+          period?: 'daily' | 'weekly';
+          rejectionRateThreshold?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            delivery: {
+              attempted: boolean;
+              channels: {
+                /** @enum {string} */
+                channel: 'shell' | 'moltbot';
+                delivered: boolean;
+                reason: string | null;
+              }[];
+              suppressedReason: string | null;
+            };
+            report: {
+              anomalies: {
+                /** @enum {string} */
+                actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+                autonomousSince: string;
+                executedCount: number;
+                rejectionRatePostGraduation: number;
+                revertedCount: number;
+                threshold: number;
+              }[];
+              endDate: string;
+              groups: {
+                /** @enum {string} */
+                actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+                actions: {
+                  affectedIds: string[];
+                  executedAt: string;
+                  id: string;
+                  rationale: string;
+                }[];
+                count: number;
+              }[];
+              /** @enum {string} */
+              period: 'daily' | 'weekly';
+              startDate: string;
+              totalAutonomousActions: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'glia.trustState.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            states: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              approvedCount: number;
+              autonomousSince: string | null;
+              /** @enum {string} */
+              currentPhase: 'propose' | 'act_report' | 'silent';
+              graduatedAt: string | null;
+              lastRevertAt: string | null;
+              rejectedCount: number;
+              revertedCount: number;
+              updatedAt: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'glia.trustState.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            state: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              approvedCount: number;
+              autonomousSince: string | null;
+              /** @enum {string} */
+              currentPhase: 'propose' | 'act_report' | 'silent';
+              graduatedAt: string | null;
+              lastRevertAt: string | null;
+              rejectedCount: number;
+              revertedCount: number;
+              updatedAt: string;
+            };
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-glia-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-glia-schemas.ts
@@ -1,0 +1,137 @@
+/**
+ * Glia wire schemas (PRD-086 / PRD-181).
+ *
+ * Split out of `rest-glia.ts` so the contract file stays within the per-file
+ * line budget. These schemas are glia-only — `rest-schemas.ts` holds the
+ * cross-domain shared envelopes; this file holds the glia trust/action shapes.
+ */
+import { z } from 'zod';
+
+export const gliaActionTypeSchema = z.enum(['prune', 'consolidate', 'link', 'audit']);
+export type GliaActionTypeWire = z.infer<typeof gliaActionTypeSchema>;
+
+export const gliaActionStatusSchema = z.enum([
+  'pending',
+  'approved',
+  'rejected',
+  'executed',
+  'reverted',
+]);
+export type GliaActionStatusWire = z.infer<typeof gliaActionStatusSchema>;
+
+export const gliaTrustPhaseSchema = z.enum(['propose', 'act_report', 'silent']);
+export type GliaTrustPhaseWire = z.infer<typeof gliaTrustPhaseSchema>;
+
+export const gliaUserDecisionSchema = z.enum(['approve', 'reject', 'modify']);
+export type GliaUserDecisionWire = z.infer<typeof gliaUserDecisionSchema>;
+
+/** A glia action record — one row from `glia_actions` deserialised. */
+export const gliaActionSchema = z.object({
+  id: z.string().min(1),
+  actionType: gliaActionTypeSchema,
+  affectedIds: z.array(z.string()),
+  rationale: z.string(),
+  payload: z.unknown().nullable(),
+  phase: gliaTrustPhaseSchema,
+  status: gliaActionStatusSchema,
+  userDecision: gliaUserDecisionSchema.nullable(),
+  userNote: z.string().nullable(),
+  executedAt: z.string().nullable(),
+  decidedAt: z.string().nullable(),
+  revertedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type GliaActionWire = z.infer<typeof gliaActionSchema>;
+
+/** Trust state for a single action type — one row from `glia_trust_state`. */
+export const gliaTrustStateSchema = z.object({
+  actionType: gliaActionTypeSchema,
+  currentPhase: gliaTrustPhaseSchema,
+  approvedCount: z.number().int(),
+  rejectedCount: z.number().int(),
+  revertedCount: z.number().int(),
+  autonomousSince: z.string().nullable(),
+  lastRevertAt: z.string().nullable(),
+  graduatedAt: z.string().nullable(),
+  updatedAt: z.string(),
+});
+export type GliaTrustStateWire = z.infer<typeof gliaTrustStateSchema>;
+
+/** Result of an eager graduation/demotion check after a decision or revert. */
+export const gliaTransitionResultSchema = z.object({
+  transitioned: z.boolean(),
+  actionType: gliaActionTypeSchema,
+  oldPhase: gliaTrustPhaseSchema,
+  newPhase: gliaTrustPhaseSchema,
+  reason: z.string(),
+});
+export type GliaTransitionResultWire = z.infer<typeof gliaTransitionResultSchema>;
+
+/** Outcome of the file-level revert performed after a DB-state revert. */
+export const gliaRevertResultSchema = z.object({
+  success: z.boolean(),
+  restoredIds: z.array(z.string()),
+  errors: z.array(z.string()),
+});
+export type GliaRevertResultWire = z.infer<typeof gliaRevertResultSchema>;
+
+/** Filters shared by `actions.list` and `actions.history`. */
+export const gliaActionFilterSchema = z.object({
+  actionType: gliaActionTypeSchema.optional(),
+  status: gliaActionStatusSchema.optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  limit: z.number().int().positive().max(500).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+/** One autonomous action surfaced in the digest. */
+const gliaDigestActionEntrySchema = z.object({
+  id: z.string(),
+  affectedIds: z.array(z.string()),
+  rationale: z.string(),
+  executedAt: z.string(),
+});
+
+/** Per action-type grouping in the digest. */
+const gliaDigestActionGroupSchema = z.object({
+  actionType: gliaActionTypeSchema,
+  count: z.number().int(),
+  actions: z.array(gliaDigestActionEntrySchema),
+});
+
+/** Post-graduation rejection-rate anomaly. */
+const gliaDigestAnomalySchema = z.object({
+  actionType: gliaActionTypeSchema,
+  rejectionRatePostGraduation: z.number(),
+  threshold: z.number(),
+  autonomousSince: z.string(),
+  executedCount: z.number().int(),
+  revertedCount: z.number().int(),
+});
+
+/** The full autonomous digest payload. */
+export const gliaDigestReportSchema = z.object({
+  period: z.enum(['daily', 'weekly']),
+  startDate: z.string(),
+  endDate: z.string(),
+  totalAutonomousActions: z.number().int(),
+  groups: z.array(gliaDigestActionGroupSchema),
+  anomalies: z.array(gliaDigestAnomalySchema),
+});
+export type GliaDigestReportWire = z.infer<typeof gliaDigestReportSchema>;
+
+/** Outcome of a single digest delivery channel. */
+const gliaDeliveryChannelResultSchema = z.object({
+  channel: z.enum(['shell', 'moltbot']),
+  delivered: z.boolean(),
+  reason: z.string().nullable(),
+});
+
+/** The digest delivery envelope (attempted / suppressed + per-channel). */
+export const gliaDigestDeliverySchema = z.object({
+  attempted: z.boolean(),
+  suppressedReason: z.string().nullable(),
+  channels: z.array(gliaDeliveryChannelResultSchema),
+});
+export type GliaDigestDeliveryWire = z.infer<typeof gliaDigestDeliverySchema>;

--- a/pillars/cerebrum/src/contract/rest-glia.ts
+++ b/pillars/cerebrum/src/contract/rest-glia.ts
@@ -1,0 +1,162 @@
+/**
+ * ts-rest contract for `cerebrum.glia.*` (PRD-086 / PRD-181).
+ *
+ * Glia is the autonomous-curation trust/action router: a proposal queue, the
+ * decide/execute/revert lifecycle, per-action-type trust state, and an
+ * audit-trail digest. Non-identity domain — served on the docker-network trust
+ * boundary with no per-request auth (parity with templates / reflex / engrams).
+ *
+ * Typed/array/filter inputs ride in POST bodies rather than the query string
+ * (mirrors the reflex `history` + engrams `search` precedent):
+ *   - `actions.list` / `actions.history` carry enum filters in a POST body.
+ *   - `actions.decide` carries the decision enum + note in a POST body.
+ *   - `digest` carries the period/actionType/threshold/deliver flags in a body.
+ *
+ * `actions.get` and the trust-state reads carry only path params, so they stay
+ * GET. The literal-list `GET /glia/trust-state` and the param read
+ * `GET /glia/trust-state/:actionType` do not collide (the list has no path
+ * segment after `trust-state`).
+ *
+ * The glia wire schemas live in `rest-glia-schemas.ts`.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  gliaActionFilterSchema,
+  gliaActionSchema,
+  gliaActionTypeSchema,
+  gliaDigestDeliverySchema,
+  gliaDigestReportSchema,
+  gliaRevertResultSchema,
+  gliaTransitionResultSchema,
+  gliaTrustStateSchema,
+  gliaUserDecisionSchema,
+} from './rest-glia-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+const idParams = z.object({ id: z.string().min(1) });
+
+const actionsContract = c.router({
+  list: {
+    method: 'POST',
+    path: '/glia/actions/search',
+    summary: 'List glia actions matching the supplied filters (proposal queue + audit trail).',
+    body: gliaActionFilterSchema,
+    responses: {
+      200: z.object({ actions: z.array(gliaActionSchema), total: z.number().int() }),
+    },
+  },
+  get: {
+    method: 'GET',
+    path: '/glia/actions/:id',
+    summary: 'Get a single glia action by id.',
+    pathParams: idParams,
+    responses: {
+      200: z.object({ action: gliaActionSchema }),
+      404: errorBodySchema,
+    },
+  },
+  decide: {
+    method: 'POST',
+    path: '/glia/actions/:id/decide',
+    summary: 'Record a user decision on a pending action; eagerly re-evaluate graduation.',
+    pathParams: idParams,
+    body: z.object({
+      decision: gliaUserDecisionSchema,
+      note: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        action: gliaActionSchema,
+        transition: gliaTransitionResultSchema,
+      }),
+      400: errorBodySchema,
+      404: errorBodySchema,
+      409: errorBodySchema,
+    },
+  },
+  execute: {
+    method: 'POST',
+    path: '/glia/actions/:id/execute',
+    summary: 'Execute an approved action.',
+    pathParams: idParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({ action: gliaActionSchema }),
+      404: errorBodySchema,
+      409: errorBodySchema,
+    },
+  },
+  revert: {
+    method: 'POST',
+    path: '/glia/actions/:id/revert',
+    summary: 'Revert an executed action (DB-state flip + file-level undo).',
+    pathParams: idParams,
+    body: z.object({}),
+    responses: {
+      200: z.object({
+        action: gliaActionSchema,
+        transition: gliaTransitionResultSchema,
+        revertResult: gliaRevertResultSchema,
+      }),
+      400: errorBodySchema,
+      404: errorBodySchema,
+      409: errorBodySchema,
+    },
+  },
+  history: {
+    method: 'POST',
+    path: '/glia/actions/history',
+    summary: 'Query the action audit trail (filtered + paginated).',
+    body: gliaActionFilterSchema,
+    responses: {
+      200: z.object({ actions: z.array(gliaActionSchema), total: z.number().int() }),
+    },
+  },
+});
+
+const trustStateContract = c.router({
+  get: {
+    method: 'GET',
+    path: '/glia/trust-state/:actionType',
+    summary: 'Get trust state for a single action type.',
+    pathParams: z.object({ actionType: gliaActionTypeSchema }),
+    responses: {
+      200: z.object({ state: gliaTrustStateSchema }),
+      404: errorBodySchema,
+    },
+  },
+  list: {
+    method: 'GET',
+    path: '/glia/trust-state',
+    summary: 'List trust state for every action type.',
+    responses: {
+      200: z.object({ states: z.array(gliaTrustStateSchema) }),
+    },
+  },
+});
+
+export const cerebrumGliaContract = c.router({
+  actions: actionsContract,
+  trustState: trustStateContract,
+  digest: {
+    method: 'POST',
+    path: '/glia/digest',
+    summary: 'Generate (and optionally deliver) the autonomous-action digest.',
+    body: z.object({
+      period: z.enum(['daily', 'weekly']).optional(),
+      actionType: gliaActionTypeSchema.optional(),
+      rejectionRateThreshold: z.number().gt(0).lte(1).optional(),
+      deliver: z.boolean().optional(),
+    }),
+    responses: {
+      200: z.object({
+        report: gliaDigestReportSchema,
+        delivery: gliaDigestDeliverySchema,
+      }),
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 
 import { cerebrumEngramsContract } from './rest-engrams.js';
+import { cerebrumGliaContract } from './rest-glia.js';
 import { cerebrumPlexusContract } from './rest-plexus.js';
 import { cerebrumReflexContract } from './rest-reflex.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
@@ -29,6 +30,7 @@ export const cerebrumContract = c.router(
     engrams: cerebrumEngramsContract,
     scopes: cerebrumScopesContract,
     tags: cerebrumTagsContract,
+    glia: cerebrumGliaContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Summary

REST migration slice for the cerebrum **glia** domain (trust/action router, PRD-086 / PRD-181) — the autonomous-curation proposal queue, decide/execute/revert lifecycle, per-action-type trust state, and the audit-trail digest. Lifts the 9 tRPC procs off `apps/pops-api/src/modules/cerebrum/glia/*` onto the ts-rest contract + pillar handlers, following the merged templates/plexus/reflex/engrams slices exactly.

Non-identity domain: served on the docker-network trust boundary, no per-request auth.

## Wire surface (9 procs)

| tRPC proc | REST | operationId |
|---|---|---|
| `glia.actions.list` | `POST /glia/actions/search` | `glia.actions.list` |
| `glia.actions.get` | `GET /glia/actions/:id` (404) | `glia.actions.get` |
| `glia.actions.decide` | `POST /glia/actions/:id/decide` | `glia.actions.decide` |
| `glia.actions.execute` | `POST /glia/actions/:id/execute` | `glia.actions.execute` |
| `glia.actions.revert` | `POST /glia/actions/:id/revert` | `glia.actions.revert` |
| `glia.actions.history` | `POST /glia/actions/history` | `glia.actions.history` |
| `glia.trustState.get` | `GET /glia/trust-state/:actionType` (404) | `glia.trustState.get` |
| `glia.trustState.list` | `GET /glia/trust-state` | `glia.trustState.list` |
| `glia.digest` | `POST /glia/digest` | `glia.digest` |

POST-with-body where typed/array/filter inputs won't round-trip via query string. The literal-list `GET /glia/trust-state` and the param read `GET /glia/trust-state/:actionType` do not collide.

## Structure

- Contract: `src/contract/rest-glia.ts` (routes) + `src/contract/rest-glia-schemas.ts` (glia-only zod), composed into `rest.ts` alongside the existing keys.
- Handlers: `src/api/rest/glia-handlers.ts` composed in `rest/handlers.ts` over `CerebrumApiDeps`.
- Lifted code: `src/api/modules/glia/` (action-service, trust-machine, digest-service, digest-channels, autonomous-digest, revert-operations, toml-config, thresholds, helpers, instance, types).
- Errors via the pillar `HttpError` subclasses + `runHttp` (400/404/409). `getCerebrumDrizzle()` AsyncLocalStorage replaced by the injected `deps.cerebrumDb.db` threaded through the services.
- **Transactions preserved**: `decideAction` + `revertAction` keep their `db.transaction(...)` (action update + trust-state counter increment land together).

## Key deviations from the monolith

- **engram-revert wiring**: `revert-operations.ts` reuses the real in-pillar `EngramService` (`src/api/modules/engrams/service.ts`) for the file-level undo (restore archived / hardDelete / unlink). The glia handler constructs it from `deps.cerebrumDb.db` + `deps.engramRoot` + `deps.templateRegistry`, same as the engrams slice. No `EngramRevertPort` shim was needed. The minimal payload fields revert reads (`mergedEngramId`, `sourceId`/`targetId`) are parsed defensively from the opaque `payload` rather than importing the pops-api worker payload types.
- **TOML thresholds / settings DB**: `getGliaThresholds()` is replaced by `makeGliaThresholdReader(configPath)` — reads `glia.toml` (mtime-cached, hot-reload) then falls back **straight to the hardcoded ADR-021 defaults**. The monolith's middle settings-DB tier is dropped (the pillar has no settings service); the toml file remains the documented user-facing knob, so behaviour is unchanged for toml-configured deployments. Config path is env-driven (`CEREBRUM_GLIA_CONFIG` / `CEREBRUM_GLIA_CONFIG_DIR` / `CEREBRUM_ENGRAMS_DIR`), tolerant of a missing file.
- **digest delivery / Telegram**: shell channel writes `nudge_log` via the pillar db handle (kept). The cross-module moltbot/Telegram channel is inlined as a minimal env-gated sender (`POPS_ALERTS_TELEGRAM_BOT_TOKEN` / `_CHAT_ID`) that is a silent no-op when unconfigured. The `deliver:false` path and the shell channel work without any Telegram config. The 3 suppression rules (zero autonomous actions / all-silent-phase / no-channels) are preserved.
- No SSE, no cross-pillar DB, no LLM (the AuditorWorker was NOT lifted).

## Tests

- `src/api/__tests__/glia.test.ts` — supertest over temp `cerebrum.db` (0051 baseline): search empty, get unknown → 404, decide approve/reject (trust-state counters increment, transactional), 409 on re-decide, trustState list/get-404, digest `deliver:false` + the 3 suppression rules.
- Ported pure/direct unit tests: `modules/glia/autonomous-digest.test.ts`, `trust-machine.test.ts` (graduation/demotion over a real temp DB + controllable clock), `revert-operations.test.ts` (prune/consolidate/link/audit + idempotency over a real EngramService).
- `test-utils.ts makeClient` gained a `glia` section.

## Green proof (run locally)

- `oxfmt --check pillars/cerebrum/` — clean
- `oxlint pillars/cerebrum/src` — 0 errors (only the pre-existing `__resetPillarRegistryCache` warning)
- `typecheck` — clean (no `as any` / suppressions)
- `build` — clean
- `generate:openapi && git diff --exit-code` — idempotent, no drift
- `test` — 469 passed (78 in the 5 glia files)
