### PR TITLE
feat(cerebrum): REST migration slice — retrieval + cross-pillar rewire

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -4777,6 +4777,616 @@
         "tags": ["reflex"]
       }
     },
+    "/retrieval/context": {
+      "post": {
+        "operationId": "retrieval.context",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "filters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "customFields": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "dateRange": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "includeSecret": {
+                        "type": "boolean"
+                      },
+                      "scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sourceTypes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "status": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "types": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "includeMetadata": {
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "maxResults": {
+                    "default": 20,
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "tokenBudget": {
+                    "default": 4096,
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["query", "tokenBudget", "includeMetadata", "maxResults"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "context": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "chunkRange": {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "type": "array"
+                          },
+                          "relevanceScore": {
+                            "type": "number"
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["sourceType", "sourceId", "title", "relevanceScore"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "tokenEstimate": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["context", "sources", "truncated", "tokenEstimate"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Assemble a token-budgeted context window for LLM consumption.",
+        "tags": ["retrieval"]
+      }
+    },
+    "/retrieval/search": {
+      "post": {
+        "operationId": "retrieval.search",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "filters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "customFields": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "dateRange": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "includeSecret": {
+                        "type": "boolean"
+                      },
+                      "scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sourceTypes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "status": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "types": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "limit": {
+                    "default": 20,
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "default": "hybrid",
+                    "enum": ["semantic", "structured", "hybrid"],
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "threshold": {
+                    "default": 0.8,
+                    "maximum": 2,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": ["mode", "limit", "threshold", "offset"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "meta": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "mode": {
+                          "enum": ["semantic", "structured", "hybrid"],
+                          "type": "string"
+                        },
+                        "total": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["total", "mode"],
+                      "type": "object"
+                    },
+                    "results": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contentPreview": {
+                            "type": "string"
+                          },
+                          "distance": {
+                            "type": "number"
+                          },
+                          "matchType": {
+                            "enum": ["semantic", "structured", "both"],
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "score": {
+                            "type": "number"
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "sourceType",
+                          "sourceId",
+                          "title",
+                          "contentPreview",
+                          "score",
+                          "matchType",
+                          "metadata"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["results", "meta"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Unified search — semantic | structured | hybrid (default).",
+        "tags": ["retrieval"]
+      }
+    },
+    "/retrieval/similar": {
+      "post": {
+        "operationId": "retrieval.similar",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "engramId": {
+                    "type": "string"
+                  },
+                  "filters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "customFields": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "dateRange": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "includeSecret": {
+                        "type": "boolean"
+                      },
+                      "scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sourceTypes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "status": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "types": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "limit": {
+                    "default": 20,
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "threshold": {
+                    "default": 0.8,
+                    "maximum": 2,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": ["engramId", "limit", "threshold"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "results": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contentPreview": {
+                            "type": "string"
+                          },
+                          "distance": {
+                            "type": "number"
+                          },
+                          "matchType": {
+                            "enum": ["semantic", "structured", "both"],
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "score": {
+                            "type": "number"
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "sourceType",
+                          "sourceId",
+                          "title",
+                          "contentPreview",
+                          "score",
+                          "matchType",
+                          "metadata"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["results"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Find engrams similar to a given engram by its existing vector.",
+        "tags": ["retrieval"]
+      }
+    },
+    "/retrieval/stats": {
+      "get": {
+        "operationId": "retrieval.stats",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "embedded": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "indexed": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "lastUpdated": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "sourceTypes": {
+                      "additionalProperties": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["indexed", "embedded", "sourceTypes", "lastUpdated"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Retrieval layer health and coverage counts.",
+        "tags": ["retrieval"]
+      }
+    },
     "/scopes": {
       "get": {
         "operationId": "scopes.list",

--- a/pillars/cerebrum/src/api/__tests__/engrams.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/engrams.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeTemplateRegistry } from './test-utils.js';
+import { makeClient, makeEmptyPeerClients, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let engramRoot: string;
@@ -42,6 +42,7 @@ function client() {
       engramRoot,
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/glia.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/glia.test.ts
@@ -22,7 +22,12 @@ import {
   type TrustPhase,
 } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeTemplateRegistry, makeReflexService } from './test-utils.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -48,6 +53,7 @@ function client() {
       gliaConfigPath: join(tmpDir, '.config', 'glia.toml'),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/health.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/health.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeReflexService, makeTemplateRegistry } from './test-utils.js';
+import { makeEmptyPeerClients, makeReflexService, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -36,6 +36,7 @@ function makeApp(): ReturnType<typeof createCerebrumApiApp> {
     reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
     version: '0.0.1-test',
     selfBaseUrl: 'http://localhost:3007',
+    peerClients: makeEmptyPeerClients(),
   });
 }
 

--- a/pillars/cerebrum/src/api/__tests__/nudges.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/nudges.test.ts
@@ -22,7 +22,13 @@ import {
   type OpenedCerebrumDb,
 } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { HttpError, makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+import {
+  HttpError,
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
 
 interface SeedNudge {
   id: string;
@@ -98,6 +104,7 @@ function client() {
       reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/pillars.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/pillars.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
 import { __resetPillarRegistryCache } from '../pillars/registry.js';
-import { makeReflexService, makeTemplateRegistry } from './test-utils.js';
+import { makeEmptyPeerClients, makeReflexService, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -43,6 +43,7 @@ function makeApp(): ReturnType<typeof createCerebrumApiApp> {
     reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
     version: '0.0.1-test',
     selfBaseUrl: 'http://cerebrum-api:3007',
+    peerClients: makeEmptyPeerClients(),
   });
 }
 

--- a/pillars/cerebrum/src/api/__tests__/plexus.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/plexus.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, plexusService, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeTemplateRegistry } from './test-utils.js';
+import { makeClient, makeEmptyPeerClients, makeTemplateRegistry } from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -37,6 +37,7 @@ function client() {
       templateRegistry: makeTemplateRegistry(),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/reflex.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/reflex.test.ts
@@ -14,7 +14,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, reflexExecutions, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
 
 const FIXTURE_TOML = `
 [[reflex]]
@@ -65,6 +70,7 @@ function clientWith(toml: string | null) {
       reflexService: makeReflexService(cerebrumDb.db, configPath),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/retrieval.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/retrieval.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Integration tests for `cerebrum.retrieval.*` over REST.
+ *
+ * Seeds `engram_index` + junction + `embeddings` (and, where sqlite-vec is
+ * available, `embeddings_vec`) directly via raw SQL against a per-test temp
+ * cerebrum.db, then drives search / context / similar / stats through the
+ * supertest client.
+ *
+ * The cross-pillar enrichment rewire is exercised with injected fake
+ * {@link PeerClients} returning canned rows — no live peer-api needed. The
+ * embedding path is exercised with a fake embedding client — no real provider
+ * needed. The no-vec degradation is exercised by opening the db with
+ * `loadVec: false`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { makeClient, makeEmptyPeerClients, makeTemplateRegistry } from './test-utils.js';
+
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-retrieval-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-retrieval-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: true });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+interface AppOpts {
+  db?: OpenedCerebrumDb;
+  peers?: PeerClients;
+  embeddingClient?: EmbeddingClient;
+}
+
+function client(opts: AppOpts = {}) {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb: opts.db ?? cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      engramRoot,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: opts.peers ?? makeEmptyPeerClients(),
+      embeddingClient: opts.embeddingClient,
+    })
+  );
+}
+
+interface SeedEngramArgs {
+  id: string;
+  title: string;
+  type?: string;
+  status?: string;
+  scopes?: string[];
+  tags?: string[];
+  preview?: string;
+  modifiedAt?: string;
+}
+
+function seedEngram(db: OpenedCerebrumDb, args: SeedEngramArgs): void {
+  const raw = db.raw;
+  const modifiedAt = args.modifiedAt ?? '2026-01-01T00:00:00.000Z';
+  raw
+    .prepare(
+      `INSERT INTO engram_index
+        (id, file_path, type, source, status, template, created_at, modified_at, title, content_hash, word_count, custom_fields)
+       VALUES (?, ?, ?, 'manual', ?, NULL, ?, ?, ?, ?, ?, NULL)`
+    )
+    .run(
+      args.id,
+      `${args.id}.md`,
+      args.type ?? 'note',
+      args.status ?? 'active',
+      modifiedAt,
+      modifiedAt,
+      args.title,
+      `hash-${args.id}`,
+      10
+    );
+  for (const scope of args.scopes ?? []) {
+    raw.prepare('INSERT INTO engram_scopes (engram_id, scope) VALUES (?, ?)').run(args.id, scope);
+  }
+  for (const tag of args.tags ?? []) {
+    raw.prepare('INSERT INTO engram_tags (engram_id, tag) VALUES (?, ?)').run(args.id, tag);
+  }
+  raw
+    .prepare(
+      `INSERT INTO embeddings
+        (source_type, source_id, chunk_index, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('engram', ?, 0, ?, ?, 'm', 1536, ?)`
+    )
+    .run(args.id, `hash-${args.id}`, args.preview ?? `preview ${args.title}`, modifiedAt);
+}
+
+/**
+ * Seed (or reuse) the chunk-0 `embeddings` row for a source and attach a vec
+ * vector to it. `unit` selects the dimension set to 1. Engrams already carry an
+ * `embeddings` row from {@link seedEngram}, so the insert is ignore-on-conflict
+ * and the existing row's id is reused.
+ */
+function seedVector(
+  db: OpenedCerebrumDb,
+  sourceType: string,
+  sourceId: string,
+  unit: number
+): void {
+  db.raw
+    .prepare(
+      `INSERT OR IGNORE INTO embeddings
+        (source_type, source_id, chunk_index, content_hash, content_preview, model, dimensions, created_at)
+       VALUES (?, ?, 0, ?, ?, 'm', 1536, '2026-01-01T00:00:00.000Z')`
+    )
+    .run(sourceType, sourceId, `hash-${sourceId}`, `preview ${sourceId}`);
+  const id = db.raw
+    .prepare(
+      'SELECT id FROM embeddings WHERE source_type = ? AND source_id = ? AND chunk_index = 0'
+    )
+    .pluck()
+    .get(sourceType, sourceId) as number;
+  const vec = new Float32Array(1536);
+  vec[unit] = 1;
+  db.raw
+    .prepare('INSERT INTO embeddings_vec (rowid, vector) VALUES (?, ?)')
+    .run(BigInt(id), Buffer.from(vec.buffer));
+}
+
+/** A fake embedding client returning a fixed unit vector at index `unit`. */
+function fakeEmbeddingClient(unit: number): EmbeddingClient {
+  return {
+    embedQuery: async () => {
+      const v = Array.from<number>({ length: 1536 }).fill(0);
+      v[unit] = 1;
+      return v;
+    },
+  };
+}
+
+describe('GET /retrieval/stats', () => {
+  it('reports indexed + embedded counts, per-source-type breakdown, and last-updated', async () => {
+    seedEngram(cerebrumDb, { id: 'eng_20260101_0000_alpha', title: 'Alpha' });
+    seedEngram(cerebrumDb, { id: 'eng_20260101_0000_beta', title: 'Beta' });
+    seedVector(cerebrumDb, 'transaction', 'txn_1', 5);
+
+    const stats = await client().retrieval.stats();
+    expect(stats.indexed).toBe(2);
+    expect(stats.embedded).toBe(3);
+    expect(stats.sourceTypes['engram']).toBe(2);
+    expect(stats.sourceTypes['transaction']).toBe(1);
+    expect(stats.lastUpdated).not.toBeNull();
+  });
+
+  it('reports zeros on an empty index', async () => {
+    const stats = await client().retrieval.stats();
+    expect(stats).toEqual({ indexed: 0, embedded: 0, sourceTypes: {}, lastUpdated: null });
+  });
+});
+
+describe('POST /retrieval/search — structured (BM25)', () => {
+  it('filters engrams by scope and returns a total', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_alpha',
+      title: 'Alpha',
+      scopes: ['work.projects.alpha'],
+    });
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_beta',
+      title: 'Beta',
+      scopes: ['work.projects.beta'],
+    });
+
+    const res = await client().retrieval.search({
+      mode: 'structured',
+      filters: { scopes: ['work.projects.alpha'] },
+    });
+    expect(res.meta.mode).toBe('structured');
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0]?.sourceId).toBe('eng_20260101_0000_alpha');
+    expect(res.results[0]?.matchType).toBe('structured');
+    expect(res.results[0]?.contentPreview).toContain('Alpha');
+  });
+
+  it('excludes secret-scoped engrams unless includeSecret is set', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_open',
+      title: 'Open',
+      scopes: ['work.projects.alpha'],
+    });
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_secret',
+      title: 'Secret',
+      scopes: ['personal.secret.diary'],
+    });
+
+    const visible = await client().retrieval.search({
+      mode: 'structured',
+      filters: { types: ['note'] },
+    });
+    expect(visible.results.map((r) => r.sourceId)).not.toContain('eng_20260101_0000_secret');
+
+    const withSecret = await client().retrieval.search({
+      mode: 'structured',
+      filters: { types: ['note'], includeSecret: true },
+    });
+    expect(withSecret.results.map((r) => r.sourceId)).toContain('eng_20260101_0000_secret');
+  });
+
+  it('400s on structured mode with no filter', async () => {
+    await expect(client().retrieval.search({ mode: 'structured' })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('400s on semantic/hybrid mode with no query', async () => {
+    await expect(client().retrieval.search({ mode: 'semantic' })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(client().retrieval.search({ mode: 'hybrid' })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe('POST /retrieval/search — semantic + cross-pillar enrichment', () => {
+  it('embeds the query, kNN-matches a cross-pillar hit, and enriches it via the peer client', async () => {
+    seedVector(cerebrumDb, 'transaction', 'txn_42', 0);
+
+    const peers: PeerClients = {
+      finance: {
+        getTransaction: async (id) => {
+          expect(id).toBe('txn_42');
+          return {
+            description: 'Coffee at Blue Bottle',
+            entityName: 'Blue Bottle',
+            tags: ['coffee'],
+            notes: 'morning',
+          };
+        },
+      },
+    };
+
+    const res = await client({ peers, embeddingClient: fakeEmbeddingClient(0) }).retrieval.search({
+      mode: 'semantic',
+      query: 'coffee',
+    });
+
+    expect(res.results).toHaveLength(1);
+    const hit = res.results[0];
+    expect(hit?.sourceType).toBe('transaction');
+    expect(hit?.sourceId).toBe('txn_42');
+    expect(hit?.title).toBe('Coffee at Blue Bottle');
+    expect(hit?.matchType).toBe('semantic');
+    expect(String(hit?.metadata['text'])).toContain('Blue Bottle');
+  });
+
+  it('drops a cross-pillar hit when its peer is absent from the registry', async () => {
+    seedVector(cerebrumDb, 'movie', '99', 0);
+
+    // No `media` peer client → enrichment unavailable → hit dropped, no crash.
+    const res = await client({
+      peers: makeEmptyPeerClients(),
+      embeddingClient: fakeEmbeddingClient(0),
+    }).retrieval.search({ mode: 'semantic', query: 'film' });
+
+    expect(res.results).toHaveLength(0);
+  });
+
+  it('returns no semantic results when no embedding client is configured', async () => {
+    seedVector(cerebrumDb, 'transaction', 'txn_1', 0);
+    const res = await client().retrieval.search({ mode: 'semantic', query: 'anything' });
+    expect(res.results).toHaveLength(0);
+  });
+});
+
+describe('POST /retrieval/search — hybrid degradation', () => {
+  it('falls back to BM25-only when the db has no vec support', async () => {
+    const noVecDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-retrieval-novec-'));
+    const noVecDb = openCerebrumDb(join(noVecDir, 'cerebrum.db'), { loadVec: false });
+    expect(noVecDb.vecAvailable).toBe(false);
+    seedEngram(noVecDb, {
+      id: 'eng_20260101_0000_alpha',
+      title: 'Alpha',
+      scopes: ['work.projects.alpha'],
+      tags: ['x'],
+    });
+
+    try {
+      // Hybrid with an embedding client but no vec → semantic leg throws
+      // vec-unavailable, hybrid swallows it, BM25 leg still returns the engram.
+      const res = await client({
+        db: noVecDb,
+        embeddingClient: fakeEmbeddingClient(0),
+      }).retrieval.search({ mode: 'hybrid', query: 'alpha', filters: { tags: ['x'] } });
+      expect(res.results.map((r) => r.sourceId)).toContain('eng_20260101_0000_alpha');
+    } finally {
+      noVecDb.raw.close();
+      rmSync(noVecDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('POST /retrieval/similar', () => {
+  it('returns the other engrams sharing the query engram vector, excluding itself', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_self',
+      title: 'Self',
+      scopes: ['work.projects.alpha'],
+    });
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_other',
+      title: 'Other',
+      scopes: ['work.projects.alpha'],
+    });
+    seedVector(cerebrumDb, 'engram', 'eng_20260101_0000_self', 0);
+    seedVector(cerebrumDb, 'engram', 'eng_20260101_0000_other', 0);
+
+    const res = await client().retrieval.similar({ engramId: 'eng_20260101_0000_self' });
+    const ids = res.results.map((r) => r.sourceId);
+    expect(ids).toContain('eng_20260101_0000_other');
+    expect(ids).not.toContain('eng_20260101_0000_self');
+  });
+
+  it('returns an empty list for an engram with no vector', async () => {
+    const res = await client().retrieval.similar({ engramId: 'eng_20260101_0000_missing' });
+    expect(res.results).toEqual([]);
+  });
+});
+
+describe('POST /retrieval/context', () => {
+  it('assembles a token-budgeted context window with source attribution', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0000_alpha',
+      title: 'Alpha',
+      scopes: ['work.projects.alpha'],
+      tags: ['ctx'],
+      preview: 'The alpha engram body for context.',
+    });
+
+    const res = await client().retrieval.context({
+      query: 'alpha',
+      filters: { tags: ['ctx'] },
+      tokenBudget: 2048,
+    });
+    expect(res.context).toContain('Query: alpha');
+    expect(res.context).toContain('Alpha');
+    expect(res.sources.map((s) => s.sourceId)).toContain('eng_20260101_0000_alpha');
+    expect(res.truncated).toBe(false);
+    expect(res.tokenEstimate).toBeGreaterThan(0);
+  });
+
+  it('400s on an empty query', async () => {
+    await expect(client().retrieval.context({ query: '   ' })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/templates.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/templates.test.ts
@@ -12,7 +12,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
 import { createCerebrumApiApp } from '../app.js';
-import { makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
@@ -35,6 +40,7 @@ function client() {
       reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
       version: '0.0.1-test',
       selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
     })
   );
 }

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -32,6 +32,13 @@ import type {
   NudgeWire,
 } from '../../contract/rest-nudges.js';
 import type {
+  RetrievalFiltersWire,
+  RetrievalModeWire,
+  RetrievalResultWire,
+  RetrievalStatsWire,
+  SourceAttributionWire,
+} from '../../contract/rest-retrieval-schemas.js';
+import type {
   EngramWire,
   PlexusAdapterWire,
   PlexusFilterDefinitionWire,
@@ -50,6 +57,7 @@ import type {
 } from '../../contract/rest-schemas.js';
 import type { CerebrumDb } from '../../db/index.js';
 import type { ReflexService } from '../modules/reflex/reflex-service.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
 
 /** Bundled engram-template fixtures shipped with the pillar. */
 export const TEST_TEMPLATES_DIR = resolve(
@@ -71,6 +79,15 @@ export function makeTemplateRegistry(): TemplateRegistry {
  */
 export function makeReflexService(db: CerebrumDb, configPath: string): ReflexService {
   return buildReflexService({ db, configPath, watch: false });
+}
+
+/**
+ * Empty peer-client set — no cross-pillar enrichment. The default for tests
+ * that don't exercise the `retrieval` cross-pillar path; pass a partial fake
+ * to {@link createCerebrumApiApp} where enrichment is under test.
+ */
+export function makeEmptyPeerClients(): PeerClients {
+  return {};
 }
 
 export class HttpError extends Error {
@@ -164,6 +181,30 @@ export interface ListContradictionsFilters {
   status?: NudgeStatusWire | null;
   limit?: number;
   offset?: number;
+}
+
+export interface RetrievalSearchBody {
+  query?: string;
+  mode?: RetrievalModeWire;
+  filters?: RetrievalFiltersWire;
+  limit?: number;
+  threshold?: number;
+  offset?: number;
+}
+
+export interface RetrievalContextBody {
+  query: string;
+  filters?: RetrievalFiltersWire;
+  tokenBudget?: number;
+  includeMetadata?: boolean;
+  maxResults?: number;
+}
+
+export interface RetrievalSimilarBody {
+  engramId: string;
+  limit?: number;
+  threshold?: number;
+  filters?: RetrievalFiltersWire;
 }
 
 export function makeClient(app: Express) {
@@ -291,6 +332,22 @@ export function makeClient(app: Express) {
         send<{ report: GliaDigestReportWire; delivery: GliaDigestDeliveryWire }>(
           r.post('/glia/digest').send(input)
         ),
+    },
+    retrieval: {
+      search: (body: RetrievalSearchBody = {}) =>
+        send<{ results: RetrievalResultWire[]; meta: { total: number; mode: RetrievalModeWire } }>(
+          r.post('/retrieval/search').send(body)
+        ),
+      context: (body: RetrievalContextBody) =>
+        send<{
+          context: string;
+          sources: SourceAttributionWire[];
+          truncated: boolean;
+          tokenEstimate: number;
+        }>(r.post('/retrieval/context').send(body)),
+      similar: (body: RetrievalSimilarBody) =>
+        send<{ results: RetrievalResultWire[] }>(r.post('/retrieval/similar').send(body)),
+      stats: () => send<RetrievalStatsWire>(r.get('/retrieval/stats')),
     },
   };
 }

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -11,6 +11,8 @@ import type { PillarRegistryEntry } from '@pops/types';
 
 import type { OpenedCerebrumDb } from '../db/index.js';
 import type { ReflexService } from './modules/reflex/reflex-service.js';
+import type { EmbeddingClient } from './modules/retrieval/embedding-client.js';
+import type { PeerClients } from './modules/retrieval/peer-clients.js';
 import type { TemplateRegistry } from './modules/templates/registry.js';
 
 export interface CerebrumApiDeps {
@@ -39,6 +41,19 @@ export interface CerebrumApiDeps {
    * special-case the host pillar.
    */
   selfBaseUrl: string;
+  /**
+   * Cross-pillar enrichment clients for `retrieval` semantic-search metadata
+   * resolution. Built from `POPS_PILLARS` in `server.ts`; tests inject fakes.
+   * A peer absent from the registry yields an `undefined` client for that
+   * source type (enrichment skipped, not a crash).
+   */
+  peerClients: PeerClients;
+  /**
+   * Optional query-embedding client for `retrieval` semantic search. Absent
+   * (no `EMBEDDING_API_KEY`) → semantic search returns no results and hybrid
+   * degrades to BM25-only.
+   */
+  embeddingClient?: EmbeddingClient;
 }
 
 export interface HealthResponse {

--- a/pillars/cerebrum/src/api/modules/retrieval/context-assembly.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/context-assembly.ts
@@ -1,0 +1,124 @@
+/**
+ * ContextAssemblyService — assembles a token-budgeted context window from
+ * retrieval results, formatted for LLM consumption with source attribution.
+ * Ported verbatim from the monolith; the only change is replacing the
+ * settings-service default budget with a constant.
+ *
+ * Token counting: word_count * 1.3 approximation (no tokeniser dependency).
+ * Truncation: at a sentence boundary (regex /[.!?]\s/) or hard at budget.
+ */
+import type { RetrievalResult, SourceAttribution } from './types.js';
+
+const DEFAULT_TOKEN_BUDGET = 4096;
+const WORDS_TO_TOKENS = 1.3;
+const SENTENCE_BOUNDARY = /[.!?]\s/;
+
+function estimateTokens(text: string): number {
+  const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.ceil(wordCount * WORDS_TO_TOKENS);
+}
+
+function truncateToTokenBudget(text: string, budget: number): { text: string; truncated: boolean } {
+  if (budget <= 0) return { text: '[truncated]', truncated: true };
+  const estimated = estimateTokens(text);
+  if (estimated <= budget) return { text, truncated: false };
+
+  const targetWords = Math.max(0, Math.floor(budget / WORDS_TO_TOKENS));
+  if (targetWords === 0) return { text: '[truncated]', truncated: true };
+
+  const words = text.split(/\s+/);
+  const sliced = words.slice(0, targetWords).join(' ');
+
+  const lookback = Math.floor(sliced.length * 0.2);
+  const searchRegion = sliced.slice(sliced.length - lookback);
+  const match = searchRegion.search(SENTENCE_BOUNDARY);
+
+  if (match !== -1) {
+    const cutPos = sliced.length - lookback + match + 1;
+    return { text: sliced.slice(0, cutPos).trimEnd() + ' [truncated]', truncated: true };
+  }
+
+  return { text: sliced.trimEnd() + ' [truncated]', truncated: true };
+}
+
+function formatSection(result: RetrievalResult, includeMetadata: boolean): string {
+  const header = `[${result.sourceType}:${result.sourceId}] ${result.title}`;
+
+  let meta = '';
+  if (includeMetadata) {
+    const parts: string[] = [];
+    if (result.metadata['type']) parts.push(`type: ${String(result.metadata['type'])}`);
+    const scopes = result.metadata['scopes'] as string[] | undefined;
+    if (scopes?.length) parts.push(`scopes: ${scopes.join(', ')}`);
+    const tags = result.metadata['tags'] as string[] | undefined;
+    if (tags?.length) parts.push(`tags: ${tags.join(', ')}`);
+    if (result.metadata['createdAt']) parts.push(`date: ${String(result.metadata['createdAt'])}`);
+    if (parts.length) meta = `(${parts.join(' | ')})`;
+  }
+
+  const body = result.contentPreview || '(no preview)';
+  const headerLine = meta ? `${header} ${meta}` : header;
+
+  return `---\n${headerLine}\n${body}`;
+}
+
+export interface ContextAssemblyInput {
+  query: string;
+  results: RetrievalResult[];
+  tokenBudget?: number;
+  includeMetadata?: boolean;
+}
+
+export interface ContextAssemblyOutput {
+  context: string;
+  sources: SourceAttribution[];
+  truncated: boolean;
+  tokenEstimate: number;
+}
+
+export class ContextAssemblyService {
+  assemble(input: ContextAssemblyInput): ContextAssemblyOutput {
+    const { query, results, tokenBudget = DEFAULT_TOKEN_BUDGET, includeMetadata = true } = input;
+
+    const seen = new Set<string>();
+    const sections: string[] = [];
+    const sources: SourceAttribution[] = [];
+    let anyTruncated = false;
+
+    const preamble = `Query: ${query}\n`;
+    const preambleTokens = estimateTokens(preamble);
+    let remaining = Math.max(0, tokenBudget - preambleTokens);
+
+    for (const result of results) {
+      const hashKey = (result.metadata['contentHash'] as string | undefined) ?? '';
+      const dedupeKey = hashKey || `${result.sourceType}:${result.sourceId}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+
+      if (remaining <= 0) break;
+
+      const section = formatSection(result, includeMetadata);
+      const { text: fitted, truncated } = truncateToTokenBudget(section, remaining);
+      const usedTokens = estimateTokens(fitted);
+
+      sections.push(fitted);
+      sources.push({
+        sourceType: result.sourceType,
+        sourceId: result.sourceId,
+        title: result.title,
+        relevanceScore: result.score,
+      });
+
+      remaining = Math.max(0, remaining - usedTokens);
+      if (truncated) {
+        anyTruncated = true;
+        break;
+      }
+    }
+
+    const context = sections.length > 0 ? `${preamble}\n${sections.join('\n')}` : preamble;
+    const tokenEstimate = tokenBudget - remaining;
+
+    return { context, sources, truncated: anyTruncated, tokenEstimate };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/embedding-client.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/embedding-client.ts
@@ -1,0 +1,109 @@
+/**
+ * Query-embedding client for semantic search, ported from the monolith
+ * `apps/pops-api/src/shared/embedding-client.ts` (OpenAI- / Voyage-compatible).
+ *
+ * Configured entirely from environment variables so the model choice is not
+ * baked into code:
+ *   EMBEDDING_API_URL    — base URL (default https://api.openai.com/v1)
+ *   EMBEDDING_API_KEY    — API key (required for real embedding; absent → no
+ *                          embedder, semantic search degrades to BM25-only)
+ *   EMBEDDING_MODEL      — model name (default text-embedding-3-small)
+ *   EMBEDDING_DIMENSIONS — vector dimensions (default 1536, matches the
+ *                          `embeddings_vec` virtual table)
+ *
+ * The retrieval handlers receive an {@link EmbeddingClient} via
+ * `CerebrumApiDeps.embeddingClient`. The real default is constructed from env
+ * in `server.ts`; when `EMBEDDING_API_KEY` is unset the default is `undefined`
+ * so semantic search short-circuits to no semantic results (and hybrid falls
+ * back to BM25). Tests inject a fake to exercise the embed path without a live
+ * provider.
+ */
+type EmbeddingProvider = 'openai' | 'voyage';
+
+export interface EmbeddingClient {
+  /** Embed a retrieval query into a dense vector. */
+  embedQuery(query: string): Promise<number[]>;
+}
+
+interface EmbeddingConfig {
+  apiUrl: string;
+  apiKey: string;
+  model: string;
+  dimensions: number;
+  provider: EmbeddingProvider;
+}
+
+function detectProvider(apiUrl: string): EmbeddingProvider {
+  return apiUrl.includes('voyageai.com') ? 'voyage' : 'openai';
+}
+
+function readEmbeddingConfig(): EmbeddingConfig {
+  const apiUrl = process.env['EMBEDDING_API_URL'] ?? 'https://api.openai.com/v1';
+  return {
+    apiUrl,
+    apiKey: process.env['EMBEDDING_API_KEY'] ?? '',
+    model: process.env['EMBEDDING_MODEL'] ?? 'text-embedding-3-small',
+    dimensions: Number.parseInt(process.env['EMBEDDING_DIMENSIONS'] ?? '1536', 10),
+    provider: detectProvider(apiUrl),
+  };
+}
+
+function buildRequestBody(text: string, config: EmbeddingConfig): Record<string, unknown> {
+  if (config.provider === 'voyage') {
+    return {
+      input: text,
+      model: config.model,
+      output_dimension: config.dimensions,
+      input_type: 'query',
+    };
+  }
+  return { input: text, model: config.model, dimensions: config.dimensions };
+}
+
+type FetchImpl = typeof globalThis.fetch;
+
+/**
+ * Build the HTTP-backed embedding client. `fetchImpl` is injectable so tests
+ * can drive it without a live provider.
+ */
+export function createHttpEmbeddingClient(
+  config: EmbeddingConfig,
+  fetchImpl: FetchImpl = globalThis.fetch
+): EmbeddingClient {
+  return {
+    async embedQuery(query) {
+      if (!query.trim()) throw new Error('Cannot embed empty text');
+      if (!config.apiKey) throw new Error('EMBEDDING_API_KEY is not configured');
+
+      const response = await fetchImpl(`${config.apiUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify(buildRequestBody(query, config)),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`Embedding API error ${response.status}: ${body}`);
+      }
+
+      const data = (await response.json()) as { data: { embedding: number[] }[] };
+      const vector = data.data[0]?.embedding;
+      if (!vector) throw new Error('Embedding API returned no vector');
+      return vector;
+    },
+  };
+}
+
+/**
+ * Construct the env-driven embedding client, or `undefined` when no
+ * `EMBEDDING_API_KEY` is configured. A missing client makes semantic search
+ * degrade to no semantic results (hybrid falls back to BM25-only).
+ */
+export function resolveEmbeddingClientFromEnv(): EmbeddingClient | undefined {
+  const config = readEmbeddingConfig();
+  if (!config.apiKey) return undefined;
+  return createHttpEmbeddingClient(config);
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/hybrid-search.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/hybrid-search.ts
@@ -1,0 +1,147 @@
+/**
+ * HybridSearchService — orchestrates {@link SemanticSearchService} and
+ * {@link StructuredQueryService}, merges with reciprocal rank fusion (RRF,
+ * k=60), and backs the `search` / `context` / `similar` handlers.
+ *
+ * Graceful degradation: the semantic leg is best-effort. A missing embedding
+ * client, a vec-unavailable database, or a provider error all collapse the
+ * semantic leg to an empty list (logged), so hybrid retrieval falls back to
+ * the BM25 (structured) leg, which is independent. This mirrors the monolith's
+ * `Thalamus retrieval failed` fallback.
+ */
+import { SemanticSearchService, type SemanticSearchDeps } from './semantic-search.js';
+import { StructuredQueryService } from './structured-query.js';
+
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const RRF_K = 60;
+const DEFAULT_LIMIT = 20;
+const DEFAULT_THRESHOLD = 0.8;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/** Apply RRF to merge two ranked lists. Returns merged list sorted by descending score. */
+function reciprocalRankFusion(
+  semanticResults: RetrievalResult[],
+  structuredResults: RetrievalResult[],
+  limit: number
+): RetrievalResult[] {
+  const scores = new Map<string, { score: number; result: RetrievalResult; inBoth: boolean }>();
+
+  for (const [i, r] of semanticResults.entries()) {
+    const key = `${r.sourceType}:${r.sourceId}`;
+    const contribution = 1 / (RRF_K + i + 1);
+    const existing = scores.get(key);
+    if (existing) {
+      existing.score += contribution;
+      existing.inBoth = true;
+    } else {
+      scores.set(key, { score: contribution, result: r, inBoth: false });
+    }
+  }
+
+  for (const [i, r] of structuredResults.entries()) {
+    const key = `${r.sourceType}:${r.sourceId}`;
+    const contribution = 1 / (RRF_K + i + 1);
+    const existing = scores.get(key);
+    if (existing) {
+      existing.score += contribution;
+      existing.inBoth = true;
+      existing.result = {
+        ...existing.result,
+        metadata: { ...existing.result.metadata, ...r.metadata },
+      };
+    } else {
+      scores.set(key, { score: contribution, result: r, inBoth: false });
+    }
+  }
+
+  return [...scores.values()]
+    .toSorted((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ score, result, inBoth }) => ({
+      ...result,
+      score,
+      matchType: inBoth ? ('both' as const) : result.matchType,
+    }));
+}
+
+export class HybridSearchService {
+  private readonly semanticSvc: SemanticSearchService;
+  private readonly structuredSvc: StructuredQueryService;
+
+  constructor(deps: SemanticSearchDeps) {
+    this.semanticSvc = new SemanticSearchService(deps);
+    this.structuredSvc = new StructuredQueryService(deps.db);
+  }
+
+  async hybrid(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    const fetchLimit = limit * 3;
+
+    const [semanticResults, structuredResults] = await Promise.all([
+      this.semanticSvc.search(query, filters, limit, threshold).catch((error: unknown) => {
+        console.warn(
+          `[retrieval/hybrid] Semantic search failed — falling back to BM25-only: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        return [] as RetrievalResult[];
+      }),
+      Promise.resolve(this.structuredSvc.query(filters, fetchLimit)),
+    ]);
+
+    const merged = reciprocalRankFusion(semanticResults, structuredResults, limit);
+
+    if (!filters.includeSecret) {
+      return merged.filter((r) => {
+        const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+        return !scopes.some(isSecretScope);
+      });
+    }
+
+    return merged;
+  }
+
+  async semanticSearch(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    return this.semanticSvc.search(query, filters, limit, threshold);
+  }
+
+  structuredOnly(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
+    return this.structuredSvc.query(filters, limit, offset);
+  }
+
+  /**
+   * Find engrams similar to the given engram by its existing embedding vector.
+   * No embedding call — reads the vector directly from `embeddings_vec`.
+   */
+  async similar(
+    engramId: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    const vector = this.semanticSvc.getVectorForEngram(engramId);
+    if (!vector) {
+      return [];
+    }
+    return this.semanticSvc.searchByVector({
+      vectorBlob: vector,
+      sourceIdToExclude: engramId,
+      filters,
+      limit,
+      threshold,
+    });
+  }
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/peer-clients.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/peer-clients.ts
@@ -1,0 +1,133 @@
+/**
+ * Cross-pillar enrichment clients for semantic-search metadata resolution.
+ *
+ * The monolith resolver (`semantic-search-metadata.ts`) joined `engram_index`
+ * against `transactions` (`@pops/finance-db`), `movies` / `tv_shows`
+ * (`@pops/media-db`) and `home_inventory` (`@pops/inventory-db`) in a single
+ * SQL handle. Those tables no longer live in the cerebrum file, so enrichment
+ * for cross-pillar source types is fetched over REST from the owning pillar
+ * (bare `fetch`, docker-network trust → no auth header). The base URLs are
+ * resolved from `POPS_PILLARS`.
+ *
+ * Each peer endpoint returns `{ data: Schema }`. We hand-type a minimal shape
+ * per peer (only the fields the formatters use) rather than importing the
+ * peers' generated `api-types` — that would couple cerebrum's build to the
+ * peers' `dist/` artifacts for four scalar fields.
+ *
+ * Graceful absence: if a peer is not present in `POPS_PILLARS`, its client is
+ * `undefined` and enrichment for that source type is skipped (the engram-only
+ * leg still works; the cross-pillar hit is simply dropped — the monolith
+ * returned `null` metadata for an unresolvable domain row too). A live fetch
+ * failure surfaces as a thrown error caught by the hybrid fallback.
+ */
+import { parsePillarsEnv } from '../../pillars/env.js';
+
+export interface FinanceTransactionRow {
+  description?: string | null;
+  entityName?: string | null;
+  tags?: string[] | null;
+  notes?: string | null;
+}
+
+export interface MediaMovieRow {
+  title?: string | null;
+  overview?: string | null;
+  genres?: string[] | null;
+}
+
+export interface MediaTvShowRow {
+  name?: string | null;
+  overview?: string | null;
+  genres?: string[] | null;
+}
+
+export interface InventoryItemRow {
+  itemName?: string | null;
+  brand?: string | null;
+  type?: string | null;
+  location?: string | null;
+}
+
+export interface PeerClients {
+  finance?: { getTransaction(id: string): Promise<FinanceTransactionRow | null> };
+  media?: {
+    getMovie(id: number): Promise<MediaMovieRow | null>;
+    getTvShow(id: number): Promise<MediaTvShowRow | null>;
+  };
+  inventory?: { getItem(id: string): Promise<InventoryItemRow | null> };
+}
+
+type FetchImpl = typeof globalThis.fetch;
+
+function resolvePeerBaseUrl(id: string): string | undefined {
+  return parsePillarsEnv(process.env['POPS_PILLARS']).find((p) => p.id === id)?.baseUrl;
+}
+
+async function getData<T>(
+  fetchImpl: FetchImpl,
+  baseUrl: string,
+  path: string,
+  label: string
+): Promise<T | null> {
+  const res = await fetchImpl(`${baseUrl.replace(/\/$/, '')}${path}`, {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`${label} → HTTP ${res.status}`);
+  const text = await res.text();
+  if (text.length === 0) return null;
+  const json = JSON.parse(text) as { data?: T };
+  return json.data ?? null;
+}
+
+/**
+ * Build the cross-pillar enrichment clients from `POPS_PILLARS`. A peer absent
+ * from the registry yields an `undefined` client for that source type.
+ */
+export function resolvePeerClientsFromEnv(fetchImpl: FetchImpl = globalThis.fetch): PeerClients {
+  const financeUrl = resolvePeerBaseUrl('finance');
+  const mediaUrl = resolvePeerBaseUrl('media');
+  const inventoryUrl = resolvePeerBaseUrl('inventory');
+
+  return {
+    finance:
+      financeUrl === undefined
+        ? undefined
+        : {
+            getTransaction: (id) =>
+              getData<FinanceTransactionRow>(
+                fetchImpl,
+                financeUrl,
+                `/transactions/${encodeURIComponent(id)}`,
+                'finance GET /transactions/:id'
+              ),
+          },
+    media:
+      mediaUrl === undefined
+        ? undefined
+        : {
+            getMovie: (id) =>
+              getData<MediaMovieRow>(fetchImpl, mediaUrl, `/movies/${id}`, 'media GET /movies/:id'),
+            getTvShow: (id) =>
+              getData<MediaTvShowRow>(
+                fetchImpl,
+                mediaUrl,
+                `/tv-shows/${id}`,
+                'media GET /tv-shows/:id'
+              ),
+          },
+    inventory:
+      inventoryUrl === undefined
+        ? undefined
+        : {
+            getItem: (id) =>
+              getData<InventoryItemRow>(
+                fetchImpl,
+                inventoryUrl,
+                `/items/${encodeURIComponent(id)}`,
+                'inventory GET /items/:id'
+              ),
+          },
+  };
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/semantic-search-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/semantic-search-helpers.ts
@@ -1,0 +1,113 @@
+/**
+ * kNN query + result-shaping helpers for {@link SemanticSearchService}.
+ *
+ * Ported from the monolith. The one structural change vs. pops-api: `knnQuery`
+ * takes the pillar's own `better-sqlite3` raw handle
+ * (`deps.cerebrumDb.raw`) instead of reading the shared pops.db singleton via
+ * `getDb()`. The embeddings + `embeddings_vec` virtual table live in
+ * cerebrum.db (migration 0054), and in the standalone pillar
+ * `embeddings.id == embeddings_vec.rowid` is consistent, so the kNN JOIN SQL is
+ * preserved verbatim (no rowid≠id backfill caveat).
+ */
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+export interface VectorRow {
+  source_type: string;
+  source_id: string;
+  chunk_index: number;
+  content_preview: string;
+  content_hash: string;
+  distance: number;
+}
+
+/** Run a single k-NN query against `embeddings_vec` on the pillar handle. */
+export function knnQuery(
+  raw: BetterSqlite3.Database,
+  vectorBlob: Float32Array,
+  fetchLimit: number
+): VectorRow[] {
+  return raw
+    .prepare(
+      `
+      SELECT
+        e.source_type,
+        e.source_id,
+        e.chunk_index,
+        e.content_preview,
+        e.content_hash,
+        ev.distance
+      FROM embeddings_vec ev
+      JOIN embeddings e ON e.id = ev.rowid
+      WHERE ev.vector MATCH ?
+        AND ev.k = ?
+      ORDER BY ev.distance
+    `
+    )
+    .all(vectorBlob, fetchLimit) as VectorRow[];
+}
+
+/** Deduplicate by sourceId — keep the closest chunk per source. */
+export function dedupeBySource(rows: VectorRow[]): Map<string, VectorRow> {
+  const seen = new Map<string, VectorRow>();
+  for (const row of rows) {
+    const key = `${row.source_type}:${row.source_id}`;
+    if (!seen.has(key)) seen.set(key, row);
+  }
+  return seen;
+}
+
+export interface ResolvedMetadata {
+  title: string;
+  fields: Record<string, unknown>;
+}
+
+export function makeRetrievalResult(row: VectorRow, metadata: ResolvedMetadata): RetrievalResult {
+  return {
+    sourceType: row.source_type,
+    sourceId: row.source_id,
+    title: metadata.title,
+    contentPreview: row.content_preview.slice(0, 200),
+    score: Math.max(0, 1 - row.distance),
+    distance: row.distance,
+    matchType: 'semantic',
+    metadata: {
+      ...metadata.fields,
+      contentHash: row.content_hash,
+    },
+  };
+}
+
+export interface CollectArgs {
+  rows: Iterable<VectorRow>;
+  filters: RetrievalFilters;
+  limit: number;
+  resolveMetadata: (
+    sourceType: string,
+    sourceId: string,
+    filters: RetrievalFilters
+  ) => Promise<ResolvedMetadata | null>;
+}
+
+export async function collectResults(args: CollectArgs): Promise<RetrievalResult[]> {
+  const results: RetrievalResult[] = [];
+  for (const row of args.rows) {
+    if (args.filters.sourceTypes && !args.filters.sourceTypes.includes(row.source_type)) continue;
+    const metadata = await args.resolveMetadata(row.source_type, row.source_id, args.filters);
+    if (!metadata) continue;
+    results.push(makeRetrievalResult(row, metadata));
+    if (results.length >= args.limit) break;
+  }
+  return results;
+}
+
+export function vecUnavailableError(): Error {
+  return Object.assign(new Error('Vector features unavailable: sqlite-vec extension not loaded'), {
+    code: 'VEC_UNAVAILABLE',
+  });
+}
+
+export function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/semantic-search-metadata.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/semantic-search-metadata.ts
@@ -1,0 +1,188 @@
+/**
+ * Engram metadata + cross-pillar enrichment resolver for
+ * {@link SemanticSearchService}.
+ *
+ * Two rewires vs. the monolith:
+ *
+ *  1. Engram metadata is read from the cerebrum pillar's own drizzle handle
+ *     (`engram_index` + `engram_scopes` live in cerebrum.db) rather than the
+ *     shared pops.db.
+ *  2. Cross-pillar enrichment (`transaction` / `movie` / `tv_show` /
+ *     `inventory`) is fetched over REST via injected {@link PeerClients}
+ *     instead of SQL joins against the peers' tables. A peer absent from
+ *     `POPS_PILLARS` (its client `undefined`) → enrichment unavailable for
+ *     that source type → the hit is dropped (returns `null`), matching the
+ *     monolith's behaviour for an unresolvable domain row.
+ *
+ * The `to*Text` formatters fold the fetched fields into a single `text`
+ * preview string so the assembled context window has a human-readable body for
+ * cross-pillar sources (which carry no `content_preview` of their own beyond
+ * the embedded chunk).
+ */
+import { eq } from 'drizzle-orm';
+
+import { engramIndex, engramScopes } from '../../../db/index.js';
+import { isSecretScope, type ResolvedMetadata } from './semantic-search-helpers.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type {
+  FinanceTransactionRow,
+  InventoryItemRow,
+  MediaMovieRow,
+  MediaTvShowRow,
+  PeerClients,
+} from './peer-clients.js';
+import type { RetrievalFilters } from './types.js';
+
+function joinNonEmpty(parts: (string | null | undefined)[]): string {
+  return parts.filter((p): p is string => typeof p === 'string' && p.length > 0).join(' — ');
+}
+
+function toTransactionText(row: FinanceTransactionRow): string {
+  return joinNonEmpty([
+    row.description,
+    row.entityName,
+    row.tags?.length ? `tags: ${row.tags.join(', ')}` : null,
+    row.notes,
+  ]);
+}
+
+function toMovieText(row: MediaMovieRow): string {
+  return joinNonEmpty([
+    row.title,
+    row.genres?.length ? `genres: ${row.genres.join(', ')}` : null,
+    row.overview,
+  ]);
+}
+
+function toTvShowText(row: MediaTvShowRow): string {
+  return joinNonEmpty([
+    row.name,
+    row.genres?.length ? `genres: ${row.genres.join(', ')}` : null,
+    row.overview,
+  ]);
+}
+
+function toInventoryText(row: InventoryItemRow): string {
+  return joinNonEmpty([row.itemName, row.brand, row.type, row.location]);
+}
+
+type CrossPillarResolver = (
+  peers: PeerClients,
+  sourceId: string
+) => Promise<ResolvedMetadata | null>;
+
+const CROSS_PILLAR_RESOLVERS: Record<string, CrossPillarResolver> = {
+  transaction: async (peers, sourceId) => {
+    const row = peers.finance ? await peers.finance.getTransaction(sourceId) : null;
+    if (!row) return null;
+    return {
+      title: row.description ?? 'Transaction',
+      fields: { ...row, text: toTransactionText(row) },
+    };
+  },
+  movie: async (peers, sourceId) => {
+    const row = peers.media ? await peers.media.getMovie(Number(sourceId)) : null;
+    if (!row) return null;
+    return { title: row.title ?? 'Movie', fields: { ...row, text: toMovieText(row) } };
+  },
+  tv_show: async (peers, sourceId) => {
+    const row = peers.media ? await peers.media.getTvShow(Number(sourceId)) : null;
+    if (!row) return null;
+    return { title: row.name ?? 'TV Show', fields: { ...row, text: toTvShowText(row) } };
+  },
+  inventory: async (peers, sourceId) => {
+    const row = peers.inventory ? await peers.inventory.getItem(sourceId) : null;
+    if (!row) return null;
+    return {
+      title: row.itemName ?? 'Inventory item',
+      fields: { ...row, text: toInventoryText(row) },
+    };
+  },
+};
+
+async function resolveCrossPillarMetadata(
+  peers: PeerClients,
+  sourceType: string,
+  sourceId: string
+): Promise<ResolvedMetadata | null> {
+  const resolver = CROSS_PILLAR_RESOLVERS[sourceType];
+  return resolver ? resolver(peers, sourceId) : null;
+}
+
+interface EngramRow {
+  type: string;
+  source: string;
+  status: string;
+  title: string;
+  createdAt: string;
+  modifiedAt: string;
+  wordCount: number;
+}
+
+function matchesScopes(scopes: string[], scopeFilters: string[]): boolean {
+  return scopes.some((s) => scopeFilters.some((f) => s === f || s.startsWith(f + '.')));
+}
+
+function passesArrayFilter(value: string, allowed: string[] | undefined): boolean {
+  if (!allowed || allowed.length === 0) return true;
+  return allowed.includes(value);
+}
+
+function passesEngramFilters(row: EngramRow, scopes: string[], filters: RetrievalFilters): boolean {
+  if (row.status === 'orphaned') return false;
+  if (!passesArrayFilter(row.type, filters.types)) return false;
+  if (!passesArrayFilter(row.status, filters.status)) return false;
+  if (!filters.includeSecret && scopes.some(isSecretScope)) return false;
+  if (filters.scopes?.length && !matchesScopes(scopes, filters.scopes)) return false;
+  return true;
+}
+
+function resolveEngramMetadata(
+  db: CerebrumDb,
+  sourceId: string,
+  filters: RetrievalFilters
+): ResolvedMetadata | null {
+  const rows = db.select().from(engramIndex).where(eq(engramIndex.id, sourceId)).all();
+  const row = rows[0];
+  if (!row) return null;
+
+  const scopes = db
+    .select({ scope: engramScopes.scope })
+    .from(engramScopes)
+    .where(eq(engramScopes.engramId, sourceId))
+    .all()
+    .map((s) => s.scope);
+
+  if (!passesEngramFilters(row, scopes, filters)) return null;
+
+  return {
+    title: row.title,
+    fields: {
+      type: row.type,
+      source: row.source,
+      status: row.status,
+      scopes,
+      createdAt: row.createdAt,
+      modifiedAt: row.modifiedAt,
+      wordCount: row.wordCount,
+    },
+  };
+}
+
+export interface MetadataResolverDeps {
+  db: CerebrumDb;
+  peers: PeerClients;
+}
+
+export async function resolveMetadata(
+  deps: MetadataResolverDeps,
+  sourceType: string,
+  sourceId: string,
+  filters: RetrievalFilters
+): Promise<ResolvedMetadata | null> {
+  if (sourceType === 'engram') {
+    return resolveEngramMetadata(deps.db, sourceId, filters);
+  }
+  return resolveCrossPillarMetadata(deps.peers, sourceType, sourceId);
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/semantic-search.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/semantic-search.ts
@@ -1,0 +1,146 @@
+import {
+  collectResults,
+  dedupeBySource,
+  knnQuery,
+  vecUnavailableError,
+} from './semantic-search-helpers.js';
+import { resolveMetadata } from './semantic-search-metadata.js';
+
+/**
+ * SemanticSearchService — k-NN over `embeddings_vec` with engram + cross-pillar
+ * metadata resolution, scope/type/status filtering, and `RetrievalResult`
+ * shaping.
+ *
+ * Ported from the monolith with three deltas:
+ *
+ *  - The query vector is produced by an injected {@link EmbeddingClient}
+ *    rather than the shared pops-api embedding client + Redis cache. When no
+ *    embedding client is configured (no `EMBEDDING_API_KEY`), `search` returns
+ *    no semantic results — hybrid then degrades to BM25-only. A provider error
+ *    is swallowed to the same no-results path so a flaky embedder never crashes
+ *    retrieval.
+ *  - kNN reads the pillar's own raw handle (`embeddings` + `embeddings_vec`
+ *    live in cerebrum.db); vector availability is the pillar's
+ *    `openCerebrumDb(...).vecAvailable`, captured at construction.
+ *  - Metadata resolution goes through {@link resolveMetadata} with the pillar
+ *    drizzle handle + injected peer clients.
+ */
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type { EmbeddingClient } from './embedding-client.js';
+import type { PeerClients } from './peer-clients.js';
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_THRESHOLD = 0.8;
+
+export interface SemanticSearchDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  peers: PeerClients;
+  /** Absent → semantic search returns no results (hybrid degrades to BM25). */
+  embeddingClient?: EmbeddingClient;
+}
+
+export interface SearchByVectorOptions {
+  vectorBlob: Float32Array;
+  sourceIdToExclude: string;
+  filters?: RetrievalFilters;
+  limit?: number;
+  threshold?: number;
+}
+
+export class SemanticSearchService {
+  constructor(private readonly deps: SemanticSearchDeps) {}
+
+  /** Embed `query` via the injected client; null when unconfigured or failing. */
+  private async embedQuery(query: string): Promise<number[] | null> {
+    if (!this.deps.embeddingClient) return null;
+    try {
+      return await this.deps.embeddingClient.embedQuery(query);
+    } catch (err) {
+      console.warn(
+        `[retrieval/semantic] embedQuery failed; returning no semantic results: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return null;
+    }
+  }
+
+  async search(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    if (!query.trim()) {
+      throw Object.assign(new Error('Query is required for semantic search'), {
+        code: 'EMPTY_QUERY',
+      });
+    }
+    if (!this.deps.embeddingClient) return [];
+    if (!this.deps.vecAvailable) throw vecUnavailableError();
+
+    const queryVector = await this.embedQuery(query);
+    if (!queryVector) return [];
+    const vectorBlob = Float32Array.from(queryVector);
+    const rows = knnQuery(this.deps.raw, vectorBlob, limit * 3).filter(
+      (r) => r.distance <= threshold
+    );
+    const seen = dedupeBySource(rows);
+
+    return collectResults({
+      rows: seen.values(),
+      filters,
+      limit,
+      resolveMetadata: (st, sid, f) =>
+        resolveMetadata({ db: this.deps.db, peers: this.deps.peers }, st, sid, f),
+    });
+  }
+
+  /**
+   * Run a k-NN search using an existing vector blob (read from embeddings_vec).
+   * Used by `similar` — no embedding call needed.
+   */
+  async searchByVector(opts: SearchByVectorOptions): Promise<RetrievalResult[]> {
+    if (!this.deps.vecAvailable) throw vecUnavailableError();
+    const limit = opts.limit ?? DEFAULT_LIMIT;
+    const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+    const filters = opts.filters ?? {};
+
+    const rows = knnQuery(this.deps.raw, opts.vectorBlob, limit * 3).filter(
+      (r) => r.distance <= threshold && r.source_id !== opts.sourceIdToExclude
+    );
+    const seen = dedupeBySource(rows);
+
+    return collectResults({
+      rows: seen.values(),
+      filters,
+      limit,
+      resolveMetadata: (st, sid, f) =>
+        resolveMetadata({ db: this.deps.db, peers: this.deps.peers }, st, sid, f),
+    });
+  }
+
+  /** Retrieve the embedding vector blob for an engram by its source ID. */
+  getVectorForEngram(engramId: string): Float32Array | null {
+    const row = this.deps.raw
+      .prepare(
+        `
+        SELECT ev.vector
+        FROM embeddings_vec ev
+        JOIN embeddings e ON e.id = ev.rowid
+        WHERE e.source_type = 'engram' AND e.source_id = ?
+        ORDER BY e.chunk_index
+        LIMIT 1
+      `
+      )
+      .get(engramId) as { vector: Buffer } | undefined;
+
+    if (!row) return null;
+    return new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
+  }
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/structured-query-conditions.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/structured-query-conditions.ts
@@ -1,0 +1,91 @@
+import { gte, inArray, lte, ne, sql } from 'drizzle-orm';
+
+import { engramIndex, engramScopes, engramTags } from '../../../db/index.js';
+
+import type { SQL } from 'drizzle-orm';
+
+import type { RetrievalFilters } from './types.js';
+
+function statusConditions(filters: RetrievalFilters): SQL[] {
+  if (filters.status?.length) {
+    return [inArray(engramIndex.status, filters.status)];
+  }
+  return [ne(engramIndex.status, 'orphaned')];
+}
+
+function customFieldConditions(filters: RetrievalFilters): SQL[] {
+  if (!filters.customFields) return [];
+  return Object.entries(filters.customFields).map(
+    ([key, value]) => sql`json_extract(${engramIndex.customFields}, ${`$.${key}`}) = ${value}`
+  );
+}
+
+function secretExclusionCondition(filters: RetrievalFilters): SQL[] {
+  if (filters.includeSecret) return [];
+  return [
+    sql`not exists (
+      select 1 from ${engramScopes}
+      where ${engramScopes.engramId} = ${engramIndex.id}
+        and (
+          ${engramScopes.scope} = 'secret'
+          or ${engramScopes.scope} like '%.secret.%'
+          or ${engramScopes.scope} like 'secret.%'
+          or ${engramScopes.scope} like '%.secret'
+        )
+    )`,
+  ];
+}
+
+function scopeFilterCondition(filters: RetrievalFilters): SQL[] {
+  const scopeFilters = filters.scopes;
+  if (!scopeFilters || scopeFilters.length === 0) return [];
+  const scopePredicates = scopeFilters.map((f) => {
+    const prefix = `${f}.%`;
+    return sql`(${engramScopes.scope} = ${f} or ${engramScopes.scope} like ${prefix})`;
+  });
+  return [
+    sql`exists (
+      select 1 from ${engramScopes}
+      where ${engramScopes.engramId} = ${engramIndex.id}
+        and (${sql.join(scopePredicates, sql` or `)})
+    )`,
+  ];
+}
+
+function tagFilterCondition(filters: RetrievalFilters): SQL[] {
+  const tagFilters = filters.tags ? [...new Set(filters.tags)] : undefined;
+  if (!tagFilters || tagFilters.length === 0) return [];
+  const tagParams = tagFilters.map((t) => sql`${t}`);
+  return [
+    sql`(
+      select count(distinct ${engramTags.tag})
+      from ${engramTags}
+      where ${engramTags.engramId} = ${engramIndex.id}
+        and ${engramTags.tag} in (${sql.join(tagParams, sql`, `)})
+    ) = ${tagFilters.length}`,
+  ];
+}
+
+function dateRangeConditions(filters: RetrievalFilters): SQL[] {
+  const conditions: SQL[] = [];
+  if (filters.dateRange?.from) conditions.push(gte(engramIndex.createdAt, filters.dateRange.from));
+  if (filters.dateRange?.to) conditions.push(lte(engramIndex.createdAt, filters.dateRange.to));
+  return conditions;
+}
+
+function typeConditions(filters: RetrievalFilters): SQL[] {
+  if (!filters.types?.length) return [];
+  return [inArray(engramIndex.type, filters.types)];
+}
+
+export function buildStructuredConditions(filters: RetrievalFilters): SQL[] {
+  return [
+    ...statusConditions(filters),
+    ...typeConditions(filters),
+    ...dateRangeConditions(filters),
+    ...customFieldConditions(filters),
+    ...secretExclusionCondition(filters),
+    ...scopeFilterCondition(filters),
+    ...tagFilterCondition(filters),
+  ];
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/structured-query.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/structured-query.ts
@@ -1,0 +1,124 @@
+/**
+ * StructuredQueryService — filters `engram_index` + junction tables (the BM25
+ * leg) on the pillar drizzle handle. Returns `RetrievalResult[]` with
+ * `matchType: 'structured'`. Ported from the monolith; the only change is the
+ * schema import path (cerebrum pillar db instead of `@pops/cerebrum-db`).
+ */
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import { embeddings, engramIndex, engramScopes, engramTags } from '../../../db/index.js';
+import { buildStructuredConditions } from './structured-query-conditions.js';
+
+import type { CerebrumDb } from '../../../db/index.js';
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+interface JunctionMaps {
+  scopesByEngramId: Map<string, string[]>;
+  tagsByEngramId: Map<string, string[]>;
+  previewByEngramId: Map<string, string>;
+}
+
+function bucketByEngram(
+  rows: { engramId: string }[],
+  valueKey: 'scope' | 'tag'
+): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const row of rows) {
+    const value = (row as Record<string, unknown>)[valueKey] as string;
+    const arr = map.get(row.engramId);
+    if (arr) arr.push(value);
+    else map.set(row.engramId, [value]);
+  }
+  return map;
+}
+
+export class StructuredQueryService {
+  constructor(private readonly db: CerebrumDb) {}
+
+  query(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
+    if (filters.sourceTypes && !filters.sourceTypes.includes('engram')) return [];
+
+    const cappedLimit = Math.min(limit, MAX_LIMIT);
+    const conditions = buildStructuredConditions(filters);
+
+    const rows = this.db
+      .select()
+      .from(engramIndex)
+      .where(and(...conditions))
+      .orderBy(desc(engramIndex.modifiedAt))
+      .limit(cappedLimit)
+      .offset(offset)
+      .all();
+
+    if (rows.length === 0) return [];
+
+    const maps = this.fetchJunctionData(rows.map((r) => r.id));
+    return rows.map((row) => this.toRetrievalResult(row, maps));
+  }
+
+  private fetchJunctionData(rowIds: string[]): JunctionMaps {
+    const scopeRows = this.db
+      .select({ engramId: engramScopes.engramId, scope: engramScopes.scope })
+      .from(engramScopes)
+      .where(inArray(engramScopes.engramId, rowIds))
+      .all();
+
+    const tagRows = this.db
+      .select({ engramId: engramTags.engramId, tag: engramTags.tag })
+      .from(engramTags)
+      .where(inArray(engramTags.engramId, rowIds))
+      .all();
+
+    const previewRows = this.db
+      .select({ sourceId: embeddings.sourceId, contentPreview: embeddings.contentPreview })
+      .from(embeddings)
+      .where(
+        and(
+          eq(embeddings.sourceType, 'engram'),
+          inArray(embeddings.sourceId, rowIds),
+          eq(embeddings.chunkIndex, 0)
+        )
+      )
+      .all();
+
+    const previewByEngramId = new Map<string, string>();
+    for (const { sourceId, contentPreview } of previewRows) {
+      previewByEngramId.set(sourceId, contentPreview);
+    }
+
+    return {
+      scopesByEngramId: bucketByEngram(scopeRows, 'scope'),
+      tagsByEngramId: bucketByEngram(tagRows, 'tag'),
+      previewByEngramId,
+    };
+  }
+
+  private toRetrievalResult(
+    row: typeof engramIndex.$inferSelect,
+    maps: JunctionMaps
+  ): RetrievalResult {
+    return {
+      sourceType: 'engram',
+      sourceId: row.id,
+      title: row.title,
+      contentPreview: maps.previewByEngramId.get(row.id) ?? '',
+      score: 1,
+      matchType: 'structured' as const,
+      metadata: {
+        type: row.type,
+        source: row.source,
+        status: row.status,
+        scopes: maps.scopesByEngramId.get(row.id) ?? [],
+        tags: maps.tagsByEngramId.get(row.id) ?? [],
+        createdAt: row.createdAt,
+        modifiedAt: row.modifiedAt,
+        wordCount: row.wordCount,
+        customFields: row.customFields,
+        contentHash: row.contentHash,
+      },
+    };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/retrieval/types.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal retrieval types. The wire projection of these lives in
+ * `src/contract/rest-retrieval-schemas.ts`; these are the service-layer shapes
+ * the lifted search/context/structured services traffic in.
+ */
+export interface RetrievalResult {
+  sourceType: string;
+  sourceId: string;
+  title: string;
+  contentPreview: string;
+  score: number;
+  distance?: number;
+  matchType: 'semantic' | 'structured' | 'both';
+  metadata: Record<string, unknown>;
+}
+
+export interface SourceAttribution {
+  sourceType: string;
+  sourceId: string;
+  title: string;
+  relevanceScore: number;
+  chunkRange?: [number, number];
+}
+
+export interface RetrievalFilters {
+  types?: string[];
+  scopes?: string[];
+  tags?: string[];
+  dateRange?: { from?: string; to?: string };
+  status?: string[];
+  sourceTypes?: string[];
+  customFields?: Record<string, unknown>;
+  includeSecret?: boolean;
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -14,6 +14,7 @@ import { makeGliaHandlers } from './glia-handlers.js';
 import { makeNudgesHandlers } from './nudges-handlers.js';
 import { makePlexusHandlers } from './plexus-handlers.js';
 import { makeReflexHandlers } from './reflex-handlers.js';
+import { makeRetrievalHandlers } from './retrieval-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
 import { makeTagsHandlers } from './tags-handlers.js';
 import { makeTemplatesHandlers } from './templates-handlers.js';
@@ -44,5 +45,12 @@ export function makeCerebrumRestHandlers(
       configPath: deps.gliaConfigPath ?? resolveGliaConfigPath(),
     }),
     nudges: makeNudgesHandlers(deps.cerebrumDb.db),
+    retrieval: makeRetrievalHandlers({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+    }),
   });
 }

--- a/pillars/cerebrum/src/api/rest/retrieval-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/retrieval-handlers.ts
@@ -1,0 +1,152 @@
+import { initServer } from '@ts-rest/express';
+/**
+ * ts-rest handlers for `cerebrum.retrieval.*`.
+ *
+ * Each handler builds a request-scoped {@link HybridSearchService} bound to the
+ * pillar db (drizzle + raw + vec availability), the injected peer clients, and
+ * the optional embedding client. The services are stateless — all filtering
+ * rides in the request body — so there is no per-request auth.
+ *
+ * `stats` reads coverage counts straight off the pillar drizzle handle. The
+ * search/context query-required + structured filter-required guards map to 400
+ * via the pillar {@link ValidationError} + `runHttp`.
+ */
+import { count, sql } from 'drizzle-orm';
+
+import { cerebrumRetrievalContract } from '../../contract/rest-retrieval.js';
+import { embeddings, engramIndex, type CerebrumDb } from '../../db/index.js';
+import { ContextAssemblyService } from '../modules/retrieval/context-assembly.js';
+import { HybridSearchService } from '../modules/retrieval/hybrid-search.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+import type { RetrievalFilters } from '../modules/retrieval/types.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface RetrievalHandlerDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  peers: PeerClients;
+  embeddingClient?: EmbeddingClient;
+}
+
+function hasAnyStructuredFilter(filters: RetrievalFilters): boolean {
+  if (filters.customFields) return true;
+  if (filters.dateRange?.from || filters.dateRange?.to) return true;
+  const arrayLengths = [
+    filters.types?.length,
+    filters.scopes?.length,
+    filters.tags?.length,
+    filters.status?.length,
+    filters.sourceTypes?.length,
+  ];
+  return arrayLengths.some((n) => (n ?? 0) > 0);
+}
+
+function readStats(db: CerebrumDb): {
+  indexed: number;
+  embedded: number;
+  sourceTypes: Record<string, number>;
+  lastUpdated: string | null;
+} {
+  const [indexedRow] = db.select({ count: count() }).from(engramIndex).all();
+  const indexed = indexedRow?.count ?? 0;
+
+  const sourceTypeRows = db
+    .select({ sourceType: embeddings.sourceType, count: count() })
+    .from(embeddings)
+    .groupBy(embeddings.sourceType)
+    .all();
+
+  const embedded = sourceTypeRows.reduce((sum, r) => sum + r.count, 0);
+  const sourceTypes = Object.fromEntries(sourceTypeRows.map((r) => [r.sourceType, r.count]));
+
+  const [lastRow] = db
+    .select({ lastUpdated: sql<string | null>`max(${embeddings.createdAt})` })
+    .from(embeddings)
+    .all();
+
+  return { indexed, embedded, sourceTypes, lastUpdated: lastRow?.lastUpdated ?? null };
+}
+
+export function makeRetrievalHandlers(
+  deps: RetrievalHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumRetrievalContract>> {
+  const newService = (): HybridSearchService =>
+    new HybridSearchService({
+      db: deps.db,
+      raw: deps.raw,
+      vecAvailable: deps.vecAvailable,
+      peers: deps.peers,
+      embeddingClient: deps.embeddingClient,
+    });
+
+  return server.router(cerebrumRetrievalContract, {
+    search: async ({ body }) =>
+      runHttp(async () => {
+        const filters: RetrievalFilters = body.filters ?? {};
+
+        if (body.mode !== 'structured' && !body.query?.trim()) {
+          throw new ValidationError({ message: 'retrieval.queryRequired' });
+        }
+        if (body.mode === 'structured' && !hasAnyStructuredFilter(filters)) {
+          throw new ValidationError({ message: 'retrieval.filterRequired' });
+        }
+
+        const svc = newService();
+        const query = body.query ?? '';
+        let results;
+        switch (body.mode) {
+          case 'semantic':
+            results = await svc.semanticSearch(query, filters, body.limit, body.threshold);
+            break;
+          case 'structured':
+            results = svc.structuredOnly(filters, body.limit, body.offset);
+            break;
+          case 'hybrid':
+          default:
+            results = await svc.hybrid(query, filters, body.limit, body.threshold);
+        }
+
+        return {
+          status: 200 as const,
+          body: { results, meta: { total: results.length, mode: body.mode } },
+        };
+      }),
+
+    context: async ({ body }) =>
+      runHttp(async () => {
+        if (!body.query.trim()) {
+          throw new ValidationError({ message: 'retrieval.contextQueryRequired' });
+        }
+        const svc = newService();
+        const assembler = new ContextAssemblyService();
+        const filters: RetrievalFilters = body.filters ?? {};
+
+        const results = await svc.hybrid(body.query, filters, body.maxResults, 0.8);
+        const output = assembler.assemble({
+          query: body.query,
+          results,
+          tokenBudget: body.tokenBudget,
+          includeMetadata: body.includeMetadata,
+        });
+
+        return { status: 200 as const, body: output };
+      }),
+
+    similar: async ({ body }) => {
+      const svc = newService();
+      const filters: RetrievalFilters = body.filters ?? {};
+      const results = await svc.similar(body.engramId, filters, body.limit, body.threshold);
+      return { status: 200, body: { results } };
+    },
+
+    stats: async () => ({ status: 200, body: readStats(deps.db) }),
+  });
+}

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -22,6 +22,8 @@ import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { buildCerebrumManifest } from './manifest.js';
 import { resolveEngramRoot } from './modules/engrams/instance.js';
 import { getReflexService } from './modules/reflex/instance.js';
+import { resolveEmbeddingClientFromEnv } from './modules/retrieval/embedding-client.js';
+import { resolvePeerClientsFromEnv } from './modules/retrieval/peer-clients.js';
 import { TemplateRegistry } from './modules/templates/registry.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -68,6 +70,8 @@ const app = createCerebrumApiApp({
   reflexService,
   version,
   selfBaseUrl,
+  peerClients: resolvePeerClientsFromEnv(),
+  embeddingClient: resolveEmbeddingClientFromEnv(),
 });
 
 let pillarHandle: PillarBootstrapHandle | undefined;

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -550,6 +550,74 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/retrieval/context': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Assemble a token-budgeted context window for LLM consumption. */
+    post: operations['retrieval.context'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/retrieval/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Unified search — semantic | structured | hybrid (default). */
+    post: operations['retrieval.search'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/retrieval/similar': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Find engrams similar to a given engram by its existing vector. */
+    post: operations['retrieval.similar'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/retrieval/stats': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Retrieval layer health and coverage counts. */
+    get: operations['retrieval.stats'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/scopes': {
     parameters: {
       query?: never;
@@ -2750,6 +2818,263 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'retrieval.context': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          filters?: {
+            customFields?: {
+              [key: string]: unknown;
+            };
+            dateRange?: {
+              from?: string;
+              to?: string;
+            };
+            includeSecret?: boolean;
+            scopes?: string[];
+            sourceTypes?: string[];
+            status?: string[];
+            tags?: string[];
+            types?: string[];
+          };
+          /** @default true */
+          includeMetadata: boolean;
+          /** @default 20 */
+          maxResults: number;
+          query: string;
+          /** @default 4096 */
+          tokenBudget: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            context: string;
+            sources: {
+              chunkRange?: number[];
+              relevanceScore: number;
+              sourceId: string;
+              sourceType: string;
+              title: string;
+            }[];
+            tokenEstimate: number;
+            truncated: boolean;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'retrieval.search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          filters?: {
+            customFields?: {
+              [key: string]: unknown;
+            };
+            dateRange?: {
+              from?: string;
+              to?: string;
+            };
+            includeSecret?: boolean;
+            scopes?: string[];
+            sourceTypes?: string[];
+            status?: string[];
+            tags?: string[];
+            types?: string[];
+          };
+          /** @default 20 */
+          limit: number;
+          /**
+           * @default hybrid
+           * @enum {string}
+           */
+          mode: 'semantic' | 'structured' | 'hybrid';
+          /** @default 0 */
+          offset: number;
+          query?: string;
+          /** @default 0.8 */
+          threshold: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            meta: {
+              /** @enum {string} */
+              mode: 'semantic' | 'structured' | 'hybrid';
+              total: number;
+            };
+            results: {
+              contentPreview: string;
+              distance?: number;
+              /** @enum {string} */
+              matchType: 'semantic' | 'structured' | 'both';
+              metadata: {
+                [key: string]: unknown;
+              };
+              score: number;
+              sourceId: string;
+              sourceType: string;
+              title: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'retrieval.similar': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          engramId: string;
+          filters?: {
+            customFields?: {
+              [key: string]: unknown;
+            };
+            dateRange?: {
+              from?: string;
+              to?: string;
+            };
+            includeSecret?: boolean;
+            scopes?: string[];
+            sourceTypes?: string[];
+            status?: string[];
+            tags?: string[];
+            types?: string[];
+          };
+          /** @default 20 */
+          limit: number;
+          /** @default 0.8 */
+          threshold: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            results: {
+              contentPreview: string;
+              distance?: number;
+              /** @enum {string} */
+              matchType: 'semantic' | 'structured' | 'both';
+              metadata: {
+                [key: string]: unknown;
+              };
+              score: number;
+              sourceId: string;
+              sourceType: string;
+              title: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'retrieval.stats': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            embedded: number;
+            indexed: number;
+            lastUpdated: string | null;
+            sourceTypes: {
+              [key: string]: number;
+            };
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-retrieval-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-retrieval-schemas.ts
@@ -1,0 +1,65 @@
+/**
+ * Wire schemas for `cerebrum.retrieval.*`.
+ *
+ * The retrieval surface returns deep aggregates — a `RetrievalResult` carries a
+ * free-form `metadata` bag whose keys depend on the source type (engram
+ * frontmatter vs. cross-pillar domain rows), so it is projected as
+ * `z.record(z.string(), z.unknown())` rather than a closed shape (mirrors how
+ * food projected its deep recipe aggregates). The scalar/identity fields stay
+ * strongly typed.
+ *
+ * Lives in its own file (not the shared `rest-schemas.ts`) so that file stays
+ * under the oxlint `max-lines: 200` cap; no other domain consumes these.
+ */
+import { z } from 'zod';
+
+export const retrievalModeSchema = z.enum(['semantic', 'structured', 'hybrid']);
+export type RetrievalModeWire = z.infer<typeof retrievalModeSchema>;
+
+export const retrievalFiltersSchema = z.object({
+  types: z.array(z.string()).optional(),
+  scopes: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+  dateRange: z.object({ from: z.string().optional(), to: z.string().optional() }).optional(),
+  status: z.array(z.string()).optional(),
+  sourceTypes: z.array(z.string()).optional(),
+  customFields: z.record(z.string(), z.unknown()).optional(),
+  includeSecret: z.boolean().optional(),
+});
+export type RetrievalFiltersWire = z.infer<typeof retrievalFiltersSchema>;
+
+/**
+ * A single retrieval hit. `metadata` is an open bag — engram hits carry
+ * `type`/`scopes`/`tags`/`wordCount`/…, cross-pillar hits carry the enriched
+ * domain fields. Modelled as an opaque record so the contract doesn't have to
+ * enumerate every source type's projection.
+ */
+export const retrievalResultSchema = z.object({
+  sourceType: z.string(),
+  sourceId: z.string(),
+  title: z.string(),
+  contentPreview: z.string(),
+  score: z.number(),
+  distance: z.number().optional(),
+  matchType: z.enum(['semantic', 'structured', 'both']),
+  metadata: z.record(z.string(), z.unknown()),
+});
+export type RetrievalResultWire = z.infer<typeof retrievalResultSchema>;
+
+/** A context-window source attribution row. */
+export const sourceAttributionSchema = z.object({
+  sourceType: z.string(),
+  sourceId: z.string(),
+  title: z.string(),
+  relevanceScore: z.number(),
+  chunkRange: z.tuple([z.number(), z.number()]).optional(),
+});
+export type SourceAttributionWire = z.infer<typeof sourceAttributionSchema>;
+
+export const retrievalStatsSchema = z.object({
+  indexed: z.number().int(),
+  embedded: z.number().int(),
+  sourceTypes: z.record(z.string(), z.number().int()),
+  lastUpdated: z.string().nullable(),
+});
+export type RetrievalStatsWire = z.infer<typeof retrievalStatsSchema>;

--- a/pillars/cerebrum/src/contract/rest-retrieval.ts
+++ b/pillars/cerebrum/src/contract/rest-retrieval.ts
@@ -1,0 +1,100 @@
+/**
+ * ts-rest contract for `cerebrum.retrieval.*` — the unified read surface
+ * (search, context, similar, stats).
+ *
+ * The retrieval services are STATELESS: scope/type/status filtering rides in
+ * the request body (`RetrievalFilters`), never derived from a caller identity.
+ * The domain is therefore served on the docker-network trust boundary with no
+ * per-request auth, like the other migrated domains.
+ *
+ * `search` / `context` / `similar` are POST-with-body (they carry the filter
+ * object and/or arrays that don't round-trip cleanly through a query string —
+ * mirrors the engrams `search` + nudges `list` precedent). `stats` takes no
+ * input and stays a GET.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  retrievalFiltersSchema,
+  retrievalModeSchema,
+  retrievalResultSchema,
+  retrievalStatsSchema,
+  sourceAttributionSchema,
+} from './rest-retrieval-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+const searchBody = z.object({
+  query: z.string().optional(),
+  mode: retrievalModeSchema.default('hybrid'),
+  filters: retrievalFiltersSchema.optional(),
+  limit: z.number().int().positive().max(100).default(20),
+  threshold: z.number().min(0).max(2).default(0.8),
+  offset: z.number().int().min(0).default(0),
+});
+
+const contextBody = z.object({
+  query: z.string(),
+  filters: retrievalFiltersSchema.optional(),
+  tokenBudget: z.number().int().positive().default(4096),
+  includeMetadata: z.boolean().default(true),
+  maxResults: z.number().int().positive().max(100).default(20),
+});
+
+const similarBody = z.object({
+  engramId: z.string(),
+  limit: z.number().int().positive().max(100).default(20),
+  threshold: z.number().min(0).max(2).default(0.8),
+  filters: retrievalFiltersSchema.optional(),
+});
+
+export const cerebrumRetrievalContract = c.router({
+  search: {
+    method: 'POST',
+    path: '/retrieval/search',
+    summary: 'Unified search — semantic | structured | hybrid (default).',
+    body: searchBody,
+    responses: {
+      200: z.object({
+        results: z.array(retrievalResultSchema),
+        meta: z.object({ total: z.number().int(), mode: retrievalModeSchema }),
+      }),
+      400: errorBodySchema,
+    },
+  },
+  context: {
+    method: 'POST',
+    path: '/retrieval/context',
+    summary: 'Assemble a token-budgeted context window for LLM consumption.',
+    body: contextBody,
+    responses: {
+      200: z.object({
+        context: z.string(),
+        sources: z.array(sourceAttributionSchema),
+        truncated: z.boolean(),
+        tokenEstimate: z.number().int(),
+      }),
+      400: errorBodySchema,
+    },
+  },
+  similar: {
+    method: 'POST',
+    path: '/retrieval/similar',
+    summary: 'Find engrams similar to a given engram by its existing vector.',
+    body: similarBody,
+    responses: {
+      200: z.object({ results: z.array(retrievalResultSchema) }),
+      400: errorBodySchema,
+    },
+  },
+  stats: {
+    method: 'GET',
+    path: '/retrieval/stats',
+    summary: 'Retrieval layer health and coverage counts.',
+    responses: {
+      200: retrievalStatsSchema,
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -17,6 +17,7 @@ import { cerebrumGliaContract } from './rest-glia.js';
 import { cerebrumNudgesContract } from './rest-nudges.js';
 import { cerebrumPlexusContract } from './rest-plexus.js';
 import { cerebrumReflexContract } from './rest-reflex.js';
+import { cerebrumRetrievalContract } from './rest-retrieval.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
 import { cerebrumTagsContract } from './rest-tags.js';
 import { cerebrumTemplatesContract } from './rest-templates.js';
@@ -33,6 +34,7 @@ export const cerebrumContract = c.router(
     tags: cerebrumTagsContract,
     glia: cerebrumGliaContract,
     nudges: cerebrumNudgesContract,
+    retrieval: cerebrumRetrievalContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Summary

Migrates the cerebrum **retrieval** read surface from the monolith (`apps/pops-api/src/modules/cerebrum/retrieval/`) onto the `@pops/cerebrum` pillar over ts-rest. Four `protectedProcedure`-equivalent reads, served on the docker-network trust boundary (stateless services — scopes ride in the request body, no per-request auth, parity with the other 8 migrated domains).

### Surface (added to `rest.ts` + `rest/handlers.ts` alongside the existing 8 keys)
- `POST /retrieval/search` — semantic | structured | hybrid (default) → `{ results, meta: { total, mode } }`
- `POST /retrieval/context` — hybrid search + token-budgeted context-window assembly → `{ context, sources, truncated, tokenEstimate }`
- `POST /retrieval/similar` — kNN from an existing engram's stored vector (no re-embed) → `{ results }`
- `GET /retrieval/stats` — coverage counts → `{ indexed, embedded, sourceTypes, lastUpdated }`

Dotted operationIds (`retrieval.search` …) fall out of the nested router key. `RetrievalResult.metadata` / cross-pillar aggregates are projected as `z.record(z.string(), z.unknown())` (deep, source-type-dependent); identity/scalar fields stay strongly typed.

### The two hard rewires
1. **Cross-pillar enrichment** — the monolith's `fetchDomainRow` SQL-joined `@pops/finance-db` / `@pops/media-db` / `@pops/inventory-db`. Replaced with bare-`fetch` peer clients (`peer-clients.ts`), injectable on `CerebrumApiDeps.peerClients`, base URLs resolved from `POPS_PILLARS`. Each peer endpoint returns `{ data }`; `transaction`→`/transactions/:id`, `movie`→`/movies/:id`, `tv_show`→`/tv-shows/:id`, `inventory`→`/items/:id`. A peer absent from `POPS_PILLARS` ⇒ `undefined` client ⇒ that source type's hit is dropped (no crash) — matching the monolith's `null`-metadata behaviour. Minimal hand-typed peer shapes (avoids coupling cerebrum's build to peers' `dist/` for four scalar fields each); `to{Transaction,Movie,TvShow,Inventory}Text` formatters fold the fetched fields into the result body.
2. **`embeddings_vec` on the pillar db** — `knnQuery` now reads `deps.cerebrumDb.raw` (the `embeddings` + `embeddings_vec` virtual table live in cerebrum.db, migration 0054; `embeddings.id == embeddings_vec.rowid` is consistent standalone, so the exact kNN JOIN SQL is preserved). Vector availability is the pillar's `openCerebrumDb(...).vecAvailable`. Graceful degradation chain intact: no-vec ⇒ semantic throws vec-unavailable ⇒ hybrid swallows it ⇒ BM25-only results.

### Query-vector / embedding client
The shared pops-api embedding-client + Redis query-vec cache is replaced by an env-gated, injectable `EmbeddingClient` (`embeddingClient` on deps). No `EMBEDDING_API_KEY` ⇒ no client ⇒ semantic search returns no results ⇒ hybrid degrades to BM25. A provider error is swallowed to the same no-results path. Tests inject a fake — no real embedding API required.

### Out of scope
`cerebrum.index.*` / `CrossSourceIndexer` (the embedding-enqueue/reindex path) — a later slice with the embeddings queue. This is the retrieval read path only.

## Tests
`retrieval.test.ts` (14 cases): stats; structured/BM25 (scope filter, secret exclusion, 400 guards for no-filter + no-query); semantic + cross-pillar enrichment via injected fake peer clients with a real `embeddings_vec`-seeded kNN; cross-pillar hit dropped when peer absent; no-embedding-client degradation; hybrid no-vec → BM25 fallback; `similar` (excludes self, empty for no-vector); context-window assembly + empty-query 400.

## Green proof
- `oxfmt --check` clean
- `oxlint pillars/cerebrum/src` — 0 errors (only the pre-existing `registry.ts` dangling-underscore warning)
- `typecheck` clean — no `as any` / `as unknown as T` / suppressions
- `build` clean (regenerates openapi + api-types)
- `generate:openapi && git diff --exit-code` — deterministic, clean
- `test` — 495 passed (34 files)
