### PR TITLE
feat(media): REST migration slice 11b — rotation scheduler (in-process) + test isolation hardening

### DIFF
--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -11814,6 +11814,843 @@
         "tags": ["rotation"]
       }
     },
+    "/rotation/scheduler/disk-space": {
+      "get": {
+        "operationId": "rotation.schedulerDiskSpace",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "available": {
+                          "type": "boolean"
+                        },
+                        "disks": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "freeSpace": {
+                                "type": "number"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "totalSpace": {
+                                "type": "number"
+                              }
+                            },
+                            "required": ["path", "label", "freeSpace", "totalSpace"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["available", "disks"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Radarr disk space (degrades to available:false when unreachable)",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/last-cycle": {
+      "get": {
+        "operationId": "rotation.schedulerLastCycleLog",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "details": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "executedAt": {
+                          "type": "string"
+                        },
+                        "freeSpaceGb": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "number"
+                        },
+                        "moviesAdded": {
+                          "type": "number"
+                        },
+                        "moviesMarkedLeaving": {
+                          "type": "number"
+                        },
+                        "moviesRemoved": {
+                          "type": "number"
+                        },
+                        "removalsFailed": {
+                          "type": "number"
+                        },
+                        "skippedReason": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "targetFreeGb": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "executedAt",
+                        "moviesMarkedLeaving",
+                        "moviesRemoved",
+                        "moviesAdded",
+                        "removalsFailed",
+                        "freeSpaceGb",
+                        "targetFreeGb",
+                        "skippedReason",
+                        "details"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Read the most recent rotation cycle log entry",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/leaving": {
+      "get": {
+        "operationId": "rotation.schedulerLeavingMovies",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "posterPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "rotationExpiresAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "rotationMarkedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "tmdbId": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "tmdbId",
+                          "title",
+                          "posterPath",
+                          "rotationExpiresAt",
+                          "rotationMarkedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Movies currently in the 'leaving' state, soonest expiry first",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/leaving/{movieId}/cancel": {
+      "post": {
+        "operationId": "rotation.schedulerCancelLeaving",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "movieId",
+            "required": true,
+            "schema": {
+              "maximum": 9007199254740991,
+              "minimum": -9007199254740991,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["success", "message"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Clear a movie's 'leaving' status",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/log": {
+      "get": {
+        "operationId": "rotation.listRotationLog",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "items": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "details": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "executedAt": {
+                                "type": "string"
+                              },
+                              "freeSpaceGb": {
+                                "type": "number"
+                              },
+                              "id": {
+                                "type": "number"
+                              },
+                              "moviesAdded": {
+                                "type": "number"
+                              },
+                              "moviesMarkedLeaving": {
+                                "type": "number"
+                              },
+                              "moviesRemoved": {
+                                "type": "number"
+                              },
+                              "removalsFailed": {
+                                "type": "number"
+                              },
+                              "skippedReason": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "targetFreeGb": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "executedAt",
+                              "moviesMarkedLeaving",
+                              "moviesRemoved",
+                              "moviesAdded",
+                              "removalsFailed",
+                              "freeSpaceGb",
+                              "targetFreeGb",
+                              "skippedReason",
+                              "details"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "total": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["items", "total"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Paginated rotation log entries, newest first",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/log-stats": {
+      "get": {
+        "operationId": "rotation.rotationLogStats",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "avgPerDay": {
+                          "type": "number"
+                        },
+                        "streak": {
+                          "type": "number"
+                        },
+                        "totalRotated": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["totalRotated", "avgPerDay", "streak"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Summary statistics for the rotation log page",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/run-now": {
+      "post": {
+        "operationId": "rotation.schedulerRunNow",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "result": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "freeSpaceGb": {
+                              "type": "number"
+                            },
+                            "moviesAdded": {
+                              "type": "number"
+                            },
+                            "moviesMarkedLeaving": {
+                              "type": "number"
+                            },
+                            "moviesRemoved": {
+                              "type": "number"
+                            },
+                            "removalsFailed": {
+                              "type": "number"
+                            },
+                            "skippedReason": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "targetFreeGb": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "moviesMarkedLeaving",
+                            "moviesRemoved",
+                            "moviesAdded",
+                            "removalsFailed",
+                            "freeSpaceGb",
+                            "targetFreeGb",
+                            "skippedReason"
+                          ],
+                          "type": "object"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["success", "result"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Trigger one rotation cycle immediately",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/status": {
+      "get": {
+        "operationId": "rotation.schedulerStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cronExpression": {
+                          "type": "string"
+                        },
+                        "intervalMs": {
+                          "type": "number"
+                        },
+                        "isCycleRunning": {
+                          "type": "boolean"
+                        },
+                        "isRunning": {
+                          "type": "boolean"
+                        },
+                        "lastCycleAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastCycleError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "nextRunAt": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "isRunning",
+                        "isCycleRunning",
+                        "intervalMs",
+                        "cronExpression",
+                        "lastCycleAt",
+                        "lastCycleError",
+                        "nextRunAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Read the rotation scheduler run state + last-cycle stats",
+        "tags": ["rotation"]
+      }
+    },
+    "/rotation/scheduler/toggle": {
+      "post": {
+        "operationId": "rotation.schedulerToggle",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cronExpression": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["enabled"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cronExpression": {
+                          "type": "string"
+                        },
+                        "intervalMs": {
+                          "type": "number"
+                        },
+                        "isCycleRunning": {
+                          "type": "boolean"
+                        },
+                        "isRunning": {
+                          "type": "boolean"
+                        },
+                        "lastCycleAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "lastCycleError": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "nextRunAt": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "isRunning",
+                        "isCycleRunning",
+                        "intervalMs",
+                        "cronExpression",
+                        "lastCycleAt",
+                        "lastCycleError",
+                        "nextRunAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Start or stop the rotation scheduler (persists the enabled flag)",
+        "tags": ["rotation"]
+      }
+    },
     "/rotation/settings": {
       "get": {
         "operationId": "rotation.getSettings",

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -410,6 +410,55 @@ interface RotationSettingsWire {
   protectedDays: string;
 }
 
+interface RotationSchedulerStatusWire {
+  isRunning: boolean;
+  isCycleRunning: boolean;
+  intervalMs: number;
+  cronExpression: string;
+  lastCycleAt: string | null;
+  lastCycleError: string | null;
+  nextRunAt: string | null;
+}
+
+interface RotationLogRowWire {
+  id: number;
+  executedAt: string;
+  moviesMarkedLeaving: number;
+  moviesRemoved: number;
+  moviesAdded: number;
+  removalsFailed: number;
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  skippedReason: string | null;
+  details: string | null;
+}
+
+interface CycleResultWire {
+  moviesMarkedLeaving: number;
+  moviesRemoved: number;
+  moviesAdded: number;
+  removalsFailed: number;
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  skippedReason: string | null;
+}
+
+interface LeavingMovieWire {
+  id: number;
+  tmdbId: number;
+  title: string;
+  posterPath: string | null;
+  rotationExpiresAt: string | null;
+  rotationMarkedAt: string | null;
+}
+
+interface RadarrDiskWire {
+  path: string;
+  label: string;
+  freeSpace: number;
+  totalSpace: number;
+}
+
 function makeRotationClient(r: ReturnType<typeof supertest>) {
   return {
     addToQueue: (body: Record<string, unknown>) =>
@@ -450,6 +499,34 @@ function makeRotationClient(r: ReturnType<typeof supertest>) {
     saveSettings: (body: Record<string, unknown>) =>
       send<{ data: { success: boolean; updated: number } }>(
         r.post('/rotation/settings').send(body)
+      ),
+    schedulerStatus: () =>
+      send<{ data: RotationSchedulerStatusWire }>(r.get('/rotation/scheduler/status')),
+    schedulerToggle: (body: { enabled: boolean; cronExpression?: string }) =>
+      send<{ data: RotationSchedulerStatusWire }>(r.post('/rotation/scheduler/toggle').send(body)),
+    schedulerRunNow: () =>
+      send<{ data: { success: boolean; result: CycleResultWire | null } }>(
+        r.post('/rotation/scheduler/run-now').send({})
+      ),
+    schedulerLeavingMovies: () =>
+      send<{ data: LeavingMovieWire[] }>(r.get('/rotation/scheduler/leaving')),
+    schedulerCancelLeaving: (movieId: number) =>
+      send<{ data: { success: boolean; message: string } }>(
+        r.post(`/rotation/scheduler/leaving/${movieId}/cancel`).send({})
+      ),
+    schedulerLastCycleLog: () =>
+      send<{ data: RotationLogRowWire | null }>(r.get('/rotation/scheduler/last-cycle')),
+    schedulerDiskSpace: () =>
+      send<{ data: { available: boolean; disks: RadarrDiskWire[] } }>(
+        r.get('/rotation/scheduler/disk-space')
+      ),
+    listRotationLog: (query: { limit?: number; offset?: number } = {}) =>
+      send<{ data: { items: RotationLogRowWire[]; total: number } }>(
+        r.get('/rotation/scheduler/log').query(query)
+      ),
+    rotationLogStats: () =>
+      send<{ data: { totalRotated: number; avgPerDay: number; streak: number } }>(
+        r.get('/rotation/scheduler/log-stats')
       ),
   };
 }

--- a/pillars/media/src/api/clients/arr/index.ts
+++ b/pillars/media/src/api/clients/arr/index.ts
@@ -59,6 +59,7 @@ export type {
   DownloadQueueItem,
   RadarrCheckResult,
   RadarrCommandResponse,
+  RadarrDiskSpace,
   RadarrMovie,
   RadarrQualityProfile,
   RadarrRootFolder,

--- a/pillars/media/src/api/cron/__tests__/rotation-scheduler.test.ts
+++ b/pillars/media/src/api/cron/__tests__/rotation-scheduler.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for the singleton rotation-scheduler controller + the `rotation.*`
+ * scheduler REST surface (slice 11b).
+ *
+ * `runOnce` is exercised DIRECTLY (no real timer): upstream Radarr HTTP is
+ * mocked at `globalThis.fetch` with a (method, url-substring) route table, so
+ * the real client → cycle → log path runs end-to-end. The recursive arm timer
+ * is only touched in the toggle tests, driven with `vi.useFakeTimers()` and
+ * restored in `afterEach`; `rotationScheduler._reset()` clears the module-level
+ * singleton after every test so no timer leaks between cases.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  moviesService,
+  openMediaDb,
+  rotationCandidatesService,
+  rotationLogService,
+  rotationRemovalQueries,
+  rotationSettingsService,
+  type OpenedMediaDb,
+} from '../../../db/index.js';
+import { makeClient } from '../../__tests__/test-utils.js';
+import { createMediaApiApp } from '../../app.js';
+import { clearStatusCache } from '../../clients/arr/index.js';
+import { rotationScheduler } from '../rotation-scheduler.js';
+
+import type { Express } from 'express';
+
+const RADARR_URL = 'http://radarr.test:7878';
+const GB = 1_073_741_824;
+
+interface RouteResponse {
+  status?: number;
+  body: unknown;
+}
+type RouteHandler = (init: { method: string; url: string; body: unknown }) => RouteResponse;
+interface RouteRule {
+  method: string;
+  match: string;
+  handler: RouteHandler;
+}
+
+let routes: RouteRule[];
+let calls: { method: string; url: string; body: unknown }[];
+
+function route(method: string, match: string, handler: RouteHandler): void {
+  routes.push({ method, match, handler });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const body = typeof init?.body === 'string' ? (JSON.parse(init.body) as unknown) : undefined;
+  calls.push({ method, url, body });
+  const rule = routes.find((r) => r.method === method && url.includes(r.match));
+  if (!rule) return Promise.resolve(jsonResponse({ error: `unmatched ${method} ${url}` }, 404));
+  const res = rule.handler({ method, url, body });
+  return Promise.resolve(jsonResponse(res.body, res.status ?? 200));
+});
+
+let tmpDir: string;
+let opened: OpenedMediaDb;
+
+function app(): Express {
+  return createMediaApiApp({ mediaDb: opened, version: '0.0.1-test', selfBaseUrl: RADARR_URL });
+}
+
+function enableRadarr(): void {
+  process.env['RADARR_URL'] = RADARR_URL;
+  process.env['RADARR_API_KEY'] = 'radarr-key';
+  process.env['RADARR_QUALITY_PROFILE_ID'] = '4';
+  process.env['RADARR_ROOT_FOLDER_PATH'] = '/movies';
+}
+
+/** Radarr /diskspace responding with `freeGb` free on the first disk. */
+function routeDiskSpace(freeGb: number, totalGb = 1000): void {
+  route('GET', '/diskspace', () => ({
+    body: [{ path: '/movies', label: 'media', freeSpace: freeGb * GB, totalSpace: totalGb * GB }],
+  }));
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-rotation-sched-'));
+  opened = openMediaDb(join(tmpDir, 'media.db'));
+  routes = [];
+  calls = [];
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+  clearStatusCache();
+});
+
+afterEach(() => {
+  rotationScheduler._reset();
+  opened.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  clearStatusCache();
+  delete process.env['RADARR_URL'];
+  delete process.env['RADARR_API_KEY'];
+  delete process.env['RADARR_QUALITY_PROFILE_ID'];
+  delete process.env['RADARR_ROOT_FOLDER_PATH'];
+  delete process.env['TMDB_API_KEY'];
+  vi.clearAllMocks();
+});
+
+describe('rotationScheduler.runOnce — cycle', () => {
+  it('marks the oldest eligible movie leaving when disk is below target', async () => {
+    enableRadarr();
+    rotationSettingsService.setMany(opened.db, [
+      { key: 'rotation_target_free_gb', value: '100' },
+      { key: 'rotation_leaving_days', value: '7' },
+      { key: 'rotation_daily_additions', value: '0' },
+    ]);
+    const older = moviesService.createMovie(opened.db, { tmdbId: 11, title: 'Old One' });
+    const newer = moviesService.createMovie(opened.db, { tmdbId: 22, title: 'New One' });
+    opened.raw.exec(`UPDATE movies SET created_at='2020-01-01' WHERE id=${older.id}`);
+    opened.raw.exec(`UPDATE movies SET created_at='2024-01-01' WHERE id=${newer.id}`);
+
+    // Free space (50) well below target (100); both movies are 30 GB on disk.
+    routeDiskSpace(50);
+    route('GET', '/movie?tmdbId', () => ({ body: [] }));
+    route('GET', '/queue', () => ({ body: { totalRecords: 0, records: [] } }));
+    route('GET', '/movie', () => ({
+      body: [
+        {
+          id: 1,
+          title: 'Old One',
+          tmdbId: 11,
+          monitored: true,
+          hasFile: true,
+          sizeOnDisk: 30 * GB,
+        },
+        {
+          id: 2,
+          title: 'New One',
+          tmdbId: 22,
+          monitored: true,
+          hasFile: true,
+          sizeOnDisk: 30 * GB,
+        },
+      ],
+    }));
+
+    await rotationScheduler.runOnce(opened.db);
+
+    const leaving = rotationRemovalQueries.getLeavingMovies(opened.db);
+    // Deficit = 100 - 50 = 50 GB; oldest (30 GB) alone is < 50, so both eligible
+    // get marked until the cumulative size covers the deficit.
+    expect(leaving.map((m) => m.tmdbId)).toEqual([11, 22]);
+
+    const log = rotationLogService.lastCycleLog(opened.db);
+    expect(log?.moviesMarkedLeaving).toBe(2);
+    expect(log?.skippedReason).toBeNull();
+  });
+
+  it('expires + deletes a leaving movie from Radarr once its window elapsed', async () => {
+    enableRadarr();
+    rotationSettingsService.setMany(opened.db, [
+      { key: 'rotation_target_free_gb', value: '0' },
+      { key: 'rotation_daily_additions', value: '0' },
+    ]);
+    const movie = moviesService.createMovie(opened.db, { tmdbId: 77, title: 'Expired' });
+    rotationRemovalQueries.markMoviesAsLeaving(opened.db, [movie.id], '2020-01-01T00:00:00.000Z');
+
+    routeDiskSpace(500);
+    route('GET', '/movie?tmdbId', () => ({
+      body: [{ id: 9, title: 'Expired', tmdbId: 77, monitored: true, hasFile: true }],
+    }));
+    route('GET', '/queue', () => ({ body: { totalRecords: 0, records: [] } }));
+    route('GET', '/movie', () => ({ body: [] }));
+    let deleted = false;
+    route('DELETE', '/movie/9', () => {
+      deleted = true;
+      return { body: {} };
+    });
+
+    await rotationScheduler.runOnce(opened.db);
+
+    expect(deleted).toBe(true);
+    expect(moviesService.getMovieByTmdbId(opened.db, 77)?.rotationStatus).toBeNull();
+    expect(rotationLogService.lastCycleLog(opened.db)?.moviesRemoved).toBe(1);
+  });
+
+  it('downloads up to the daily cap when disk is above target', async () => {
+    enableRadarr();
+    rotationSettingsService.setMany(opened.db, [
+      { key: 'rotation_target_free_gb', value: '100' },
+      { key: 'rotation_daily_additions', value: '2' },
+      { key: 'rotation_avg_movie_gb', value: '10' },
+    ]);
+    rotationCandidatesService.addToQueue(opened.db, { tmdbId: 101, title: 'Cand A', rating: 8 });
+    rotationCandidatesService.addToQueue(opened.db, { tmdbId: 102, title: 'Cand B', rating: 8 });
+    rotationCandidatesService.addToQueue(opened.db, { tmdbId: 103, title: 'Cand C', rating: 8 });
+
+    routeDiskSpace(500); // well above target → budget = min(2, floor(400/10)) = 2
+    route('GET', '/movie?tmdbId', () => ({ body: [] }));
+    route('GET', '/queue', () => ({ body: { totalRecords: 0, records: [] } }));
+    route('GET', '/movie', () => ({ body: [] }));
+    route('POST', '/api/v3/movie', ({ body }) => {
+      const tmdbId = (body as { tmdbId: number }).tmdbId;
+      return { body: { id: tmdbId, title: 'Added', tmdbId, monitored: true, hasFile: false } };
+    });
+
+    await rotationScheduler.runOnce(opened.db);
+
+    const adds = calls.filter((c) => c.method === 'POST' && c.url.includes('/api/v3/movie'));
+    expect(adds).toHaveLength(2);
+    expect(rotationLogService.lastCycleLog(opened.db)?.moviesAdded).toBe(2);
+    expect(rotationCandidatesService.listCandidates(opened.db, { status: 'added' }).total).toBe(2);
+  });
+
+  it('skips additions when disk is at/below target', async () => {
+    enableRadarr();
+    rotationSettingsService.setMany(opened.db, [
+      { key: 'rotation_target_free_gb', value: '100' },
+      { key: 'rotation_daily_additions', value: '3' },
+      { key: 'rotation_avg_movie_gb', value: '10' },
+    ]);
+    rotationCandidatesService.addToQueue(opened.db, { tmdbId: 201, title: 'No Room', rating: 9 });
+
+    routeDiskSpace(80); // below target → budget 0, no eligible removals either
+    route('GET', '/movie?tmdbId', () => ({ body: [] }));
+    route('GET', '/queue', () => ({ body: { totalRecords: 0, records: [] } }));
+    route('GET', '/movie', () => ({ body: [] }));
+
+    await rotationScheduler.runOnce(opened.db);
+
+    const adds = calls.filter((c) => c.method === 'POST' && c.url.includes('/api/v3/movie'));
+    expect(adds).toHaveLength(0);
+    expect(rotationLogService.lastCycleLog(opened.db)?.moviesAdded).toBe(0);
+    expect(rotationCandidatesService.listCandidates(opened.db, { status: 'pending' }).total).toBe(
+      1
+    );
+  });
+
+  it('records a skipped cycle log when Radarr is unconfigured', async () => {
+    // No enableRadarr() → getRadarrClient returns null.
+    await rotationScheduler.runOnce(opened.db);
+    const log = rotationLogService.lastCycleLog(opened.db);
+    expect(log?.skippedReason).toBe('Radarr not configured');
+  });
+});
+
+describe('rotationScheduler — controller toggle', () => {
+  it('start arms the timer + fires one immediate cycle; stop clears it', async () => {
+    vi.useFakeTimers();
+    try {
+      const status = rotationScheduler.start({ db: opened.db, intervalMs: 1_000 });
+      expect(status.isRunning).toBe(true);
+      await vi.runOnlyPendingTimersAsync();
+      // Cycle no-ops (Radarr unconfigured) but still writes one log row.
+      expect(rotationLogService.listRotationLog(opened.db, 100, 0).total).toBeGreaterThanOrEqual(1);
+
+      rotationScheduler.stop(opened.db);
+      expect(rotationScheduler.status(opened.db).isRunning).toBe(false);
+
+      const before = rotationLogService.listRotationLog(opened.db, 100, 0).total;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(rotationLogService.listRotationLog(opened.db, 100, 0).total).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('persists enabled=true + cron on start, enabled=false on stop', () => {
+    vi.useFakeTimers();
+    try {
+      rotationScheduler.start({ db: opened.db, intervalMs: 5_000, cronExpression: '0 4 * * *' });
+      expect(rotationSettingsService.get(opened.db, 'rotation_enabled')).toBe('true');
+      expect(rotationSettingsService.get(opened.db, 'rotation_cron_expression')).toBe('0 4 * * *');
+
+      rotationScheduler.stop(opened.db);
+      expect(rotationSettingsService.get(opened.db, 'rotation_enabled')).toBe('false');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resumeIfEnabled starts only when the persisted flag is "true"', () => {
+    vi.useFakeTimers();
+    try {
+      expect(rotationScheduler.resumeIfEnabled(opened.db)).toBeNull();
+      rotationSettingsService.set(opened.db, 'rotation_enabled', 'true');
+      const status = rotationScheduler.resumeIfEnabled(opened.db);
+      expect(status?.isRunning).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('rotation scheduler — REST', () => {
+  it('toggle on reports isRunning, toggle off clears it', async () => {
+    vi.useFakeTimers();
+    try {
+      const on = await makeClient(app()).rotation.schedulerToggle({ enabled: true });
+      expect(on.data.isRunning).toBe(true);
+      expect((await makeClient(app()).rotation.schedulerStatus()).data.isRunning).toBe(true);
+
+      const off = await makeClient(app()).rotation.schedulerToggle({ enabled: false });
+      expect(off.data.isRunning).toBe(false);
+    } finally {
+      rotationScheduler.stop(opened.db);
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancelLeaving clears the leaving flag and returns success', async () => {
+    const movie = moviesService.createMovie(opened.db, { tmdbId: 55, title: 'Going' });
+    rotationRemovalQueries.markMoviesAsLeaving(opened.db, [movie.id], '2099-01-01T00:00:00.000Z');
+
+    const leaving = await makeClient(app()).rotation.schedulerLeavingMovies();
+    expect(leaving.data.map((m) => m.tmdbId)).toEqual([55]);
+
+    const cancelled = await makeClient(app()).rotation.schedulerCancelLeaving(movie.id);
+    expect(cancelled.data.success).toBe(true);
+    expect(moviesService.getMovie(opened.db, movie.id).rotationStatus).toBeNull();
+
+    const missing = await makeClient(app()).rotation.schedulerCancelLeaving(movie.id);
+    expect(missing.data.success).toBe(false);
+  });
+
+  it('getDiskSpace returns available:true with Radarr disks', async () => {
+    enableRadarr();
+    routeDiskSpace(250, 1000);
+    const res = await makeClient(app()).rotation.schedulerDiskSpace();
+    expect(res.data.available).toBe(true);
+    expect(res.data.disks[0]?.freeSpace).toBe(250 * GB);
+  });
+
+  it('getDiskSpace degrades to available:false when Radarr is unconfigured', async () => {
+    const res = await makeClient(app()).rotation.schedulerDiskSpace();
+    expect(res.data).toEqual({ available: false, disks: [] });
+  });
+
+  it('listRotationLog + log-stats reflect written cycles', async () => {
+    rotationLogService.writeCycleLog(opened.db, {
+      moviesMarkedLeaving: 0,
+      moviesRemoved: 2,
+      moviesAdded: 1,
+      removalsFailed: 0,
+      freeSpaceGb: 120,
+      targetFreeGb: 100,
+      skippedReason: null,
+      marked: [],
+      removed: [],
+      added: [],
+      failed: [],
+    });
+
+    const log = await makeClient(app()).rotation.listRotationLog({ limit: 10 });
+    expect(log.data.total).toBe(1);
+    expect(log.data.items[0]?.moviesRemoved).toBe(2);
+
+    const stats = await makeClient(app()).rotation.rotationLogStats();
+    expect(stats.data.totalRotated).toBe(3);
+    expect(stats.data.streak).toBe(1);
+  });
+});

--- a/pillars/media/src/api/cron/rotation-scheduler.ts
+++ b/pillars/media/src/api/cron/rotation-scheduler.ts
@@ -1,0 +1,197 @@
+/**
+ * In-process rotation-cycle scheduler (slice 11b).
+ *
+ * Re-architected from the monolith's `node-cron` task to a recursive
+ * `setTimeout` driven by a MODULE-LEVEL singleton controller, mirroring
+ * `plex-scheduler.ts`: the `server.ts` boot path and the REST
+ * `/rotation/scheduler/{toggle,run-now}` handlers all drive the SAME timer,
+ * and the next tick is armed only AFTER the current cycle resolves (no
+ * pile-up). One immediate tick fires on `start`.
+ *
+ * Cron-vs-interval decision: `cron-parser` / `node-cron` are NOT workspace
+ * dependencies of `@pops/media`, so per the migration runbook this controller
+ * runs on a fixed INTERVAL (env `MEDIA_ROTATION_INTERVAL_MS`, default daily)
+ * rather than parsing a cron expression. The monolith's
+ * `rotation_cron_expression` is still read/persisted as stored config (the FE
+ * settings surface keeps editing it) but does not drive the timer; `nextRunAt`
+ * is computed from the interval. Swap in a cron parser later by replacing
+ * `armDelayMs` + `nextRunAt` only.
+ *
+ * Persisted state lives in `rotation_settings` (`rotation_enabled` +
+ * `rotation_cron_expression`); `resumeIfEnabled` reads it on boot.
+ */
+import { type MediaDb, rotationLogService, rotationSettingsService } from '../../db/index.js';
+import { getRotationCyclePolicy } from '../modules/rotation-cycle-policy.js';
+import { emptyResult } from '../modules/rotation-cycle-types.js';
+import { executeRotationCycle } from '../modules/rotation-cycle.js';
+
+const ENABLED_KEY = 'rotation_enabled';
+const CRON_KEY = 'rotation_cron_expression';
+const DEFAULT_CRON = '0 3 * * *';
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export interface RotationSchedulerStatus {
+  isRunning: boolean;
+  isCycleRunning: boolean;
+  intervalMs: number;
+  cronExpression: string;
+  lastCycleAt: string | null;
+  lastCycleError: string | null;
+  nextRunAt: string | null;
+}
+
+interface SchedulerState {
+  db: MediaDb;
+  intervalMs: number;
+  cronExpression: string;
+  timer: NodeJS.Timeout | undefined;
+}
+
+let state: SchedulerState | null = null;
+let isCycleRunning = false;
+let lastCycleAt: string | null = null;
+let lastCycleError: string | null = null;
+let nextRunAt: string | null = null;
+
+function resolveDefaultIntervalMs(): number {
+  const raw = process.env['MEDIA_ROTATION_INTERVAL_MS'];
+  if (raw === undefined || raw === '') return DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MS;
+}
+
+function persistEnabled(db: MediaDb, cronExpression: string): void {
+  rotationSettingsService.set(db, ENABLED_KEY, 'true');
+  rotationSettingsService.set(db, CRON_KEY, cronExpression);
+}
+
+function persistDisabled(db: MediaDb): void {
+  rotationSettingsService.set(db, ENABLED_KEY, 'false');
+}
+
+/**
+ * Run one cycle, writing exactly one `rotation_log` row. A concurrent call
+ * (cycle already running) writes a skipped row and returns without re-entering
+ * the cycle, matching the monolith's single-flight guard.
+ */
+async function runCycle(db: MediaDb): Promise<void> {
+  if (isCycleRunning) {
+    const policy = getRotationCyclePolicy(db);
+    rotationLogService.writeCycleLog(db, {
+      ...emptyResult(policy.targetFreeGb),
+      skippedReason: 'Concurrent cycle already running',
+    });
+    return;
+  }
+
+  isCycleRunning = true;
+  try {
+    const result = await executeRotationCycle(db);
+    rotationLogService.writeCycleLog(db, result);
+    lastCycleAt = new Date().toISOString();
+    lastCycleError = result.skippedReason;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    lastCycleAt = new Date().toISOString();
+    lastCycleError = `Cycle error: ${message}`;
+    const policy = getRotationCyclePolicy(db);
+    rotationLogService.writeCycleLog(db, {
+      ...emptyResult(policy.targetFreeGb),
+      skippedReason: lastCycleError,
+    });
+  } finally {
+    isCycleRunning = false;
+  }
+}
+
+function arm(): void {
+  if (state === null) return;
+  const current = state;
+  nextRunAt = new Date(Date.now() + current.intervalMs).toISOString();
+  current.timer = setTimeout(() => {
+    void tick();
+  }, current.intervalMs);
+}
+
+async function tick(): Promise<void> {
+  if (state === null) return;
+  const current = state;
+  try {
+    await runCycle(current.db);
+  } catch (err) {
+    console.warn('[media-api] rotation scheduler tick failed', err);
+  }
+  arm();
+}
+
+export interface RotationSchedulerStartOptions {
+  db: MediaDb;
+  intervalMs?: number;
+  cronExpression?: string;
+}
+
+export const rotationScheduler = {
+  /**
+   * Arm the recursive timer + fire one cycle immediately. Idempotent: a second
+   * `start` clears the prior timer and re-arms with the new options. Persists
+   * the enabled flag + cron expression to `rotation_settings`.
+   */
+  start(options: RotationSchedulerStartOptions): RotationSchedulerStatus {
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    const cronExpression =
+      options.cronExpression ?? rotationSettingsService.get(options.db, CRON_KEY) ?? DEFAULT_CRON;
+    state = {
+      db: options.db,
+      intervalMs: options.intervalMs ?? resolveDefaultIntervalMs(),
+      cronExpression,
+      timer: undefined,
+    };
+    persistEnabled(options.db, cronExpression);
+    void tick();
+    return rotationScheduler.status(options.db);
+  },
+
+  /** Clear the timer + persist the disabled flag. No-op if not running. */
+  stop(db: MediaDb): RotationSchedulerStatus {
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    persistDisabled(db);
+    state = null;
+    nextRunAt = null;
+    return rotationScheduler.status(db);
+  },
+
+  /** Run a single cycle directly (no timer arming). Writes a rotation log. */
+  async runOnce(db: MediaDb): Promise<void> {
+    await runCycle(db);
+  },
+
+  /** Start with the persisted cron if `rotation_enabled` is `'true'`. */
+  resumeIfEnabled(db: MediaDb): RotationSchedulerStatus | null {
+    if (rotationSettingsService.get(db, ENABLED_KEY) !== 'true') return null;
+    const cronExpression = rotationSettingsService.get(db, CRON_KEY) ?? DEFAULT_CRON;
+    return rotationScheduler.start({ db, cronExpression });
+  },
+
+  status(db: MediaDb): RotationSchedulerStatus {
+    return {
+      isRunning: state !== null,
+      isCycleRunning,
+      intervalMs: state?.intervalMs ?? resolveDefaultIntervalMs(),
+      cronExpression:
+        state?.cronExpression ?? rotationSettingsService.get(db, CRON_KEY) ?? DEFAULT_CRON,
+      lastCycleAt,
+      lastCycleError,
+      nextRunAt,
+    };
+  },
+
+  /** Reset all in-memory state — for tests only. */
+  _reset(): void {
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    state = null;
+    isCycleRunning = false;
+    lastCycleAt = null;
+    lastCycleError = null;
+    nextRunAt = null;
+  },
+};

--- a/pillars/media/src/api/modules/rotation-addition.ts
+++ b/pillars/media/src/api/modules/rotation-addition.ts
@@ -1,0 +1,119 @@
+/**
+ * Radarr-backed addition phase for the rotation cycle (api-layer).
+ *
+ * Selects up to `budget` pending candidates via the weighted selection policy
+ * and adds each to Radarr (skipping any already present), best-effort enriches
+ * the POPS library entry, and marks the candidate `added` / `skipped`. Ported
+ * from the monolith `addition-gating.ts`; gating math + candidate selection are
+ * pure/db-layer concerns, so this file only owns the Radarr + TMDB calls.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  type MediaDb,
+  rotationCandidates,
+  rotationSelectionService,
+  type SelectedCandidate,
+} from '../../db/index.js';
+import { getRadarrClient, getRotationDefaults, type RadarrClient } from '../clients/arr/index.js';
+import { getImageCache, getTmdbClient } from '../clients/tmdb/index.js';
+import { addMovie } from './library-mutations.js';
+
+import type { RotationMovieRef } from './rotation-cycle-types.js';
+
+export interface AdditionResult {
+  added: number;
+  addedMovies: RotationMovieRef[];
+  skippedReason: string | null;
+}
+
+function markCandidate(db: MediaDb, candidateId: number, status: 'added' | 'skipped'): void {
+  db.update(rotationCandidates).set({ status }).where(eq(rotationCandidates.id, candidateId)).run();
+}
+
+async function enrichLibrary(db: MediaDb, tmdbId: number, title: string): Promise<void> {
+  try {
+    await addMovie({ db, tmdbClient: getTmdbClient(), imageCache: getImageCache() }, tmdbId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[rotation] Library entry creation failed for ${title} (tmdb=${tmdbId}): ${msg}`);
+  }
+}
+
+async function addCandidate(
+  db: MediaDb,
+  candidate: SelectedCandidate,
+  client: RadarrClient,
+  defaults: { qualityProfileId: number; rootFolderPath: string }
+): Promise<RotationMovieRef | null> {
+  try {
+    const check = await client.checkMovie(candidate.tmdbId);
+    if (check.exists) {
+      markCandidate(db, candidate.candidateId, 'skipped');
+      return null;
+    }
+
+    await client.addMovie({
+      tmdbId: candidate.tmdbId,
+      title: candidate.title,
+      year: candidate.year ?? new Date().getFullYear(),
+      qualityProfileId: defaults.qualityProfileId,
+      rootFolderPath: defaults.rootFolderPath,
+    });
+
+    await enrichLibrary(db, candidate.tmdbId, candidate.title);
+    markCandidate(db, candidate.candidateId, 'added');
+    return { tmdbId: candidate.tmdbId, title: candidate.title };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[rotation] Failed to add candidate ${candidate.title}: ${msg}`);
+    markCandidate(db, candidate.candidateId, 'skipped');
+    return null;
+  }
+}
+
+/**
+ * Add up to `budget` weighted-sampled candidates to Radarr. Returns the count
+ * + per-movie refs of what was actually added, plus a `skippedReason` when the
+ * whole phase no-ops (budget 0, Radarr/defaults unconfigured, empty queue).
+ */
+export async function addMoviesFromQueue(db: MediaDb, budget: number): Promise<AdditionResult> {
+  if (budget <= 0) {
+    return {
+      added: 0,
+      addedMovies: [],
+      skippedReason: 'additions skipped — below target free space',
+    };
+  }
+
+  const client = getRadarrClient();
+  if (!client) {
+    return {
+      added: 0,
+      addedMovies: [],
+      skippedReason: 'Radarr not configured — cannot add movies',
+    };
+  }
+
+  const defaults = getRotationDefaults();
+  if (!defaults) {
+    return {
+      added: 0,
+      addedMovies: [],
+      skippedReason: 'RADARR_QUALITY_PROFILE_ID or RADARR_ROOT_FOLDER_PATH not configured',
+    };
+  }
+
+  const selected = rotationSelectionService.aggregateCandidates(db, budget);
+  if (selected.length === 0) {
+    return { added: 0, addedMovies: [], skippedReason: 'no pending candidates in queue' };
+  }
+
+  const addedMovies: RotationMovieRef[] = [];
+  for (const candidate of selected) {
+    const ref = await addCandidate(db, candidate, client, defaults);
+    if (ref) addedMovies.push(ref);
+  }
+
+  return { added: addedMovies.length, addedMovies, skippedReason: null };
+}

--- a/pillars/media/src/api/modules/rotation-cycle-policy.ts
+++ b/pillars/media/src/api/modules/rotation-cycle-policy.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolve the numeric rotation-cycle policy from the `rotation_settings` kv
+ * table (api-layer). Reuses the wire-shaped {@link getRotationSettings} reader
+ * (which already applies defaults for unset keys) and coerces the string
+ * values to the numbers the cycle math expects, re-defaulting any non-finite
+ * parse so a corrupt row can never NaN-poison the cycle.
+ */
+import { type MediaDb } from '../../db/index.js';
+import { getRotationSettings, ROTATION_SETTING_KEYS } from './rotation-settings-config.js';
+
+export interface RotationCyclePolicy {
+  targetFreeGb: number;
+  leavingDays: number;
+  dailyAdditions: number;
+  avgMovieGb: number;
+}
+
+function num(value: string, fallback: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number(fallback);
+}
+
+/** Read the numeric cycle policy (target free GB, leaving days, daily cap, avg GB). */
+export function getRotationCyclePolicy(db: MediaDb): RotationCyclePolicy {
+  const settings = getRotationSettings(db);
+  return {
+    targetFreeGb: num(settings.targetFreeGb, ROTATION_SETTING_KEYS.targetFreeGb.default),
+    leavingDays: num(settings.leavingDays, ROTATION_SETTING_KEYS.leavingDays.default),
+    dailyAdditions: num(settings.dailyAdditions, ROTATION_SETTING_KEYS.dailyAdditions.default),
+    avgMovieGb: num(settings.avgMovieGb, ROTATION_SETTING_KEYS.avgMovieGb.default),
+  };
+}

--- a/pillars/media/src/api/modules/rotation-cycle-types.ts
+++ b/pillars/media/src/api/modules/rotation-cycle-types.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared types + pure policy math for the rotation cycle (api-layer).
+ *
+ * Ported from the monolith `rotation-cycle-types.ts` + the pure helpers of
+ * `removal-selection.ts` / `addition-gating.ts`. The `RotationMovieRef` /
+ * `RotationFailedMovieRef` shapes are re-exported from the db `rotationLog`
+ * service so the cycle result and the persisted log share one definition.
+ */
+import type { RotationFailedMovieRef, RotationMovieRef } from '../../db/index.js';
+
+export type { RotationFailedMovieRef, RotationMovieRef } from '../../db/index.js';
+
+const BYTES_PER_GB = 1_073_741_824;
+
+export interface RotationCycleResult {
+  moviesMarkedLeaving: number;
+  moviesRemoved: number;
+  moviesAdded: number;
+  removalsFailed: number;
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  skippedReason: string | null;
+  marked: RotationMovieRef[];
+  removed: RotationMovieRef[];
+  added: RotationMovieRef[];
+  failed: RotationFailedMovieRef[];
+}
+
+export function emptyResult(targetFreeGb: number): RotationCycleResult {
+  return {
+    moviesMarkedLeaving: 0,
+    moviesRemoved: 0,
+    moviesAdded: 0,
+    removalsFailed: 0,
+    freeSpaceGb: 0,
+    targetFreeGb,
+    skippedReason: null,
+    marked: [],
+    removed: [],
+    added: [],
+    failed: [],
+  };
+}
+
+/** Convert a byte size to GB. */
+export function bytesToGb(bytes: number): number {
+  return bytes / BYTES_PER_GB;
+}
+
+/**
+ * GB of movies that must be removed:
+ * `target_free - current_free - sizeOf(leaving movies)`, clamped to >= 0.
+ */
+export function calculateRemovalDeficit(
+  targetFreeGb: number,
+  currentFreeGb: number,
+  leavingSizeGb: number
+): number {
+  return Math.max(0, targetFreeGb - currentFreeGb - leavingSizeGb);
+}
+
+/**
+ * How many movies may be added without dropping below the target. Returns 0
+ * when already below target (or `avgMovieGb <= 0`); otherwise
+ * `min(dailyAdditions, floor((free - target) / avgMovieGb))`.
+ */
+export function getAdditionBudget(
+  freeSpaceGb: number,
+  targetFreeGb: number,
+  avgMovieGb: number,
+  dailyAdditions: number
+): number {
+  if (freeSpaceGb < targetFreeGb) return 0;
+  if (avgMovieGb <= 0) return 0;
+  const maxBySpace = Math.floor((freeSpaceGb - targetFreeGb) / avgMovieGb);
+  return Math.min(dailyAdditions, maxBySpace);
+}

--- a/pillars/media/src/api/modules/rotation-cycle.ts
+++ b/pillars/media/src/api/modules/rotation-cycle.ts
@@ -1,0 +1,139 @@
+/**
+ * The rotation cycle orchestration (api-layer).
+ *
+ * One cycle: batch-sync sources → sweep expired `leaving` movies (delete from
+ * Radarr) → measure free disk → mark the oldest eligible movies `leaving` to
+ * cover the deficit → re-measure disk → add up to the daily cap of candidates
+ * when space allows. Returns a {@link RotationCycleResult} the scheduler writes
+ * to the rotation log. Ported from the monolith `rotation-cycle.ts`; repointed
+ * onto the env-only Radarr client + the pillar's `rotation_settings` kv table.
+ */
+import { type MediaDb, type MovieSizeMap, rotationRemovalQueries } from '../../db/index.js';
+import { getRadarrClient, type RadarrClient } from '../clients/arr/index.js';
+import { addMoviesFromQueue } from './rotation-addition.js';
+import { getRotationCyclePolicy } from './rotation-cycle-policy.js';
+import {
+  calculateRemovalDeficit,
+  emptyResult,
+  getAdditionBudget,
+  type RotationCycleResult,
+  type RotationMovieRef,
+} from './rotation-cycle-types.js';
+import {
+  getDownloadingTmdbIds,
+  getRadarrDiskSpace,
+  getRadarrMovieSizes,
+  processExpiredMovies,
+} from './rotation-removal.js';
+import { syncAllSources } from './rotation-sync-all.js';
+
+interface MarkLeavingArgs {
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  leavingDays: number;
+  movieSizes: MovieSizeMap;
+}
+
+async function markLeaving(
+  db: MediaDb,
+  client: RadarrClient,
+  args: MarkLeavingArgs
+): Promise<RotationMovieRef[]> {
+  const { freeSpaceGb, targetFreeGb, leavingDays, movieSizes } = args;
+  const leavingSizeGb = rotationRemovalQueries.getLeavingMovieSizeGb(db, movieSizes);
+  const deficit = calculateRemovalDeficit(targetFreeGb, freeSpaceGb, leavingSizeGb);
+  if (deficit <= 0) return [];
+
+  const downloadingIds = await getDownloadingTmdbIds(client);
+  const eligible = rotationRemovalQueries.getEligibleForRemoval(db, movieSizes, downloadingIds);
+
+  const toMark: typeof eligible = [];
+  let accumulated = 0;
+  for (const movie of eligible) {
+    const sizeGb = movieSizes.get(movie.tmdbId) ?? 0;
+    if (sizeGb <= 0) continue;
+    toMark.push(movie);
+    accumulated += sizeGb;
+    if (accumulated >= deficit) break;
+  }
+  if (toMark.length === 0) return [];
+
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + leavingDays);
+  rotationRemovalQueries.markMoviesAsLeaving(
+    db,
+    toMark.map((m) => m.id),
+    expiresAt.toISOString()
+  );
+  return toMark.map((m) => ({ tmdbId: m.tmdbId, title: m.title }));
+}
+
+async function reCheckFreeSpace(client: RadarrClient, fallbackGb: number): Promise<number> {
+  try {
+    return await getRadarrDiskSpace(client);
+  } catch {
+    return fallbackGb;
+  }
+}
+
+/**
+ * Run a single rotation cycle. A missing Radarr client (after the expiry
+ * sweep) short-circuits to a skipped result that still reflects the removals.
+ */
+export async function executeRotationCycle(db: MediaDb): Promise<RotationCycleResult> {
+  const policy = getRotationCyclePolicy(db);
+  const { targetFreeGb, leavingDays } = policy;
+
+  await syncAllSources(db);
+
+  const client = getRadarrClient();
+  if (!client) {
+    return { ...emptyResult(targetFreeGb), skippedReason: 'Radarr not configured' };
+  }
+
+  const expired = await processExpiredMovies(db, client);
+
+  let freeSpaceGb: number;
+  try {
+    freeSpaceGb = await getRadarrDiskSpace(client);
+  } catch {
+    return {
+      ...emptyResult(targetFreeGb),
+      moviesRemoved: expired.removed.length,
+      removalsFailed: expired.failed.length,
+      removed: expired.removed,
+      failed: expired.failed,
+      skippedReason: 'Radarr unavailable — cannot measure disk space',
+    };
+  }
+
+  const movieSizes = await getRadarrMovieSizes(client);
+  const marked = await markLeaving(db, client, {
+    freeSpaceGb,
+    targetFreeGb,
+    leavingDays,
+    movieSizes,
+  });
+
+  const postFreeSpaceGb = await reCheckFreeSpace(client, freeSpaceGb);
+  const budget = getAdditionBudget(
+    postFreeSpaceGb,
+    targetFreeGb,
+    policy.avgMovieGb,
+    policy.dailyAdditions
+  );
+  const additions = await addMoviesFromQueue(db, budget);
+
+  return {
+    ...emptyResult(targetFreeGb),
+    moviesMarkedLeaving: marked.length,
+    moviesRemoved: expired.removed.length,
+    moviesAdded: additions.added,
+    removalsFailed: expired.failed.length,
+    freeSpaceGb,
+    marked,
+    removed: expired.removed,
+    added: additions.addedMovies,
+    failed: expired.failed,
+  };
+}

--- a/pillars/media/src/api/modules/rotation-download-candidate.ts
+++ b/pillars/media/src/api/modules/rotation-download-candidate.ts
@@ -8,8 +8,9 @@
  * repointed onto the pillar's env-only Radarr defaults (parity with the arr
  * `downloadAndProtect` path) and the pillar `(db, …)` services.
  *
- * The `rotationStatus='protected'` write is data-plane and stays in this slice.
- * The scheduler / rotation cycle that consumes that flag is slice 11b.
+ * The `rotationStatus='protected'` write keeps a downloaded movie out of the
+ * removal phase — `rotation-removal-queries.getEligibleForRemoval` skips
+ * unexpired `protected` rows.
  */
 import {
   type MediaDb,

--- a/pillars/media/src/api/modules/rotation-removal.ts
+++ b/pillars/media/src/api/modules/rotation-removal.ts
@@ -1,0 +1,86 @@
+/**
+ * Radarr-backed removal helpers for the rotation cycle (api-layer).
+ *
+ * Wraps the env-configured Radarr client: free disk space, per-movie sizes,
+ * the active download set, and the expiry sweep that deletes `leaving` movies
+ * (with files) once their window elapses and clears their POPS rotation flags.
+ * Ported from the monolith `removal-selection.ts` (the Radarr parts). The pure
+ * SQLite queries live in the db `removal-queries.ts` service; the pure math in
+ * `rotation-cycle-types.ts`.
+ */
+import { type MediaDb, type MovieSizeMap, rotationRemovalQueries } from '../../db/index.js';
+import { type RadarrClient } from '../clients/arr/index.js';
+import {
+  bytesToGb,
+  type RotationFailedMovieRef,
+  type RotationMovieRef,
+} from './rotation-cycle-types.js';
+
+/** Free space in GB of Radarr's primary (first) disk. Throws if unavailable. */
+export async function getRadarrDiskSpace(client: RadarrClient): Promise<number> {
+  const disks = await client.getDiskSpace();
+  const disk = disks[0];
+  if (!disk) throw new Error('Radarr returned no disk space info');
+  return bytesToGb(disk.freeSpace);
+}
+
+/** Map of TMDB id → size in GB for every Radarr movie with a file on disk. */
+export async function getRadarrMovieSizes(client: RadarrClient): Promise<MovieSizeMap> {
+  const radarrMovies = await client.getMovies();
+  const map: MovieSizeMap = new Map();
+  for (const m of radarrMovies) {
+    if (m.sizeOnDisk && m.sizeOnDisk > 0) map.set(m.tmdbId, bytesToGb(m.sizeOnDisk));
+  }
+  return map;
+}
+
+/** TMDB ids currently downloading in Radarr (queue ↔ movie-list join). */
+export async function getDownloadingTmdbIds(client: RadarrClient): Promise<Set<number>> {
+  const [queue, radarrMovies] = await Promise.all([client.getQueue(), client.getMovies()]);
+  const radarrIdToTmdb = new Map<number, number>();
+  for (const m of radarrMovies) radarrIdToTmdb.set(m.id, m.tmdbId);
+  const downloading = new Set<number>();
+  for (const record of queue.records) {
+    const tmdbId = radarrIdToTmdb.get(record.movieId);
+    if (tmdbId) downloading.add(tmdbId);
+  }
+  return downloading;
+}
+
+export interface ExpiredOutcome {
+  removed: RotationMovieRef[];
+  failed: RotationFailedMovieRef[];
+}
+
+/**
+ * Delete each expired `leaving` movie from Radarr (with files) and clear its
+ * POPS rotation flags. Continues on individual failures — one bad delete never
+ * aborts the sweep. Returns the per-movie removed / failed lists.
+ */
+export async function processExpiredMovies(
+  db: MediaDb,
+  client: RadarrClient
+): Promise<ExpiredOutcome> {
+  const expired = rotationRemovalQueries.getExpiredLeavingMovies(db);
+  const removed: RotationMovieRef[] = [];
+  const failed: RotationFailedMovieRef[] = [];
+
+  for (const movie of expired) {
+    try {
+      const check = await client.checkMovie(movie.tmdbId);
+      if (check.exists && check.radarrId != null) {
+        await client.deleteMovie(check.radarrId, true);
+      }
+      rotationRemovalQueries.clearRotationStatus(db, movie.id);
+      removed.push({ tmdbId: movie.tmdbId, title: movie.title });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[rotation] Failed to remove expired movie ${movie.title} (tmdb=${movie.tmdbId}): ${error}`
+      );
+      failed.push({ tmdbId: movie.tmdbId, title: movie.title, error });
+    }
+  }
+
+  return { removed, failed };
+}

--- a/pillars/media/src/api/modules/rotation-source-sync.ts
+++ b/pillars/media/src/api/modules/rotation-source-sync.ts
@@ -5,8 +5,8 @@
  * `rotation_candidates` table. This is an api-layer concern (it calls the
  * upstream TMDB / Plex clients), NOT a db service — the `src/db` layer stays
  * HTTP-free. Ported from the monolith `sync-source.ts` (the single-source
- * path; the batch `syncAllSources` + interval gating belongs to the scheduler
- * slice 11b and is intentionally NOT ported here).
+ * path). The batch `syncAllSources` + per-source interval gating lives in
+ * `rotation-sync-all.ts`, which the rotation cycle drives each tick.
  */
 import {
   type MediaDb,

--- a/pillars/media/src/api/modules/rotation-sync-all.ts
+++ b/pillars/media/src/api/modules/rotation-sync-all.ts
@@ -1,0 +1,65 @@
+/**
+ * Batch source sync with per-source interval gating (api-layer).
+ *
+ * Ported from the monolith `sync-source.ts` `syncAllSources` (the data-plane
+ * slice deferred batching + interval gating to this scheduler slice). Syncs
+ * every enabled source whose `sync_interval_hours` has elapsed since its last
+ * sync; each source is independent so one failure never blocks the others. A
+ * module-level guard prevents concurrent syncs of the same source.
+ */
+import { type MediaDb, rotationSourcesService } from '../../db/index.js';
+import { type SyncSourceResult, syncSource } from './rotation-source-sync.js';
+
+const DEFAULT_SYNC_INTERVAL_HOURS = 24;
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+export interface SyncAllResult {
+  synced: SyncSourceResult[];
+  skipped: number;
+  errors: { sourceId: number; sourceName: string; error: string }[];
+}
+
+const syncingSourceIds = new Set<number>();
+
+function intervalElapsed(lastSyncedAt: string | null, intervalHours: number): boolean {
+  if (!lastSyncedAt) return true;
+  const elapsed = Date.now() - new Date(lastSyncedAt).getTime();
+  return elapsed >= (intervalHours || DEFAULT_SYNC_INTERVAL_HOURS) * MS_PER_HOUR;
+}
+
+/**
+ * Sync all enabled sources whose interval has elapsed. Sources synced too
+ * recently — or already mid-sync — count toward `skipped`. Errors are
+ * collected per source rather than thrown.
+ */
+export async function syncAllSources(db: MediaDb): Promise<SyncAllResult> {
+  const sources = rotationSourcesService.listSources(db).filter((s) => s.enabled === 1);
+
+  const synced: SyncSourceResult[] = [];
+  const errors: SyncAllResult['errors'] = [];
+  let skipped = 0;
+
+  for (const source of sources) {
+    if (!intervalElapsed(source.lastSyncedAt, source.syncIntervalHours)) {
+      skipped++;
+      continue;
+    }
+    if (syncingSourceIds.has(source.id)) {
+      skipped++;
+      continue;
+    }
+
+    syncingSourceIds.add(source.id);
+    try {
+      synced.push(await syncSource(db, source.id));
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      errors.push({ sourceId: source.id, sourceName: source.name, error });
+      console.error(`[rotation] Source sync failed for "${source.name}": ${error}`);
+    } finally {
+      syncingSourceIds.delete(source.id);
+    }
+  }
+
+  return { synced, skipped, errors };
+}

--- a/pillars/media/src/api/rest/rotation-handlers.ts
+++ b/pillars/media/src/api/rest/rotation-handlers.ts
@@ -1,21 +1,20 @@
 /**
  * Composer for the `rotation.*` handler factories.
  *
- * Stitches the candidate-queue / exclusion handlers and the source / settings
- * handlers into the single map the contract router consumes. Split across two
- * factory files to keep each within the per-file line cap.
- *
- * NOTE: this is the rotation DATA PLANE only. The scheduler / rotation-cycle /
- * leaving-lifecycle / disk-space / rotation-log read procedures are slice 11b
- * and are intentionally not wired here.
+ * Stitches the candidate-queue / exclusion handlers, the source / settings
+ * handlers, and the scheduler / rotation-log handlers into the single map the
+ * contract router consumes. Split across factory files to keep each within the
+ * per-file line cap.
  */
 import { type MediaDb } from '../../db/index.js';
 import { makeRotationCandidateHandlers } from './rotation-candidate-handlers.js';
+import { makeRotationSchedulerHandlers } from './rotation-scheduler-handlers.js';
 import { makeRotationSourceHandlers } from './rotation-source-handlers.js';
 
 export function makeRotationHandlers(db: MediaDb) {
   return {
     ...makeRotationCandidateHandlers(db),
     ...makeRotationSourceHandlers(db),
+    ...makeRotationSchedulerHandlers(db),
   };
 }

--- a/pillars/media/src/api/rest/rotation-scheduler-handlers.ts
+++ b/pillars/media/src/api/rest/rotation-scheduler-handlers.ts
@@ -1,0 +1,124 @@
+/**
+ * Handlers for the `rotation.*` scheduler routes (slice 11b) — drive the
+ * module-level singleton `rotationScheduler` controller. `toggle` / `run-now`
+ * / `status` all touch the SAME timer the `server.ts` boot path uses, so a
+ * scheduler resumed on boot can be observed + stopped over REST and vice-versa.
+ *
+ * `disk-space` degrades to `{ available: false, disks: [] }` when Radarr is
+ * unconfigured or unreachable (parity with the monolith); `cancelLeaving`
+ * returns `success:false` rather than 404 when the movie is not `leaving`.
+ */
+import { type MediaDb, rotationLogService, rotationRemovalQueries } from '../../db/index.js';
+import { getRadarrClient, type RadarrDiskSpace } from '../clients/arr/index.js';
+import { rotationScheduler } from '../cron/rotation-scheduler.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { mediaRotationContract } from '../../contract/rest-rotation.js';
+
+type Req = ServerInferRequest<typeof mediaRotationContract>;
+
+async function readDiskSpace(): Promise<{ available: boolean; disks: RadarrDiskSpace[] }> {
+  try {
+    const client = getRadarrClient();
+    if (!client) return { available: false, disks: [] };
+    return { available: true, disks: await client.getDiskSpace() };
+  } catch {
+    return { available: false, disks: [] };
+  }
+}
+
+const DEFAULT_LOG_LIMIT = 20;
+const DEFAULT_LOG_OFFSET = 0;
+
+export function makeRotationSchedulerHandlers(db: MediaDb) {
+  return {
+    schedulerStatus: () =>
+      runHttp(() => ({ status: 200 as const, body: { data: rotationScheduler.status(db) } })),
+
+    schedulerToggle: ({ body }: Req['schedulerToggle']) =>
+      runHttp(() => {
+        const data = body.enabled
+          ? rotationScheduler.start({ db, cronExpression: body.cronExpression })
+          : rotationScheduler.stop(db);
+        return { status: 200 as const, body: { data } };
+      }),
+
+    schedulerRunNow: () =>
+      runHttp(async () => {
+        if (rotationScheduler.status(db).isCycleRunning) {
+          return { status: 200 as const, body: { data: { success: false, result: null } } };
+        }
+        await rotationScheduler.runOnce(db);
+        const result = rotationLogService.lastCycleLog(db);
+        return {
+          status: 200 as const,
+          body: {
+            data: {
+              success: true,
+              result:
+                result === null
+                  ? null
+                  : {
+                      moviesMarkedLeaving: result.moviesMarkedLeaving,
+                      moviesRemoved: result.moviesRemoved,
+                      moviesAdded: result.moviesAdded,
+                      removalsFailed: result.removalsFailed,
+                      freeSpaceGb: result.freeSpaceGb,
+                      targetFreeGb: result.targetFreeGb,
+                      skippedReason: result.skippedReason,
+                    },
+            },
+          },
+        };
+      }),
+
+    schedulerLeavingMovies: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: rotationRemovalQueries.getLeavingMovies(db) },
+      })),
+
+    schedulerCancelLeaving: ({ params }: Req['schedulerCancelLeaving']) =>
+      runHttp(() => {
+        const updated = rotationRemovalQueries.cancelLeaving(db, params.movieId);
+        return {
+          status: 200 as const,
+          body: {
+            data: {
+              success: updated,
+              message: updated ? 'Leaving status cancelled' : 'Movie not found or not leaving',
+            },
+          },
+        };
+      }),
+
+    schedulerLastCycleLog: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: rotationLogService.lastCycleLog(db) },
+      })),
+
+    schedulerDiskSpace: () =>
+      runHttp(async () => ({ status: 200 as const, body: { data: await readDiskSpace() } })),
+
+    listRotationLog: ({ query }: Req['listRotationLog']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: {
+          data: rotationLogService.listRotationLog(
+            db,
+            query.limit ?? DEFAULT_LOG_LIMIT,
+            query.offset ?? DEFAULT_LOG_OFFSET
+          ),
+        },
+      })),
+
+    rotationLogStats: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: rotationLogService.getRotationLogStats(db) },
+      })),
+  };
+}

--- a/pillars/media/src/api/server.ts
+++ b/pillars/media/src/api/server.ts
@@ -16,6 +16,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { openMediaDb } from '../db/index.js';
 import { createMediaApiApp } from './app.js';
 import { plexScheduler } from './cron/plex-scheduler.js';
+import { rotationScheduler } from './cron/rotation-scheduler.js';
 import { buildMediaManifest } from './manifest.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
@@ -70,6 +71,16 @@ if (process.env['PLEX_SCHEDULER_ENABLED'] === 'true') {
   plexScheduler.resumeIfEnabled(mediaDb.db);
 }
 
+// Rotation-cycle scheduler (slice 11b). Mirror of the Plex scheduler:
+// MEDIA_ROTATION_SCHEDULER_ENABLED force-starts; otherwise auto-resume from
+// the persisted `rotation_enabled` flag. The controller is a module-level
+// singleton so the REST toggle/run-now handlers drive the same timer.
+if (process.env['MEDIA_ROTATION_SCHEDULER_ENABLED'] === 'true') {
+  rotationScheduler.start({ db: mediaDb.db });
+} else {
+  rotationScheduler.resumeIfEnabled(mediaDb.db);
+}
+
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
@@ -88,6 +99,7 @@ function shutdown(signal: NodeJS.Signals): void {
   shuttingDown = true;
   console.warn(`[media-api] Shutting down (${signal})`);
   plexScheduler.stop();
+  rotationScheduler.stop(mediaDb.db);
   void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
     server.close(() => {
       mediaDb.raw.close();

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -1321,6 +1321,159 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/rotation/scheduler/disk-space': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Radarr disk space (degrades to available:false when unreachable) */
+    get: operations['rotation.schedulerDiskSpace'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/last-cycle': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read the most recent rotation cycle log entry */
+    get: operations['rotation.schedulerLastCycleLog'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/leaving': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Movies currently in the 'leaving' state, soonest expiry first */
+    get: operations['rotation.schedulerLeavingMovies'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/leaving/{movieId}/cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Clear a movie's 'leaving' status */
+    post: operations['rotation.schedulerCancelLeaving'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/log': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Paginated rotation log entries, newest first */
+    get: operations['rotation.listRotationLog'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/log-stats': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Summary statistics for the rotation log page */
+    get: operations['rotation.rotationLogStats'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/run-now': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Trigger one rotation cycle immediately */
+    post: operations['rotation.schedulerRunNow'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read the rotation scheduler run state + last-cycle stats */
+    get: operations['rotation.schedulerStatus'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rotation/scheduler/toggle': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Start or stop the rotation scheduler (persists the enabled flag) */
+    post: operations['rotation.schedulerToggle'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/rotation/settings': {
     parameters: {
       query?: never;
@@ -7411,6 +7564,418 @@ export interface operations {
                 uuid: string;
               }[];
             };
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerDiskSpace': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              available: boolean;
+              disks: {
+                freeSpace: number;
+                label: string;
+                path: string;
+                totalSpace: number;
+              }[];
+            };
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerLastCycleLog': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              details: string | null;
+              executedAt: string;
+              freeSpaceGb: number;
+              id: number;
+              moviesAdded: number;
+              moviesMarkedLeaving: number;
+              moviesRemoved: number;
+              removalsFailed: number;
+              skippedReason: string | null;
+              targetFreeGb: number;
+            } | null;
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerLeavingMovies': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              id: number;
+              posterPath: string | null;
+              rotationExpiresAt: string | null;
+              rotationMarkedAt: string | null;
+              title: string;
+              tmdbId: number;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerCancelLeaving': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        movieId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              message: string;
+              success: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'rotation.listRotationLog': {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              items: {
+                details: string | null;
+                executedAt: string;
+                freeSpaceGb: number;
+                id: number;
+                moviesAdded: number;
+                moviesMarkedLeaving: number;
+                moviesRemoved: number;
+                removalsFailed: number;
+                skippedReason: string | null;
+                targetFreeGb: number;
+              }[];
+              total: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'rotation.rotationLogStats': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              avgPerDay: number;
+              streak: number;
+              totalRotated: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerRunNow': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              result: {
+                freeSpaceGb: number;
+                moviesAdded: number;
+                moviesMarkedLeaving: number;
+                moviesRemoved: number;
+                removalsFailed: number;
+                skippedReason: string | null;
+                targetFreeGb: number;
+              } | null;
+              success: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerStatus': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              cronExpression: string;
+              intervalMs: number;
+              isCycleRunning: boolean;
+              isRunning: boolean;
+              lastCycleAt: string | null;
+              lastCycleError: string | null;
+              nextRunAt: string | null;
+            };
+          };
+        };
+      };
+    };
+  };
+  'rotation.schedulerToggle': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cronExpression?: string;
+          enabled: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              cronExpression: string;
+              intervalMs: number;
+              isCycleRunning: boolean;
+              isRunning: boolean;
+              lastCycleAt: string | null;
+              lastCycleError: string | null;
+              nextRunAt: string | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/media/src/contract/rest-rotation-scheduler.ts
+++ b/pillars/media/src/contract/rest-rotation-scheduler.ts
@@ -1,0 +1,152 @@
+/**
+ * `rotation.*` scheduler routes (slice 11b) — control + observe the
+ * in-process rotation-cycle controller (`src/api/cron/rotation-scheduler.ts`)
+ * and read the rotation log. Spread into `mediaRotationContract` so operation
+ * ids stay `rotation.<route>`.
+ *
+ * Re-architecture vs the monolith: the monolith armed a `node-cron` task; the
+ * pillar drives a recursive `setTimeout` interval via a module-level singleton
+ * (cron-parser is not a workspace dep — see the controller header). The wire
+ * shapes mirror the legacy `scheduler.*` tRPC procedures (status / toggle /
+ * runNow / cancelLeaving / getLeavingMovies / getLastCycleLog / getDiskSpace /
+ * listRotationLog / getRotationLogStats).
+ */
+import { z } from 'zod';
+
+import { ERR_RESPONSES, IdParam } from './rest-schemas.js';
+
+const SchedulerStatusSchema = z.object({
+  isRunning: z.boolean(),
+  isCycleRunning: z.boolean(),
+  intervalMs: z.number(),
+  cronExpression: z.string(),
+  lastCycleAt: z.string().nullable(),
+  lastCycleError: z.string().nullable(),
+  nextRunAt: z.string().nullable(),
+});
+
+const RotationLogRowSchema = z.object({
+  id: z.number(),
+  executedAt: z.string(),
+  moviesMarkedLeaving: z.number(),
+  moviesRemoved: z.number(),
+  moviesAdded: z.number(),
+  removalsFailed: z.number(),
+  freeSpaceGb: z.number(),
+  targetFreeGb: z.number(),
+  skippedReason: z.string().nullable(),
+  details: z.string().nullable(),
+});
+
+const CycleResultSchema = z.object({
+  moviesMarkedLeaving: z.number(),
+  moviesRemoved: z.number(),
+  moviesAdded: z.number(),
+  removalsFailed: z.number(),
+  freeSpaceGb: z.number(),
+  targetFreeGb: z.number(),
+  skippedReason: z.string().nullable(),
+});
+
+const LeavingMovieSchema = z.object({
+  id: z.number(),
+  tmdbId: z.number(),
+  title: z.string(),
+  posterPath: z.string().nullable(),
+  rotationExpiresAt: z.string().nullable(),
+  rotationMarkedAt: z.string().nullable(),
+});
+
+const DiskSchema = z.object({
+  path: z.string(),
+  label: z.string(),
+  freeSpace: z.number(),
+  totalSpace: z.number(),
+});
+
+export const rotationSchedulerRoutes = {
+  schedulerStatus: {
+    method: 'GET',
+    path: '/rotation/scheduler/status',
+    responses: { 200: z.object({ data: SchedulerStatusSchema }) },
+    summary: 'Read the rotation scheduler run state + last-cycle stats',
+  },
+  schedulerToggle: {
+    method: 'POST',
+    path: '/rotation/scheduler/toggle',
+    body: z.object({ enabled: z.boolean(), cronExpression: z.string().min(1).optional() }),
+    responses: { 200: z.object({ data: SchedulerStatusSchema }), ...ERR_RESPONSES },
+    summary: 'Start or stop the rotation scheduler (persists the enabled flag)',
+  },
+  schedulerRunNow: {
+    method: 'POST',
+    path: '/rotation/scheduler/run-now',
+    body: z.object({}).optional(),
+    responses: {
+      200: z.object({
+        data: z.object({ success: z.boolean(), result: CycleResultSchema.nullable() }),
+      }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Trigger one rotation cycle immediately',
+  },
+  schedulerLeavingMovies: {
+    method: 'GET',
+    path: '/rotation/scheduler/leaving',
+    responses: { 200: z.object({ data: z.array(LeavingMovieSchema) }) },
+    summary: "Movies currently in the 'leaving' state, soonest expiry first",
+  },
+  schedulerCancelLeaving: {
+    method: 'POST',
+    path: '/rotation/scheduler/leaving/:movieId/cancel',
+    pathParams: z.object({ movieId: IdParam }),
+    body: z.object({}).optional(),
+    responses: {
+      200: z.object({ data: z.object({ success: z.boolean(), message: z.string() }) }),
+      ...ERR_RESPONSES,
+    },
+    summary: "Clear a movie's 'leaving' status",
+  },
+  schedulerLastCycleLog: {
+    method: 'GET',
+    path: '/rotation/scheduler/last-cycle',
+    responses: { 200: z.object({ data: RotationLogRowSchema.nullable() }) },
+    summary: 'Read the most recent rotation cycle log entry',
+  },
+  schedulerDiskSpace: {
+    method: 'GET',
+    path: '/rotation/scheduler/disk-space',
+    responses: {
+      200: z.object({ data: z.object({ available: z.boolean(), disks: z.array(DiskSchema) }) }),
+    },
+    summary: 'Radarr disk space (degrades to available:false when unreachable)',
+  },
+  listRotationLog: {
+    method: 'GET',
+    path: '/rotation/scheduler/log',
+    query: z.object({
+      limit: z.coerce.number().int().min(1).max(100).optional(),
+      offset: z.coerce.number().int().min(0).optional(),
+    }),
+    responses: {
+      200: z.object({
+        data: z.object({ items: z.array(RotationLogRowSchema), total: z.number() }),
+      }),
+    },
+    summary: 'Paginated rotation log entries, newest first',
+  },
+  rotationLogStats: {
+    method: 'GET',
+    path: '/rotation/scheduler/log-stats',
+    responses: {
+      200: z.object({
+        data: z.object({
+          totalRotated: z.number(),
+          avgPerDay: z.number(),
+          streak: z.number(),
+        }),
+      }),
+    },
+    summary: 'Summary statistics for the rotation log page',
+  },
+} as const;

--- a/pillars/media/src/contract/rest-rotation-schemas.ts
+++ b/pillars/media/src/contract/rest-rotation-schemas.ts
@@ -3,8 +3,8 @@
  *
  * Split from `rest-rotation.ts` so the route map stays focused. Zod-only — no
  * imports from `src/api/` or `src/db/`, honouring the package boundary. Wire
- * shapes mirror the legacy `media.rotation.*` tRPC procedures (data plane only;
- * the scheduler surface is slice 11b).
+ * shapes mirror the legacy `media.rotation.*` tRPC procedures (data plane); the
+ * scheduler surface lives in `rest-rotation-scheduler.ts`.
  */
 import { z } from 'zod';
 

--- a/pillars/media/src/contract/rest-rotation.ts
+++ b/pillars/media/src/contract/rest-rotation.ts
@@ -4,9 +4,9 @@
  * runtime-tunable settings.
  *
  * Ported from the monolith `media.rotation.*` tRPC routers (candidates,
- * exclusions, sources, config). The scheduler / rotation-cycle / leaving
- * lifecycle / disk-space / rotation-log reads are deferred to slice 11b and
- * are NOT declared here.
+ * exclusions, sources, config) + the scheduler procedures (slice 11b, spread
+ * from `rest-rotation-scheduler.ts`: status / toggle / runNow / cancelLeaving /
+ * leaving / lastCycle / diskSpace / log / log-stats).
  *
  * Config is repointed off `core/settings` onto the pillar-owned
  * `rotation_settings` kv table. Route order matters: literal sub-paths are
@@ -16,6 +16,7 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import { rotationSchedulerRoutes } from './rest-rotation-scheduler.js';
 import {
   AddExclusionBody,
   AddToQueueBody,
@@ -166,4 +167,6 @@ export const mediaRotationContract = c.router({
     responses: { 200: z.object({ data: SaveSettingsResultSchema }), ...ERR_RESPONSES },
     summary: 'Save rotation settings',
   },
+
+  ...rotationSchedulerRoutes,
 });

--- a/pillars/media/src/db/index.ts
+++ b/pillars/media/src/db/index.ts
@@ -84,6 +84,30 @@ export * as rotationSourcesService from './services/rotation/sources.js';
 
 export * as rotationSettingsService from './services/rotation/settings.js';
 
+export type {
+  ListRotationLogResult,
+  RotationCycleLog,
+  RotationFailedMovieRef,
+  RotationLogRow,
+  RotationLogStats,
+  RotationMovieRef,
+} from './services/rotation/rotation-log.js';
+
+export * as rotationLogService from './services/rotation/rotation-log.js';
+
+export type { SelectedCandidate } from './services/rotation/selection-policy.js';
+
+export * as rotationSelectionService from './services/rotation/selection-policy.js';
+
+export type {
+  EligibleMovie,
+  ExpiredMovie,
+  LeavingMovie,
+  MovieSizeMap,
+} from './services/rotation/removal-queries.js';
+
+export * as rotationRemovalQueries from './services/rotation/removal-queries.js';
+
 export type { DismissedDiscoverRow } from './services/dismissed-discover.js';
 
 export * as dismissedDiscoverService from './services/dismissed-discover.js';

--- a/pillars/media/src/db/services/rotation/removal-queries.ts
+++ b/pillars/media/src/db/services/rotation/removal-queries.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure-db queries for the rotation removal phase + leaving lifecycle.
+ *
+ * HTTP-free; `(db, …)`-arg. Ported from the monolith `removal-selection.ts`
+ * (the SQLite parts) + `leaving-lifecycle.ts`. The Radarr-touching pieces
+ * (disk space, per-movie sizes, the download queue, the actual delete) live in
+ * the api layer (`rotation-removal.ts`); this module only reads/writes the
+ * `movies` + `watchlist` tables. The pillar's watchlist is local, so
+ * watchlist exclusion joins the pillar `watchlist` table rather than the
+ * monolith's shared `media_watchlist`.
+ */
+import { and, asc, eq, inArray, ne, sql } from 'drizzle-orm';
+
+import { mediaWatchlist, movies } from '../../schema.js';
+
+import type { MediaDb } from '../internal.js';
+
+/** Map of TMDB id → size in GB, as measured from Radarr. */
+export type MovieSizeMap = Map<number, number>;
+
+export interface EligibleMovie {
+  id: number;
+  tmdbId: number;
+  title: string;
+  createdAt: string;
+}
+
+export interface LeavingMovie {
+  id: number;
+  tmdbId: number;
+  title: string;
+  posterPath: string | null;
+  rotationExpiresAt: string | null;
+  rotationMarkedAt: string | null;
+}
+
+export interface ExpiredMovie {
+  id: number;
+  tmdbId: number;
+  title: string;
+}
+
+/**
+ * Movies eligible for removal, oldest first. Excludes watchlist items,
+ * unexpired protected movies, currently-downloading movies, and movies with no
+ * Radarr file (size 0 / absent). Already-`leaving` movies are filtered in SQL.
+ */
+export function getEligibleForRemoval(
+  db: MediaDb,
+  movieSizes: MovieSizeMap,
+  downloadingTmdbIds: ReadonlySet<number>
+): EligibleMovie[] {
+  const now = new Date().toISOString();
+
+  const watchlistRows = db
+    .select({ mediaId: mediaWatchlist.mediaId })
+    .from(mediaWatchlist)
+    .where(eq(mediaWatchlist.mediaType, 'movie'))
+    .all();
+  const watchlistMovieIds = new Set(watchlistRows.map((r) => r.mediaId));
+
+  const candidates = db
+    .select({
+      id: movies.id,
+      tmdbId: movies.tmdbId,
+      title: movies.title,
+      createdAt: movies.createdAt,
+      rotationStatus: movies.rotationStatus,
+      rotationExpiresAt: movies.rotationExpiresAt,
+    })
+    .from(movies)
+    .where(ne(sql`coalesce(${movies.rotationStatus}, '')`, sql`'leaving'`))
+    .orderBy(asc(movies.createdAt))
+    .all();
+
+  return candidates.filter((m) => {
+    if (watchlistMovieIds.has(m.id)) return false;
+    if (m.rotationStatus === 'protected' && m.rotationExpiresAt && m.rotationExpiresAt > now) {
+      return false;
+    }
+    if (downloadingTmdbIds.has(m.tmdbId)) return false;
+    const sizeGb = movieSizes.get(m.tmdbId);
+    if (sizeGb === undefined || sizeGb <= 0) return false;
+    return true;
+  });
+}
+
+/** Total size in GB of movies currently in the `leaving` state. */
+export function getLeavingMovieSizeGb(db: MediaDb, movieSizes: MovieSizeMap): number {
+  const leaving = db
+    .select({ tmdbId: movies.tmdbId })
+    .from(movies)
+    .where(eq(movies.rotationStatus, 'leaving'))
+    .all();
+  let total = 0;
+  for (const m of leaving) total += movieSizes.get(m.tmdbId) ?? 0;
+  return total;
+}
+
+/** Mark the given movie ids as `leaving` with the supplied expiry timestamp. */
+export function markMoviesAsLeaving(db: MediaDb, movieIds: number[], expiresAt: string): void {
+  if (movieIds.length === 0) return;
+  db.update(movies)
+    .set({
+      rotationStatus: 'leaving',
+      rotationExpiresAt: expiresAt,
+      rotationMarkedAt: new Date().toISOString(),
+    })
+    .where(inArray(movies.id, movieIds))
+    .run();
+}
+
+/** `leaving` movies whose `rotation_expires_at` is in the past. */
+export function getExpiredLeavingMovies(db: MediaDb): ExpiredMovie[] {
+  const now = new Date().toISOString();
+  return db
+    .select({ id: movies.id, tmdbId: movies.tmdbId, title: movies.title })
+    .from(movies)
+    .where(and(eq(movies.rotationStatus, 'leaving'), sql`${movies.rotationExpiresAt} <= ${now}`))
+    .all();
+}
+
+/** `leaving` movies sorted by expiry (soonest first) for the UI. */
+export function getLeavingMovies(db: MediaDb): LeavingMovie[] {
+  return db
+    .select({
+      id: movies.id,
+      tmdbId: movies.tmdbId,
+      title: movies.title,
+      posterPath: movies.posterPath,
+      rotationExpiresAt: movies.rotationExpiresAt,
+      rotationMarkedAt: movies.rotationMarkedAt,
+    })
+    .from(movies)
+    .where(eq(movies.rotationStatus, 'leaving'))
+    .orderBy(asc(movies.rotationExpiresAt))
+    .all();
+}
+
+/** Clear all rotation fields on a movie by id (post-removal / cancel). */
+export function clearRotationStatus(db: MediaDb, id: number): void {
+  db.update(movies)
+    .set({ rotationStatus: null, rotationExpiresAt: null, rotationMarkedAt: null })
+    .where(eq(movies.id, id))
+    .run();
+}
+
+/**
+ * Clear `leaving` status for a movie. Returns `true` when the movie existed and
+ * was actually in the `leaving` state, `false` otherwise.
+ */
+export function cancelLeaving(db: MediaDb, movieId: number): boolean {
+  const movie = db
+    .select({ id: movies.id, rotationStatus: movies.rotationStatus })
+    .from(movies)
+    .where(eq(movies.id, movieId))
+    .get();
+  if (!movie || movie.rotationStatus !== 'leaving') return false;
+  clearRotationStatus(db, movieId);
+  return true;
+}

--- a/pillars/media/src/db/services/rotation/rotation-log.ts
+++ b/pillars/media/src/db/services/rotation/rotation-log.ts
@@ -1,0 +1,159 @@
+/**
+ * Rotation-cycle log persistence against the media pillar's SQLite.
+ *
+ * HTTP-free; `(db, …)`-arg. Ported from the monolith `rotation-log.ts`
+ * (the cycle-log writer) and the `rotation-scheduler-router.ts` read
+ * procedures (`listRotationLog` / `getRotationLogStats` / `getLastCycleLog`).
+ * The api-layer rotation cycle owns the {@link RotationCycleLog} shape; this
+ * service just serialises the per-movie detail lists to the `details` JSON
+ * column and reads them back.
+ */
+import { count, desc, isNull, sql, sum } from 'drizzle-orm';
+
+import { rotationLog } from '../../schema.js';
+
+import type { MediaDb } from '../internal.js';
+
+export type RotationLogRow = typeof rotationLog.$inferSelect;
+
+/** Per-movie reference stored in the rotation log `details` column. */
+export interface RotationMovieRef {
+  tmdbId: number;
+  title: string;
+}
+
+/** Per-movie reference for failed removals, which may carry an error message. */
+export interface RotationFailedMovieRef extends RotationMovieRef {
+  error?: string;
+}
+
+/** The cycle outcome the api layer hands to {@link writeCycleLog}. */
+export interface RotationCycleLog {
+  moviesMarkedLeaving: number;
+  moviesRemoved: number;
+  moviesAdded: number;
+  removalsFailed: number;
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  skippedReason: string | null;
+  marked: RotationMovieRef[];
+  removed: RotationMovieRef[];
+  added: RotationMovieRef[];
+  failed: RotationFailedMovieRef[];
+}
+
+export interface ListRotationLogResult {
+  items: RotationLogRow[];
+  total: number;
+}
+
+export interface RotationLogStats {
+  totalRotated: number;
+  avgPerDay: number;
+  streak: number;
+}
+
+function encodeDetails(result: RotationCycleLog): string | null {
+  const hasDetails =
+    result.marked.length > 0 ||
+    result.removed.length > 0 ||
+    result.added.length > 0 ||
+    result.failed.length > 0;
+  if (!hasDetails) return null;
+  return JSON.stringify({
+    marked: result.marked,
+    removed: result.removed,
+    added: result.added,
+    failed: result.failed,
+  });
+}
+
+/** Persist one rotation-cycle outcome as a `rotation_log` row. */
+export function writeCycleLog(db: MediaDb, result: RotationCycleLog): void {
+  db.insert(rotationLog)
+    .values({
+      executedAt: new Date().toISOString(),
+      moviesMarkedLeaving: result.moviesMarkedLeaving,
+      moviesRemoved: result.moviesRemoved,
+      moviesAdded: result.moviesAdded,
+      removalsFailed: result.removalsFailed,
+      freeSpaceGb: result.freeSpaceGb,
+      targetFreeGb: result.targetFreeGb,
+      skippedReason: result.skippedReason,
+      details: encodeDetails(result),
+    })
+    .run();
+}
+
+/** The most recent cycle-log row, or `null` when no cycle has run. */
+export function lastCycleLog(db: MediaDb): RotationLogRow | null {
+  return db.select().from(rotationLog).orderBy(desc(rotationLog.id)).limit(1).get() ?? null;
+}
+
+/** Paginated cycle-log rows, newest first. */
+export function listRotationLog(db: MediaDb, limit: number, offset: number): ListRotationLogResult {
+  const items = db
+    .select()
+    .from(rotationLog)
+    .orderBy(desc(rotationLog.executedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const countRow = db.select({ total: count() }).from(rotationLog).get();
+  return { items, total: countRow?.total ?? 0 };
+}
+
+function computeAvgPerDay(
+  totalRotated: number,
+  minDate: string | null,
+  maxDate: string | null
+): number {
+  if (!minDate || !maxDate) return 0;
+  const days = Math.max(
+    1,
+    (new Date(maxDate).getTime() - new Date(minDate).getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return Math.round((totalRotated / days) * 10) / 10;
+}
+
+function computeStreak(db: MediaDb): number {
+  const rows = db
+    .select({ skippedReason: rotationLog.skippedReason })
+    .from(rotationLog)
+    .orderBy(desc(rotationLog.executedAt))
+    .all();
+  let streak = 0;
+  for (const row of rows) {
+    if (row.skippedReason) break;
+    streak++;
+  }
+  return streak;
+}
+
+/** Summary statistics for the rotation log page. PRD-072 US-06. */
+export function getRotationLogStats(db: MediaDb): RotationLogStats {
+  const totals = db
+    .select({
+      totalRemoved: sum(rotationLog.moviesRemoved),
+      totalAdded: sum(rotationLog.moviesAdded),
+    })
+    .from(rotationLog)
+    .where(isNull(rotationLog.skippedReason))
+    .get();
+  const totalRotated = (Number(totals?.totalRemoved) || 0) + (Number(totals?.totalAdded) || 0);
+
+  const range = db
+    .select({
+      minDate: sql<string | null>`MIN(${rotationLog.executedAt})`,
+      maxDate: sql<string | null>`MAX(${rotationLog.executedAt})`,
+    })
+    .from(rotationLog)
+    .where(isNull(rotationLog.skippedReason))
+    .get();
+
+  return {
+    totalRotated,
+    avgPerDay: computeAvgPerDay(totalRotated, range?.minDate ?? null, range?.maxDate ?? null),
+    streak: computeStreak(db),
+  };
+}

--- a/pillars/media/src/db/services/rotation/selection-policy.ts
+++ b/pillars/media/src/db/services/rotation/selection-policy.ts
@@ -1,0 +1,173 @@
+/**
+ * Weighted candidate selection for the rotation addition phase.
+ *
+ * HTTP-free; `(db, …)`-arg. Ported verbatim from the monolith
+ * `rotation/selection-policy.ts`: `aggregateCandidates(count)` picks pending
+ * candidates with `source_priority × (rating / 10)` weighting, dedupes by
+ * tmdbId (max priority wins), and drops anything already in the library or on
+ * the exclusion list. The addition orchestration (slice 11b) consumes this.
+ */
+import { eq } from 'drizzle-orm';
+
+import { movies, rotationCandidates, rotationExclusions, rotationSources } from '../../schema.js';
+
+import type { MediaDb } from '../internal.js';
+
+export interface SelectedCandidate {
+  candidateId: number;
+  tmdbId: number;
+  title: string;
+  year: number | null;
+  rating: number | null;
+  posterPath: string | null;
+  sourcePriority: number;
+  weight: number;
+}
+
+interface PendingRow {
+  candidateId: number;
+  tmdbId: number;
+  title: string;
+  year: number | null;
+  rating: number | null;
+  posterPath: string | null;
+  sourceId: number;
+}
+
+interface DedupedCandidate {
+  candidateId: number;
+  tmdbId: number;
+  title: string;
+  year: number | null;
+  rating: number | null;
+  posterPath: string | null;
+  sourcePriority: number;
+}
+
+const DEFAULT_SOURCE_PRIORITY = 5;
+const NULL_RATING_WEIGHT_FACTOR = 0.5;
+
+function fetchPendingCandidates(db: MediaDb): PendingRow[] {
+  return db
+    .select({
+      candidateId: rotationCandidates.id,
+      tmdbId: rotationCandidates.tmdbId,
+      title: rotationCandidates.title,
+      year: rotationCandidates.year,
+      rating: rotationCandidates.rating,
+      posterPath: rotationCandidates.posterPath,
+      sourceId: rotationCandidates.sourceId,
+    })
+    .from(rotationCandidates)
+    .where(eq(rotationCandidates.status, 'pending'))
+    .all();
+}
+
+function buildSourcePriorityMap(db: MediaDb): Map<number, number> {
+  const sources = db
+    .select({ id: rotationSources.id, priority: rotationSources.priority })
+    .from(rotationSources)
+    .all();
+  return new Map(sources.map((s) => [s.id, s.priority]));
+}
+
+function buildExcludedSets(db: MediaDb): {
+  excludedTmdbIds: Set<number>;
+  libraryTmdbIds: Set<number>;
+} {
+  const exclusions = db
+    .select({ tmdbId: rotationExclusions.tmdbId })
+    .from(rotationExclusions)
+    .all();
+  const libraryMovies = db.select({ tmdbId: movies.tmdbId }).from(movies).all();
+  return {
+    excludedTmdbIds: new Set(exclusions.map((e) => e.tmdbId)),
+    libraryTmdbIds: new Set(libraryMovies.map((m) => m.tmdbId)),
+  };
+}
+
+function dedupePendingCandidates(
+  pending: PendingRow[],
+  sourcePriorityMap: Map<number, number>,
+  excludedTmdbIds: Set<number>,
+  libraryTmdbIds: Set<number>
+): Map<number, DedupedCandidate> {
+  const deduped = new Map<number, DedupedCandidate>();
+  for (const c of pending) {
+    if (excludedTmdbIds.has(c.tmdbId)) continue;
+    if (libraryTmdbIds.has(c.tmdbId)) continue;
+    const priority = sourcePriorityMap.get(c.sourceId) ?? DEFAULT_SOURCE_PRIORITY;
+    const existing = deduped.get(c.tmdbId);
+    if (!existing || priority > existing.sourcePriority) {
+      deduped.set(c.tmdbId, {
+        candidateId: c.candidateId,
+        tmdbId: c.tmdbId,
+        title: c.title,
+        year: c.year,
+        rating: c.rating,
+        posterPath: c.posterPath,
+        sourcePriority: priority,
+      });
+    }
+  }
+  return deduped;
+}
+
+/**
+ * Weighted random sampling without replacement: pick proportional to weight,
+ * remove the selected element, repeat until `count` is reached or the pool is
+ * exhausted (or its total weight collapses to zero).
+ */
+export function weightedSample<T extends { weight: number }>(items: T[], count: number): T[] {
+  const pool = [...items];
+  const selected: T[] = [];
+
+  for (let i = 0; i < count && pool.length > 0; i++) {
+    const totalWeight = pool.reduce((sumWeight, item) => sumWeight + item.weight, 0);
+    if (totalWeight <= 0) break;
+
+    let r = Math.random() * totalWeight;
+    let idx = 0;
+    for (; idx < pool.length - 1; idx++) {
+      const item = pool[idx];
+      if (item) r -= item.weight;
+      if (r <= 0) break;
+    }
+
+    const chosen = pool[idx];
+    if (chosen) selected.push(chosen);
+    pool.splice(idx, 1);
+  }
+
+  return selected;
+}
+
+/**
+ * Select up to `count` pending candidates by weighted random sampling. Weight
+ * is `source_priority × (rating / 10)`; a null rating uses
+ * `source_priority × 0.5`. Returns `[]` for a non-positive count or an empty
+ * eligible pool.
+ */
+export function aggregateCandidates(db: MediaDb, count: number): SelectedCandidate[] {
+  if (count <= 0) return [];
+
+  const pending = fetchPendingCandidates(db);
+  if (pending.length === 0) return [];
+
+  const sourcePriorityMap = buildSourcePriorityMap(db);
+  const { excludedTmdbIds, libraryTmdbIds } = buildExcludedSets(db);
+  const deduped = dedupePendingCandidates(
+    pending,
+    sourcePriorityMap,
+    excludedTmdbIds,
+    libraryTmdbIds
+  );
+
+  const weighted = Array.from(deduped.values()).map((c) => ({
+    ...c,
+    weight: c.sourcePriority * (c.rating != null ? c.rating / 10 : NULL_RATING_WEIGHT_FACTOR),
+  }));
+  if (weighted.length === 0) return [];
+
+  return weightedSample(weighted, Math.min(count, weighted.length));
+}

--- a/pillars/media/vitest.config.ts
+++ b/pillars/media/vitest.config.ts
@@ -4,6 +4,15 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    // Reliability: the many client suites stub `globalThis.fetch` via
+    // `vi.stubGlobal`. Auto-restore stubbed globals/mocks after every test,
+    // and run test files sequentially, so a fetch stub from one suite can
+    // never bleed into a DB-only suite running concurrently (the source of
+    // an intermittent cross-file 401 / enrichment flake).
+    restoreMocks: true,
+    unstubGlobals: true,
+    unstubEnvs: true,
+    fileParallelism: false,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],


### PR DESCRIPTION
Wave 3, part c (rotation, 2 of 2). The rotation **scheduler**, re-architected from a cron worker to an in-process interval controller (mirrors `plex-scheduler`).

- `src/api/cron/rotation-scheduler.ts` — singleton `start/stop/runOnce/resumeIfEnabled/status`, recursive `setTimeout`, single-flight cycle guard; resumes on boot (`MEDIA_ROTATION_SCHEDULER_ENABLED` / persisted `rotation_enabled`, `MEDIA_ROTATION_INTERVAL_MS`) and stops on SIGTERM.
- the **rotation cycle** (`src/api/modules/rotation-{cycle,removal,addition,sync-all}`): age-based 'leaving' selection + Radarr-disk-gated additions + expiry sweep; writes a `rotationLog` row per cycle (`rotationLogService`).
- 9 `/rotation/scheduler/*` routes (status / toggle / run-now / leaving / cancel / last-cycle / disk-space / log / log-stats).
- cron expression kept as stored config; the timer is **interval-based** (`cron-parser` isn't a pillar dep) — per the runbook's in-process decision.

**Test-infra hardening** (`pillars/media/vitest.config.ts`): `restoreMocks`/`unstubGlobals`/`unstubEnvs` + `fileParallelism:false` to eliminate an intermittent **cross-file `vi.stubGlobal('fetch')` bleed** (was failing ~1/10 full-suite runs in `tv-shows`/`watch-history`). **8/8 clean full-suite runs** after the fix.

13 scheduler tests (**382 total**). Verified: typecheck ✓ · build ✓ · 382/382 ✓ (×8) · format ✓ · lint exit 0 (`.oxlintrc` untouched) ✓ · drift idempotent ✓. Stacks on #3391.