### PR TITLE
feat(cerebrum): REST migration slice — emit + query (+SSE)

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -9,6 +9,1072 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/emit/generate": {
+      "post": {
+        "operationId": "emit.generate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audienceScope": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "dateRange": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "from": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "to": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["from", "to"],
+                    "type": "object"
+                  },
+                  "format": {
+                    "enum": ["markdown", "plain"],
+                    "type": "string"
+                  },
+                  "groupBy": {
+                    "enum": ["type", "month", "quarter"],
+                    "type": "string"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "mode": {
+                    "enum": ["report", "summary", "timeline"],
+                    "type": "string"
+                  },
+                  "query": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "types": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["mode"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "document": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "audienceScope": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "dateRange": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "from": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "to": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": ["from", "to"],
+                          "type": "object"
+                        },
+                        "metadata": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dateRange": {
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "properties": {
+                                "from": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "to": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "type": "object"
+                            },
+                            "mode": {
+                              "enum": ["report", "summary", "timeline"],
+                              "type": "string"
+                            },
+                            "scopeCoverage": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "sourceCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "truncated": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "sourceCount",
+                            "dateRange",
+                            "scopeCoverage",
+                            "mode",
+                            "truncated"
+                          ],
+                          "type": "object"
+                        },
+                        "mode": {
+                          "enum": ["report", "summary", "timeline"],
+                          "type": "string"
+                        },
+                        "sources": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "excerpt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "relevance": {
+                                "type": "number"
+                              },
+                              "scope": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "body",
+                        "mode",
+                        "sources",
+                        "audienceScope",
+                        "dateRange",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    },
+                    "notice": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["document"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Run the full document-generation pipeline for any mode.",
+        "tags": ["emit"]
+      }
+    },
+    "/emit/preview": {
+      "post": {
+        "operationId": "emit.preview",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audienceScope": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "dateRange": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "from": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "to": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["from", "to"],
+                    "type": "object"
+                  },
+                  "format": {
+                    "enum": ["markdown", "plain"],
+                    "type": "string"
+                  },
+                  "groupBy": {
+                    "enum": ["type", "month", "quarter"],
+                    "type": "string"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "mode": {
+                    "enum": ["report", "summary", "timeline"],
+                    "type": "string"
+                  },
+                  "query": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "types": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["mode"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "outline": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "excerpt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "relevance": {
+                            "type": "number"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["sources", "outline"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Dry-run the pipeline: return sources + an outline without synthesis.",
+        "tags": ["emit"]
+      }
+    },
+    "/emit/report": {
+      "post": {
+        "operationId": "emit.generateReport",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audienceScope": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "query": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "types": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["query"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "document": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "audienceScope": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "dateRange": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "from": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "to": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": ["from", "to"],
+                          "type": "object"
+                        },
+                        "metadata": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dateRange": {
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "properties": {
+                                "from": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "to": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "type": "object"
+                            },
+                            "mode": {
+                              "enum": ["report", "summary", "timeline"],
+                              "type": "string"
+                            },
+                            "scopeCoverage": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "sourceCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "truncated": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "sourceCount",
+                            "dateRange",
+                            "scopeCoverage",
+                            "mode",
+                            "truncated"
+                          ],
+                          "type": "object"
+                        },
+                        "mode": {
+                          "enum": ["report", "summary", "timeline"],
+                          "type": "string"
+                        },
+                        "sources": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "excerpt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "relevance": {
+                                "type": "number"
+                              },
+                              "scope": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "body",
+                        "mode",
+                        "sources",
+                        "audienceScope",
+                        "dateRange",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["document"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Generate a structured report from a query.",
+        "tags": ["emit"]
+      }
+    },
+    "/emit/summary": {
+      "post": {
+        "operationId": "emit.generateSummary",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audienceScope": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "dateRange": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "from": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "to": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["from", "to"],
+                    "type": "object"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "query": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "types": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["dateRange"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "document": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "audienceScope": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "dateRange": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "from": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "to": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": ["from", "to"],
+                          "type": "object"
+                        },
+                        "metadata": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dateRange": {
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "properties": {
+                                "from": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "to": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "type": "object"
+                            },
+                            "mode": {
+                              "enum": ["report", "summary", "timeline"],
+                              "type": "string"
+                            },
+                            "scopeCoverage": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "sourceCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "truncated": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "sourceCount",
+                            "dateRange",
+                            "scopeCoverage",
+                            "mode",
+                            "truncated"
+                          ],
+                          "type": "object"
+                        },
+                        "mode": {
+                          "enum": ["report", "summary", "timeline"],
+                          "type": "string"
+                        },
+                        "sources": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "excerpt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "relevance": {
+                                "type": "number"
+                              },
+                              "scope": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "body",
+                        "mode",
+                        "sources",
+                        "audienceScope",
+                        "dateRange",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["document"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Generate a summary digest over a date range.",
+        "tags": ["emit"]
+      }
+    },
+    "/emit/timeline": {
+      "post": {
+        "operationId": "emit.generateTimeline",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audienceScope": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "dateRange": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "from": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "to": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["from", "to"],
+                    "type": "object"
+                  },
+                  "groupBy": {
+                    "enum": ["type", "month", "quarter"],
+                    "type": "string"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "query": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "types": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "document": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "audienceScope": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "dateRange": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "from": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "to": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": ["from", "to"],
+                          "type": "object"
+                        },
+                        "metadata": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dateRange": {
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "properties": {
+                                "from": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "to": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "type": "object"
+                            },
+                            "mode": {
+                              "enum": ["report", "summary", "timeline"],
+                              "type": "string"
+                            },
+                            "scopeCoverage": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "sourceCount": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "truncated": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "sourceCount",
+                            "dateRange",
+                            "scopeCoverage",
+                            "mode",
+                            "truncated"
+                          ],
+                          "type": "object"
+                        },
+                        "mode": {
+                          "enum": ["report", "summary", "timeline"],
+                          "type": "string"
+                        },
+                        "sources": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "excerpt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "relevance": {
+                                "type": "number"
+                              },
+                              "scope": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "body",
+                        "mode",
+                        "sources",
+                        "audienceScope",
+                        "dateRange",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["document"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Generate a chronological timeline from dated engrams.",
+        "tags": ["emit"]
+      }
+    },
     "/engrams": {
       "post": {
         "operationId": "engrams.create",
@@ -4977,6 +6043,400 @@
         },
         "summary": "Shut down and remove an adapter.",
         "tags": ["plexus", "adapters"]
+      }
+    },
+    "/query/ask": {
+      "post": {
+        "operationId": "query.ask",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "domains": {
+                    "items": {
+                      "enum": ["engrams", "transactions", "media", "inventory"],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "maxSources": {
+                    "exclusiveMinimum": true,
+                    "maximum": 50,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "question": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["question"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "answer": {
+                      "type": "string"
+                    },
+                    "confidence": {
+                      "enum": ["high", "medium", "low"],
+                      "type": "string"
+                    },
+                    "scopes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "sources": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "excerpt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "relevance": {
+                            "type": "number"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["answer", "sources", "scopes", "confidence"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Full NL Q&A: scope inference → retrieval → LLM → citation parsing.",
+        "tags": ["query"]
+      }
+    },
+    "/query/explain": {
+      "post": {
+        "operationId": "query.explain",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "question": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["question"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "retrievalPlan": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "filters": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "customFields": {
+                              "additionalProperties": {},
+                              "type": "object"
+                            },
+                            "dateRange": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "from": {
+                                  "type": "string"
+                                },
+                                "to": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "includeSecret": {
+                              "type": "boolean"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "sourceTypes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "status": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tags": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "types": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "maxSources": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "threshold": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["filters", "maxSources", "threshold"],
+                      "type": "object"
+                    },
+                    "scopeInference": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "scopes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "source": {
+                          "enum": ["explicit", "inferred", "default"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["scopes", "source"],
+                      "type": "object"
+                    },
+                    "secretNotice": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["scopeInference", "retrievalPlan", "secretNotice"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Debug: show scope inference + retrieval plan without executing.",
+        "tags": ["query"]
+      }
+    },
+    "/query/retrieve": {
+      "post": {
+        "operationId": "query.retrieve",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "includeSecret": {
+                    "type": "boolean"
+                  },
+                  "maxSources": {
+                    "exclusiveMinimum": true,
+                    "maximum": 50,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "question": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["question"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "sources": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "excerpt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "relevance": {
+                            "type": "number"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "type", "title", "excerpt", "relevance", "scope"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["sources"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Retrieval-only — returns sources without calling the LLM.",
+        "tags": ["query"]
       }
     },
     "/reflex": {

--- a/pillars/cerebrum/src/api/__tests__/emit.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/emit.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for `cerebrum.emit.*` over REST.
+ *
+ * Boots the app against a per-test temp cerebrum.db seeded with engram-index +
+ * embeddings rows (so the structured/BM25 retrieval leg returns sources without
+ * any embedding provider), an injected offline {@link makeFakeGenerationLlm}
+ * (no real Anthropic call), and empty peer clients. The fake LLM echoes a
+ * citation so the citation-parser path is exercised end-to-end.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeFakeGenerationLlm,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { GenerationLlm } from '../modules/emit/llm.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-emit-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-emit-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+interface SeedEngramArgs {
+  id: string;
+  title: string;
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+  preview?: string;
+  createdAt?: string;
+}
+
+function seedEngram(db: OpenedCerebrumDb, args: SeedEngramArgs): void {
+  const raw = db.raw;
+  const createdAt = args.createdAt ?? '2026-01-01T00:00:00.000Z';
+  raw
+    .prepare(
+      `INSERT INTO engram_index
+        (id, file_path, type, source, status, template, created_at, modified_at, title, content_hash, word_count, custom_fields)
+       VALUES (?, ?, ?, 'manual', 'active', NULL, ?, ?, ?, ?, ?, NULL)`
+    )
+    .run(
+      args.id,
+      `${args.id}.md`,
+      args.type ?? 'note',
+      createdAt,
+      createdAt,
+      args.title,
+      `hash-${args.id}`,
+      10
+    );
+  for (const scope of args.scopes ?? []) {
+    raw.prepare('INSERT INTO engram_scopes (engram_id, scope) VALUES (?, ?)').run(args.id, scope);
+  }
+  for (const tag of args.tags ?? []) {
+    raw.prepare('INSERT INTO engram_tags (engram_id, tag) VALUES (?, ?)').run(args.id, tag);
+  }
+  raw
+    .prepare(
+      `INSERT INTO embeddings
+        (source_type, source_id, chunk_index, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('engram', ?, 0, ?, ?, 'm', 1536, ?)`
+    )
+    .run(args.id, `hash-${args.id}`, args.preview ?? `preview ${args.title}`, createdAt);
+}
+
+function client(llm: GenerationLlm = makeFakeGenerationLlm()) {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
+      emitLlm: llm,
+    })
+  );
+}
+
+describe('POST /emit/report', () => {
+  it('synthesises a report and parses valid citations from the LLM output', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0001_db',
+      title: 'DB choice',
+      scopes: ['work.arch'],
+    });
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260102_0002_cache',
+      title: 'Cache layer',
+      scopes: ['work.arch'],
+    });
+
+    const llm = makeFakeGenerationLlm(
+      () =>
+        '# Architecture\n\nWe chose SQLite [eng_20260101_0001_db] and added a cache [eng_20260102_0002_cache].'
+    );
+    const { document } = await client(llm).emit.generateReport({ query: 'architecture' });
+
+    expect(document).not.toBeNull();
+    expect(document?.mode).toBe('report');
+    expect(document?.title).toBe('Architecture');
+    expect(document?.sources.map((s) => s.id).toSorted()).toEqual([
+      'eng_20260101_0001_db',
+      'eng_20260102_0002_cache',
+    ]);
+    expect(document?.metadata.sourceCount).toBe(2);
+  });
+
+  it('returns an insufficient-data notice with fewer than two sources', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0001_db',
+      title: 'DB choice',
+      scopes: ['work.arch'],
+    });
+    const result = await client().emit.generateReport({
+      query: 'architecture',
+      scopes: ['work.arch'],
+    });
+    expect(result.document).toBeNull();
+    expect(result.notice).toMatch(/insufficient/i);
+  });
+});
+
+describe('POST /emit/summary', () => {
+  it('requires from <= to (400 on inverted range)', async () => {
+    await expect(
+      client().emit.generateSummary({ dateRange: { from: '2026-02-01', to: '2026-01-01' } })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('returns an empty-summary document when no engrams match', async () => {
+    const { document } = await client().emit.generateSummary({
+      dateRange: { from: '2026-01-01', to: '2026-01-31' },
+    });
+    expect(document).not.toBeNull();
+    expect(document?.mode).toBe('summary');
+    expect(document?.metadata.sourceCount).toBe(0);
+  });
+});
+
+describe('POST /emit/timeline', () => {
+  it('orders entries chronologically and tags the source set', async () => {
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260101_0001_a',
+      title: 'First',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    seedEngram(cerebrumDb, {
+      id: 'eng_20260301_0002_b',
+      title: 'Second',
+      createdAt: '2026-03-01T00:00:00.000Z',
+    });
+
+    const { document } = await client(
+      makeFakeGenerationLlm(() => '# Timeline\n\nentries')
+    ).emit.generateTimeline({ query: 'history' });
+
+    expect(document?.mode).toBe('timeline');
+    expect(document?.metadata.sourceCount).toBe(2);
+  });
+});
+
+describe('POST /emit/generate', () => {
+  it('rejects report mode without a query (400)', async () => {
+    await expect(client().emit.generate({ mode: 'report' })).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects summary mode without a date range (400)', async () => {
+    await expect(client().emit.generate({ mode: 'summary' })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe('POST /emit/preview', () => {
+  it('returns sources + an outline without full synthesis', async () => {
+    seedEngram(cerebrumDb, { id: 'eng_20260101_0001_x', title: 'X', scopes: ['work'] });
+    seedEngram(cerebrumDb, { id: 'eng_20260102_0002_y', title: 'Y', scopes: ['work'] });
+
+    const result = await client(
+      makeFakeGenerationLlm(() => '# Outline\n\n- Section [eng_20260101_0001_x]')
+    ).emit.preview({ mode: 'report', query: 'topic' });
+
+    expect(result.sources.length).toBe(2);
+    expect(result.outline).toContain('Outline');
+  });
+
+  it('returns a no-sources outline when retrieval is empty', async () => {
+    const result = await client().emit.preview({ mode: 'report', query: 'nothing here' });
+    expect(result.sources).toEqual([]);
+    expect(result.outline).toMatch(/no sources/i);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/query.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/query.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for `cerebrum.query.*` + the `POST /query/stream` SSE route.
+ *
+ * Boots the app against a per-test temp cerebrum.db seeded with engram-index +
+ * embeddings rows (the structured/BM25 leg returns sources without an embedding
+ * provider). The one-shot LLM is an injected {@link makeFakeQueryLlm}; the SSE
+ * route is driven with an injected {@link makeFakeQueryStreamLlm} yielding
+ * canned tokens — no real Anthropic call is ever made.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeFakeQueryLlm,
+  makeFakeQueryStreamLlm,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { Express } from 'express';
+
+import type { QueryLlm, QueryStreamLlm } from '../modules/query/llm.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-query-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-query-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+function seedEngram(db: OpenedCerebrumDb, id: string, title: string, scopes: string[]): void {
+  const raw = db.raw;
+  const at = '2026-01-01T00:00:00.000Z';
+  raw
+    .prepare(
+      `INSERT INTO engram_index
+        (id, file_path, type, source, status, template, created_at, modified_at, title, content_hash, word_count, custom_fields)
+       VALUES (?, ?, 'note', 'manual', 'active', NULL, ?, ?, ?, ?, 10, NULL)`
+    )
+    .run(id, `${id}.md`, at, at, title, `hash-${id}`);
+  for (const scope of scopes) {
+    raw.prepare('INSERT INTO engram_scopes (engram_id, scope) VALUES (?, ?)').run(id, scope);
+  }
+  raw
+    .prepare(
+      `INSERT INTO embeddings
+        (source_type, source_id, chunk_index, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('engram', ?, 0, ?, ?, 'm', 1536, ?)`
+    )
+    .run(id, `hash-${id}`, `preview ${title}`, at);
+}
+
+interface AppDeps {
+  llm?: QueryLlm;
+  streamLlm?: QueryStreamLlm;
+}
+
+function buildApp(deps: AppDeps = {}): Express {
+  return createCerebrumApiApp({
+    cerebrumDb,
+    templateRegistry: makeTemplateRegistry(),
+    engramRoot,
+    reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3007',
+    peerClients: makeEmptyPeerClients(),
+    queryLlm: deps.llm ?? makeFakeQueryLlm(),
+    queryStreamLlm: deps.streamLlm ?? makeFakeQueryStreamLlm(),
+  });
+}
+
+function client(deps: AppDeps = {}) {
+  return makeClient(buildApp(deps));
+}
+
+describe('POST /query/ask', () => {
+  it('answers from retrieved sources and parses valid citations', async () => {
+    seedEngram(cerebrumDb, 'eng_20260101_0001_db', 'DB choice', ['work']);
+    const llm = makeFakeQueryLlm(() => 'We picked SQLite [eng_20260101_0001_db].');
+
+    const res = await client({ llm }).query.ask({
+      question: 'which database?',
+      scopes: ['work'],
+    });
+
+    expect(res.answer).toContain('SQLite');
+    expect(res.sources.map((s) => s.id)).toEqual(['eng_20260101_0001_db']);
+    expect(res.scopes).toEqual(['work']);
+  });
+
+  it('strips hallucinated citations the LLM invents', async () => {
+    seedEngram(cerebrumDb, 'eng_20260101_0001_real', 'Real', ['work']);
+    const llm = makeFakeQueryLlm(
+      () => 'Real [eng_20260101_0001_real] and fake [eng_20269999_9999_ghost].'
+    );
+
+    const res = await client({ llm }).query.ask({ question: 'what is real?' });
+
+    expect(res.sources.map((s) => s.id)).toEqual(['eng_20260101_0001_real']);
+    expect(res.answer).not.toContain('ghost');
+  });
+
+  it('returns a low-confidence no-info answer when nothing is retrieved', async () => {
+    const res = await client().query.ask({ question: 'absolutely nothing matches' });
+    expect(res.confidence).toBe('low');
+    expect(res.sources).toEqual([]);
+  });
+});
+
+describe('POST /query/retrieve', () => {
+  it('returns sources without calling the LLM', async () => {
+    seedEngram(cerebrumDb, 'eng_20260101_0001_a', 'Alpha', ['work']);
+    const res = await client().query.retrieve({ question: 'alpha' });
+    expect(res.sources.map((s) => s.id)).toEqual(['eng_20260101_0001_a']);
+  });
+});
+
+describe('POST /query/explain', () => {
+  it('echoes scope inference + retrieval plan and flags secret mentions', async () => {
+    const res = await client().query.explain('what is my secret password?');
+    expect(res.scopeInference.source).toBe('default');
+    expect(res.retrievalPlan.maxSources).toBeGreaterThan(0);
+    expect(res.secretNotice).not.toBeNull();
+  });
+});
+
+function parseSseFrames(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n\n')
+    .map((chunk) => chunk.trim())
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice('data: '.length)) as Record<string, unknown>);
+}
+
+describe('POST /query/stream (SSE)', () => {
+  it('streams token frames followed by a terminal done frame', async () => {
+    seedEngram(cerebrumDb, 'eng_20260101_0001_s', 'Streamed', ['work']);
+    const streamLlm = makeFakeQueryStreamLlm(['SQLite ', '[eng_20260101_0001_s] ', 'wins.']);
+
+    const res = await supertest
+      .agent(buildApp({ streamLlm }))
+      .post('/query/stream')
+      .send({ question: 'which database?' });
+
+    expect(res.headers['content-type']).toContain('text/event-stream');
+
+    const frames = parseSseFrames(res.text);
+    const tokens = frames.filter((f) => f['type'] === 'token');
+    const done = frames.find((f) => f['type'] === 'done');
+
+    expect(tokens.length).toBe(3);
+    expect(tokens.map((t) => t['text']).join('')).toContain('SQLite');
+    if (done === undefined) throw new Error('expected a done frame');
+    expect(done['answer']).toContain('SQLite');
+    expect((done['sources'] as Array<{ id: string }>).map((s) => s.id)).toEqual([
+      'eng_20260101_0001_s',
+    ]);
+  });
+
+  it('emits a single-token no-info stream when nothing is retrieved', async () => {
+    const res = await supertest
+      .agent(buildApp())
+      .post('/query/stream')
+      .send({ question: 'nothing at all matches this' });
+
+    const frames = parseSseFrames(res.text);
+    const done = frames.find((f) => f['type'] === 'done');
+    expect(done?.['confidence']).toBe('low');
+    expect(done?.['sources']).toEqual([]);
+  });
+
+  it('rejects an invalid body with 400 before opening the stream', async () => {
+    const res = await supertest.agent(buildApp()).post('/query/stream').send({ question: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -14,6 +14,12 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 import type { Express } from 'express';
 
 import type {
+  EmitSourceCitationWire,
+  GeneratedDocumentWire,
+  GenerationGroupByWire,
+  GenerationModeWire,
+} from '../../contract/rest-emit-schemas.js';
+import type {
   GliaActionTypeWire,
   GliaActionStatusWire,
   GliaActionWire,
@@ -42,6 +48,11 @@ import type {
   NudgeWire,
 } from '../../contract/rest-nudges.js';
 import type {
+  QueryConfidenceWire,
+  QueryDomainWire,
+  QuerySourceCitationWire,
+} from '../../contract/rest-query-schemas.js';
+import type {
   RetrievalFiltersWire,
   RetrievalModeWire,
   RetrievalResultWire,
@@ -66,7 +77,9 @@ import type {
   TemplateWire,
 } from '../../contract/rest-schemas.js';
 import type { CerebrumDb } from '../../db/index.js';
+import type { GenerationLlm } from '../modules/emit/llm.js';
 import type { IngestLlm, IngestLlmRequest } from '../modules/ingest/llm.js';
+import type { QueryLlm, QueryStreamChunk, QueryStreamLlm } from '../modules/query/llm.js';
 import type { ReflexService } from '../modules/reflex/reflex-service.js';
 import type { PeerClients } from '../modules/retrieval/peer-clients.js';
 
@@ -82,6 +95,50 @@ export function makeFakeIngestLlm(
     modelFor: () => 'fake-haiku',
     complete: (req) => Promise.resolve(responders[req.operation]?.(req) ?? null),
   };
+}
+
+/**
+ * Offline {@link GenerationLlm} stub for the `emit` slice. The responder
+ * receives the system prompt + user message and returns canned document text;
+ * the default echoes a fixed string. Never reaches a real API.
+ */
+export function makeFakeGenerationLlm(
+  responder: (systemPrompt: string, userMessage: string) => string = () => '# Generated\n\nbody'
+): GenerationLlm {
+  return {
+    generate: (systemPrompt, userMessage) => Promise.resolve(responder(systemPrompt, userMessage)),
+  };
+}
+
+/**
+ * Offline one-shot {@link QueryLlm} stub for `query.ask`. The responder returns
+ * the canned answer text; the default is a fixed string. Never reaches a real
+ * API.
+ */
+export function makeFakeQueryLlm(
+  responder: (systemPrompt: string, question: string) => string = () => 'A canned answer.'
+): QueryLlm {
+  return {
+    complete: (systemPrompt, question) => Promise.resolve(responder(systemPrompt, question)),
+  };
+}
+
+/**
+ * Offline streaming {@link QueryStreamLlm} stub for the SSE route. Yields each
+ * supplied token as a `delta`, then a `final` carrying the given usage counts.
+ * Never reaches a real API.
+ */
+export function makeFakeQueryStreamLlm(
+  tokens: string[] = ['Canned ', 'streamed ', 'answer.'],
+  usage: { tokensIn: number; tokensOut: number } = { tokensIn: 0, tokensOut: 0 }
+): QueryStreamLlm {
+  async function* stream(): AsyncGenerator<QueryStreamChunk> {
+    for (const text of tokens) {
+      yield { kind: 'delta', text };
+    }
+    yield { kind: 'final', tokensIn: usage.tokensIn, tokensOut: usage.tokensOut };
+  }
+  return { stream };
 }
 
 /** Bundled engram-template fixtures shipped with the pillar. */
@@ -258,6 +315,82 @@ export interface RetrievalSimilarBody {
   filters?: RetrievalFiltersWire;
 }
 
+export interface EmitGenerateInput {
+  mode: GenerationModeWire;
+  query?: string;
+  dateRange?: { from: string; to: string };
+  scopes?: string[];
+  audienceScope?: string;
+  includeSecret?: boolean;
+  types?: string[];
+  tags?: string[];
+  format?: 'markdown' | 'plain';
+  groupBy?: GenerationGroupByWire;
+}
+
+export interface EmitReportInput {
+  query: string;
+  scopes?: string[];
+  audienceScope?: string;
+  includeSecret?: boolean;
+  types?: string[];
+  tags?: string[];
+}
+
+export interface EmitSummaryInput {
+  dateRange: { from: string; to: string };
+  query?: string;
+  scopes?: string[];
+  audienceScope?: string;
+  includeSecret?: boolean;
+  types?: string[];
+  tags?: string[];
+}
+
+export interface EmitTimelineInput {
+  query?: string;
+  dateRange?: { from: string; to: string };
+  scopes?: string[];
+  audienceScope?: string;
+  includeSecret?: boolean;
+  types?: string[];
+  tags?: string[];
+  groupBy?: GenerationGroupByWire;
+}
+
+export interface QueryAskInput {
+  question: string;
+  scopes?: string[];
+  includeSecret?: boolean;
+  maxSources?: number;
+  domains?: QueryDomainWire[];
+}
+
+export interface QueryRetrieveInput {
+  question: string;
+  scopes?: string[];
+  includeSecret?: boolean;
+  maxSources?: number;
+}
+
+type EmitDocumentResponse = {
+  document: GeneratedDocumentWire | null;
+  notice?: string;
+};
+
+type QueryAskResponse = {
+  answer: string;
+  sources: QuerySourceCitationWire[];
+  scopes: string[];
+  confidence: QueryConfidenceWire;
+};
+
+type QueryExplainResponse = {
+  scopeInference: { scopes: string[]; source: 'explicit' | 'inferred' | 'default' };
+  retrievalPlan: { filters: RetrievalFiltersWire; maxSources: number; threshold: number };
+  secretNotice: string | null;
+};
+
 export function makeClient(app: Express) {
   const r = supertest.agent(app);
   return {
@@ -427,6 +560,27 @@ export function makeClient(app: Express) {
       similar: (body: RetrievalSimilarBody) =>
         send<{ results: RetrievalResultWire[] }>(r.post('/retrieval/similar').send(body)),
       stats: () => send<RetrievalStatsWire>(r.get('/retrieval/stats')),
+    },
+    emit: {
+      generate: (body: EmitGenerateInput) =>
+        send<EmitDocumentResponse>(r.post('/emit/generate').send(body)),
+      generateReport: (body: EmitReportInput) =>
+        send<EmitDocumentResponse>(r.post('/emit/report').send(body)),
+      generateSummary: (body: EmitSummaryInput) =>
+        send<EmitDocumentResponse>(r.post('/emit/summary').send(body)),
+      generateTimeline: (body: EmitTimelineInput) =>
+        send<EmitDocumentResponse>(r.post('/emit/timeline').send(body)),
+      preview: (body: EmitGenerateInput) =>
+        send<{ sources: EmitSourceCitationWire[]; outline: string }>(
+          r.post('/emit/preview').send(body)
+        ),
+    },
+    query: {
+      ask: (body: QueryAskInput) => send<QueryAskResponse>(r.post('/query/ask').send(body)),
+      retrieve: (body: QueryRetrieveInput) =>
+        send<{ sources: QuerySourceCitationWire[] }>(r.post('/query/retrieve').send(body)),
+      explain: (question: string) =>
+        send<QueryExplainResponse>(r.post('/query/explain').send({ question })),
     },
   };
 }

--- a/pillars/cerebrum/src/api/app.ts
+++ b/pillars/cerebrum/src/api/app.ts
@@ -15,7 +15,9 @@ import express, { type Express, type Request, type Response } from 'express';
 
 import { cerebrumContract } from '../contract/rest.js';
 import { type CerebrumApiDeps, makeRequestHandler } from './handlers.js';
+import { AnthropicQueryLlm, AnthropicQueryStreamLlm } from './modules/query/llm.js';
 import { makeCerebrumRestHandlers } from './rest/handlers.js';
+import { makeQueryStreamHandler } from './rest/query-stream-route.js';
 
 /**
  * JSON body cap. Ingest/emit payloads and (later) chat bodies can be large;
@@ -37,6 +39,21 @@ export function createCerebrumApiApp(deps: CerebrumApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  // SSE: ts-rest can't model an event stream, so the query stream route is a
+  // plain Express handler mounted ahead of the generated endpoints.
+  app.post(
+    '/query/stream',
+    makeQueryStreamHandler({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+      llm: deps.queryLlm ?? new AnthropicQueryLlm(),
+      streamLlm: deps.queryStreamLlm ?? new AnthropicQueryStreamLlm(),
+    })
+  );
 
   createExpressEndpoints(cerebrumContract, makeCerebrumRestHandlers(deps), app);
 

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -10,8 +10,10 @@ import { getPillarRegistry } from './pillars/registry.js';
 import type { PillarRegistryEntry } from '@pops/types';
 
 import type { OpenedCerebrumDb } from '../db/index.js';
+import type { GenerationLlm } from './modules/emit/llm.js';
 import type { IngestLlm } from './modules/ingest/llm.js';
 import type { CurationQueueAccessor } from './modules/ingest/pipeline.js';
+import type { QueryLlm, QueryStreamLlm } from './modules/query/llm.js';
 import type { ReflexService } from './modules/reflex/reflex-service.js';
 import type { EmbeddingClient } from './modules/retrieval/embedding-client.js';
 import type { PeerClients } from './modules/retrieval/peer-clients.js';
@@ -69,6 +71,24 @@ export interface CerebrumApiDeps {
    * degrades to BM25-only.
    */
   embeddingClient?: EmbeddingClient;
+  /**
+   * LLM port driving the `emit` document-generation pipeline. Optional —
+   * defaults to an Anthropic-backed client (`ANTHROPIC_API_KEY`,
+   * `claude-sonnet-4-6` / `CEREBRUM_EMIT_MODEL`). Tests inject an offline fake.
+   */
+  emitLlm?: GenerationLlm;
+  /**
+   * One-shot LLM port driving `query.ask`. Optional — defaults to an
+   * Anthropic-backed client (`ANTHROPIC_API_KEY`, `claude-sonnet-4-6` /
+   * `CEREBRUM_QUERY_MODEL`). Tests inject an offline fake.
+   */
+  queryLlm?: QueryLlm;
+  /**
+   * Streaming LLM port driving the `POST /query/stream` SSE route. Optional —
+   * defaults to an Anthropic streaming client. Tests inject a fake that yields
+   * canned tokens (no real API).
+   */
+  queryStreamLlm?: QueryStreamLlm;
 }
 
 export interface HealthResponse {

--- a/pillars/cerebrum/src/api/modules/emit/generation-service.ts
+++ b/pillars/cerebrum/src/api/modules/emit/generation-service.ts
@@ -1,0 +1,196 @@
+/**
+ * GenerationService — pipeline orchestrator for document generation (PRD-083).
+ *
+ * Methods:
+ *   generate         — full generation pipeline for any mode
+ *   generateReport   — shorthand for report mode
+ *   generateSummary  — shorthand for summary mode
+ *   generateTimeline — shorthand for timeline mode
+ *   preview          — dry run returning sources + outline
+ *
+ * Reuses the in-pillar retrieval slice (`HybridSearchService`,
+ * `ContextAssemblyService`) and the query slice's `CitationParser`. The LLM
+ * port is injected so tests stay offline. Settings-service tunables are
+ * replaced with constants (the pillar has no settings service).
+ */
+import { CitationParser } from '../query/citation-parser.js';
+import { ContextAssemblyService } from '../retrieval/context-assembly.js';
+import { HybridSearchService } from '../retrieval/hybrid-search.js';
+import { toSourceCitations } from './helpers.js';
+import { buildReportDocument, checkReportSources } from './modes/report.js';
+import { buildEmptySummary, buildSummaryDocument, capSummaryResults } from './modes/summary.js';
+import { buildTimelineDocument, sortChronologically } from './modes/timeline.js';
+import {
+  buildOutlinePrompt,
+  buildReportPrompt,
+  buildSummaryPrompt,
+  buildTimelinePrompt,
+} from './prompts.js';
+import { buildScopeFilters, computeDefaultAudienceScope, filterByScope } from './scope-filter.js';
+
+import type { SemanticSearchDeps } from '../retrieval/semantic-search.js';
+import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
+import type { GenerationLlm } from './llm.js';
+import type { GenerationRequest, GenerationResult, PreviewResult } from './types.js';
+
+const EMIT_TOKEN_BUDGET = 8192;
+const EMIT_RELEVANCE_THRESHOLD = 0.2;
+const EMIT_MAX_SOURCES = 20;
+
+/** Retrieval deps + the injected LLM port the generation pipeline consumes. */
+export interface GenerationServiceDeps extends SemanticSearchDeps {
+  llm: GenerationLlm;
+}
+
+/** Build retrieval filters from a generation request. */
+function buildFiltersFromRequest(request: GenerationRequest): RetrievalFilters {
+  const base: RetrievalFilters = { sourceTypes: ['engram'] };
+  if (request.types?.length) base.types = request.types;
+  if (request.tags?.length) base.tags = request.tags;
+  if (request.dateRange) {
+    base.dateRange = { from: request.dateRange.from, to: request.dateRange.to };
+  }
+  if (request.scopes?.length) base.scopes = request.scopes;
+  return buildScopeFilters(base, request.audienceScope, request.includeSecret ?? false);
+}
+
+export class GenerationService {
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+  private readonly search: HybridSearchService;
+
+  constructor(private readonly deps: GenerationServiceDeps) {
+    this.search = new HybridSearchService(deps);
+  }
+
+  /** Full generation pipeline: retrieve -> scope filter -> synthesise -> format. */
+  async generate(request: GenerationRequest): Promise<GenerationResult> {
+    switch (request.mode) {
+      case 'report':
+        return this.generateReport(request);
+      case 'summary':
+        return this.generateSummary(request);
+      case 'timeline':
+        return this.generateTimeline(request);
+    }
+  }
+
+  /** Generate a structured report from a query. */
+  async generateReport(request: GenerationRequest): Promise<GenerationResult> {
+    const query = request.query ?? '';
+    const includeSecret = request.includeSecret ?? false;
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+
+    const insufficientCheck = checkReportSources(filtered);
+    if (insufficientCheck) return insufficientCheck;
+
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: filtered,
+      tokenBudget: EMIT_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildReportPrompt(assembled.context, audienceScope);
+    const llmOutput = await this.deps.llm.generate(prompt, query);
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmOutput, filtered);
+
+    return { document: buildReportDocument(cleanedAnswer, citations, audienceScope, filtered) };
+  }
+
+  /** Generate a summary digest over a date range. */
+  async generateSummary(request: GenerationRequest): Promise<GenerationResult> {
+    const includeSecret = request.includeSecret ?? false;
+    const query = request.query ?? 'summary of all content';
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+    const effectiveDateRange = request.dateRange ?? { from: 'unknown', to: 'unknown' };
+
+    if (filtered.length === 0) {
+      return { document: buildEmptySummary(effectiveDateRange, audienceScope) };
+    }
+
+    const { capped, truncated } = capSummaryResults(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: capped,
+      tokenBudget: EMIT_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildSummaryPrompt(assembled.context, effectiveDateRange, audienceScope);
+    const llmOutput = await this.deps.llm.generate(prompt, query);
+    const { cleanedAnswer } = this.citationParser.parse(llmOutput, capped);
+
+    return {
+      document: buildSummaryDocument({
+        llmOutput: cleanedAnswer,
+        results: capped,
+        dateRange: effectiveDateRange,
+        audienceScope,
+        truncated,
+      }),
+    };
+  }
+
+  /** Generate a chronological timeline from dated engrams. */
+  async generateTimeline(request: GenerationRequest): Promise<GenerationResult> {
+    const includeSecret = request.includeSecret ?? false;
+    const query = request.query ?? 'timeline of all events';
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+
+    if (filtered.length === 0) {
+      return { document: null, notice: 'No relevant engrams found for this timeline' };
+    }
+
+    const sorted = sortChronologically(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: sorted,
+      tokenBudget: EMIT_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildTimelinePrompt(assembled.context, audienceScope, request.groupBy);
+    const llmOutput = await this.deps.llm.generate(prompt, query);
+    const { cleanedAnswer } = this.citationParser.parse(llmOutput, sorted);
+
+    return { document: buildTimelineDocument(cleanedAnswer, sorted, audienceScope) };
+  }
+
+  /** Preview: returns sources and a generated outline without full generation. */
+  async preview(request: GenerationRequest): Promise<PreviewResult> {
+    const query = request.query ?? 'preview';
+    const includeSecret = request.includeSecret ?? false;
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const sources = toSourceCitations(filtered);
+
+    if (filtered.length === 0) {
+      return { sources, outline: 'No sources found — cannot generate outline.' };
+    }
+
+    const assembled = this.assembler.assemble({
+      query,
+      results: filtered,
+      tokenBudget: EMIT_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+    const outline = await this.deps.llm.generate(buildOutlinePrompt(assembled.context), query);
+    return { sources, outline };
+  }
+
+  /** Run hybrid search against the in-pillar retrieval slice. */
+  private async retrieve(query: string, filters: RetrievalFilters): Promise<RetrievalResult[]> {
+    return this.search.hybrid(query, filters, EMIT_MAX_SOURCES, EMIT_RELEVANCE_THRESHOLD);
+  }
+}

--- a/pillars/cerebrum/src/api/modules/emit/helpers.ts
+++ b/pillars/cerebrum/src/api/modules/emit/helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared helpers for document generation modes (PRD-083).
+ *
+ * Reduces duplication across report, summary, and timeline modes. Lifted
+ * verbatim from the monolith (pure logic).
+ */
+import type { SourceCitation } from '../query/types.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { DateRange } from './types.js';
+
+const EXCERPT_MAX_LENGTH = 200;
+
+/** Extract the actual date range covered by retrieved results. */
+export function extractDateRange(results: RetrievalResult[]): DateRange | null {
+  const dates: string[] = [];
+  for (const r of results) {
+    const createdAt = r.metadata['createdAt'] as string | undefined;
+    if (createdAt) dates.push(createdAt);
+  }
+  if (dates.length === 0) return null;
+  const sorted = dates.toSorted();
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  if (!first || !last) return null;
+  return { from: first, to: last };
+}
+
+/** Truncate to 200 chars at word boundary with ellipsis. */
+export function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '...';
+}
+
+/** Extract primary scope from retrieval result metadata. */
+export function extractPrimaryScope(result: RetrievalResult): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+/** Map retrieval results to source citations. */
+export function toSourceCitations(results: RetrievalResult[]): SourceCitation[] {
+  return results.map((r) => ({
+    id: r.sourceId,
+    type: r.sourceType,
+    title: r.title,
+    excerpt: truncateExcerpt(r.contentPreview ?? ''),
+    relevance: r.score,
+    scope: extractPrimaryScope(r),
+  }));
+}
+
+/** Extract title from LLM output (first H1 line) or return fallback. */
+export function extractTitle(llmOutput: string, fallback: string): string {
+  const titleMatch = llmOutput.match(/^#\s+(.+)$/m);
+  return titleMatch?.[1] ?? fallback;
+}
+
+/** Collect unique scope prefixes from results. */
+export function collectScopeCoverage(results: RetrievalResult[]): string[] {
+  const scopes = new Set<string>();
+  for (const r of results) {
+    const s = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    for (const scope of s) scopes.add(scope);
+  }
+  return [...scopes];
+}

--- a/pillars/cerebrum/src/api/modules/emit/llm.ts
+++ b/pillars/cerebrum/src/api/modules/emit/llm.ts
@@ -1,0 +1,76 @@
+/**
+ * LLM port for the cerebrum document-generation engine (PRD-083).
+ *
+ * The generation pipeline needs one capability: send a system prompt + user
+ * message and get the synthesised document text back. Modelled as the
+ * {@link GenerationLlm} port so it runs against a real Anthropic client in
+ * production and a canned fake in tests (tests MUST NOT reach a real API).
+ *
+ * Deviations from the monolith (parity with the ingest + query slices):
+ * - Model overrides / settings → hardcoded `claude-sonnet-4-6` with optional
+ *   `CEREBRUM_EMIT_MODEL` env override. Max-tokens is a constant.
+ * - `trackInference` / `ai_inference_log` dropped; only the 429 backoff
+ *   ({@link withRateLimitRetry}, reused from the ingest slice) is kept.
+ * - Degradation parity: a missing API key returns a placeholder string (the
+ *   monolith's behaviour) rather than throwing; a transport error throws so
+ *   the handler surfaces a 500.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { withRateLimitRetry } from '../ingest/llm.js';
+
+export const DEFAULT_EMIT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MAX_TOKENS = 2048;
+const UNAVAILABLE_MSG = '(Document generation unavailable — LLM API key not configured)';
+
+function emitModel(): string {
+  const value = process.env['CEREBRUM_EMIT_MODEL'];
+  return value !== undefined && value !== '' ? value : DEFAULT_EMIT_MODEL;
+}
+
+/** Capability the generation modes depend on. */
+export interface GenerationLlm {
+  /**
+   * Synthesise a document from a system prompt + user message. Returns a
+   * placeholder string when the model is unavailable (no API key); throws on
+   * a transport error so the caller surfaces a 500.
+   */
+  generate(systemPrompt: string, userMessage: string): Promise<string>;
+}
+
+/**
+ * Real Anthropic-backed {@link GenerationLlm}. Reads `ANTHROPIC_API_KEY` lazily
+ * so a missing key degrades to the unavailable placeholder rather than
+ * throwing at construction.
+ */
+export class AnthropicGenerationLlm implements GenerationLlm {
+  async generate(systemPrompt: string, userMessage: string): Promise<string> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-emit] ANTHROPIC_API_KEY not set — cannot generate document');
+      return UNAVAILABLE_MSG;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    try {
+      const response = await withRateLimitRetry(
+        () =>
+          client.messages.create({
+            model: emitModel(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: 0,
+            system: systemPrompt,
+            messages: [{ role: 'user', content: userMessage }],
+          }),
+        'cerebrum.emit'
+      );
+      const first = response.content[0];
+      return first?.type === 'text' ? first.text : '';
+    } catch (err) {
+      throw new Error(
+        `Document generation failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err }
+      );
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/emit/modes/report.ts
+++ b/pillars/cerebrum/src/api/modules/emit/modes/report.ts
@@ -1,0 +1,59 @@
+/**
+ * Report generation mode (PRD-083 US-01).
+ *
+ * Pipeline: retrieve relevant engrams -> group by subtopic -> synthesise
+ * sections -> format with citations. Requires a query and minimum 2 sources.
+ */
+import { collectScopeCoverage, extractDateRange, extractTitle } from '../helpers.js';
+
+import type { SourceCitation } from '../../query/types.js';
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { GeneratedDocument, GenerationResult } from '../types.js';
+
+const MIN_SOURCES_FOR_REPORT = 2;
+
+/**
+ * Check if enough sources exist for a meaningful report.
+ * Returns an insufficient-data notice if fewer than 2 sources.
+ */
+export function checkReportSources(results: RetrievalResult[]): GenerationResult | null {
+  if (results.length === 0) {
+    return { document: null, notice: 'No relevant engrams found for this query' };
+  }
+
+  if (results.length < MIN_SOURCES_FOR_REPORT) {
+    return { document: null, notice: 'Insufficient data to generate a meaningful report' };
+  }
+
+  return null;
+}
+
+/**
+ * Build the final report document from LLM output and source data.
+ */
+export function buildReportDocument(
+  llmOutput: string,
+  sources: SourceCitation[],
+  audienceScope: string,
+  results: RetrievalResult[]
+): GeneratedDocument {
+  const title = extractTitle(llmOutput, 'Generated Report');
+  const dateRange = extractDateRange(results);
+  const scopeCoverage = collectScopeCoverage(results);
+
+  return {
+    title,
+    body: llmOutput,
+    mode: 'report',
+    sources,
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange,
+      scopeCoverage,
+      mode: 'report',
+      truncated: false,
+    },
+  };
+}

--- a/pillars/cerebrum/src/api/modules/emit/modes/summary.ts
+++ b/pillars/cerebrum/src/api/modules/emit/modes/summary.ts
@@ -1,0 +1,104 @@
+/**
+ * Summary generation mode (PRD-083 US-02).
+ *
+ * Retrieves engrams within a date range, groups by type/topic, and produces a
+ * digestible overview (weekly digest, monthly review).
+ */
+import {
+  collectScopeCoverage,
+  extractDateRange,
+  extractTitle,
+  toSourceCitations,
+} from '../helpers.js';
+import { TYPE_IMPORTANCE } from '../types.js';
+
+import type { SourceCitation } from '../../query/types.js';
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { DateRange, GeneratedDocument } from '../types.js';
+
+/** Maximum number of sources for a single summary to avoid context overflow. */
+const MAX_SUMMARY_SOURCES = 50;
+
+/**
+ * Build an empty summary document for date ranges with zero engrams.
+ */
+export function buildEmptySummary(dateRange: DateRange, audienceScope: string): GeneratedDocument {
+  return {
+    title: `Summary: ${dateRange.from} to ${dateRange.to}`,
+    body: `# Summary: ${dateRange.from} to ${dateRange.to}\n\nNo engrams found between ${dateRange.from} and ${dateRange.to}.`,
+    mode: 'summary',
+    sources: [],
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: 0,
+      dateRange,
+      scopeCoverage: [],
+      mode: 'summary',
+      truncated: false,
+    },
+  };
+}
+
+/**
+ * Cap results at MAX_SUMMARY_SOURCES, sorted by relevance.
+ * Returns the capped list and whether truncation occurred.
+ */
+export function capSummaryResults(results: RetrievalResult[]): {
+  capped: RetrievalResult[];
+  truncated: boolean;
+} {
+  if (results.length <= MAX_SUMMARY_SOURCES) {
+    return { capped: results, truncated: false };
+  }
+  const sorted = [...results].toSorted((a, b) => b.score - a.score);
+  return { capped: sorted.slice(0, MAX_SUMMARY_SOURCES), truncated: true };
+}
+
+/**
+ * Sort sources by type importance for highlights extraction.
+ * Returns sources ordered by TYPE_IMPORTANCE descending.
+ */
+export function sortByTypeImportance(sources: SourceCitation[]): SourceCitation[] {
+  return [...sources].toSorted((a, b) => {
+    const aImportance = TYPE_IMPORTANCE[a.type] ?? 0;
+    const bImportance = TYPE_IMPORTANCE[b.type] ?? 0;
+    return bImportance - aImportance;
+  });
+}
+
+/** Parameters for building a summary document. */
+interface BuildSummaryParams {
+  llmOutput: string;
+  results: RetrievalResult[];
+  dateRange: DateRange;
+  audienceScope: string;
+  truncated: boolean;
+}
+
+/**
+ * Build the final summary document from LLM output and source data.
+ */
+export function buildSummaryDocument(params: BuildSummaryParams): GeneratedDocument {
+  const { llmOutput, results, dateRange, audienceScope, truncated } = params;
+  const sources = toSourceCitations(results);
+  const actualDateRange = extractDateRange(results) ?? dateRange;
+  const scopeCoverage = collectScopeCoverage(results);
+  const title = extractTitle(llmOutput, `Summary: ${dateRange.from} to ${dateRange.to}`);
+
+  return {
+    title,
+    body: llmOutput,
+    mode: 'summary',
+    sources,
+    audienceScope,
+    dateRange: actualDateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange: actualDateRange,
+      scopeCoverage,
+      mode: 'summary',
+      truncated,
+    },
+  };
+}

--- a/pillars/cerebrum/src/api/modules/emit/modes/timeline.ts
+++ b/pillars/cerebrum/src/api/modules/emit/modes/timeline.ts
@@ -1,0 +1,65 @@
+/**
+ * Timeline generation mode (PRD-083 US-03).
+ *
+ * Retrieves dated engrams, produces chronological sequences.
+ * Each entry: date, title, type badge, one-line summary.
+ */
+import {
+  collectScopeCoverage,
+  extractDateRange,
+  extractTitle,
+  toSourceCitations,
+} from '../helpers.js';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { GeneratedDocument } from '../types.js';
+
+/**
+ * Sort retrieval results chronologically by createdAt date (oldest first).
+ */
+export function sortChronologically(results: RetrievalResult[]): RetrievalResult[] {
+  return [...results].toSorted((a, b) => {
+    const dateA = (a.metadata['createdAt'] as string | undefined) ?? '';
+    const dateB = (b.metadata['createdAt'] as string | undefined) ?? '';
+    return dateA.localeCompare(dateB);
+  });
+}
+
+/**
+ * Build a single-entry timeline notice.
+ */
+export function buildSingleEntryNotice(): string {
+  return '\n\n*This timeline represents a single point in time.*';
+}
+
+/**
+ * Build the final timeline document from LLM output and source data.
+ */
+export function buildTimelineDocument(
+  llmOutput: string,
+  results: RetrievalResult[],
+  audienceScope: string
+): GeneratedDocument {
+  const sources = toSourceCitations(results);
+  const dateRange = extractDateRange(results);
+  const scopeCoverage = collectScopeCoverage(results);
+  const title = extractTitle(llmOutput, 'Timeline');
+
+  const body = results.length === 1 ? llmOutput + buildSingleEntryNotice() : llmOutput;
+
+  return {
+    title,
+    body,
+    mode: 'timeline',
+    sources,
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange,
+      scopeCoverage,
+      mode: 'timeline',
+      truncated: false,
+    },
+  };
+}

--- a/pillars/cerebrum/src/api/modules/emit/prompts.ts
+++ b/pillars/cerebrum/src/api/modules/emit/prompts.ts
@@ -1,0 +1,109 @@
+/**
+ * LLM prompt templates for document generation (PRD-083).
+ *
+ * Each mode has a dedicated prompt builder that accepts the assembled context
+ * and mode-specific parameters. Prompts instruct the model to synthesise
+ * (not copy), cite sources by ID, and never introduce external information.
+ * Lifted verbatim from the monolith.
+ */
+import type { DateRange, TimelineGroupBy } from './types.js';
+
+/**
+ * Build the system prompt for report generation.
+ * Produces structured Markdown with introduction, body sections, and conclusion.
+ */
+export function buildReportPrompt(context: string, audienceScope: string): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a structured report on the topic described in the user query.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Structure the report as: a short title (H1), an introduction paragraph, body sections (H2) grouped by subtopic, and a brief conclusion.
+2. Synthesise information — do NOT copy source text verbatim. Rephrase and integrate.
+3. Cite every claim by including the source ID in square brackets, e.g. [eng_20260417_0942_agent-coordination].
+4. Never introduce information not present in the sources.
+5. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+6. If sources are contradictory, note the disagreement and cite both sides.
+7. Keep sections focused — each section should cover one coherent subtopic.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for generating a report outline (preview mode).
+ * Returns section headings and which sources map to each, without full synthesis.
+ */
+export function buildOutlinePrompt(context: string): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Given the sources below, produce ONLY an outline for a structured report.
+Format: an H1 title, then a bulleted list of H2 section headings.
+Under each heading, list the source IDs (in brackets) that would be used for that section.
+Do NOT generate full prose — only the outline structure.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for summary generation.
+ * Produces a digest grouped by type or topic with highlights.
+ */
+export function buildSummaryPrompt(
+  context: string,
+  dateRange: DateRange,
+  audienceScope: string
+): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a summary digest covering the period from ${dateRange.from} to ${dateRange.to}.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Start with a short title (H1) including the date range.
+2. Add a "Highlights" section (H2) with the 3-5 most significant items ranked by importance (decisions > research > meetings > ideas > journal > notes > captures).
+3. Group remaining content by type (H2 sections: Decisions, Research, Meetings, Ideas, Journal, Notes, Captures). Only include sections that have content.
+4. Under each type section, produce a bulleted list: each item has title, date, and a one-sentence summary synthesised from the body.
+5. Cite every referenced engram by ID in brackets: [engram_id].
+6. Never introduce information not present in the sources.
+7. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+8. If covering a subset of a larger result set, note this at the end.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for timeline generation.
+ * Produces a chronological list of dated entries.
+ */
+export function buildTimelinePrompt(
+  context: string,
+  audienceScope: string,
+  groupBy?: TimelineGroupBy
+): string {
+  const groupInstructionMap: Record<string, string> = {
+    type: 'Group entries by type (H2 sections), with each group in chronological order.',
+    month:
+      'Group entries by month (H2 sections with "YYYY-MM" headers), chronological within each month.',
+    quarter:
+      'Group entries by quarter (H2 sections with "YYYY QN" headers), chronological within each quarter.',
+  };
+  const groupInstruction =
+    (groupBy && groupInstructionMap[groupBy]) ??
+    'Present all entries in a single chronological list (oldest first).';
+
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a chronological timeline from the provided dated entries.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Start with a short title (H1) describing the timeline scope.
+2. ${groupInstruction}
+3. Each entry format: **YYYY-MM-DD** — [type_badge] **Title** — one-line summary [engram_id]
+   Where type_badge is one of: [decision], [meeting], [research], [idea], [journal], [note], [capture].
+4. For entries with empty bodies, write "metadata only" instead of a summary.
+5. Order entries chronologically (oldest first) within each group.
+6. Cite every entry by its engram ID in brackets.
+7. Never introduce information not present in the sources.
+8. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+
+Sources:
+${context}`;
+}

--- a/pillars/cerebrum/src/api/modules/emit/scope-filter.ts
+++ b/pillars/cerebrum/src/api/modules/emit/scope-filter.ts
@@ -1,0 +1,136 @@
+/**
+ * Scope filtering for document generation (PRD-083 US-04).
+ *
+ * Applied at retrieval time to enforce audience scope boundaries and
+ * hard-block *.secret.* content. Secret content never enters the LLM
+ * context window — this is a security requirement, not a convenience filter.
+ * Lifted verbatim from the monolith (pure logic).
+ */
+import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
+
+/**
+ * Check whether a scope path contains a "secret" segment.
+ * E.g. "personal.secret.therapy" -> true, "work.projects.karbon" -> false.
+ */
+export function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/**
+ * Check whether a scope matches an audience scope prefix.
+ * E.g. scope "work.projects.karbon" matches audience "work.*" or "work.projects.*".
+ * An exact match (scope === audience without wildcard) also passes.
+ */
+export function matchesAudienceScope(scope: string, audienceScope: string): boolean {
+  const prefix = audienceScope.endsWith('.*') ? audienceScope.slice(0, -2) : audienceScope;
+  return scope === prefix || scope.startsWith(prefix + '.');
+}
+
+/**
+ * Determine whether an engram should be included based on its scopes,
+ * the audience scope filter, and the includeSecret flag.
+ *
+ * An engram with ANY secret scope is treated as secret (most restrictive wins).
+ * When includeSecret is true with an audienceScope, only secret content within
+ * that audience scope is included (e.g., work.secret.* but not personal.secret.*).
+ */
+export function shouldIncludeEngram(
+  engramScopes: string[],
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): boolean {
+  const hasSecretScope = engramScopes.some(isSecretScope);
+
+  if (hasSecretScope && !includeSecret) {
+    return false;
+  }
+
+  if (!audienceScope) {
+    return true;
+  }
+
+  const matchesAudience = engramScopes.some((s) => matchesAudienceScope(s, audienceScope));
+
+  if (!matchesAudience) {
+    return false;
+  }
+
+  if (hasSecretScope && includeSecret) {
+    const secretScopes = engramScopes.filter(isSecretScope);
+    return secretScopes.some((s) => matchesAudienceScope(s, audienceScope));
+  }
+
+  return true;
+}
+
+/**
+ * Filter retrieval results by audience scope and secret rules.
+ * Applied post-retrieval as a safety net (retrieval filters are the primary gate).
+ */
+export function filterByScope(
+  results: RetrievalResult[],
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): RetrievalResult[] {
+  return results.filter((r) => {
+    const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    return shouldIncludeEngram(scopes, audienceScope, includeSecret);
+  });
+}
+
+/**
+ * Build retrieval filters incorporating audience scope and secret rules.
+ * These are applied at query time so secret content never enters the pipeline.
+ */
+export function buildScopeFilters(
+  baseFilters: RetrievalFilters,
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): RetrievalFilters {
+  const filters: RetrievalFilters = { ...baseFilters };
+
+  if (audienceScope) {
+    const prefix = audienceScope.endsWith('.*') ? audienceScope.slice(0, -2) : audienceScope;
+    filters.scopes = [...(filters.scopes ?? []), prefix];
+  }
+
+  if (includeSecret) {
+    filters.includeSecret = true;
+  }
+
+  return filters;
+}
+
+/**
+ * Compute the default audience scope from retrieved sources.
+ * Returns the broadest (shortest) non-secret scope prefix among all sources.
+ * Returns 'all' if no scopes are found.
+ */
+export function computeDefaultAudienceScope(results: RetrievalResult[]): string {
+  const allScopes = new Set<string>();
+
+  for (const r of results) {
+    const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    for (const s of scopes) {
+      if (!isSecretScope(s)) {
+        allScopes.add(s);
+      }
+    }
+  }
+
+  if (allScopes.size === 0) return 'all';
+
+  const scopeList = [...allScopes].toSorted((a, b) => a.length - b.length);
+  const shortest = scopeList[0];
+  if (!shortest) return 'all';
+
+  const segments = shortest.split('.');
+  for (let i = segments.length; i > 0; i--) {
+    const candidate = segments.slice(0, i).join('.');
+    if (scopeList.every((s) => s === candidate || s.startsWith(candidate + '.'))) {
+      return candidate + '.*';
+    }
+  }
+
+  return 'all';
+}

--- a/pillars/cerebrum/src/api/modules/emit/types.ts
+++ b/pillars/cerebrum/src/api/modules/emit/types.ts
@@ -1,0 +1,95 @@
+/**
+ * Types for the cerebrum document-generation engine (PRD-083).
+ *
+ * Covers: GenerationRequest, GeneratedDocument, GenerationMode, and the
+ * preview/generation pipeline interfaces. Lifted verbatim from the monolith.
+ */
+import type { SourceCitation } from '../query/types.js';
+
+/** Supported document generation modes. */
+export type GenerationMode = 'report' | 'summary' | 'timeline';
+
+/** Supported output formats. */
+export type OutputFormat = 'markdown' | 'plain';
+
+/** Date range filter with ISO 8601 strings. */
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+/** Optional grouping strategies for timelines. */
+export type TimelineGroupBy = 'type' | 'month' | 'quarter';
+
+/**
+ * Generation request — the input to the document generation pipeline.
+ * Corresponds to the PRD-083 GenerationRequest data model.
+ */
+export interface GenerationRequest {
+  /** Output mode: report, summary, or timeline. */
+  mode: GenerationMode;
+  /** Topic or question — required for report mode. */
+  query?: string;
+  /** Date range filter — required for summary mode. */
+  dateRange?: DateRange;
+  /** Explicit scope filter for retrieval. */
+  scopes?: string[];
+  /** Intended audience scope (e.g., 'work.*'). Controls content inclusion. */
+  audienceScope?: string;
+  /** Opt-in for *.secret.* content (default: false). */
+  includeSecret?: boolean;
+  /** Filter engrams by type (e.g., 'decision', 'meeting'). */
+  types?: string[];
+  /** Filter engrams by tags. */
+  tags?: string[];
+  /** Output format (default: 'markdown'). */
+  format?: OutputFormat;
+  /** Grouping strategy for timeline mode. */
+  groupBy?: TimelineGroupBy;
+}
+
+/** Metadata about the generation process. */
+export interface GenerationMetadata {
+  sourceCount: number;
+  dateRange: DateRange | null;
+  scopeCoverage: string[];
+  mode: GenerationMode;
+  truncated: boolean;
+}
+
+/**
+ * Generated document — the output of the document generation pipeline.
+ * Corresponds to the PRD-083 GeneratedDocument data model.
+ */
+export interface GeneratedDocument {
+  title: string;
+  body: string;
+  mode: GenerationMode;
+  sources: SourceCitation[];
+  audienceScope: string;
+  dateRange: DateRange | null;
+  metadata: GenerationMetadata;
+}
+
+/** Result of a generate call — document or notice on insufficient data. */
+export interface GenerationResult {
+  document: GeneratedDocument | null;
+  notice?: string;
+}
+
+/** Result of a preview call — sources and outline without full generation. */
+export interface PreviewResult {
+  sources: SourceCitation[];
+  outline: string;
+}
+
+/** Type importance ranking for summary highlights (higher = more important). */
+export const TYPE_IMPORTANCE: Record<string, number> = {
+  decision: 7,
+  research: 6,
+  meeting: 5,
+  idea: 4,
+  journal: 3,
+  note: 2,
+  capture: 1,
+};

--- a/pillars/cerebrum/src/api/modules/query/citation-parser.ts
+++ b/pillars/cerebrum/src/api/modules/query/citation-parser.ts
@@ -1,0 +1,149 @@
+/**
+ * CitationParser — extracts and validates inline source citations from LLM
+ * output against the retrieved source set (PRD-082 US-03).
+ *
+ * Handles:
+ *  - Bracketed engram IDs: [eng_20260417_0942_agent-coordination]
+ *  - Bracketed sourceType:sourceId references: [engram:eng_20260417_0942_...]
+ *  - Strips hallucinated citations (IDs not in retrieved set), logging them.
+ *  - Truncates excerpts to 200 chars at word boundary with ellipsis.
+ *  - Orders output citations by relevance (highest first).
+ *
+ * Deviation from the monolith: the excerpt-length setting and `logger` are
+ * replaced with a constant + `console.warn` (the pillar has no settings
+ * service and no shared pino logger).
+ */
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { CitationParseResult, SourceCitation } from './types.js';
+
+/** Matches bracketed engram IDs like [eng_20260417_0942_agent-coordination]. */
+const ENGRAM_CITATION_RE = /\[eng_\d{8}_\d{4}_[a-z0-9-]+\]/g;
+
+/**
+ * Matches bracketed sourceType:sourceId references like [engram:eng_...].
+ * Captures sourceType and sourceId in groups.
+ */
+const TYPED_CITATION_RE = /\[(engram|transaction|media|inventory):([^\]]+)\]/g;
+
+const EXCERPT_MAX_LENGTH = 200;
+
+/**
+ * Truncate text to a maximum length at a word boundary, appending ellipsis.
+ */
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '…';
+}
+
+/**
+ * Determine the primary scope from RetrievalResult metadata.
+ */
+function extractPrimaryScope(result: RetrievalResult): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+/** Push a labelled metadata field into parts if the value is defined. */
+function pushIfDefined(parts: string[], label: string, value: unknown): void {
+  if (value !== undefined) parts.push(`${label}: ${String(value)}`);
+}
+
+/** Extract domain-specific metadata parts for enriching excerpts. */
+function extractDomainMetaParts(metadata: Record<string, unknown>, sourceType: string): string[] {
+  const parts: string[] = [];
+  switch (sourceType) {
+    case 'transaction':
+      pushIfDefined(parts, 'Amount', metadata['amount']);
+      pushIfDefined(parts, 'Date', metadata['date'] ?? metadata['createdAt']);
+      pushIfDefined(parts, 'Category', metadata['category']);
+      break;
+    case 'media':
+      pushIfDefined(parts, 'Type', metadata['type'] ?? metadata['mediaType']);
+      pushIfDefined(parts, 'Rating', metadata['rating']);
+      break;
+    case 'inventory':
+      pushIfDefined(parts, 'Location', metadata['location']);
+      break;
+  }
+  return parts;
+}
+
+/**
+ * Format a domain-specific excerpt with additional metadata when available.
+ */
+function formatExcerpt(result: RetrievalResult): string {
+  const parts = extractDomainMetaParts(result.metadata, result.sourceType);
+  const metaPrefix = parts.length > 0 ? parts.join(' | ') + ' — ' : '';
+  return truncateExcerpt(metaPrefix + (result.contentPreview ?? ''));
+}
+
+export class CitationParser {
+  /**
+   * Parse citations from LLM output, mapping them to retrieved sources.
+   *
+   * @param llmOutput        - Raw text from the LLM response.
+   * @param retrievedSources - The source set from HybridSearchService.
+   */
+  parse(llmOutput: string, retrievedSources: RetrievalResult[]): CitationParseResult {
+    const bySourceId = new Map<string, RetrievalResult>();
+    const byCompositeKey = new Map<string, RetrievalResult>();
+    for (const r of retrievedSources) {
+      bySourceId.set(r.sourceId, r);
+      byCompositeKey.set(`${r.sourceType}:${r.sourceId}`, r);
+    }
+
+    const matchedIds = new Set<string>();
+    let cleanedAnswer = llmOutput;
+
+    for (const match of llmOutput.matchAll(ENGRAM_CITATION_RE)) {
+      const id = match[0].slice(1, -1);
+      if (bySourceId.has(id)) {
+        matchedIds.add(id);
+      } else {
+        console.warn(`[cerebrum-query] Stripped hallucinated citation: ${id}`);
+        cleanedAnswer = cleanedAnswer.replace(match[0], '');
+      }
+    }
+
+    for (const match of llmOutput.matchAll(TYPED_CITATION_RE)) {
+      const fullMatch = match[0];
+      const sourceType = match[1];
+      const sourceId = match[2];
+      if (!sourceType || !sourceId) continue;
+      const key = `${sourceType}:${sourceId}`;
+      const result = byCompositeKey.get(key);
+      if (result) {
+        matchedIds.add(result.sourceId);
+      } else if (bySourceId.has(sourceId)) {
+        matchedIds.add(sourceId);
+      } else {
+        console.warn(`[cerebrum-query] Stripped hallucinated typed citation: ${fullMatch}`);
+        cleanedAnswer = cleanedAnswer.replace(fullMatch, '');
+      }
+    }
+
+    const citations: SourceCitation[] = [];
+    for (const id of matchedIds) {
+      const result = bySourceId.get(id);
+      if (!result) continue;
+      citations.push({
+        id: result.sourceId,
+        type: result.sourceType,
+        title: result.title,
+        excerpt: formatExcerpt(result),
+        relevance: result.score,
+        scope: extractPrimaryScope(result),
+      });
+    }
+
+    citations.sort((a, b) => b.relevance - a.relevance);
+
+    cleanedAnswer = cleanedAnswer.replace(/  +/g, ' ').trim();
+
+    return { cleanedAnswer, citations };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/query/llm.ts
+++ b/pillars/cerebrum/src/api/modules/query/llm.ts
@@ -1,0 +1,167 @@
+/**
+ * LLM ports for the cerebrum query engine.
+ *
+ * Two capabilities, both injectable so the engine runs against a real
+ * Anthropic client in production and canned fakes in tests (tests MUST NOT
+ * reach a real API):
+ *
+ *  - {@link QueryLlm}       — one-shot completion for `ask` (system + question →
+ *                             text). Degrades to a display-safe fallback string
+ *                             when the API key is missing or the call throws.
+ *  - {@link QueryStreamLlm} — token-streaming completion for the SSE route,
+ *                             yielding incremental text deltas then a final
+ *                             token-usage record.
+ *
+ * Deviations from the monolith (parity with the ingest slice):
+ * - Model overrides / settings → hardcoded `claude-sonnet-4-6` constant with an
+ *   optional `CEREBRUM_QUERY_MODEL` env override. No settings-DB tier.
+ * - `trackInference` / `ai_inference_log` dropped entirely. Only the 429
+ *   backoff ({@link withRateLimitRetry}, reused from the ingest slice) is kept.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { withRateLimitRetry } from '../ingest/llm.js';
+
+import type { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
+
+export const DEFAULT_QUERY_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MAX_TOKENS = 1024;
+
+const LLM_UNAVAILABLE_MSG =
+  "I don't have enough information to answer that fully. (LLM unavailable)";
+const LLM_ERROR_MSG = "I don't have enough information to answer that fully. (LLM error)";
+
+function queryModel(): string {
+  const value = process.env['CEREBRUM_QUERY_MODEL'];
+  return value !== undefined && value !== '' ? value : DEFAULT_QUERY_MODEL;
+}
+
+/** One-shot query completion. */
+export interface QueryLlm {
+  /**
+   * Return the model's answer for a system prompt + question. Always resolves
+   * to a display-safe string — never throws — degrading to a fallback message
+   * when the model is unavailable.
+   */
+  complete(systemPrompt: string, question: string): Promise<string>;
+}
+
+/** A single text delta yielded while the model streams. */
+export interface QueryStreamDelta {
+  kind: 'delta';
+  text: string;
+}
+
+/** Terminal record yielded once the model stream completes. */
+export interface QueryStreamFinal {
+  kind: 'final';
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export type QueryStreamChunk = QueryStreamDelta | QueryStreamFinal;
+
+/** Token-streaming query completion. */
+export interface QueryStreamLlm {
+  /**
+   * Stream the model's answer as text deltas, terminated by a single `final`
+   * chunk carrying token usage. Never throws — a missing key / SDK error
+   * yields a fallback delta then a zero-usage `final`.
+   */
+  stream(systemPrompt: string, question: string): AsyncGenerator<QueryStreamChunk>;
+}
+
+/**
+ * Real Anthropic-backed {@link QueryLlm}. Reads `ANTHROPIC_API_KEY` lazily so a
+ * missing key degrades to a fallback message rather than throwing.
+ */
+export class AnthropicQueryLlm implements QueryLlm {
+  async complete(systemPrompt: string, question: string): Promise<string> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-query] ANTHROPIC_API_KEY not set — returning fallback answer');
+      return LLM_UNAVAILABLE_MSG;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    try {
+      const response = await withRateLimitRetry(
+        () =>
+          client.messages.create({
+            model: queryModel(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: 0,
+            system: systemPrompt,
+            messages: [{ role: 'user', content: question }],
+          }),
+        'cerebrum.query'
+      );
+      const first = response.content[0];
+      return first?.type === 'text' ? first.text : '';
+    } catch (err) {
+      console.warn(
+        `[cerebrum-query] LLM call failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return LLM_ERROR_MSG;
+    }
+  }
+}
+
+async function* iterateStream(stream: MessageStream): AsyncGenerator<QueryStreamChunk> {
+  for await (const event of stream) {
+    if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+      yield { kind: 'delta', text: event.delta.text };
+    }
+  }
+  const finalMessage = await stream.finalMessage();
+  yield {
+    kind: 'final',
+    tokensIn: finalMessage.usage.input_tokens,
+    tokensOut: finalMessage.usage.output_tokens,
+  };
+}
+
+/**
+ * Real Anthropic-backed {@link QueryStreamLlm}. Mirrors {@link AnthropicQueryLlm}'s
+ * degradation: a missing key yields the unavailable fallback, an SDK error
+ * yields the error fallback, both terminated by a zero-usage `final`.
+ */
+export class AnthropicQueryStreamLlm implements QueryStreamLlm {
+  async *stream(systemPrompt: string, question: string): AsyncGenerator<QueryStreamChunk> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-query] ANTHROPIC_API_KEY not set — yielding fallback answer');
+      yield { kind: 'delta', text: LLM_UNAVAILABLE_MSG };
+      yield { kind: 'final', tokensIn: 0, tokensOut: 0 };
+      return;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    let stream: MessageStream;
+    try {
+      stream = client.messages.stream({
+        model: queryModel(),
+        max_tokens: DEFAULT_MAX_TOKENS,
+        temperature: 0,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: question }],
+      });
+    } catch (err) {
+      console.warn(
+        `[cerebrum-query] stream creation failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      yield { kind: 'delta', text: LLM_ERROR_MSG };
+      yield { kind: 'final', tokensIn: 0, tokensOut: 0 };
+      return;
+    }
+
+    try {
+      yield* iterateStream(stream);
+    } catch (err) {
+      console.warn(
+        `[cerebrum-query] stream processing failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      yield { kind: 'final', tokensIn: 0, tokensOut: 0 };
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/query/prompts.ts
+++ b/pillars/cerebrum/src/api/modules/query/prompts.ts
@@ -1,0 +1,26 @@
+/**
+ * LLM system prompt templates for the cerebrum query engine (PRD-082).
+ *
+ * Prompts are exported as template functions so they can be configured or
+ * overridden in tests without hardcoding strings in the service.
+ */
+
+/**
+ * Build the system prompt for the query answering LLM call.
+ *
+ * @param context - Pre-assembled, token-budgeted context window from ContextAssemblyService.
+ */
+export function buildQuerySystemPrompt(context: string): string {
+  return `You are Cerebrum, a personal knowledge retrieval engine. Answer the user's question
+using ONLY the context provided below. Follow these rules strictly:
+
+1. Answer only from the provided context. Do not use external knowledge.
+2. Cite every claim by including the source ID in square brackets, e.g. [eng_20260417_0942_agent-coordination].
+3. If the context does not contain enough information to answer, say: "I don't have enough information to answer that fully." and cite what you can.
+4. Keep answers concise and direct.
+5. When citing transactions, include the amount and date.
+6. When citing media, include the title and type.
+
+Context:
+${context}`;
+}

--- a/pillars/cerebrum/src/api/modules/query/query-service.ts
+++ b/pillars/cerebrum/src/api/modules/query/query-service.ts
@@ -1,0 +1,239 @@
+/**
+ * QueryService — pipeline orchestrator for the cerebrum query engine (PRD-082).
+ *
+ * Methods:
+ *   ask           — full NL Q&A: scope inference → retrieval → LLM → citations
+ *   prepareStream — streaming variant: same pre-LLM pipeline, then a token stream
+ *   retrieve      — retrieval-only (no LLM), returns sources
+ *   explain       — debug: shows what the pipeline would do without executing
+ *
+ * Reuses the in-pillar retrieval slice (`HybridSearchService`,
+ * `ContextAssemblyService`). The LLM ports are injected so tests stay offline.
+ * Settings-service tunables are replaced with constants (the pillar has no
+ * settings service).
+ */
+import { ContextAssemblyService } from '../retrieval/context-assembly.js';
+import { HybridSearchService } from '../retrieval/hybrid-search.js';
+import { CitationParser } from './citation-parser.js';
+import { buildQuerySystemPrompt } from './prompts.js';
+import { streamQueryAnswer } from './query-stream.js';
+import { QueryScopeInferencer } from './scope-inferencer.js';
+
+import type { SemanticSearchDeps } from '../retrieval/semantic-search.js';
+import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
+import type { QueryLlm, QueryStreamLlm } from './llm.js';
+import type { QueryStreamEvent } from './query-stream.js';
+import type {
+  ConfidenceLevel,
+  QueryDomain,
+  QueryRequest,
+  QueryResponse,
+  ScopeInferenceResult,
+  SourceCitation,
+} from './types.js';
+
+const QUERY_MAX_SOURCES = 10;
+const QUERY_RELEVANCE_THRESHOLD = 0.3;
+const QUERY_TOKEN_BUDGET = 4096;
+const EXCERPT_MAX_LENGTH = 200;
+
+const NO_INFO_ANSWER = "I don't have information about that.";
+
+/** Retrieval deps + the injected LLM ports the query pipeline consumes. */
+export interface QueryServiceDeps extends SemanticSearchDeps {
+  llm: QueryLlm;
+  streamLlm: QueryStreamLlm;
+}
+
+/** Map domain names to retrieval sourceType values. */
+const DOMAIN_MAP: Record<QueryDomain, string> = {
+  engrams: 'engram',
+  transactions: 'transaction',
+  media: 'media',
+  inventory: 'inventory',
+};
+
+type PreparedQuery =
+  | { kind: 'no-results'; scopes: string[] }
+  | {
+      kind: 'prepared';
+      question: string;
+      scopes: string[];
+      results: RetrievalResult[];
+      systemPrompt: string;
+    };
+
+async function* emitNoResultsStream(scopes: string[]): AsyncGenerator<QueryStreamEvent> {
+  yield { type: 'token', text: NO_INFO_ANSWER };
+  yield {
+    type: 'done',
+    answer: NO_INFO_ANSWER,
+    sources: [],
+    scopes,
+    confidence: 'low',
+    tokensIn: 0,
+    tokensOut: 0,
+  };
+}
+
+function computeConfidence(sources: SourceCitation[]): ConfidenceLevel {
+  if (sources.length === 0) return 'low';
+  const topScore = sources[0]?.relevance ?? 0;
+  if (topScore > 0.8) return 'high';
+  if (topScore >= 0.5) return 'medium';
+  return 'low';
+}
+
+function buildRetrievalFilters(
+  scopes: string[],
+  includeSecret: boolean,
+  domains?: QueryDomain[]
+): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+  if (scopes.length > 0) filters.scopes = scopes;
+  if (includeSecret) filters.includeSecret = true;
+  if (domains && domains.length > 0) filters.sourceTypes = domains.map((d) => DOMAIN_MAP[d]);
+  return filters;
+}
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '…';
+}
+
+function extractPrimaryScope(result: { metadata: Record<string, unknown> }): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+export class QueryService {
+  private readonly inferencer = new QueryScopeInferencer();
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+  private readonly search: HybridSearchService;
+
+  constructor(private readonly deps: QueryServiceDeps) {
+    this.search = new HybridSearchService(deps);
+  }
+
+  /** Full NL Q&A pipeline: infer scopes → retrieve → LLM → parse citations. */
+  async ask(request: QueryRequest): Promise<QueryResponse> {
+    const prepared = await this.prepareCommon(request);
+    if (prepared.kind === 'no-results') {
+      return { answer: NO_INFO_ANSWER, sources: [], scopes: prepared.scopes, confidence: 'low' };
+    }
+
+    const llmAnswer = await this.deps.llm.complete(prepared.systemPrompt, prepared.question);
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmAnswer, prepared.results);
+
+    const confidence = citations.length === 0 ? 'low' : computeConfidence(citations);
+
+    return { answer: cleanedAnswer, sources: citations, scopes: prepared.scopes, confidence };
+  }
+
+  /**
+   * Streaming variant of `ask()`. Runs the same retrieval + context assembly
+   * up-front, then returns an async generator that yields `token` events while
+   * the LLM streams and a final `done` event with parsed citations.
+   */
+  async prepareStream(request: QueryRequest): Promise<AsyncGenerator<QueryStreamEvent>> {
+    const prepared = await this.prepareCommon(request);
+    if (prepared.kind === 'no-results') {
+      return emitNoResultsStream(prepared.scopes);
+    }
+    return streamQueryAnswer({
+      llm: this.deps.streamLlm,
+      systemPrompt: prepared.systemPrompt,
+      question: prepared.question,
+      retrievedResults: prepared.results,
+      scopes: prepared.scopes,
+    });
+  }
+
+  /** Shared pre-LLM pipeline used by both `ask()` and `prepareStream()`. */
+  private async prepareCommon(request: QueryRequest): Promise<PreparedQuery> {
+    const question = request.question.trim();
+    const maxSources = request.maxSources ?? QUERY_MAX_SOURCES;
+    const includeSecret = request.includeSecret ?? false;
+
+    const scopeResult = this.inferencer.infer(question, undefined, request.scopes, includeSecret);
+    const filters = buildRetrievalFilters(scopeResult.scopes, includeSecret, request.domains);
+    const results = await this.search.hybrid(
+      question,
+      filters,
+      maxSources,
+      QUERY_RELEVANCE_THRESHOLD
+    );
+
+    if (results.length === 0) {
+      return { kind: 'no-results', scopes: scopeResult.scopes };
+    }
+
+    const assembled = this.assembler.assemble({
+      query: question,
+      results,
+      tokenBudget: QUERY_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    return {
+      kind: 'prepared',
+      question,
+      scopes: scopeResult.scopes,
+      results,
+      systemPrompt: buildQuerySystemPrompt(assembled.context),
+    };
+  }
+
+  /** Retrieval-only: returns sources without calling the LLM. */
+  async retrieve(
+    question: string,
+    scopes?: string[],
+    includeSecret?: boolean,
+    maxSources?: number
+  ): Promise<{ sources: SourceCitation[] }> {
+    const trimmed = question.trim();
+    const limit = maxSources ?? QUERY_MAX_SOURCES;
+    const secret = includeSecret ?? false;
+
+    const scopeResult = this.inferencer.infer(trimmed, undefined, scopes, secret);
+    const filters = buildRetrievalFilters(scopeResult.scopes, secret);
+    const results = await this.search.hybrid(trimmed, filters, limit, QUERY_RELEVANCE_THRESHOLD);
+
+    const sources: SourceCitation[] = results.map((r) => ({
+      id: r.sourceId,
+      type: r.sourceType,
+      title: r.title,
+      excerpt: truncateExcerpt(r.contentPreview ?? ''),
+      relevance: r.score,
+      scope: extractPrimaryScope(r),
+    }));
+
+    return { sources };
+  }
+
+  /** Debug: shows scope inference + retrieval plan without executing. */
+  explain(question: string): {
+    scopeInference: ScopeInferenceResult;
+    retrievalPlan: { filters: RetrievalFilters; maxSources: number; threshold: number };
+    secretNotice: string | null;
+  } {
+    const trimmed = question.trim();
+    const scopeResult = this.inferencer.infer(trimmed);
+    const filters = buildRetrievalFilters(scopeResult.scopes, false);
+    const secretNotice = this.inferencer.detectSecretMention(trimmed);
+
+    return {
+      scopeInference: scopeResult,
+      retrievalPlan: {
+        filters,
+        maxSources: QUERY_MAX_SOURCES,
+        threshold: QUERY_RELEVANCE_THRESHOLD,
+      },
+      secretNotice,
+    };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/query/query-stream.ts
+++ b/pillars/cerebrum/src/api/modules/query/query-stream.ts
@@ -1,0 +1,94 @@
+/**
+ * Streaming generator for the cerebrum query engine (PRD-082, issue #2596).
+ *
+ * Companion to `query-service.ts`: drives the injected {@link QueryStreamLlm}
+ * port, yielding incremental `token` events while the model streams and a
+ * final `done` event with parsed citations + confidence.
+ *
+ * Deviation from the monolith: the Anthropic call is no longer inlined here —
+ * it lives behind the {@link QueryStreamLlm} port so tests inject a fake that
+ * yields canned tokens. `trackInference` is dropped (no `ai_inference_log` in
+ * the pillar).
+ */
+import { CitationParser } from './citation-parser.js';
+
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { QueryStreamLlm } from './llm.js';
+import type { ConfidenceLevel, SourceCitation } from './types.js';
+
+/** Event yielded while tokens are still streaming. */
+export interface QueryStreamToken {
+  type: 'token';
+  text: string;
+}
+
+/** Final event emitted after the LLM stream completes. */
+export interface QueryStreamDone {
+  type: 'done';
+  /** Cleaned answer text (citations stripped of hallucinations). */
+  answer: string;
+  sources: SourceCitation[];
+  scopes: string[];
+  confidence: ConfidenceLevel;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Union type for all events yielded by `streamQueryAnswer`. */
+export type QueryStreamEvent = QueryStreamToken | QueryStreamDone;
+
+function computeConfidence(sources: SourceCitation[]): ConfidenceLevel {
+  if (sources.length === 0) return 'low';
+  const topScore = sources[0]?.relevance ?? 0;
+  if (topScore > 0.8) return 'high';
+  if (topScore >= 0.5) return 'medium';
+  return 'low';
+}
+
+export interface StreamQueryAnswerParams {
+  llm: QueryStreamLlm;
+  systemPrompt: string;
+  question: string;
+  retrievedResults: RetrievalResult[];
+  scopes: string[];
+}
+
+/**
+ * Stream a query answer token-by-token, then emit a single `done` event with
+ * the parsed citation set, computed confidence and the final scopes used.
+ * The injected {@link QueryStreamLlm} handles its own degradation, so this
+ * generator stays purely about wiring tokens through and parsing the result.
+ */
+export async function* streamQueryAnswer(
+  params: StreamQueryAnswerParams
+): AsyncGenerator<QueryStreamEvent> {
+  const { llm, systemPrompt, question, retrievedResults, scopes } = params;
+  const citationParser = new CitationParser();
+
+  let fullText = '';
+  let tokensIn = 0;
+  let tokensOut = 0;
+
+  for await (const chunk of llm.stream(systemPrompt, question)) {
+    if (chunk.kind === 'delta') {
+      fullText += chunk.text;
+      yield { type: 'token', text: chunk.text };
+    } else {
+      tokensIn = chunk.tokensIn;
+      tokensOut = chunk.tokensOut;
+    }
+  }
+
+  const { cleanedAnswer, citations } = citationParser.parse(fullText, retrievedResults);
+  const confidence: ConfidenceLevel = citations.length === 0 ? 'low' : computeConfidence(citations);
+
+  yield {
+    type: 'done',
+    answer: cleanedAnswer,
+    sources: citations,
+    scopes,
+    confidence,
+    tokensIn,
+    tokensOut,
+  };
+}

--- a/pillars/cerebrum/src/api/modules/query/scope-inferencer.ts
+++ b/pillars/cerebrum/src/api/modules/query/scope-inferencer.ts
@@ -1,0 +1,110 @@
+/**
+ * QueryScopeInferencer — keyword-based scope inference for the query engine
+ * (PRD-082 US-02).
+ *
+ * Matches question text against work/personal keyword lists to narrow retrieval
+ * scopes. Falls back to all non-secret scopes when ambiguous. Lifted verbatim
+ * from the monolith (pure logic, no settings/logger dependency).
+ */
+import type { ScopeInferenceResult } from './types.js';
+
+const WORK_KEYWORDS = [
+  'work',
+  'office',
+  'meeting',
+  'project',
+  'client',
+  'deadline',
+  'sprint',
+  'standup',
+  'pr',
+  'prs',
+  'deploy',
+];
+
+const PERSONAL_KEYWORDS = [
+  'journal',
+  'diary',
+  'therapy',
+  'family',
+  'personal',
+  'health',
+  'exercise',
+  'hobby',
+];
+
+const SECRET_KEYWORDS = ['secret', 'password', 'private key', 'credential'];
+
+/**
+ * Check whether a scope path contains a "secret" segment.
+ * E.g. "personal.secret.keys" → true, "work.notes" → false.
+ */
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/**
+ * Test whether any keyword appears as a standalone word in the question.
+ * Uses a word-boundary regex to avoid partial matches (e.g. "therapy" should
+ * not match "the").
+ */
+function matchesKeywords(question: string, keywords: readonly string[]): boolean {
+  const lower = question.toLowerCase();
+  return keywords.some((kw) => new RegExp(`\\b${kw}\\b`, 'i').test(lower));
+}
+
+export class QueryScopeInferencer {
+  /**
+   * Infer retrieval scopes from the question text.
+   *
+   * @param question      - The user's natural language question.
+   * @param knownScopes   - All scopes available in the system (optional).
+   * @param explicit      - Explicit scopes from QueryRequest (skip inference).
+   * @param includeSecret - If true, allow secret scopes through.
+   */
+  infer(
+    question: string,
+    knownScopes?: string[],
+    explicit?: string[],
+    includeSecret?: boolean
+  ): ScopeInferenceResult {
+    if (explicit && explicit.length > 0) {
+      const scopes = includeSecret ? explicit : explicit.filter((s) => !isSecretScope(s));
+      return { scopes, source: 'explicit' };
+    }
+
+    const pool = knownScopes ?? [];
+
+    if (matchesKeywords(question, WORK_KEYWORDS)) {
+      const workScopes = pool.filter(
+        (s) => s.startsWith('work.') && (includeSecret === true || !isSecretScope(s))
+      );
+      if (workScopes.length > 0) {
+        return { scopes: workScopes, source: 'inferred' };
+      }
+    }
+
+    if (matchesKeywords(question, PERSONAL_KEYWORDS)) {
+      const personalScopes = pool.filter(
+        (s) => s.startsWith('personal.') && (includeSecret === true || !isSecretScope(s))
+      );
+      if (personalScopes.length > 0) {
+        return { scopes: personalScopes, source: 'inferred' };
+      }
+    }
+
+    const defaultScopes = includeSecret ? pool : pool.filter((s) => !isSecretScope(s));
+    return { scopes: defaultScopes, source: 'default' };
+  }
+
+  /**
+   * Detect whether the question mentions secret/sensitive concepts.
+   * Returns a notice string if detected, null otherwise.
+   */
+  detectSecretMention(question: string): string | null {
+    if (matchesKeywords(question, SECRET_KEYWORDS)) {
+      return 'Your question may reference sensitive data. Secret scopes are excluded unless explicitly enabled.';
+    }
+    return null;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/query/types.ts
+++ b/pillars/cerebrum/src/api/modules/query/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Types for the cerebrum query engine (PRD-082).
+ *
+ * Covers: QueryRequest, QueryResponse, SourceCitation, ScopeInferenceResult,
+ * and domain-to-sourceType mappings. Lifted verbatim from the monolith.
+ */
+
+export type QueryDomain = 'engrams' | 'transactions' | 'media' | 'inventory';
+
+/** Supported query domains mapped to retrieval sourceType values. */
+export const DOMAIN_SOURCE_TYPE_MAP: Record<QueryDomain, string> = {
+  engrams: 'engram',
+  transactions: 'transaction',
+  media: 'media',
+  inventory: 'inventory',
+};
+
+export const ALL_QUERY_DOMAINS: QueryDomain[] = ['engrams', 'transactions', 'media', 'inventory'];
+
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+export interface QueryRequest {
+  question: string;
+  scopes?: string[];
+  includeSecret?: boolean;
+  /** Maximum number of sources to retrieve (default 10). */
+  maxSources?: number;
+  /** Filter by domain. Omit or empty to search all. */
+  domains?: QueryDomain[];
+}
+
+export interface QueryResponse {
+  answer: string;
+  sources: SourceCitation[];
+  /** Scopes used for retrieval (explicit or inferred). */
+  scopes: string[];
+  confidence: ConfidenceLevel;
+}
+
+export interface SourceCitation {
+  id: string;
+  type: string;
+  title: string;
+  /** Max 200 chars, truncated at word boundary with ellipsis. */
+  excerpt: string;
+  /** Relevance score 0–1. */
+  relevance: number;
+  /** Primary scope of the source. */
+  scope: string;
+}
+
+export type ScopeInferenceSource = 'explicit' | 'inferred' | 'default';
+
+export interface ScopeInferenceResult {
+  scopes: string[];
+  source: ScopeInferenceSource;
+}
+
+/** Internal result from the citation parser. */
+export interface CitationParseResult {
+  cleanedAnswer: string;
+  citations: SourceCitation[];
+}

--- a/pillars/cerebrum/src/api/rest/emit-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/emit-handlers.ts
@@ -1,0 +1,153 @@
+/**
+ * ts-rest handlers for `cerebrum.emit.*` (PRD-083 document generation).
+ *
+ * Each handler builds a request-scoped {@link GenerationService} bound to the
+ * pillar db (drizzle + raw + vec availability), the injected peer/embedding
+ * retrieval clients, and the injected {@link GenerationLlm} port, then
+ * delegates. The service is stateless — all scope/audience filtering rides in
+ * the request body — so there is no per-request auth.
+ *
+ * Mode-specific guards (report needs a query, summary needs a date range,
+ * `from <= to`) map to 400 via the pillar {@link ValidationError} + `runHttp`.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumEmitContract } from '../../contract/rest-emit.js';
+import { type CerebrumDb } from '../../db/index.js';
+import {
+  GenerationService,
+  type GenerationServiceDeps,
+} from '../modules/emit/generation-service.js';
+import { type GenerationLlm } from '../modules/emit/llm.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { EmitDateRangeWire } from '../../contract/rest-emit-schemas.js';
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface EmitHandlerDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  peers: PeerClients;
+  embeddingClient?: EmbeddingClient;
+  llm: GenerationLlm;
+}
+
+function validateDateRange(dateRange: EmitDateRangeWire | undefined): void {
+  if (!dateRange) return;
+  if (dateRange.from > dateRange.to) {
+    throw new ValidationError({
+      message: 'Invalid date range: from must be before or equal to to',
+    });
+  }
+}
+
+export function makeEmitHandlers(
+  deps: EmitHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumEmitContract>> {
+  const serviceDeps: GenerationServiceDeps = {
+    db: deps.db,
+    raw: deps.raw,
+    vecAvailable: deps.vecAvailable,
+    peers: deps.peers,
+    embeddingClient: deps.embeddingClient,
+    llm: deps.llm,
+  };
+  const service = (): GenerationService => new GenerationService(serviceDeps);
+
+  return server.router(cerebrumEmitContract, {
+    generate: async ({ body }) =>
+      runHttp(async () => {
+        if (body.mode === 'report' && !body.query) {
+          throw new ValidationError({ message: 'Query is required for report mode' });
+        }
+        if (body.mode === 'summary' && !body.dateRange) {
+          throw new ValidationError({ message: 'Date range is required for summary mode' });
+        }
+        validateDateRange(body.dateRange);
+        const result = await service().generate({
+          mode: body.mode,
+          query: body.query,
+          dateRange: body.dateRange,
+          scopes: body.scopes,
+          audienceScope: body.audienceScope,
+          includeSecret: body.includeSecret,
+          types: body.types,
+          tags: body.tags,
+          format: body.format === 'plain' ? 'plain' : 'markdown',
+          groupBy: body.groupBy,
+        });
+        return { status: 200 as const, body: result };
+      }),
+
+    generateReport: async ({ body }) =>
+      runHttp(async () => {
+        const result = await service().generateReport({
+          mode: 'report',
+          query: body.query,
+          scopes: body.scopes,
+          audienceScope: body.audienceScope,
+          includeSecret: body.includeSecret,
+          types: body.types,
+          tags: body.tags,
+        });
+        return { status: 200 as const, body: result };
+      }),
+
+    generateSummary: async ({ body }) =>
+      runHttp(async () => {
+        validateDateRange(body.dateRange);
+        const result = await service().generateSummary({
+          mode: 'summary',
+          query: body.query,
+          dateRange: body.dateRange,
+          scopes: body.scopes,
+          audienceScope: body.audienceScope,
+          includeSecret: body.includeSecret,
+          types: body.types,
+          tags: body.tags,
+        });
+        return { status: 200 as const, body: result };
+      }),
+
+    generateTimeline: async ({ body }) =>
+      runHttp(async () => {
+        validateDateRange(body.dateRange);
+        const result = await service().generateTimeline({
+          mode: 'timeline',
+          query: body.query,
+          dateRange: body.dateRange,
+          scopes: body.scopes,
+          audienceScope: body.audienceScope,
+          includeSecret: body.includeSecret,
+          types: body.types,
+          tags: body.tags,
+          groupBy: body.groupBy,
+        });
+        return { status: 200 as const, body: result };
+      }),
+
+    preview: async ({ body }) =>
+      runHttp(async () => {
+        validateDateRange(body.dateRange);
+        const result = await service().preview({
+          mode: body.mode,
+          query: body.query,
+          dateRange: body.dateRange,
+          scopes: body.scopes,
+          audienceScope: body.audienceScope,
+          includeSecret: body.includeSecret,
+          types: body.types,
+          tags: body.tags,
+          groupBy: body.groupBy,
+        });
+        return { status: 200 as const, body: result };
+      }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -8,14 +8,18 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
+import { AnthropicGenerationLlm } from '../modules/emit/llm.js';
 import { resolveGliaConfigPath } from '../modules/glia/instance.js';
 import { AnthropicIngestLlm } from '../modules/ingest/llm.js';
 import { getCurationQueue } from '../modules/ingest/queue.js';
+import { AnthropicQueryLlm, AnthropicQueryStreamLlm } from '../modules/query/llm.js';
+import { makeEmitHandlers } from './emit-handlers.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
 import { makeGliaHandlers } from './glia-handlers.js';
 import { makeIngestHandlers } from './ingest-handlers.js';
 import { makeNudgesHandlers } from './nudges-handlers.js';
 import { makePlexusHandlers } from './plexus-handlers.js';
+import { makeQueryHandlers } from './query-handlers.js';
 import { makeReflexHandlers } from './reflex-handlers.js';
 import { makeRetrievalHandlers } from './retrieval-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
@@ -61,6 +65,23 @@ export function makeCerebrumRestHandlers(
       vecAvailable: deps.cerebrumDb.vecAvailable,
       peers: deps.peerClients,
       embeddingClient: deps.embeddingClient,
+    }),
+    emit: makeEmitHandlers({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+      llm: deps.emitLlm ?? new AnthropicGenerationLlm(),
+    }),
+    query: makeQueryHandlers({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+      llm: deps.queryLlm ?? new AnthropicQueryLlm(),
+      streamLlm: deps.queryStreamLlm ?? new AnthropicQueryStreamLlm(),
     }),
   });
 }

--- a/pillars/cerebrum/src/api/rest/query-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/query-handlers.ts
@@ -1,0 +1,82 @@
+/**
+ * ts-rest handlers for `cerebrum.query.*` (PRD-082 NL Q&A engine).
+ *
+ * Each handler builds a request-scoped {@link QueryService} bound to the pillar
+ * db (drizzle + raw + vec availability), the injected peer/embedding retrieval
+ * clients, and the injected {@link QueryLlm}/{@link QueryStreamLlm} ports, then
+ * delegates. The service is stateless — all scope/domain filtering rides in the
+ * request body — so there is no per-request auth.
+ *
+ * The streaming variant is NOT here: SSE can't be modelled by ts-rest, so it is
+ * mounted as a plain Express route in `app.ts`.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumQueryContract } from '../../contract/rest-query.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { type QueryLlm, type QueryStreamLlm } from '../modules/query/llm.js';
+import { QueryService, type QueryServiceDeps } from '../modules/query/query-service.js';
+import { runHttp } from './error-mapping.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface QueryHandlerDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  peers: PeerClients;
+  embeddingClient?: EmbeddingClient;
+  llm: QueryLlm;
+  streamLlm: QueryStreamLlm;
+}
+
+export function makeQueryHandlers(
+  deps: QueryHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumQueryContract>> {
+  const serviceDeps: QueryServiceDeps = {
+    db: deps.db,
+    raw: deps.raw,
+    vecAvailable: deps.vecAvailable,
+    peers: deps.peers,
+    embeddingClient: deps.embeddingClient,
+    llm: deps.llm,
+    streamLlm: deps.streamLlm,
+  };
+  const service = (): QueryService => new QueryService(serviceDeps);
+
+  return server.router(cerebrumQueryContract, {
+    ask: async ({ body }) =>
+      runHttp(async () => {
+        const result = await service().ask({
+          question: body.question,
+          scopes: body.scopes,
+          includeSecret: body.includeSecret,
+          maxSources: body.maxSources,
+          domains: body.domains,
+        });
+        return { status: 200 as const, body: result };
+      }),
+
+    retrieve: async ({ body }) =>
+      runHttp(async () => {
+        const result = await service().retrieve(
+          body.question,
+          body.scopes,
+          body.includeSecret,
+          body.maxSources
+        );
+        return { status: 200 as const, body: result };
+      }),
+
+    explain: async ({ body }) =>
+      runHttp(() => {
+        const result = service().explain(body.question);
+        return { status: 200 as const, body: result };
+      }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/query-stream-route.ts
+++ b/pillars/cerebrum/src/api/rest/query-stream-route.ts
@@ -1,0 +1,99 @@
+/**
+ * SSE route handler for streaming cerebrum query answers (PRD-082, issue
+ * #2596).
+ *
+ * `POST /query/stream` — ts-rest can't model SSE, so this is mounted as a plain
+ * Express handler in `app.ts` BEFORE `createExpressEndpoints(...)` (food
+ * precedent: the recipe-file route is registered ahead of the generated
+ * endpoints). The body matches `cerebrum.query.ask` (+ `domains`).
+ *
+ * It runs the SAME retrieval + context-assembly pipeline as `ask` (via
+ * {@link QueryService.prepareStream}) and then streams the injected
+ * {@link QueryStreamLlm}'s tokens. Wire shape mirrors the monolith:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","answer":"...","sources":[...],"scopes":[...],
+ *          "confidence":"high|medium|low","tokensIn":N,"tokensOut":N}
+ *   data: {"type":"error","message":"..."}
+ */
+import { queryStreamBodySchema } from '../../contract/rest-query-schemas.js';
+import { QueryService, type QueryServiceDeps } from '../modules/query/query-service.js';
+import { HttpError } from '../shared/errors.js';
+
+import type { Request, RequestHandler, Response } from 'express';
+
+function setSseHeaders(res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+function writeSseEvent(res: Response, data: Record<string, unknown>): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof HttpError) return err.message;
+  return err instanceof Error ? err.message : 'Internal server error';
+}
+
+async function pipeStreamEvents(
+  res: Response,
+  service: QueryService,
+  input: ReturnType<typeof queryStreamBodySchema.parse>
+): Promise<void> {
+  const stream = await service.prepareStream({
+    question: input.question,
+    scopes: input.scopes,
+    includeSecret: input.includeSecret,
+    maxSources: input.maxSources,
+    domains: input.domains,
+  });
+
+  for await (const event of stream) {
+    if (res.writableEnded || res.destroyed) break;
+
+    if (event.type === 'token') {
+      writeSseEvent(res, { type: 'token', text: event.text });
+    } else {
+      writeSseEvent(res, {
+        type: 'done',
+        answer: event.answer,
+        sources: event.sources,
+        scopes: event.scopes,
+        confidence: event.confidence,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+      });
+    }
+  }
+}
+
+/**
+ * Build the `POST /query/stream` Express handler over the query service deps.
+ * Validates the body up-front (400 on failure, before switching to SSE), then
+ * sets SSE headers and streams events; pipeline errors are surfaced as a
+ * terminal `error` frame.
+ */
+export function makeQueryStreamHandler(deps: QueryServiceDeps): RequestHandler {
+  return (req: Request, res: Response): void => {
+    const parsed = queryStreamBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'Invalid request body', details: parsed.error.issues });
+      return;
+    }
+
+    setSseHeaders(res);
+
+    void (async (): Promise<void> => {
+      try {
+        await pipeStreamEvents(res, new QueryService(deps), parsed.data);
+      } catch (err) {
+        writeSseEvent(res, { type: 'error', message: describeError(err) });
+      } finally {
+        res.end();
+      }
+    })();
+  };
+}

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -20,9 +20,11 @@ import { openCerebrumDb } from '../db/index.js';
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { buildCerebrumManifest } from './manifest.js';
+import { AnthropicGenerationLlm } from './modules/emit/llm.js';
 import { resolveEngramRoot } from './modules/engrams/instance.js';
 import { AnthropicIngestLlm } from './modules/ingest/llm.js';
 import { closeCerebrumIngestQueue, getCurationQueue } from './modules/ingest/queue.js';
+import { AnthropicQueryLlm, AnthropicQueryStreamLlm } from './modules/query/llm.js';
 import { getReflexService } from './modules/reflex/instance.js';
 import { resolveEmbeddingClientFromEnv } from './modules/retrieval/embedding-client.js';
 import { resolvePeerClientsFromEnv } from './modules/retrieval/peer-clients.js';
@@ -76,6 +78,9 @@ const app = createCerebrumApiApp({
   selfBaseUrl,
   peerClients: resolvePeerClientsFromEnv(),
   embeddingClient: resolveEmbeddingClientFromEnv(),
+  emitLlm: new AnthropicGenerationLlm(),
+  queryLlm: new AnthropicQueryLlm(),
+  queryStreamLlm: new AnthropicQueryStreamLlm(),
 });
 
 let pillarHandle: PillarBootstrapHandle | undefined;

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -3,6 +3,91 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/cerebrum generate:api-types`.
  */
 export interface paths {
+  '/emit/generate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run the full document-generation pipeline for any mode. */
+    post: operations['emit.generate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/emit/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dry-run the pipeline: return sources + an outline without synthesis. */
+    post: operations['emit.preview'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/emit/report': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate a structured report from a query. */
+    post: operations['emit.generateReport'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/emit/summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate a summary digest over a date range. */
+    post: operations['emit.generateSummary'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/emit/timeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate a chronological timeline from dated engrams. */
+    post: operations['emit.generateTimeline'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/engrams': {
     parameters: {
       query?: never;
@@ -584,6 +669,57 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/query/ask': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Full NL Q&A: scope inference → retrieval → LLM → citation parsing. */
+    post: operations['query.ask'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/query/explain': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Debug: show scope inference + retrieval plan without executing. */
+    post: operations['query.explain'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/query/retrieve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Retrieval-only — returns sources without calling the LLM. */
+    post: operations['query.retrieve'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/reflex': {
     parameters: {
       query?: never;
@@ -902,6 +1038,396 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'emit.generate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          audienceScope?: string;
+          dateRange?: {
+            from: string;
+            to: string;
+          };
+          /** @enum {string} */
+          format?: 'markdown' | 'plain';
+          /** @enum {string} */
+          groupBy?: 'type' | 'month' | 'quarter';
+          includeSecret?: boolean;
+          /** @enum {string} */
+          mode: 'report' | 'summary' | 'timeline';
+          query?: string;
+          scopes?: string[];
+          tags?: string[];
+          types?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            document: {
+              audienceScope: string;
+              body: string;
+              dateRange: {
+                from: string;
+                to: string;
+              } | null;
+              metadata: {
+                dateRange: {
+                  from: string;
+                  to: string;
+                } | null;
+                /** @enum {string} */
+                mode: 'report' | 'summary' | 'timeline';
+                scopeCoverage: string[];
+                sourceCount: number;
+                truncated: boolean;
+              };
+              /** @enum {string} */
+              mode: 'report' | 'summary' | 'timeline';
+              sources: {
+                excerpt: string;
+                id: string;
+                relevance: number;
+                scope: string;
+                title: string;
+                type: string;
+              }[];
+              title: string;
+            } | null;
+            notice?: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'emit.preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          audienceScope?: string;
+          dateRange?: {
+            from: string;
+            to: string;
+          };
+          /** @enum {string} */
+          format?: 'markdown' | 'plain';
+          /** @enum {string} */
+          groupBy?: 'type' | 'month' | 'quarter';
+          includeSecret?: boolean;
+          /** @enum {string} */
+          mode: 'report' | 'summary' | 'timeline';
+          query?: string;
+          scopes?: string[];
+          tags?: string[];
+          types?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            outline: string;
+            sources: {
+              excerpt: string;
+              id: string;
+              relevance: number;
+              scope: string;
+              title: string;
+              type: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'emit.generateReport': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          audienceScope?: string;
+          includeSecret?: boolean;
+          query: string;
+          scopes?: string[];
+          tags?: string[];
+          types?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            document: {
+              audienceScope: string;
+              body: string;
+              dateRange: {
+                from: string;
+                to: string;
+              } | null;
+              metadata: {
+                dateRange: {
+                  from: string;
+                  to: string;
+                } | null;
+                /** @enum {string} */
+                mode: 'report' | 'summary' | 'timeline';
+                scopeCoverage: string[];
+                sourceCount: number;
+                truncated: boolean;
+              };
+              /** @enum {string} */
+              mode: 'report' | 'summary' | 'timeline';
+              sources: {
+                excerpt: string;
+                id: string;
+                relevance: number;
+                scope: string;
+                title: string;
+                type: string;
+              }[];
+              title: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'emit.generateSummary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          audienceScope?: string;
+          dateRange: {
+            from: string;
+            to: string;
+          };
+          includeSecret?: boolean;
+          query?: string;
+          scopes?: string[];
+          tags?: string[];
+          types?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            document: {
+              audienceScope: string;
+              body: string;
+              dateRange: {
+                from: string;
+                to: string;
+              } | null;
+              metadata: {
+                dateRange: {
+                  from: string;
+                  to: string;
+                } | null;
+                /** @enum {string} */
+                mode: 'report' | 'summary' | 'timeline';
+                scopeCoverage: string[];
+                sourceCount: number;
+                truncated: boolean;
+              };
+              /** @enum {string} */
+              mode: 'report' | 'summary' | 'timeline';
+              sources: {
+                excerpt: string;
+                id: string;
+                relevance: number;
+                scope: string;
+                title: string;
+                type: string;
+              }[];
+              title: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'emit.generateTimeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          audienceScope?: string;
+          dateRange?: {
+            from: string;
+            to: string;
+          };
+          /** @enum {string} */
+          groupBy?: 'type' | 'month' | 'quarter';
+          includeSecret?: boolean;
+          query?: string;
+          scopes?: string[];
+          tags?: string[];
+          types?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            document: {
+              audienceScope: string;
+              body: string;
+              dateRange: {
+                from: string;
+                to: string;
+              } | null;
+              metadata: {
+                dateRange: {
+                  from: string;
+                  to: string;
+                } | null;
+                /** @enum {string} */
+                mode: 'report' | 'summary' | 'timeline';
+                scopeCoverage: string[];
+                sourceCount: number;
+                truncated: boolean;
+              };
+              /** @enum {string} */
+              mode: 'report' | 'summary' | 'timeline';
+              sources: {
+                excerpt: string;
+                id: string;
+                relevance: number;
+                scope: string;
+                title: string;
+                type: string;
+              }[];
+              title: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'engrams.create': {
     parameters: {
       query?: never;
@@ -3051,6 +3577,181 @@ export interface operations {
         content: {
           'application/json': {
             success: boolean;
+          };
+        };
+      };
+    };
+  };
+  'query.ask': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          domains?: ('engrams' | 'transactions' | 'media' | 'inventory')[];
+          includeSecret?: boolean;
+          maxSources?: number;
+          question: string;
+          scopes?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            answer: string;
+            /** @enum {string} */
+            confidence: 'high' | 'medium' | 'low';
+            scopes: string[];
+            sources: {
+              excerpt: string;
+              id: string;
+              relevance: number;
+              scope: string;
+              title: string;
+              type: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'query.explain': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          question: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            retrievalPlan: {
+              filters: {
+                customFields?: {
+                  [key: string]: unknown;
+                };
+                dateRange?: {
+                  from?: string;
+                  to?: string;
+                };
+                includeSecret?: boolean;
+                scopes?: string[];
+                sourceTypes?: string[];
+                status?: string[];
+                tags?: string[];
+                types?: string[];
+              };
+              maxSources: number;
+              threshold: number;
+            };
+            scopeInference: {
+              scopes: string[];
+              /** @enum {string} */
+              source: 'explicit' | 'inferred' | 'default';
+            };
+            secretNotice: string | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'query.retrieve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          includeSecret?: boolean;
+          maxSources?: number;
+          question: string;
+          scopes?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            sources: {
+              excerpt: string;
+              id: string;
+              relevance: number;
+              scope: string;
+              title: string;
+              type: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-emit-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-emit-schemas.ts
@@ -1,0 +1,124 @@
+/**
+ * Wire schemas for `cerebrum.emit.*` (PRD-083 document generation).
+ *
+ * The `GeneratedDocument` envelope is fully tractable (a closed scalar set, a
+ * fixed `metadata` block, and typed source-citation rows), so it is enumerated
+ * here rather than collapsed to an opaque record. The request inputs and the
+ * `sources`/`outline` preview shape are likewise fully typed.
+ *
+ * Lives in its own file (not the shared `rest-schemas.ts`) so that file stays
+ * under the oxlint `max-lines: 200` cap; no other domain consumes these.
+ */
+import { z } from 'zod';
+
+export const generationModeSchema = z.enum(['report', 'summary', 'timeline']);
+export type GenerationModeWire = z.infer<typeof generationModeSchema>;
+
+export const generationGroupBySchema = z.enum(['type', 'month', 'quarter']);
+export type GenerationGroupByWire = z.infer<typeof generationGroupBySchema>;
+
+export const generationFormatSchema = z.enum(['markdown', 'plain']);
+
+export const emitDateRangeSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+});
+export type EmitDateRangeWire = z.infer<typeof emitDateRangeSchema>;
+
+/** A single source-citation row attached to a generated document. */
+export const emitSourceCitationSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+  excerpt: z.string(),
+  relevance: z.number(),
+  scope: z.string(),
+});
+export type EmitSourceCitationWire = z.infer<typeof emitSourceCitationSchema>;
+
+/** Per-generation metadata block attached to a document. */
+export const generationMetadataSchema = z.object({
+  sourceCount: z.number().int(),
+  dateRange: emitDateRangeSchema.nullable(),
+  scopeCoverage: z.array(z.string()),
+  mode: generationModeSchema,
+  truncated: z.boolean(),
+});
+
+/**
+ * Wire projection of `GeneratedDocument`. The shape is fully tractable (closed
+ * scalar set + a fixed `metadata` block + typed citation rows), so it is
+ * enumerated rather than projected as an opaque record — there is no mode-
+ * dependent variation in the document envelope itself.
+ */
+export const generatedDocumentSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  mode: generationModeSchema,
+  sources: z.array(emitSourceCitationSchema),
+  audienceScope: z.string(),
+  dateRange: emitDateRangeSchema.nullable(),
+  metadata: generationMetadataSchema,
+});
+export type GeneratedDocumentWire = z.infer<typeof generatedDocumentSchema>;
+
+export const emitGenerateBodySchema = z.object({
+  mode: generationModeSchema,
+  query: z.string().min(1).optional(),
+  dateRange: emitDateRangeSchema.optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  format: generationFormatSchema.optional(),
+  groupBy: generationGroupBySchema.optional(),
+});
+export type EmitGenerateBodyWire = z.infer<typeof emitGenerateBodySchema>;
+
+export const emitReportBodySchema = z.object({
+  query: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+export type EmitReportBodyWire = z.infer<typeof emitReportBodySchema>;
+
+export const emitSummaryBodySchema = z.object({
+  dateRange: emitDateRangeSchema,
+  query: z.string().min(1).optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+export type EmitSummaryBodyWire = z.infer<typeof emitSummaryBodySchema>;
+
+export const emitTimelineBodySchema = z.object({
+  query: z.string().min(1).optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  dateRange: emitDateRangeSchema.optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  groupBy: generationGroupBySchema.optional(),
+});
+export type EmitTimelineBodyWire = z.infer<typeof emitTimelineBodySchema>;
+
+export const emitGenerateResponseSchema = z.object({
+  document: generatedDocumentSchema.nullable(),
+  notice: z.string().optional(),
+});
+
+export const emitDocumentResponseSchema = z.object({
+  document: generatedDocumentSchema.nullable(),
+});
+
+export const emitPreviewResponseSchema = z.object({
+  sources: z.array(emitSourceCitationSchema),
+  outline: z.string(),
+});

--- a/pillars/cerebrum/src/contract/rest-emit.ts
+++ b/pillars/cerebrum/src/contract/rest-emit.ts
@@ -1,0 +1,82 @@
+/**
+ * ts-rest contract for `cerebrum.emit.*` — document generation (PRD-083).
+ *
+ * The generation pipeline is STATELESS: scope/audience/type filtering rides in
+ * the request body, never derived from a caller identity. The domain is served
+ * on the docker-network trust boundary with no per-request auth, like the other
+ * migrated domains.
+ *
+ * Every procedure is POST (the bodies carry filter objects + arrays that don't
+ * round-trip cleanly through a query string — mirrors the ingest + retrieval
+ * precedent). The generated OpenAPI derives dotted operation ids
+ * (`emit.generate`, …) from the router keys via `setOperationId`.
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  emitDocumentResponseSchema,
+  emitGenerateBodySchema,
+  emitGenerateResponseSchema,
+  emitPreviewResponseSchema,
+  emitReportBodySchema,
+  emitSummaryBodySchema,
+  emitTimelineBodySchema,
+} from './rest-emit-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const cerebrumEmitContract = c.router({
+  generate: {
+    method: 'POST',
+    path: '/emit/generate',
+    summary: 'Run the full document-generation pipeline for any mode.',
+    body: emitGenerateBodySchema,
+    responses: {
+      200: emitGenerateResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  generateReport: {
+    method: 'POST',
+    path: '/emit/report',
+    summary: 'Generate a structured report from a query.',
+    body: emitReportBodySchema,
+    responses: {
+      200: emitDocumentResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  generateSummary: {
+    method: 'POST',
+    path: '/emit/summary',
+    summary: 'Generate a summary digest over a date range.',
+    body: emitSummaryBodySchema,
+    responses: {
+      200: emitDocumentResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  generateTimeline: {
+    method: 'POST',
+    path: '/emit/timeline',
+    summary: 'Generate a chronological timeline from dated engrams.',
+    body: emitTimelineBodySchema,
+    responses: {
+      200: emitDocumentResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  preview: {
+    method: 'POST',
+    path: '/emit/preview',
+    summary: 'Dry-run the pipeline: return sources + an outline without synthesis.',
+    body: emitGenerateBodySchema,
+    responses: {
+      200: emitPreviewResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+});
+
+export type CerebrumEmitContract = typeof cerebrumEmitContract;

--- a/pillars/cerebrum/src/contract/rest-query-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-query-schemas.ts
@@ -1,0 +1,83 @@
+/**
+ * Wire schemas for `cerebrum.query.*` (PRD-082 NL Q&A engine).
+ *
+ * The query surface returns well-bounded shapes (answer text + citation rows +
+ * scope/plan scalars), so unlike emit there is no opaque-record escape hatch
+ * here — every field is typed. The `retrievalPlan.filters` shape reuses the
+ * retrieval domain's filter schema.
+ *
+ * Lives in its own file (not the shared `rest-schemas.ts`) so that file stays
+ * under the oxlint `max-lines: 200` cap; no other domain consumes these.
+ */
+import { z } from 'zod';
+
+import { retrievalFiltersSchema } from './rest-retrieval-schemas.js';
+
+export const queryDomainSchema = z.enum(['engrams', 'transactions', 'media', 'inventory']);
+export type QueryDomainWire = z.infer<typeof queryDomainSchema>;
+
+export const queryConfidenceSchema = z.enum(['high', 'medium', 'low']);
+export type QueryConfidenceWire = z.infer<typeof queryConfidenceSchema>;
+
+export const queryScopeInferenceSourceSchema = z.enum(['explicit', 'inferred', 'default']);
+
+/** A single source-citation row attached to a query answer. */
+export const querySourceCitationSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+  excerpt: z.string(),
+  relevance: z.number(),
+  scope: z.string(),
+});
+export type QuerySourceCitationWire = z.infer<typeof querySourceCitationSchema>;
+
+export const queryAskBodySchema = z.object({
+  question: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  includeSecret: z.boolean().optional(),
+  maxSources: z.number().int().positive().max(50).optional(),
+  domains: z.array(queryDomainSchema).optional(),
+});
+export type QueryAskBodyWire = z.infer<typeof queryAskBodySchema>;
+
+export const queryRetrieveBodySchema = z.object({
+  question: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  includeSecret: z.boolean().optional(),
+  maxSources: z.number().int().positive().max(50).optional(),
+});
+export type QueryRetrieveBodyWire = z.infer<typeof queryRetrieveBodySchema>;
+
+export const queryExplainBodySchema = z.object({
+  question: z.string().min(1),
+});
+export type QueryExplainBodyWire = z.infer<typeof queryExplainBodySchema>;
+
+/** Body accepted by the SSE `/query/stream` route — `ask` body + `domains`. */
+export const queryStreamBodySchema = queryAskBodySchema;
+export type QueryStreamBodyWire = z.infer<typeof queryStreamBodySchema>;
+
+export const queryAskResponseSchema = z.object({
+  answer: z.string(),
+  sources: z.array(querySourceCitationSchema),
+  scopes: z.array(z.string()),
+  confidence: queryConfidenceSchema,
+});
+
+export const queryRetrieveResponseSchema = z.object({
+  sources: z.array(querySourceCitationSchema),
+});
+
+export const queryExplainResponseSchema = z.object({
+  scopeInference: z.object({
+    scopes: z.array(z.string()),
+    source: queryScopeInferenceSourceSchema,
+  }),
+  retrievalPlan: z.object({
+    filters: retrievalFiltersSchema,
+    maxSources: z.number().int(),
+    threshold: z.number(),
+  }),
+  secretNotice: z.string().nullable(),
+});

--- a/pillars/cerebrum/src/contract/rest-query.ts
+++ b/pillars/cerebrum/src/contract/rest-query.ts
@@ -1,0 +1,62 @@
+/**
+ * ts-rest contract for `cerebrum.query.*` — the NL Q&A engine (PRD-082).
+ *
+ * STATELESS: scope/domain filtering rides in the request body, never derived
+ * from a caller identity. Served on the docker-network trust boundary with no
+ * per-request auth, like the other migrated domains.
+ *
+ * `ask` / `retrieve` / `explain` are all POST (the bodies carry scope/domain
+ * arrays). The SSE stream variant (`POST /query/stream`) cannot be modelled by
+ * ts-rest, so it is mounted as a plain Express route in `app.ts` ahead of
+ * `createExpressEndpoints`; its request body matches `queryStreamBodySchema`
+ * (the `ask` body). The generated OpenAPI derives dotted operation ids
+ * (`query.ask`, …) from the router keys via `setOperationId`.
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  queryAskBodySchema,
+  queryAskResponseSchema,
+  queryExplainBodySchema,
+  queryExplainResponseSchema,
+  queryRetrieveBodySchema,
+  queryRetrieveResponseSchema,
+} from './rest-query-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const cerebrumQueryContract = c.router({
+  ask: {
+    method: 'POST',
+    path: '/query/ask',
+    summary: 'Full NL Q&A: scope inference → retrieval → LLM → citation parsing.',
+    body: queryAskBodySchema,
+    responses: {
+      200: queryAskResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  retrieve: {
+    method: 'POST',
+    path: '/query/retrieve',
+    summary: 'Retrieval-only — returns sources without calling the LLM.',
+    body: queryRetrieveBodySchema,
+    responses: {
+      200: queryRetrieveResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  explain: {
+    method: 'POST',
+    path: '/query/explain',
+    summary: 'Debug: show scope inference + retrieval plan without executing.',
+    body: queryExplainBodySchema,
+    responses: {
+      200: queryExplainResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+});
+
+export type CerebrumQueryContract = typeof cerebrumQueryContract;

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -12,11 +12,13 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { cerebrumEmitContract } from './rest-emit.js';
 import { cerebrumEngramsContract } from './rest-engrams.js';
 import { cerebrumGliaContract } from './rest-glia.js';
 import { cerebrumIngestContract } from './rest-ingest.js';
 import { cerebrumNudgesContract } from './rest-nudges.js';
 import { cerebrumPlexusContract } from './rest-plexus.js';
+import { cerebrumQueryContract } from './rest-query.js';
 import { cerebrumReflexContract } from './rest-reflex.js';
 import { cerebrumRetrievalContract } from './rest-retrieval.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
@@ -37,6 +39,8 @@ export const cerebrumContract = c.router(
     nudges: cerebrumNudgesContract,
     ingest: cerebrumIngestContract,
     retrieval: cerebrumRetrievalContract,
+    emit: cerebrumEmitContract,
+    query: cerebrumQueryContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Summary

Migrates the cerebrum **emit** (document generation, PRD-083) and **query** (NL Q&A engine, PRD-082) domains onto the pillar's ts-rest REST surface — 8 procedures + 1 SSE route — alongside the 10 already-migrated domains. Both reuse the in-pillar `retrieval` slice (`HybridSearchService` + `ContextAssemblyService`) and the `query` slice's `CitationParser`; nothing is re-lifted.

### Surface
**emit** (all POST, stateless, docker-net trust):
- `emit.generate` → `POST /emit/generate` → `{document|null, notice?}`
- `emit.generateReport` → `POST /emit/report` → `{document|null}`
- `emit.generateSummary` → `POST /emit/summary` → `{document|null}`
- `emit.generateTimeline` → `POST /emit/timeline` → `{document|null}`
- `emit.preview` → `POST /emit/preview` → `{sources, outline}`

**query** (all POST + SSE, stateless):
- `query.ask` → `POST /query/ask` → `{answer, sources, scopes, confidence}`
- `query.retrieve` → `POST /query/retrieve` → `{sources}`
- `query.explain` → `POST /query/explain` → `{scopeInference, retrievalPlan, secretNotice}`
- SSE: `POST /query/stream` (token / done / error frames)

Dotted operation ids (`emit.generate`, `query.ask`, …) derive from the router keys via the existing `setOperationId: 'concatenated-path'`.

### LLM injection
Three injectable ports on `CerebrumApiDeps`, each with an Anthropic-backed default (`claude-sonnet-4-6`, `CEREBRUM_{EMIT,QUERY}_MODEL` overrides) wired in `server.ts` + the handler composer, and offline fakes in `test-utils.ts`:
- `GenerationLlm` (emit) — one-shot synthesis; missing key → placeholder, transport error → throw (monolith parity).
- `QueryLlm` (query.ask) — one-shot, degrades to a display-safe fallback string.
- `QueryStreamLlm` (SSE) — token-streaming; the fake yields canned tokens.

Settings-service tunables (`getSettingValue`/`getAiModel`) become constants; `trackInference`/`ai_inference_log` dropped. Only the 429 backoff (`withRateLimitRetry`, reused from the ingest slice) is kept. **No test hits a real API.**

### SSE mounting
ts-rest can't model an event stream, so `POST /query/stream` is a plain Express handler mounted in `app.ts` **before** `createExpressEndpoints(...)` (food precedent). It validates the body up-front (400 before switching to SSE), sets the SSE headers (`text/event-stream`, `no-cache`, `keep-alive`, `X-Accel-Buffering: no`), runs the same retrieval + context-assembly pipeline as `ask`, then streams the injected `QueryStreamLlm`'s tokens. The route factory takes db / retrieval / llm deps.

### Deviations of note
- **`GeneratedDocument` wire schema is fully typed**, not an opaque record: the document envelope (scalars + a fixed `metadata` block + typed citation rows) has no mode-dependent variation, so it's enumerated. (`GeneratedDocument` lacks an index signature, so `z.record(string, unknown)` wouldn't type-check without an `as` cast — which the rules forbid — and the shape is tractable anyway.)

## Tests
New `emit.test.ts` (report/summary/timeline/generate/preview incl. citation parsing, insufficient-data, empty-summary, date-range 400s) and `query.test.ts` (ask/retrieve/explain incl. hallucinated-citation stripping + SSE route driven via supertest asserting token/done frames and the 400-before-stream path). All injected fakes — no real API.

## Proof (run against the worktree)
- `oxfmt --check` — clean
- `oxlint src` — 0 errors
- `tsc --noEmit` (main + scripts) — 0 errors
- `tsc` build emit — 0 errors
- `generate:openapi` — deterministic (two consecutive regenerations byte-identical)
- `vitest run` — **531 passed (37 files)**