### PR TITLE
feat(cerebrum): REST migration slice — ego + workers (+SSE)

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -9,6 +9,809 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/ego/chat": {
+      "post": {
+        "operationId": "ego.chat",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "appContext": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "app": {
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "type": "string"
+                      },
+                      "entityType": {
+                        "type": "string"
+                      },
+                      "route": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["app"],
+                    "type": "object"
+                  },
+                  "channel": {
+                    "enum": ["shell", "moltbot", "mcp", "cli"],
+                    "type": "string"
+                  },
+                  "conversationId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "knownScopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["message"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "conversationId": {
+                      "type": "string"
+                    },
+                    "response": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "citations": {
+                          "nullable": true
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "conversationId": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "tokensIn": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "tokensOut": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "toolCalls": {
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conversationId",
+                        "role",
+                        "content",
+                        "citations",
+                        "toolCalls",
+                        "tokensIn",
+                        "tokensOut",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "retrievedEngrams": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "engramId": {
+                            "type": "string"
+                          },
+                          "relevanceScore": {
+                            "type": "number"
+                          }
+                        },
+                        "required": ["engramId", "relevanceScore"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "scopeNegotiation": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "changed": {
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scopes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretNotice": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["scopes", "changed", "reason", "secretNotice"],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "conversationId",
+                    "response",
+                    "retrievedEngrams",
+                    "scopeNegotiation"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Run a chat turn: retrieve context, call the LLM, persist turns.",
+        "tags": ["ego"]
+      }
+    },
+    "/ego/conversations": {
+      "post": {
+        "operationId": "ego.createConversation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "appContext": {},
+                  "model": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["model"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "conversation": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "activeScopes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "appContext": {
+                          "nullable": true
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "title",
+                        "activeScopes",
+                        "appContext",
+                        "model",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["conversation"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Create a new conversation.",
+        "tags": ["ego"]
+      }
+    },
+    "/ego/conversations/search": {
+      "post": {
+        "operationId": "ego.listConversations",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 200,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "search": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "conversations": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "activeScopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "appContext": {
+                            "nullable": true
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "activeScopes",
+                          "appContext",
+                          "model",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["conversations", "total"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "List conversations (paginated, optional title search).",
+        "tags": ["ego"]
+      }
+    },
+    "/ego/conversations/{id}": {
+      "delete": {
+        "operationId": "ego.deleteConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Delete a conversation (cascades messages + context).",
+        "tags": ["ego"]
+      },
+      "get": {
+        "operationId": "ego.getConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "conversation": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "activeScopes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "appContext": {
+                          "nullable": true
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "title",
+                        "activeScopes",
+                        "appContext",
+                        "model",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    },
+                    "messages": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "citations": {
+                            "nullable": true
+                          },
+                          "content": {
+                            "type": "string"
+                          },
+                          "conversationId": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          },
+                          "tokensIn": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "tokensOut": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "toolCalls": {
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "conversationId",
+                          "role",
+                          "content",
+                          "citations",
+                          "toolCalls",
+                          "tokensIn",
+                          "tokensOut",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["conversation", "messages"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Get a conversation with all its messages.",
+        "tags": ["ego"]
+      }
+    },
+    "/ego/conversations/{id}/context": {
+      "get": {
+        "operationId": "ego.getActiveContext",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "appContext": {
+                      "nullable": true
+                    },
+                    "engrams": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "engramId": {
+                            "type": "string"
+                          },
+                          "loadedAt": {
+                            "type": "string"
+                          },
+                          "relevanceScore": {
+                            "nullable": true,
+                            "type": "number"
+                          }
+                        },
+                        "required": ["engramId", "relevanceScore", "loadedAt"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["scopes", "appContext", "engrams"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Return the current context state (scopes, app context, engrams).",
+        "tags": ["ego"]
+      }
+    },
+    "/ego/conversations/{id}/scopes": {
+      "post": {
+        "operationId": "ego.setScopes",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "scopes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["scopes"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "scopes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["scopes"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Replace the active scopes for a conversation.",
+        "tags": ["ego"]
+      }
+    },
     "/engrams": {
       "post": {
         "operationId": "engrams.create",
@@ -2651,6 +3454,287 @@
         "tags": ["glia"]
       }
     },
+    "/glia/orphans": {
+      "get": {
+        "operationId": "workers.getOrphans",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 200,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "engrams": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "created": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "links": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "modified": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "template": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "wordCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "title",
+                          "scopes",
+                          "tags",
+                          "links",
+                          "status",
+                          "created",
+                          "modified",
+                          "template",
+                          "wordCount"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["engrams"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List active engrams with no inbound links.",
+        "tags": ["workers"]
+      }
+    },
+    "/glia/scores/quality": {
+      "post": {
+        "operationId": "workers.getQualityScore",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "engramId": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["engramId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "factors": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completeness": {
+                          "type": "number"
+                        },
+                        "linkDensity": {
+                          "type": "number"
+                        },
+                        "specificity": {
+                          "type": "number"
+                        },
+                        "templateFit": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["completeness", "specificity", "templateFit", "linkDensity"],
+                      "type": "object"
+                    },
+                    "score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["score", "factors"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Compute the quality score for a single engram.",
+        "tags": ["workers"]
+      }
+    },
+    "/glia/scores/staleness": {
+      "post": {
+        "operationId": "workers.getStalenessScore",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "engramId": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["engramId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "factors": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "daysSinceModified": {
+                          "type": "number"
+                        },
+                        "daysSinceReferenced": {
+                          "type": "number"
+                        },
+                        "inboundLinkCount": {
+                          "type": "number"
+                        },
+                        "queryHitCount": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "daysSinceModified",
+                        "daysSinceReferenced",
+                        "inboundLinkCount",
+                        "queryHitCount"
+                      ],
+                      "type": "object"
+                    },
+                    "score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["score", "factors"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Compute the staleness score for a single engram.",
+        "tags": ["workers"]
+      }
+    },
     "/glia/trust-state": {
       "get": {
         "operationId": "glia.trustState.list",
@@ -2843,6 +3927,406 @@
         },
         "summary": "Get trust state for a single action type.",
         "tags": ["glia", "trustState"]
+      }
+    },
+    "/glia/workers/audit": {
+      "post": {
+        "operationId": "workers.runAuditor",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "payload": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["proposed", "executed", "error"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "processed": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "skipped": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "processed", "skipped"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Run the auditor worker (quality, contradiction, coverage-gap).",
+        "tags": ["workers"]
+      }
+    },
+    "/glia/workers/consolidate": {
+      "post": {
+        "operationId": "workers.runConsolidator",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "payload": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["proposed", "executed", "error"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "processed": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "skipped": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "processed", "skipped"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Run the consolidator worker (similar-engram merge proposals).",
+        "tags": ["workers"]
+      }
+    },
+    "/glia/workers/link": {
+      "post": {
+        "operationId": "workers.runLinker",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "payload": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["proposed", "executed", "error"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "processed": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "skipped": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "processed", "skipped"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Run the linker worker (cross-reference proposals).",
+        "tags": ["workers"]
+      }
+    },
+    "/glia/workers/prune": {
+      "post": {
+        "operationId": "workers.runPruner",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "actionType": {
+                            "enum": ["prune", "consolidate", "link", "audit"],
+                            "type": "string"
+                          },
+                          "affectedIds": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "payload": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "phase": {
+                            "enum": ["propose", "act_report", "silent"],
+                            "type": "string"
+                          },
+                          "rationale": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["proposed", "executed", "error"],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "actionType",
+                          "affectedIds",
+                          "rationale",
+                          "payload",
+                          "phase",
+                          "status",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "processed": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "skipped": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["actions", "processed", "skipped"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Run the pruner worker (staleness + orphan archival proposals).",
+        "tags": ["workers"]
       }
     },
     "/ingest/classify": {

--- a/pillars/cerebrum/src/api/__tests__/ego.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/ego.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Integration tests for `ego.*` over REST (PRD-087).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` (conversations migration
+ * 0052 + engrams 0050 applied by `openCerebrumDb`) + a temp engram root, with
+ * an injected offline {@link makeFakeEgoLlm} (no real Anthropic call is ever
+ * made) and an empty peer-client set. Conversation CRUD + context run straight
+ * against the DB; chat exercises persist-user-then-assistant; the SSE route is
+ * driven through supertest and asserted on its `token`/`done` frames.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeFakeEgoLlm,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { EgoLlm } from '../modules/ego/llm.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-ego-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-ego-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+function client(llm: EgoLlm = makeFakeEgoLlm()) {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      egoLlm: llm,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
+    })
+  );
+}
+
+describe('ego conversations CRUD', () => {
+  it('creates a conversation and returns it', async () => {
+    const { conversation } = await client().ego.createConversation({
+      model: 'claude-sonnet-4-6',
+      title: 'My session',
+      scopes: ['personal.notes'],
+    });
+    expect(conversation.id).toMatch(/^conv_/);
+    expect(conversation.title).toBe('My session');
+    expect(conversation.activeScopes).toEqual(['personal.notes']);
+  });
+
+  it('lists conversations with total and title search', async () => {
+    const c = client();
+    await c.ego.createConversation({ model: 'm', title: 'alpha topic' });
+    await c.ego.createConversation({ model: 'm', title: 'beta topic' });
+
+    const all = await c.ego.listConversations();
+    expect(all.total).toBe(2);
+
+    const filtered = await c.ego.listConversations({ search: 'alpha' });
+    expect(filtered.total).toBe(1);
+    expect(filtered.conversations[0]?.title).toBe('alpha topic');
+  });
+
+  it('gets a conversation with its messages', async () => {
+    const c = client();
+    const { conversation } = await c.ego.createConversation({ model: 'm', title: 't' });
+    const got = await c.ego.getConversation(conversation.id);
+    expect(got.conversation.id).toBe(conversation.id);
+    expect(got.messages).toEqual([]);
+  });
+
+  it('404s on a missing conversation', async () => {
+    await expect(client().ego.getConversation('conv_missing')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('deletes a conversation', async () => {
+    const c = client();
+    const { conversation } = await c.ego.createConversation({ model: 'm', title: 't' });
+    const res = await c.ego.deleteConversation(conversation.id);
+    expect(res.success).toBe(true);
+    await expect(c.ego.getConversation(conversation.id)).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('ego context', () => {
+  it('setScopes replaces the active scopes', async () => {
+    const c = client();
+    const { conversation } = await c.ego.createConversation({ model: 'm', scopes: ['a'] });
+    const res = await c.ego.setScopes(conversation.id, ['work.x', 'work.y']);
+    expect(res.scopes).toEqual(['work.x', 'work.y']);
+
+    const active = await c.ego.getActiveContext(conversation.id);
+    expect(active.scopes).toEqual(['work.x', 'work.y']);
+  });
+
+  it('setScopes 404s on a missing conversation', async () => {
+    await expect(client().ego.setScopes('conv_missing', ['x'])).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('getActiveContext returns scopes, appContext, and engrams', async () => {
+    const c = client();
+    const { conversation } = await c.ego.createConversation({ model: 'm', scopes: ['s1'] });
+    const active = await c.ego.getActiveContext(conversation.id);
+    expect(active.scopes).toEqual(['s1']);
+    expect(active.engrams).toEqual([]);
+  });
+
+  it('getActiveContext 404s on a missing conversation', async () => {
+    await expect(client().ego.getActiveContext('conv_missing')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('ego chat', () => {
+  it('persists the user + assistant turns and returns the canned reply', async () => {
+    const c = client(makeFakeEgoLlm('Hello from the fake LLM.'));
+    const result = await c.ego.chat({ message: 'hi there' });
+
+    expect(result.conversationId).toMatch(/^conv_/);
+    expect(result.response.role).toBe('assistant');
+    expect(result.response.content).toBe('Hello from the fake LLM.');
+    expect(result.scopeNegotiation).not.toBeNull();
+
+    const conv = await c.ego.getConversation(result.conversationId);
+    expect(conv.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(conv.messages[0]?.content).toBe('hi there');
+    // First user message auto-titles the conversation.
+    expect(conv.conversation.title).toBe('hi there');
+  });
+
+  it('continues an existing conversation when conversationId is supplied', async () => {
+    const c = client();
+    const first = await c.ego.chat({ message: 'first turn' });
+    const second = await c.ego.chat({
+      conversationId: first.conversationId,
+      message: 'second turn',
+    });
+    expect(second.conversationId).toBe(first.conversationId);
+
+    const conv = await c.ego.getConversation(first.conversationId);
+    expect(conv.messages.map((m) => m.content)).toEqual([
+      'first turn',
+      'Canned ego reply.',
+      'second turn',
+      'Canned ego reply.',
+    ]);
+  });
+});
+
+function parseSseFrames(raw: string): Array<Record<string, unknown>> {
+  return raw
+    .split('\n\n')
+    .map((block) => block.replace(/^data: /, '').trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('ego SSE stream', () => {
+  it('emits token frames then a done frame and persists the assistant turn', async () => {
+    const c = client(makeFakeEgoLlm('streamed words here'));
+    const res = await c.ego.stream({ message: 'stream please' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+
+    const frames = parseSseFrames(res.text);
+    const tokens = frames.filter((f) => f['type'] === 'token');
+    const done = frames.find((f) => f['type'] === 'done');
+
+    expect(tokens.length).toBeGreaterThan(1);
+    expect(done).toBeDefined();
+    expect(done?.['conversationId']).toMatch(/^conv_/);
+
+    const conversationId = done?.['conversationId'] as string;
+    const conv = await c.ego.getConversation(conversationId);
+    expect(conv.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(conv.messages[1]?.content).toBe('streamed words here');
+  });
+
+  it('rejects an invalid body with 400', async () => {
+    const res = await client().ego.stream({ message: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -14,6 +14,13 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 import type { Express } from 'express';
 
 import type {
+  ConversationMessageWire,
+  ConversationWire,
+  EgoChatBodyWire,
+  EgoChatResponseWire,
+  GetActiveContextResponseWire,
+} from '../../contract/rest-ego-schemas.js';
+import type {
   GliaActionTypeWire,
   GliaActionStatusWire,
   GliaActionWire,
@@ -65,10 +72,18 @@ import type {
   TemplateSummaryWire,
   TemplateWire,
 } from '../../contract/rest-schemas.js';
+import type {
+  OrphansResponseWire,
+  QualityResultWire,
+  StalenessResultWire,
+  WorkerRunResultWire,
+} from '../../contract/rest-workers-schemas.js';
 import type { CerebrumDb } from '../../db/index.js';
+import type { EgoLlm, EgoStreamEvent } from '../modules/ego/llm.js';
 import type { IngestLlm, IngestLlmRequest } from '../modules/ingest/llm.js';
 import type { ReflexService } from '../modules/reflex/reflex-service.js';
 import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+import type { ContradictionDetector } from '../modules/workers/auditor.js';
 
 /**
  * Offline {@link IngestLlm} stub. Tests pass a per-operation responder map
@@ -82,6 +97,36 @@ export function makeFakeIngestLlm(
     modelFor: () => 'fake-haiku',
     complete: (req) => Promise.resolve(responders[req.operation]?.(req) ?? null),
   };
+}
+
+/**
+ * Offline {@link EgoLlm} stub. `reply` is the canned chat content; `stream`
+ * splits it into per-word tokens (so SSE tests see multiple `token` frames
+ * then a `done`). Never reaches a real API.
+ */
+export function makeFakeEgoLlm(reply = 'Canned ego reply.'): EgoLlm {
+  return {
+    model: () => 'fake-sonnet',
+    chat: () => Promise.resolve({ content: reply, tokensIn: 7, tokensOut: 11 }),
+    summarise: () => Promise.resolve('Canned summary.'),
+    async *stream(): AsyncGenerator<EgoStreamEvent> {
+      const words = reply.split(' ');
+      for (const word of words) {
+        yield { type: 'token', text: `${word} ` };
+      }
+      yield { type: 'done', fullText: reply, tokensIn: 7, tokensOut: 11 };
+    },
+  };
+}
+
+/**
+ * Offline {@link ContradictionDetector} stub for the auditor worker. Returns
+ * `conflict` for every pair when set, else null (no contradiction).
+ */
+export function makeFakeContradictionDetector(
+  conflict: string | null = null
+): ContradictionDetector {
+  return { detectContradiction: () => Promise.resolve(conflict) };
 }
 
 /** Bundled engram-template fixtures shipped with the pillar. */
@@ -427,6 +472,42 @@ export function makeClient(app: Express) {
       similar: (body: RetrievalSimilarBody) =>
         send<{ results: RetrievalResultWire[] }>(r.post('/retrieval/similar').send(body)),
       stats: () => send<RetrievalStatsWire>(r.get('/retrieval/stats')),
+    },
+    ego: {
+      chat: (body: EgoChatBodyWire) => send<EgoChatResponseWire>(r.post('/ego/chat').send(body)),
+      createConversation: (body: { model: string; title?: string; scopes?: string[] }) =>
+        send<{ conversation: ConversationWire }>(r.post('/ego/conversations').send(body)),
+      listConversations: (body: { limit?: number; offset?: number; search?: string } = {}) =>
+        send<{ conversations: ConversationWire[]; total: number }>(
+          r.post('/ego/conversations/search').send(body)
+        ),
+      getConversation: (id: string) =>
+        send<{ conversation: ConversationWire; messages: ConversationMessageWire[] }>(
+          r.get(`/ego/conversations/${id}`)
+        ),
+      deleteConversation: (id: string) =>
+        send<{ success: true }>(r.delete(`/ego/conversations/${id}`)),
+      setScopes: (id: string, scopes: string[]) =>
+        send<{ scopes: string[] }>(r.post(`/ego/conversations/${id}/scopes`).send({ scopes })),
+      getActiveContext: (id: string) =>
+        send<GetActiveContextResponseWire>(r.get(`/ego/conversations/${id}/context`)),
+      stream: (body: EgoChatBodyWire) => r.post('/ego/chat/stream').send(body),
+    },
+    workers: {
+      runPruner: (dryRun?: boolean) =>
+        send<WorkerRunResultWire>(r.post('/glia/workers/prune').send({ dryRun })),
+      runConsolidator: (dryRun?: boolean) =>
+        send<WorkerRunResultWire>(r.post('/glia/workers/consolidate').send({ dryRun })),
+      runLinker: (dryRun?: boolean) =>
+        send<WorkerRunResultWire>(r.post('/glia/workers/link').send({ dryRun })),
+      runAuditor: (dryRun?: boolean) =>
+        send<WorkerRunResultWire>(r.post('/glia/workers/audit').send({ dryRun })),
+      getStalenessScore: (engramId: string) =>
+        send<StalenessResultWire>(r.post('/glia/scores/staleness').send({ engramId })),
+      getQualityScore: (engramId: string) =>
+        send<QualityResultWire>(r.post('/glia/scores/quality').send({ engramId })),
+      getOrphans: (limit?: number) =>
+        send<OrphansResponseWire>(r.get('/glia/orphans').query(limit ? { limit } : {})),
     },
   };
 }

--- a/pillars/cerebrum/src/api/__tests__/workers.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/workers.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration tests for `workers.*` over REST (PRD-085).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` + temp engram root, with
+ * an injected offline {@link makeFakeContradictionDetector} (no real Anthropic
+ * call) and an empty peer-client set. Engrams are seeded through the wire
+ * `engrams.create` so the workers operate on real index rows + files.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeFakeContradictionDetector,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { ContradictionDetector } from '../modules/workers/auditor.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-workers-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-workers-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+function client(detector: ContradictionDetector = makeFakeContradictionDetector()) {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      auditorContradictionDetector: detector,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
+    })
+  );
+}
+
+describe('workers run procedures', () => {
+  it('runPruner in dryRun mode proposes nothing on an empty library', async () => {
+    const result = await client().workers.runPruner(true);
+    expect(result.processed).toBe(0);
+    expect(result.actions).toEqual([]);
+  });
+
+  it('runPruner proposes archival for a stale, link-less engram (dryRun keeps it proposed)', async () => {
+    const c = client();
+    await c.engrams.create({
+      type: 'note',
+      title: 'Ancient orphan note',
+      body: 'short',
+      scopes: ['personal.notes'],
+    });
+
+    const result = await c.workers.runPruner(true);
+    expect(result.processed).toBe(1);
+    // A freshly created engram is not yet stale enough to archive; the run must
+    // still report it as processed and leave every proposed action in 'proposed'.
+    for (const action of result.actions) {
+      expect(action.status).toBe('proposed');
+      expect(action.actionType).toBe('prune');
+    }
+  });
+
+  it('runAuditor surfaces low-quality + coverage-gap proposals without mutating engrams', async () => {
+    const c = client();
+    await c.engrams.create({
+      type: 'note',
+      title: 'Sparse',
+      body: 'tiny',
+      scopes: ['personal.notes'],
+      tags: ['solo'],
+    });
+
+    const result = await c.workers.runAuditor(true);
+    expect(result.processed).toBe(1);
+    expect(result.actions.length).toBeGreaterThan(0);
+    expect(result.actions.every((a) => a.status === 'proposed')).toBe(true);
+  });
+});
+
+describe('workers score procedures', () => {
+  it('getStalenessScore returns a 0–1 score for an existing engram', async () => {
+    const c = client();
+    const { engram } = await c.engrams.create({
+      type: 'note',
+      title: 'Scored note',
+      body: 'body text',
+      scopes: ['personal.notes'],
+    });
+
+    const result = await c.workers.getStalenessScore(engram.id);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(1);
+    expect(result.factors.inboundLinkCount).toBe(0);
+  });
+
+  it('getQualityScore returns a 0–1 score for an existing engram', async () => {
+    const c = client();
+    const { engram } = await c.engrams.create({
+      type: 'note',
+      title: 'Quality note',
+      body: 'body text with some detail',
+      scopes: ['personal.notes'],
+      tags: ['a'],
+    });
+
+    const result = await c.workers.getQualityScore(engram.id);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+
+  it('getStalenessScore 404s on a missing engram', async () => {
+    await expect(client().workers.getStalenessScore('eng_nope')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('workers getOrphans', () => {
+  it('lists engrams with no inbound links', async () => {
+    const c = client();
+    const { engram } = await c.engrams.create({
+      type: 'note',
+      title: 'Lonely',
+      body: 'no inbound links point here',
+      scopes: ['personal.notes'],
+    });
+
+    const result = await c.workers.getOrphans();
+    expect(result.engrams.length).toBe(1);
+    expect(result.engrams[0]?.id).toBe(engram.id);
+    expect(result.engrams[0]?.links).toEqual([]);
+  });
+
+  it('respects the limit query param', async () => {
+    const c = client();
+    await c.engrams.create({ type: 'note', title: 'One', body: 'x', scopes: ['s'] });
+    await c.engrams.create({ type: 'note', title: 'Two', body: 'y', scopes: ['s'] });
+
+    const result = await c.workers.getOrphans(1);
+    expect(result.engrams.length).toBe(1);
+  });
+});

--- a/pillars/cerebrum/src/api/app.ts
+++ b/pillars/cerebrum/src/api/app.ts
@@ -15,6 +15,8 @@ import express, { type Express, type Request, type Response } from 'express';
 
 import { cerebrumContract } from '../contract/rest.js';
 import { type CerebrumApiDeps, makeRequestHandler } from './handlers.js';
+import { AnthropicEgoLlm } from './modules/ego/llm.js';
+import { makeEgoStreamRouter } from './rest/ego-stream.js';
 import { makeCerebrumRestHandlers } from './rest/handlers.js';
 
 /**
@@ -37,6 +39,21 @@ export function createCerebrumApiApp(deps: CerebrumApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  // The ego SSE route (`text/event-stream`) can't be modelled in ts-rest, so it
+  // mounts as a plain Express route BEFORE createExpressEndpoints.
+  app.use(
+    makeEgoStreamRouter({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      llm: deps.egoLlm ?? new AnthropicEgoLlm(),
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+    })
+  );
 
   createExpressEndpoints(cerebrumContract, makeCerebrumRestHandlers(deps), app);
 

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -10,12 +10,14 @@ import { getPillarRegistry } from './pillars/registry.js';
 import type { PillarRegistryEntry } from '@pops/types';
 
 import type { OpenedCerebrumDb } from '../db/index.js';
+import type { EgoLlm } from './modules/ego/llm.js';
 import type { IngestLlm } from './modules/ingest/llm.js';
 import type { CurationQueueAccessor } from './modules/ingest/pipeline.js';
 import type { ReflexService } from './modules/reflex/reflex-service.js';
 import type { EmbeddingClient } from './modules/retrieval/embedding-client.js';
 import type { PeerClients } from './modules/retrieval/peer-clients.js';
 import type { TemplateRegistry } from './modules/templates/registry.js';
+import type { ContradictionDetector } from './modules/workers/auditor.js';
 
 export interface CerebrumApiDeps {
   /** Open handle to the cerebrum pillar's SQLite (sqlite-vec loaded). */
@@ -41,6 +43,18 @@ export interface CerebrumApiDeps {
    * hardcoded haiku models). Tests inject an offline fake.
    */
   ingestLlm?: IngestLlm;
+  /**
+   * LLM port driving ego chat + streaming + history summarisation. Optional —
+   * defaults to an Anthropic-backed client (`ANTHROPIC_API_KEY`,
+   * `claude-sonnet-4-6` / `CEREBRUM_EGO_MODEL`). Tests inject an offline fake.
+   */
+  egoLlm?: EgoLlm;
+  /**
+   * Contradiction detector for the auditor worker. Optional — defaults to an
+   * Anthropic-backed haiku client. Tests inject an offline fake (or omit it to
+   * get the noop path).
+   */
+  auditorContradictionDetector?: ContradictionDetector;
   /**
    * Accessor for the `pops-curation` BullMQ queue used by ingest
    * quick-capture / retry-enrichment. Optional — defaults to the lazy

--- a/pillars/cerebrum/src/api/modules/ego/chat-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/ego/chat-helpers.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared chat orchestration helpers used by both the `ego.chat` handler and the
+ * SSE streaming route.
+ *
+ * Lifted from the monolith; the persistence + engine are passed in (no
+ * singletons) so the handler factory wires them from the injected deps.
+ */
+import { autoTitle, type ConversationPersistence } from './persistence.js';
+
+import type { Conversation, Message } from './persistence.js';
+import type { AppContext, ChatResult, ScopeNegotiation } from './types.js';
+
+/**
+ * Compare two AppContext values by value (not reference). Returns true if the
+ * incoming context is meaningfully different from the stored one.
+ */
+export function appContextChanged(
+  stored: AppContext | undefined | null,
+  incoming: AppContext | undefined
+): boolean {
+  if (!stored && !incoming) return false;
+  if (!stored || !incoming) return true;
+  return (
+    stored.app !== incoming.app ||
+    stored.route !== incoming.route ||
+    stored.entityId !== incoming.entityId ||
+    stored.entityType !== incoming.entityType
+  );
+}
+
+export interface PersistUserTurnParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  userMessage: string;
+  storedAppContext?: AppContext | null;
+  incomingAppContext?: AppContext;
+}
+
+/**
+ * Persist the user's turn before any engine work. Writing up-front means a
+ * downstream pipeline failure cannot delete the user's own input from the
+ * conversation.
+ */
+export function persistUserTurn(params: PersistUserTurnParams): Message {
+  const { persistence, conversationId, userMessage } = params;
+  if (appContextChanged(params.storedAppContext, params.incomingAppContext)) {
+    persistence.updateAppContext(conversationId, params.incomingAppContext ?? null);
+  }
+  return persistence.appendMessage(conversationId, { role: 'user', content: userMessage });
+}
+
+export interface PersistAssistantTurnParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  result: ChatResult;
+}
+
+/** Persist the assistant turn after the engine returns: scopes, message, engram context. */
+export function persistAssistantTurn(params: PersistAssistantTurnParams): Message {
+  const { persistence, conversationId, result } = params;
+
+  if (result.scopeNegotiation?.changed) {
+    persistence.updateScopes(conversationId, result.scopeNegotiation.scopes);
+  }
+
+  const assistantMsg = persistence.appendMessage(conversationId, {
+    role: 'assistant',
+    content: result.response.content,
+    citations: result.response.citations,
+    tokensIn: result.response.tokensIn,
+    tokensOut: result.response.tokensOut,
+  });
+
+  for (const { engramId, relevanceScore } of result.retrievedEngrams) {
+    persistence.upsertContext(conversationId, engramId, relevanceScore);
+  }
+
+  return assistantMsg;
+}
+
+/** Persist a placeholder assistant message so a pipeline failure shows up in the thread. */
+export function persistAssistantError(
+  persistence: ConversationPersistence,
+  conversationId: string,
+  reason: string
+): Message {
+  return persistence.appendMessage(conversationId, {
+    role: 'assistant',
+    content: `⚠️ Pipeline error: ${reason}`,
+  });
+}
+
+export interface ResolveConversationParams {
+  persistence: ConversationPersistence;
+  conversationId: string | undefined;
+  message: string;
+  scopes: string[];
+  appContext: AppContext | undefined;
+  model: string;
+}
+
+/** Load an existing conversation or create a new one. */
+export function resolveConversation(params: ResolveConversationParams): Conversation {
+  const { persistence, conversationId, message, scopes, appContext, model } = params;
+  if (conversationId) {
+    const existing = persistence.getConversation(conversationId);
+    if (existing) return existing.conversation;
+  }
+  return persistence.createConversation({
+    title: autoTitle(message),
+    scopes,
+    appContext,
+    model,
+  });
+}
+
+export interface PersistStreamParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  content: string;
+  citations: string[];
+  tokensIn: number;
+  tokensOut: number;
+  retrievedEngrams: Array<{ engramId: string; relevanceScore: number }>;
+  scopeNegotiation: ScopeNegotiation;
+}
+
+/** Persist results after a streaming chat completes. */
+export function persistStreamResults(params: PersistStreamParams): Message {
+  return persistAssistantTurn({
+    persistence: params.persistence,
+    conversationId: params.conversationId,
+    result: {
+      response: {
+        content: params.content,
+        citations: params.citations,
+        tokensIn: params.tokensIn,
+        tokensOut: params.tokensOut,
+      },
+      retrievedEngrams: params.retrievedEngrams,
+      scopeNegotiation: params.scopeNegotiation,
+    },
+  });
+}

--- a/pillars/cerebrum/src/api/modules/ego/citation-parser.ts
+++ b/pillars/cerebrum/src/api/modules/ego/citation-parser.ts
@@ -1,0 +1,144 @@
+/**
+ * CitationParser — extracts and validates inline source citations from LLM
+ * output against the retrieved source set (lifted from the monolith query
+ * module; ego is the only consumer in the pillar today).
+ *
+ * Handles bracketed engram IDs (`[eng_...]`) and typed references
+ * (`[engram:eng_...]`), strips hallucinated citations not in the retrieved
+ * set, truncates excerpts at a word boundary, and orders citations by
+ * relevance.
+ *
+ * Pillar delta: the excerpt budget is a constant (no settings service) and a
+ * stripped citation logs to `console.warn` rather than the shared logger.
+ */
+import type { RetrievalResult } from '../retrieval/types.js';
+
+/** A resolved citation rendered alongside an ego chat response. */
+export interface SourceCitation {
+  id: string;
+  type: string;
+  title: string;
+  /** Max EXCERPT_MAX_LENGTH chars, truncated at word boundary with ellipsis. */
+  excerpt: string;
+  /** Relevance score 0–1. */
+  relevance: number;
+  /** Primary scope of the source. */
+  scope: string;
+}
+
+export interface CitationParseResult {
+  cleanedAnswer: string;
+  citations: SourceCitation[];
+}
+
+const ENGRAM_CITATION_RE = /\[eng_\d{8}_\d{4}_[a-z0-9-]+\]/g;
+const TYPED_CITATION_RE = /\[(engram|transaction|media|inventory):([^\]]+)\]/g;
+const EXCERPT_MAX_LENGTH = 200;
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '…';
+}
+
+function extractPrimaryScope(result: RetrievalResult): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+function pushIfDefined(parts: string[], label: string, value: unknown): void {
+  if (value !== undefined) parts.push(`${label}: ${String(value)}`);
+}
+
+function extractDomainMetaParts(metadata: Record<string, unknown>, sourceType: string): string[] {
+  const parts: string[] = [];
+  switch (sourceType) {
+    case 'transaction':
+      pushIfDefined(parts, 'Amount', metadata['amount']);
+      pushIfDefined(parts, 'Date', metadata['date'] ?? metadata['createdAt']);
+      pushIfDefined(parts, 'Category', metadata['category']);
+      break;
+    case 'media':
+      pushIfDefined(parts, 'Type', metadata['type'] ?? metadata['mediaType']);
+      pushIfDefined(parts, 'Rating', metadata['rating']);
+      break;
+    case 'inventory':
+      pushIfDefined(parts, 'Location', metadata['location']);
+      break;
+  }
+  return parts;
+}
+
+function formatExcerpt(result: RetrievalResult): string {
+  const parts = extractDomainMetaParts(result.metadata, result.sourceType);
+  const metaPrefix = parts.length > 0 ? parts.join(' | ') + ' — ' : '';
+  return truncateExcerpt(metaPrefix + (result.contentPreview ?? ''));
+}
+
+export class CitationParser {
+  /**
+   * Parse citations from LLM output, mapping them to retrieved sources.
+   *
+   * @param llmOutput        - Raw text from the LLM response.
+   * @param retrievedSources - The source set from HybridSearchService.
+   */
+  parse(llmOutput: string, retrievedSources: RetrievalResult[]): CitationParseResult {
+    const bySourceId = new Map<string, RetrievalResult>();
+    const byCompositeKey = new Map<string, RetrievalResult>();
+    for (const r of retrievedSources) {
+      bySourceId.set(r.sourceId, r);
+      byCompositeKey.set(`${r.sourceType}:${r.sourceId}`, r);
+    }
+
+    const matchedIds = new Set<string>();
+    let cleanedAnswer = llmOutput;
+
+    for (const match of llmOutput.matchAll(ENGRAM_CITATION_RE)) {
+      const id = match[0].slice(1, -1);
+      if (bySourceId.has(id)) {
+        matchedIds.add(id);
+      } else {
+        console.warn(`[cerebrum-ego] Stripped hallucinated citation: ${id}`);
+        cleanedAnswer = cleanedAnswer.replace(match[0], '');
+      }
+    }
+
+    for (const match of llmOutput.matchAll(TYPED_CITATION_RE)) {
+      const fullMatch = match[0];
+      const sourceType = match[1];
+      const sourceId = match[2];
+      if (!sourceType || !sourceId) continue;
+      const key = `${sourceType}:${sourceId}`;
+      const result = byCompositeKey.get(key);
+      if (result) {
+        matchedIds.add(result.sourceId);
+      } else if (bySourceId.has(sourceId)) {
+        matchedIds.add(sourceId);
+      } else {
+        console.warn(`[cerebrum-ego] Stripped hallucinated typed citation: ${fullMatch}`);
+        cleanedAnswer = cleanedAnswer.replace(fullMatch, '');
+      }
+    }
+
+    const citations: SourceCitation[] = [];
+    for (const id of matchedIds) {
+      const result = bySourceId.get(id);
+      if (!result) continue;
+      citations.push({
+        id: result.sourceId,
+        type: result.sourceType,
+        title: result.title,
+        excerpt: formatExcerpt(result),
+        relevance: result.score,
+        scope: extractPrimaryScope(result),
+      });
+    }
+
+    citations.sort((a, b) => b.relevance - a.relevance);
+    cleanedAnswer = cleanedAnswer.replace(/  +/g, ' ').trim();
+
+    return { cleanedAnswer, citations };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/context-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/ego/context-helpers.ts
@@ -1,0 +1,72 @@
+/**
+ * Context-awareness helpers for the ego conversation engine (PRD-087 US-03):
+ *  - biasScopes: additive scope biasing based on the active app context
+ *  - loadViewedEngram: auto-load the viewed engram as a synthetic RetrievalResult
+ *
+ * Pillar delta: `loadViewedEngram` takes an injected {@link EngramService}
+ * rather than reaching for the monolith singleton.
+ */
+import type { EngramService } from '../engrams/service.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { AppContext } from './types.js';
+
+const APP_SCOPE_PREFIXES: Record<string, string[]> = {
+  finance: ['personal.finance'],
+  media: ['personal.media'],
+  inventory: ['personal.inventory'],
+  cerebrum: [],
+  ai: ['personal.ai', 'work.ai'],
+};
+
+/**
+ * Bias retrieval scopes towards the active app. Adds app-relevant scope
+ * prefixes to the existing scopes (additive, not exclusive). Deduplicates.
+ */
+export function biasScopes(scopes: string[], appContext?: AppContext): string[] {
+  if (!appContext) return scopes;
+  const prefixes = APP_SCOPE_PREFIXES[appContext.app];
+  if (!prefixes || prefixes.length === 0) return scopes;
+
+  const biased = new Set(scopes);
+  for (const prefix of prefixes) {
+    biased.add(prefix);
+  }
+  return [...biased];
+}
+
+/**
+ * Auto-load the viewed engram as a synthetic RetrievalResult with score 1.0.
+ * Only triggers when `appContext.entityType === 'engram'` and entityId is set.
+ */
+export function loadViewedEngram(
+  engramService: EngramService,
+  appContext?: AppContext
+): RetrievalResult | null {
+  if (!appContext?.entityId || appContext.entityType !== 'engram') return null;
+
+  try {
+    const { engram, body } = engramService.read(appContext.entityId);
+    return {
+      sourceType: 'engram',
+      sourceId: engram.id,
+      title: engram.title,
+      contentPreview: body.slice(0, 500),
+      score: 1.0,
+      matchType: 'structured',
+      metadata: {
+        type: engram.type,
+        scopes: engram.scopes,
+        tags: engram.tags,
+        createdAt: engram.created,
+        autoLoaded: true,
+      },
+    };
+  } catch (err) {
+    console.warn(
+      `[cerebrum-ego] Failed to auto-load viewed engram ${appContext.entityId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return null;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/engine-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/ego/engine-helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure helpers for the ConversationEngine.
+ *
+ * Pillar delta: the monolith reads engine tuning from `getSettingValue('ego.*')`;
+ * the pillar has no settings service, so the defaults are the hardcoded
+ * constants below (overridable per-construction via `Partial<EngineConfig>`).
+ */
+import type { RetrievalFilters } from '../retrieval/types.js';
+import type { EgoChatMessage } from './llm.js';
+import type { EngineConfig, Message } from './types.js';
+
+const DEFAULT_MAX_HISTORY = 20;
+const DEFAULT_MAX_RETRIEVAL = 5;
+const DEFAULT_TOKEN_BUDGET = 4096;
+const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+export function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+  if (scopes.length > 0) {
+    filters.scopes = scopes;
+  }
+  if (scopes.some(isSecretScope)) {
+    filters.includeSecret = true;
+  }
+  return filters;
+}
+
+function roleLabel(role: string): string {
+  if (role === 'user') return 'User';
+  if (role === 'assistant') return 'Assistant';
+  return 'System';
+}
+
+export function formatHistoryForContext(messages: Message[]): string {
+  return messages.map((m) => `${roleLabel(m.role)}: ${m.content}`).join('\n\n');
+}
+
+/**
+ * Build the LLM message array: the most recent `maxHistoryMessages` user/
+ * assistant turns, then the current message (with the retrieved-knowledge
+ * context block appended when present).
+ */
+export function buildLlmMessages(
+  history: Message[],
+  currentMessage: string,
+  contextBlock: string,
+  maxHistoryMessages: number
+): EgoChatMessage[] {
+  const messages: EgoChatMessage[] = [];
+  const recentHistory = history.slice(-maxHistoryMessages);
+
+  for (const msg of recentHistory) {
+    if (msg.role === 'user' || msg.role === 'assistant') {
+      messages.push({ role: msg.role, content: msg.content });
+    }
+  }
+
+  const userContent = contextBlock
+    ? `${currentMessage}\n\n---\nRetrieved knowledge:\n${contextBlock}`
+    : currentMessage;
+  messages.push({ role: 'user', content: userContent });
+  return messages;
+}
+
+export function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
+  return {
+    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
+    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
+    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+  };
+}

--- a/pillars/cerebrum/src/api/modules/ego/engine-stream.ts
+++ b/pillars/cerebrum/src/api/modules/ego/engine-stream.ts
@@ -1,0 +1,53 @@
+/**
+ * Streaming generator for the ego conversation engine (PRD-087 US-01 AC #6).
+ *
+ * Lifts the monolith generator onto the injected {@link EgoLlm} streaming port.
+ * Emits the scope notice (if any) as a leading token, then streams LLM token
+ * deltas, then a final `done` event carrying the citation-parsed content + token
+ * counts.
+ */
+import { CitationParser } from './citation-parser.js';
+
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { EgoChatMessage, EgoLlm } from './llm.js';
+import type { ChatStreamEvent } from './types.js';
+
+interface StreamGeneratorParams {
+  llm: EgoLlm;
+  systemPrompt: string;
+  llmMessages: EgoChatMessage[];
+  scopeNotice: string | null;
+  allResults: RetrievalResult[];
+}
+
+/**
+ * Create an async generator that streams LLM tokens and emits a final
+ * done event with parsed citations and token counts.
+ */
+export async function* generateStreamEvents(
+  params: StreamGeneratorParams
+): AsyncGenerator<ChatStreamEvent> {
+  const { llm, systemPrompt, llmMessages, scopeNotice, allResults } = params;
+  const citationParser = new CitationParser();
+
+  if (scopeNotice) {
+    yield { type: 'token', text: `${scopeNotice}\n\n` };
+  }
+
+  for await (const event of llm.stream(systemPrompt, llmMessages)) {
+    if (event.type === 'token') {
+      yield { type: 'token', text: event.text };
+    } else {
+      const { cleanedAnswer, citations } = citationParser.parse(event.fullText, allResults);
+      const responseContent = scopeNotice ? `${scopeNotice}\n\n${cleanedAnswer}` : cleanedAnswer;
+
+      yield {
+        type: 'done',
+        content: responseContent,
+        citations: citations.map((c) => c.id),
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+      };
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/engine.ts
+++ b/pillars/cerebrum/src/api/modules/ego/engine.ts
@@ -1,0 +1,224 @@
+/**
+ * ConversationEngine — multi-turn conversation manager for ego (PRD-087).
+ *
+ * Orchestrates the chat pipeline: scope negotiation, retrieval (HybridSearch),
+ * context-window assembly, the LLM call, and citation parsing.
+ *
+ * Pillar deltas vs. the monolith:
+ * - The LLM is the injected {@link EgoLlm} port (Anthropic in prod, fake in
+ *   tests) rather than module-level `callChatLlm`.
+ * - Retrieval rides the in-pillar {@link HybridSearchService} + the injected
+ *   embedding/peer deps (no AsyncLocalStorage drizzle handle).
+ * - The viewed-engram auto-load uses the injected {@link EngramService}.
+ */
+import { ContextAssemblyService } from '../retrieval/context-assembly.js';
+import { HybridSearchService } from '../retrieval/hybrid-search.js';
+import { CitationParser } from './citation-parser.js';
+import { biasScopes, loadViewedEngram } from './context-helpers.js';
+import {
+  buildDefaultConfig,
+  buildLlmMessages,
+  buildRetrievalFilters,
+  formatHistoryForContext,
+} from './engine-helpers.js';
+import { generateStreamEvents } from './engine-stream.js';
+import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
+import { ConversationScopeNegotiator } from './scope-negotiator.js';
+
+import type { EngramService } from '../engrams/service.js';
+import type { SemanticSearchDeps } from '../retrieval/semantic-search.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { EgoChatMessage, EgoLlm } from './llm.js';
+import type {
+  AppContext,
+  ChatParams,
+  ChatResult,
+  ChatStreamPreparation,
+  EngineConfig,
+  Message,
+  ScopeNegotiation,
+} from './types.js';
+
+export interface EngineDeps {
+  llm: EgoLlm;
+  /** Retrieval deps used to build a per-call HybridSearchService. */
+  search: SemanticSearchDeps;
+  engramService: EngramService;
+  config?: Partial<EngineConfig>;
+}
+
+export class ConversationEngine {
+  private readonly config: EngineConfig;
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+  private readonly scopeNegotiator = new ConversationScopeNegotiator();
+  private readonly llm: EgoLlm;
+  private readonly search: SemanticSearchDeps;
+  private readonly engramService: EngramService;
+
+  constructor(deps: EngineDeps) {
+    this.config = buildDefaultConfig(deps.config);
+    this.llm = deps.llm;
+    this.search = deps.search;
+    this.engramService = deps.engramService;
+  }
+
+  /** Process a user message and generate a response. */
+  async chat(params: ChatParams): Promise<ChatResult> {
+    const ctx = await this.assembleContext(params);
+    const llmResponse = await this.llm.chat(ctx.systemPrompt, ctx.llmMessages);
+    const { cleanedAnswer, citations } = this.citationParser.parse(
+      llmResponse.content,
+      ctx.allResults
+    );
+    const responseContent = ctx.scopeNotice
+      ? `${ctx.scopeNotice}\n\n${cleanedAnswer}`
+      : cleanedAnswer;
+
+    return {
+      response: {
+        content: responseContent,
+        citations: citations.map((c) => c.id),
+        tokensIn: llmResponse.tokensIn,
+        tokensOut: llmResponse.tokensOut,
+      },
+      retrievedEngrams: ctx.allResults.map((r) => ({
+        engramId: r.sourceId,
+        relevanceScore: r.score,
+      })),
+      scopeNegotiation: ctx.negotiation,
+    };
+  }
+
+  /** Prepare a streaming chat response. Returns metadata + an async event generator. */
+  async prepareStream(params: ChatParams): Promise<ChatStreamPreparation> {
+    const ctx = await this.assembleContext(params);
+    return {
+      stream: generateStreamEvents({
+        llm: this.llm,
+        systemPrompt: ctx.systemPrompt,
+        llmMessages: ctx.llmMessages,
+        scopeNotice: ctx.scopeNotice,
+        allResults: ctx.allResults,
+      }),
+      retrievedEngrams: ctx.allResults.map((r) => ({
+        engramId: r.sourceId,
+        relevanceScore: r.score,
+      })),
+      scopeNegotiation: ctx.negotiation,
+    };
+  }
+
+  /** Summarise older conversation messages into a condensed block. */
+  async summariseHistory(messages: Message[]): Promise<string> {
+    const formatted = formatHistoryForContext(messages);
+    const prompt = buildSummarisationPrompt(formatted);
+    return this.llm.summarise(prompt, messages.length);
+  }
+
+  private async assembleContext(params: ChatParams): Promise<{
+    negotiation: ScopeNegotiation;
+    allResults: RetrievalResult[];
+    systemPrompt: string;
+    scopeNotice: string | null;
+    llmMessages: EgoChatMessage[];
+  }> {
+    const { message, history, appContext } = params;
+    const negotiation = this.negotiateScopes(params);
+    const biasedScopes = biasScopes(negotiation.scopes, appContext);
+    const viewedEngram = loadViewedEngram(this.engramService, appContext);
+    const retrievalResults = await this.retrieveEngrams(message, biasedScopes);
+    const allResults = this.mergeViewedEngram(viewedEngram, retrievalResults);
+    const { systemPrompt, contextBlock } = this.buildContextWindow(
+      allResults,
+      negotiation.scopes,
+      appContext
+    );
+    const scopeNotice = this.buildScopeNotice(negotiation);
+    const llmMessages = buildLlmMessages(
+      history,
+      message,
+      contextBlock,
+      this.config.maxHistoryMessages
+    );
+    return { negotiation, allResults, systemPrompt, scopeNotice, llmMessages };
+  }
+
+  private negotiateScopes(params: ChatParams): ScopeNegotiation {
+    const { message, activeScopes, history, channel, knownScopes } = params;
+    const result = this.scopeNegotiator.negotiate({
+      message,
+      currentScopes: activeScopes,
+      conversationHistory: history,
+      channel: channel ?? 'shell',
+      knownScopes,
+    });
+    const secretNotice = this.scopeNegotiator.detectSecretMention(message);
+    return {
+      scopes: result.scopes,
+      changed: result.changed,
+      reason: result.reason,
+      secretNotice,
+    };
+  }
+
+  private buildScopeNotice(negotiation: ScopeNegotiation): string | null {
+    const parts: string[] = [];
+    if (negotiation.changed && negotiation.reason) {
+      parts.push(`*${negotiation.reason}*`);
+    }
+    if (negotiation.secretNotice) {
+      parts.push(negotiation.secretNotice);
+    }
+    return parts.length > 0 ? parts.join('\n\n') : null;
+  }
+
+  private mergeViewedEngram(
+    viewedEngram: RetrievalResult | null,
+    retrievalResults: RetrievalResult[]
+  ): RetrievalResult[] {
+    if (!viewedEngram) return retrievalResults;
+    const alreadyRetrieved = retrievalResults.some((r) => r.sourceId === viewedEngram.sourceId);
+    if (alreadyRetrieved) return retrievalResults;
+    return [viewedEngram, ...retrievalResults];
+  }
+
+  private async retrieveEngrams(query: string, scopes: string[]): Promise<RetrievalResult[]> {
+    try {
+      const filters = buildRetrievalFilters(scopes);
+      const hybridSearch = new HybridSearchService(this.search);
+      return await hybridSearch.hybrid(
+        query,
+        filters,
+        this.config.maxRetrievalResults,
+        this.config.relevanceThreshold
+      );
+    } catch (err) {
+      console.warn(
+        `[cerebrum-ego] retrieval failed — continuing without engram context: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return [];
+    }
+  }
+
+  private buildContextWindow(
+    retrievalResults: RetrievalResult[],
+    scopes: string[],
+    appContext?: AppContext
+  ): { systemPrompt: string; contextBlock: string } {
+    const systemPrompt = buildEgoSystemPrompt(scopes, appContext);
+    let contextBlock = '';
+    if (retrievalResults.length > 0) {
+      const assembled = this.assembler.assemble({
+        query: '',
+        results: retrievalResults,
+        tokenBudget: this.config.tokenBudget,
+        includeMetadata: true,
+      });
+      contextBlock = assembled.context;
+    }
+    return { systemPrompt, contextBlock };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/llm.ts
+++ b/pillars/cerebrum/src/api/modules/ego/llm.ts
@@ -1,0 +1,208 @@
+/**
+ * LLM port for the cerebrum ego conversation engine.
+ *
+ * Ego needs three capabilities from the model: a one-shot chat completion, a
+ * token-by-token streaming completion (SSE), and a one-shot summarisation of
+ * older history. All three are modelled on the {@link EgoLlm} port so the
+ * engine can be driven by a real Anthropic client in production and by canned
+ * fakes in tests (tests MUST NOT reach a real API).
+ *
+ * Deviations from the monolith (parity with the ingest slice):
+ * - **Model overrides / settings**: the monolith reads
+ *   `getSettingValue('ego.*')`. The pillar has no settings service, so the
+ *   model is a hardcoded constant with an optional `CEREBRUM_EGO_MODEL` env
+ *   override and the chat/summary token+temperature knobs are constants.
+ * - **Inference logging**: the monolith wraps every call in `trackInference()`.
+ *   The pillar has no such table; we keep only the 429 backoff
+ *   ({@link withRateLimitRetry}) and drop the DB logging entirely.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { withRateLimitRetry } from '../ingest/llm.js';
+
+import type { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
+
+export const DEFAULT_EGO_MODEL = 'claude-sonnet-4-6';
+
+const CHAT_MAX_TOKENS = 2048;
+const CHAT_TEMPERATURE = 0.3;
+const SUMMARY_MAX_TOKENS = 512;
+const SUMMARY_TEMPERATURE = 0;
+
+const LLM_UNAVAILABLE_MSG =
+  'I can help with that, but the LLM is currently unavailable. Please try again later.';
+const LLM_ERROR_MSG = 'I encountered an error while generating a response. Please try again.';
+
+export type EgoChatMessage = { role: 'user' | 'assistant'; content: string };
+
+/** Response from a one-shot chat completion. */
+export interface EgoLlmResponse {
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** A partial text token yielded during streaming. */
+export interface EgoStreamChunk {
+  type: 'token';
+  text: string;
+}
+
+/** Final metadata yielded when the stream completes. */
+export interface EgoStreamDone {
+  type: 'done';
+  fullText: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export type EgoStreamEvent = EgoStreamChunk | EgoStreamDone;
+
+/**
+ * Capability the ego engine depends on. The real implementation degrades to a
+ * canned "unavailable" message (chat) / fallback events (stream) / placeholder
+ * (summarise) when no API key is configured, so a missing key never throws.
+ */
+export interface EgoLlm {
+  /** Resolve the configured chat model id (env override → default). */
+  model(): string;
+  chat(systemPrompt: string, messages: EgoChatMessage[]): Promise<EgoLlmResponse>;
+  stream(systemPrompt: string, messages: EgoChatMessage[]): AsyncGenerator<EgoStreamEvent>;
+  summarise(prompt: string, messageCount: number): Promise<string>;
+}
+
+function envModel(): string {
+  const value = process.env['CEREBRUM_EGO_MODEL'];
+  return value !== undefined && value !== '' ? value : DEFAULT_EGO_MODEL;
+}
+
+function* fallbackEvents(text: string): Generator<EgoStreamEvent> {
+  yield { type: 'token', text };
+  yield { type: 'done', fullText: text, tokensIn: 0, tokensOut: 0 };
+}
+
+/**
+ * Real Anthropic-backed {@link EgoLlm}. Reads `ANTHROPIC_API_KEY` lazily on
+ * each call so a missing key degrades gracefully rather than throwing at
+ * construction. The model id comes from `CEREBRUM_EGO_MODEL` or the hardcoded
+ * sonnet default.
+ */
+export class AnthropicEgoLlm implements EgoLlm {
+  model(): string {
+    return envModel();
+  }
+
+  async chat(systemPrompt: string, messages: EgoChatMessage[]): Promise<EgoLlmResponse> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-ego] ANTHROPIC_API_KEY not set — returning unavailable message');
+      return { content: LLM_UNAVAILABLE_MSG, tokensIn: 0, tokensOut: 0 };
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    try {
+      const response = await withRateLimitRetry(
+        () =>
+          client.messages.create({
+            model: this.model(),
+            max_tokens: CHAT_MAX_TOKENS,
+            temperature: CHAT_TEMPERATURE,
+            system: systemPrompt,
+            messages,
+          }),
+        'ego.chat'
+      );
+      const first = response.content[0];
+      return {
+        content: first?.type === 'text' ? first.text : '',
+        tokensIn: response.usage.input_tokens,
+        tokensOut: response.usage.output_tokens,
+      };
+    } catch (err) {
+      console.warn(
+        `[cerebrum-ego] chat failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return { content: LLM_ERROR_MSG, tokensIn: 0, tokensOut: 0 };
+    }
+  }
+
+  async *stream(systemPrompt: string, messages: EgoChatMessage[]): AsyncGenerator<EgoStreamEvent> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-ego] ANTHROPIC_API_KEY not set — returning unavailable message');
+      yield* fallbackEvents(LLM_UNAVAILABLE_MSG);
+      return;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    let messageStream: MessageStream;
+    try {
+      messageStream = client.messages.stream({
+        model: this.model(),
+        max_tokens: CHAT_MAX_TOKENS,
+        temperature: CHAT_TEMPERATURE,
+        system: systemPrompt,
+        messages,
+      });
+    } catch (err) {
+      console.warn(
+        `[cerebrum-ego] stream creation failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      yield* fallbackEvents(LLM_ERROR_MSG);
+      return;
+    }
+
+    let fullText = '';
+    try {
+      for await (const event of messageStream) {
+        if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+          fullText += event.delta.text;
+          yield { type: 'token', text: event.delta.text };
+        }
+      }
+      const finalMessage = await messageStream.finalMessage();
+      yield {
+        type: 'done',
+        fullText,
+        tokensIn: finalMessage.usage.input_tokens,
+        tokensOut: finalMessage.usage.output_tokens,
+      };
+    } catch (err) {
+      console.warn(
+        `[cerebrum-ego] stream processing failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      if (fullText.length === 0) {
+        yield { type: 'token', text: LLM_ERROR_MSG };
+        fullText = LLM_ERROR_MSG;
+      }
+      yield { type: 'done', fullText, tokensIn: 0, tokensOut: 0 };
+    }
+  }
+
+  async summarise(prompt: string, messageCount: number): Promise<string> {
+    const fallback = `[Earlier conversation: ${messageCount} messages exchanged]`;
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') return fallback;
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    try {
+      const response = await withRateLimitRetry(
+        () =>
+          client.messages.create({
+            model: this.model(),
+            max_tokens: SUMMARY_MAX_TOKENS,
+            temperature: SUMMARY_TEMPERATURE,
+            messages: [{ role: 'user', content: prompt }],
+          }),
+        'ego.summarise'
+      );
+      const first = response.content[0];
+      return first?.type === 'text' ? first.text : fallback;
+    } catch (err) {
+      console.warn(
+        `[cerebrum-ego] summarise failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return fallback;
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/persistence.ts
+++ b/pillars/cerebrum/src/api/modules/ego/persistence.ts
@@ -1,0 +1,203 @@
+/**
+ * Ego conversation persistence for the cerebrum pillar.
+ *
+ * Thin CRUD over the pillar `conversationsService` (conversations / messages /
+ * conversation_context). Lifted from the monolith `ConversationPersistence`;
+ * the db handle is injected (`deps.cerebrumDb.db`) rather than resolved from an
+ * AsyncLocalStorage drizzle handle. Every read/write — including the auto-title
+ * read-after-write hop — runs on the one injected handle, and the
+ * append-message + updated_at bump stays transactional inside
+ * `conversationsService.insertMessage`.
+ */
+import {
+  conversationsService,
+  MESSAGE_ROLES,
+  type CerebrumDb,
+  type Conversation,
+  type ConversationContextEntry,
+  type Message,
+  type MessageRole,
+} from '../../../db/index.js';
+
+export type { Conversation, Message } from '../../../db/index.js';
+
+const MARKDOWN_NOISE = /^#{1,6}\s+|[*_~`]+/g;
+
+function shortHash(): string {
+  return crypto.randomUUID().replaceAll('-', '').slice(0, 8);
+}
+
+function idTimestamp(date: Date): string {
+  const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+  return [
+    pad(date.getFullYear(), 4),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    '_',
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+  ].join('');
+}
+
+export function generateConversationId(now: Date): string {
+  return `conv_${idTimestamp(now)}_${shortHash()}`;
+}
+
+export function generateMessageId(now: Date): string {
+  return `msg_${idTimestamp(now)}_${shortHash()}`;
+}
+
+/**
+ * Derive a title from the first user message. Strips leading Markdown heading
+ * markers and inline formatting, then truncates to 80 chars at a word boundary.
+ */
+export function autoTitle(content: string): string {
+  const cleaned = content.replace(MARKDOWN_NOISE, '').trim();
+  if (cleaned.length <= 80) return cleaned;
+  const truncated = cleaned.slice(0, 80);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated;
+}
+
+export interface CreateConversationInput {
+  title?: string;
+  scopes?: string[];
+  appContext?: unknown;
+  model: string;
+}
+
+export interface ListConversationsInput {
+  limit?: number;
+  offset?: number;
+  search?: string;
+}
+
+export interface AppendMessageInput {
+  role: string;
+  content: string;
+  citations?: string[];
+  toolCalls?: unknown[];
+  tokensIn?: number;
+  tokensOut?: number;
+}
+
+export interface ConversationPersistenceOptions {
+  db: CerebrumDb;
+  now?: () => Date;
+}
+
+export class ConversationPersistence {
+  private readonly db: CerebrumDb;
+  private readonly now: () => Date;
+
+  constructor(options: ConversationPersistenceOptions) {
+    this.db = options.db;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  createConversation(input: CreateConversationInput): Conversation {
+    const now = this.now();
+    const id = generateConversationId(now);
+    const iso = now.toISOString();
+    return conversationsService.insertConversation(this.db, {
+      id,
+      title: input.title ?? null,
+      activeScopes: input.scopes ?? [],
+      appContext: input.appContext ?? null,
+      model: input.model,
+      createdAt: iso,
+      updatedAt: iso,
+    });
+  }
+
+  listConversations(input: ListConversationsInput = {}): {
+    conversations: Conversation[];
+    total: number;
+  } {
+    return conversationsService.listConversations(this.db, {
+      search: input.search,
+      limit: input.limit ?? 50,
+      offset: input.offset ?? 0,
+    });
+  }
+
+  getConversation(id: string): { conversation: Conversation; messages: Message[] } | null {
+    const conversation = conversationsService.getConversation(this.db, id);
+    if (!conversation) return null;
+    return { conversation, messages: conversationsService.listMessages(this.db, id) };
+  }
+
+  deleteConversation(id: string): void {
+    conversationsService.deleteConversation(this.db, id);
+  }
+
+  appendMessage(conversationId: string, input: AppendMessageInput): Message {
+    const now = this.now();
+    const id = generateMessageId(now);
+    const iso = now.toISOString();
+    const row = conversationsService.insertMessage(this.db, {
+      id,
+      conversationId,
+      role: this.coerceRole(input.role),
+      content: input.content,
+      citations: input.citations ?? null,
+      toolCalls: input.toolCalls ?? null,
+      tokensIn: input.tokensIn ?? null,
+      tokensOut: input.tokensOut ?? null,
+      createdAt: iso,
+    });
+    this.maybeAutoTitle(conversationId, input, iso);
+    return row;
+  }
+
+  upsertContext(conversationId: string, engramId: string, relevanceScore?: number): void {
+    conversationsService.upsertConversationContext(this.db, {
+      conversationId,
+      engramId,
+      relevanceScore: relevanceScore ?? null,
+      loadedAt: this.now().toISOString(),
+    });
+  }
+
+  updateScopes(conversationId: string, scopes: string[]): void {
+    conversationsService.updateConversation(this.db, conversationId, {
+      activeScopes: scopes,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  updateAppContext(conversationId: string, appContext: unknown): void {
+    conversationsService.updateConversation(this.db, conversationId, {
+      appContext: appContext ?? null,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  getContextEntries(conversationId: string): ConversationContextEntry[] {
+    return conversationsService.listConversationContext(this.db, conversationId);
+  }
+
+  private maybeAutoTitle(
+    conversationId: string,
+    input: AppendMessageInput,
+    timestamp: string
+  ): void {
+    if (input.role !== 'user') return;
+    const conv = conversationsService.getConversation(this.db, conversationId);
+    if (!conv || conv.title) return;
+    const userCount = conversationsService.countMessages(this.db, conversationId, 'user');
+    if (userCount !== 1) return;
+    conversationsService.updateConversation(this.db, conversationId, {
+      title: autoTitle(input.content),
+      updatedAt: timestamp,
+    });
+  }
+
+  private coerceRole(role: string): MessageRole {
+    for (const allowed of MESSAGE_ROLES) {
+      if (allowed === role) return allowed;
+    }
+    throw new Error(`Invalid message role: ${role}`);
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/prompts.ts
+++ b/pillars/cerebrum/src/api/modules/ego/prompts.ts
@@ -1,0 +1,73 @@
+/**
+ * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01, US-03).
+ *
+ * Prompts are exported as pure functions so they can be tested and overridden
+ * without coupling to the engine class.
+ */
+
+import type { AppContext } from './types.js';
+
+/** Human-readable descriptions for each pops app. */
+const APP_DESCRIPTIONS: Record<string, string> = {
+  finance: 'the Finance app (transactions, budgets, entities, imports)',
+  media: 'the Media app (movies, TV shows, watchlist, watch history, rankings)',
+  inventory: 'the Inventory app (items, locations, warranties, insurance)',
+  cerebrum: 'the Cerebrum knowledge base (engrams, scopes, retrieval)',
+  ai: 'the AI Ops app (usage tracking, model config, rules)',
+};
+
+/**
+ * Format an AppContext into a human-readable context description block.
+ *
+ * Returns an empty string when no app context is provided.
+ */
+export function formatAppContextBlock(appContext?: AppContext): string {
+  if (!appContext) return '';
+
+  const appDesc = APP_DESCRIPTIONS[appContext.app] ?? `the ${appContext.app} app`;
+  const parts: string[] = [`The user is currently in ${appDesc}.`];
+
+  if (appContext.route) {
+    parts.push(`Current route: ${appContext.route}`);
+  }
+  if (appContext.entityId && appContext.entityType) {
+    parts.push(`Viewing ${appContext.entityType}: ${appContext.entityId}`);
+  }
+
+  return `\n\nCurrent app context:\n${parts.join('\n')}`;
+}
+
+/**
+ * Build the Ego system prompt for a conversation turn.
+ *
+ * @param scopes     - Active scopes for this conversation.
+ * @param appContext  - Current app/route context the user is viewing (optional).
+ */
+export function buildEgoSystemPrompt(scopes: string[], appContext?: AppContext): string {
+  const scopeList = scopes.length > 0 ? scopes.join(', ') : '(all non-secret scopes)';
+  const contextBlock = formatAppContextBlock(appContext);
+
+  return `You are Ego, the conversational interface to Cerebrum \u2014 a personal knowledge management system.
+
+Your capabilities:
+- Search and retrieve knowledge from the user's engram library
+- Answer questions grounded in stored engrams
+- Help the user explore connections between their stored knowledge
+
+Active scopes for this conversation: ${scopeList}${contextBlock}
+
+When referencing engrams, always cite them by ID in square brackets: [eng_YYYYMMDD_HHmm_slug]
+If the available context doesn't contain enough information, say so explicitly rather than guessing.`;
+}
+
+/**
+ * Build a summarisation prompt for compressing older conversation history.
+ *
+ * @param messages - Formatted message block to summarise.
+ */
+export function buildSummarisationPrompt(messages: string): string {
+  return `Summarise this conversation so far in 2-3 sentences. Focus on the key topics discussed, decisions made, and any engrams referenced. Be concise.
+
+Conversation:
+${messages}`;
+}

--- a/pillars/cerebrum/src/api/modules/ego/scope-keywords.ts
+++ b/pillars/cerebrum/src/api/modules/ego/scope-keywords.ts
@@ -1,0 +1,139 @@
+/**
+ * Scope keyword/phrase constants and matching helpers for scope negotiation.
+ *
+ * PRD-087 US-04: Scope Negotiation.
+ *
+ * Reuses keyword patterns from QueryScopeInferencer (cerebrum/query) but extends
+ * them for conversational phrases (e.g. "at work", "my personal stuff").
+ */
+
+// ---------------------------------------------------------------------------
+// Keyword & phrase lists
+// ---------------------------------------------------------------------------
+
+/** Phrases that indicate work context. */
+export const WORK_PHRASES: readonly string[] = [
+  'at work',
+  'for work',
+  'work stuff',
+  'work project',
+  'work related',
+  'work-related',
+  'my work',
+  'about work',
+];
+
+/** Individual work keywords (word-boundary matched). */
+export const WORK_KEYWORDS: readonly string[] = [
+  'work',
+  'office',
+  'meeting',
+  'project',
+  'client',
+  'deadline',
+  'sprint',
+  'standup',
+  'deploy',
+];
+
+/** Phrases that indicate personal context. */
+export const PERSONAL_PHRASES: readonly string[] = [
+  'my personal',
+  'at home',
+  'for personal',
+  'personal stuff',
+  'my personal stuff',
+  'only look at personal',
+  'only personal',
+];
+
+/** Individual personal keywords (word-boundary matched). */
+export const PERSONAL_KEYWORDS: readonly string[] = [
+  'personal',
+  'journal',
+  'diary',
+  'therapy',
+  'family',
+  'health',
+  'exercise',
+  'hobby',
+];
+
+/** Phrases that explicitly unlock secret scopes. */
+export const SECRET_UNLOCK_PHRASES: readonly string[] = [
+  'include secrets',
+  'include my secrets',
+  'include secret notes',
+  'include my secret notes',
+  'include secret',
+  'show secrets',
+  'show my secrets',
+  'unlock secrets',
+];
+
+/** Keywords that reference potentially secret content (triggers a notice). */
+export const SECRET_MENTION_KEYWORDS: readonly string[] = [
+  'secret',
+  'password',
+  'private key',
+  'credential',
+];
+
+// ---------------------------------------------------------------------------
+// Matching helpers
+// ---------------------------------------------------------------------------
+
+/** Test whether any phrase appears as a substring in the text (case-insensitive). */
+export function matchesPhrases(text: string, phrases: readonly string[]): boolean {
+  const lower = text.toLowerCase();
+  return phrases.some((phrase) => lower.includes(phrase));
+}
+
+/** Test whether any keyword appears as a standalone word (word-boundary). */
+export function matchesKeywords(text: string, keywords: readonly string[]): boolean {
+  const lower = text.toLowerCase();
+  return keywords.some((kw) => new RegExp(`\\b${kw}\\b`, 'i').test(lower));
+}
+
+/** Check whether a scope path contains a "secret" segment. */
+export function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/** Filter scopes by prefix, excluding secret scopes by default. */
+export function filterByPrefix(scopes: string[], prefix: string): string[] {
+  return scopes.filter((s) => s.startsWith(prefix) && !isSecretScope(s));
+}
+
+/**
+ * Match a message against known scope names (leaf segment matching).
+ * Only matches scopes with 3+ segments to avoid generic false positives.
+ */
+export function matchKnownScope(message: string, knownScopes: string[]): string | null {
+  const lower = message.toLowerCase();
+  let bestMatch: string | null = null;
+  let bestLength = 0;
+
+  for (const scope of knownScopes) {
+    if (isSecretScope(scope)) continue;
+    const segments = scope.split('.');
+    if (segments.length < 3) continue;
+
+    const leaf = segments[segments.length - 1];
+    if (leaf && leaf.length >= 3 && new RegExp(`\\b${leaf}\\b`, 'i').test(lower)) {
+      if (scope.length > bestLength) {
+        bestMatch = scope;
+        bestLength = scope.length;
+      }
+    }
+  }
+  return bestMatch;
+}
+
+/** Compare two scope arrays for equality (order-independent). */
+export function scopesEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = a.toSorted();
+  const sortedB = b.toSorted();
+  return sortedA.every((v, i) => v === sortedB[i]);
+}

--- a/pillars/cerebrum/src/api/modules/ego/scope-negotiator.ts
+++ b/pillars/cerebrum/src/api/modules/ego/scope-negotiator.ts
@@ -1,0 +1,242 @@
+/**
+ * ConversationScopeNegotiator -- infers scope adjustments during conversation.
+ *
+ * PRD-087 US-04: Scope Negotiation.
+ */
+
+import {
+  PERSONAL_KEYWORDS,
+  PERSONAL_PHRASES,
+  SECRET_MENTION_KEYWORDS,
+  SECRET_UNLOCK_PHRASES,
+  WORK_KEYWORDS,
+  WORK_PHRASES,
+  filterByPrefix,
+  isSecretScope,
+  matchKnownScope,
+  matchesKeywords,
+  matchesPhrases,
+  scopesEqual,
+} from './scope-keywords.js';
+
+import type { Message } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Channels through which Ego conversations can originate. */
+export type EgoChannel = 'shell' | 'moltbot' | 'mcp' | 'cli';
+
+export interface ScopeNegotiationResult {
+  scopes: string[];
+  changed: boolean;
+  reason: string | null;
+}
+
+export interface ScopeDefault {
+  /** Scope prefix filters. Empty array means all non-secret scopes. */
+  prefixes: string[];
+}
+
+export interface ChannelScopeDefaults {
+  shell: ScopeDefault;
+  moltbot: ScopeDefault;
+  mcp: ScopeDefault;
+  cli: ScopeDefault;
+}
+
+export interface NegotiateParams {
+  message: string;
+  currentScopes: string[];
+  conversationHistory: Message[];
+  channel: EgoChannel;
+  /** All scopes known to the system (for matching by name). */
+  knownScopes?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Channel defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CHANNEL_SCOPES: ChannelScopeDefaults = {
+  shell: { prefixes: [] },
+  moltbot: { prefixes: ['personal.'] },
+  mcp: { prefixes: ['work.'] },
+  cli: { prefixes: [] },
+};
+
+// ---------------------------------------------------------------------------
+// Negotiator
+// ---------------------------------------------------------------------------
+
+export class ConversationScopeNegotiator {
+  private readonly channelDefaults: ChannelScopeDefaults;
+
+  constructor(channelDefaults?: Partial<ChannelScopeDefaults>) {
+    this.channelDefaults = { ...DEFAULT_CHANNEL_SCOPES, ...channelDefaults };
+  }
+
+  /** Infer scope adjustments from the user's message and channel context. */
+  negotiate(params: NegotiateParams): ScopeNegotiationResult {
+    const { message, currentScopes, channel, knownScopes = [] } = params;
+    const pool = knownScopes.length > 0 ? knownScopes : currentScopes;
+
+    return (
+      this.trySecretUnlock(message, pool, currentScopes) ??
+      this.tryExplicitOverride(message, pool) ??
+      this.tryPhraseDetection(message, pool, currentScopes) ??
+      this.tryKnownScopeMatch(message, pool, currentScopes) ??
+      this.tryKeywordDetection(message, pool, currentScopes) ??
+      this.tryChannelDefaults(currentScopes, channel, pool) ?? {
+        scopes: currentScopes,
+        changed: false,
+        reason: null,
+      }
+    );
+  }
+
+  /** Detect whether the user's message mentions potentially secret content. */
+  detectSecretMention(message: string): string | null {
+    if (matchesPhrases(message, SECRET_UNLOCK_PHRASES)) return null;
+    if (matchesKeywords(message, SECRET_MENTION_KEYWORDS)) {
+      return 'Your question may reference sensitive data. Secret scopes are excluded unless you explicitly ask to include them (e.g. "include my secret notes").';
+    }
+    return null;
+  }
+
+  /** Get default scopes for a channel, filtered from the known scope pool. */
+  getChannelDefaults(channel: EgoChannel, knownScopes: string[]): string[] {
+    const config = this.channelDefaults[channel];
+    if (config.prefixes.length === 0) {
+      return knownScopes.filter((s) => !isSecretScope(s));
+    }
+    return knownScopes.filter(
+      (s) => config.prefixes.some((p) => s.startsWith(p)) && !isSecretScope(s)
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Private negotiation steps (each returns null to fall through)
+  // -----------------------------------------------------------------------
+
+  private trySecretUnlock(
+    message: string,
+    pool: string[],
+    currentScopes: string[]
+  ): ScopeNegotiationResult | null {
+    if (!matchesPhrases(message, SECRET_UNLOCK_PHRASES)) return null;
+    return {
+      scopes: pool,
+      changed: !scopesEqual(pool, currentScopes),
+      reason: 'Secret scopes unlocked by explicit request',
+    };
+  }
+
+  private tryExplicitOverride(message: string, pool: string[]): ScopeNegotiationResult | null {
+    const lower = message.toLowerCase();
+    if (!lower.includes('only')) return null;
+
+    if (lower.includes('personal') || matchesPhrases(message, PERSONAL_PHRASES)) {
+      const scopes = filterByPrefix(pool, 'personal.');
+      if (scopes.length > 0) {
+        return {
+          scopes,
+          changed: true,
+          reason: 'Explicit override: restricted to personal scopes',
+        };
+      }
+    }
+    if (lower.includes('work') || matchesPhrases(message, WORK_PHRASES)) {
+      const scopes = filterByPrefix(pool, 'work.');
+      if (scopes.length > 0) {
+        return { scopes, changed: true, reason: 'Explicit override: restricted to work scopes' };
+      }
+    }
+    return null;
+  }
+
+  private tryPhraseDetection(
+    message: string,
+    pool: string[],
+    currentScopes: string[]
+  ): ScopeNegotiationResult | null {
+    if (matchesPhrases(message, WORK_PHRASES)) {
+      const scopes = filterByPrefix(pool, 'work.');
+      if (scopes.length > 0) {
+        return this.buildResult(scopes, currentScopes, 'work');
+      }
+    }
+    if (matchesPhrases(message, PERSONAL_PHRASES)) {
+      const scopes = filterByPrefix(pool, 'personal.');
+      if (scopes.length > 0) {
+        return this.buildResult(scopes, currentScopes, 'personal');
+      }
+    }
+    return null;
+  }
+
+  private tryKnownScopeMatch(
+    message: string,
+    pool: string[],
+    currentScopes: string[]
+  ): ScopeNegotiationResult | null {
+    const match = matchKnownScope(message, pool);
+    if (!match) return null;
+
+    const prefix = match + '.';
+    const narrowed = pool.filter((s) => (s === match || s.startsWith(prefix)) && !isSecretScope(s));
+    const scopes = narrowed.length > 0 ? narrowed : [match];
+    return {
+      scopes,
+      changed: !scopesEqual(scopes, currentScopes),
+      reason: `Narrowed to ${match} based on topic mention`,
+    };
+  }
+
+  private tryKeywordDetection(
+    message: string,
+    pool: string[],
+    currentScopes: string[]
+  ): ScopeNegotiationResult | null {
+    if (matchesKeywords(message, WORK_KEYWORDS)) {
+      const scopes = filterByPrefix(pool, 'work.');
+      if (scopes.length > 0) {
+        return this.buildResult(scopes, currentScopes, 'work');
+      }
+    }
+    if (matchesKeywords(message, PERSONAL_KEYWORDS)) {
+      const scopes = filterByPrefix(pool, 'personal.');
+      if (scopes.length > 0) {
+        return this.buildResult(scopes, currentScopes, 'personal');
+      }
+    }
+    return null;
+  }
+
+  private tryChannelDefaults(
+    currentScopes: string[],
+    channel: EgoChannel,
+    pool: string[]
+  ): ScopeNegotiationResult | null {
+    if (currentScopes.length > 0) return null;
+    const defaults = this.getChannelDefaults(channel, pool);
+    return {
+      scopes: defaults,
+      changed: defaults.length > 0,
+      reason: defaults.length > 0 ? `Applied ${channel} channel default scopes` : null,
+    };
+  }
+
+  private buildResult(
+    scopes: string[],
+    currentScopes: string[],
+    domain: 'work' | 'personal'
+  ): ScopeNegotiationResult {
+    return {
+      scopes,
+      changed: !scopesEqual(scopes, currentScopes),
+      reason: `Narrowed to ${domain} scopes based on conversation content`,
+    };
+  }
+}

--- a/pillars/cerebrum/src/api/modules/ego/types.ts
+++ b/pillars/cerebrum/src/api/modules/ego/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Ego conversation engine domain types (PRD-087).
+ *
+ * The conversation/message/context row shapes live in the pillar db package
+ * (`conversationsService`); these are the engine-level shapes (chat params,
+ * results, streaming events, scope negotiation) the lifted engine traffics in.
+ */
+import type { Message } from '../../../db/index.js';
+
+export type { Message };
+
+/** Which pops app the user is currently viewing. */
+export interface AppContext {
+  app: string;
+  route?: string;
+  entityId?: string;
+  entityType?: string;
+}
+
+/** Scope negotiation outcome included in ChatResult. */
+export interface ScopeNegotiation {
+  scopes: string[];
+  changed: boolean;
+  reason: string | null;
+  secretNotice: string | null;
+}
+
+/** Result returned from ConversationEngine.chat(). */
+export interface ChatResult {
+  response: {
+    content: string;
+    citations: string[];
+    tokensIn: number;
+    tokensOut: number;
+  };
+  retrievedEngrams: Array<{ engramId: string; relevanceScore: number }>;
+  /** Scope negotiation outcome, present when negotiation was run. */
+  scopeNegotiation?: ScopeNegotiation;
+}
+
+/** A partial text token yielded during streaming. */
+export interface ChatStreamToken {
+  type: 'token';
+  text: string;
+}
+
+/** Final metadata yielded when the stream completes. */
+export interface ChatStreamDone {
+  type: 'done';
+  content: string;
+  citations: string[];
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Union of events yielded by the engine's streaming generator. */
+export type ChatStreamEvent = ChatStreamToken | ChatStreamDone;
+
+/** Preparation result from ConversationEngine.prepareStream(). */
+export interface ChatStreamPreparation {
+  stream: AsyncGenerator<ChatStreamEvent>;
+  retrievedEngrams: Array<{ engramId: string; relevanceScore: number }>;
+  scopeNegotiation: ScopeNegotiation;
+}
+
+/** Channels through which Ego conversations can originate. */
+export type EgoChannel = 'shell' | 'moltbot' | 'mcp' | 'cli';
+
+/** Parameters for ConversationEngine.chat(). */
+export interface ChatParams {
+  conversationId: string;
+  message: string;
+  history: Message[];
+  activeScopes: string[];
+  appContext?: AppContext;
+  /** Channel the conversation originates from (for scope defaults). */
+  channel?: EgoChannel;
+  /** All known scopes in the system (for scope negotiation matching). */
+  knownScopes?: string[];
+}
+
+/** Configuration for the conversation engine. */
+export interface EngineConfig {
+  maxHistoryMessages: number;
+  maxRetrievalResults: number;
+  tokenBudget: number;
+  relevanceThreshold: number;
+}

--- a/pillars/cerebrum/src/api/modules/workers/auditor-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/workers/auditor-helpers.ts
@@ -1,0 +1,161 @@
+/**
+ * Auditor worker helpers — quality scoring, contradiction pair building, and
+ * coverage gap detection. Extracted from auditor.ts to respect max-lines.
+ */
+import { topLevelScope } from './worker-base.js';
+
+import type { EngramService } from '../engrams/service.js';
+import type { Engram } from '../engrams/types.js';
+import type { QualityFactors, QualityResult } from './types.js';
+
+const QUALITY_WEIGHTS = {
+  completeness: 0.3,
+  specificity: 0.3,
+  templateFit: 0.2,
+  linkDensity: 0.2,
+} as const;
+
+const MIN_WORD_COUNT = 50;
+const MAX_LINK_DENSITY = 10;
+
+const SPECIFICITY_PATTERNS = [
+  /\b\d{4}[-/]\d{2}[-/]\d{2}\b/,
+  /\b\d+(\.\d+)?%/,
+  /\$\d+/,
+  /\b[A-Z][a-z]+(?:\s[A-Z][a-z]+)+\b/,
+  /\b\d+\s*(hours?|minutes?|days?|weeks?|months?|years?)\b/i,
+  /https?:\/\/\S+/,
+];
+
+export { MIN_WORD_COUNT };
+
+/** Compute the quality score for a single engram. */
+export function computeQualityScore(engram: Engram, engramService: EngramService): QualityResult {
+  const factors = computeFactors(engram, engramService);
+  const score = Math.min(
+    1.0,
+    Math.max(
+      0.0,
+      QUALITY_WEIGHTS.completeness * factors.completeness +
+        QUALITY_WEIGHTS.specificity * factors.specificity +
+        QUALITY_WEIGHTS.templateFit * factors.templateFit +
+        QUALITY_WEIGHTS.linkDensity * factors.linkDensity
+    )
+  );
+  return { score, factors };
+}
+
+function computeFactors(engram: Engram, engramService: EngramService): QualityFactors {
+  return {
+    completeness: scoreCompleteness(engram),
+    specificity: scoreSpecificity(engram, engramService),
+    templateFit: scoreTemplateFit(engram, engramService),
+    linkDensity: Math.min(engram.links.length / MAX_LINK_DENSITY, 1.0),
+  };
+}
+
+function scoreCompleteness(engram: Engram): number {
+  let score = 0;
+  if (engram.title && engram.title.trim().length > 0) score++;
+  if (engram.wordCount > MIN_WORD_COUNT) score++;
+  if (engram.scopes.length > 0) score++;
+  if (engram.tags.length > 0) score++;
+  return score / 4;
+}
+
+function readBody(engramId: string, engramService: EngramService): string | null {
+  try {
+    return engramService.read(engramId).body;
+  } catch {
+    return null;
+  }
+}
+
+function scoreSpecificity(engram: Engram, engramService: EngramService): number {
+  const body = readBody(engram.id, engramService);
+  if (body === null) return 0;
+  let matches = 0;
+  for (const pattern of SPECIFICITY_PATTERNS) {
+    if (pattern.test(body)) matches++;
+  }
+  const specificTags = engram.tags.filter((t) => t.includes(':'));
+  const tagBonus = Math.min(specificTags.length / 3, 1.0);
+  return (Math.min(matches / SPECIFICITY_PATTERNS.length, 1.0) + tagBonus) / 2;
+}
+
+function scoreTemplateFit(engram: Engram, engramService: EngramService): number {
+  if (!engram.template) return 0.5;
+  const body = readBody(engram.id, engramService);
+  if (body === null) return 0.5;
+  const headerPattern = /^#{1,3}\s+(.+)$/gm;
+  let headerCount = 0;
+  while (headerPattern.exec(body) !== null) headerCount++;
+  return Math.min(headerCount / 5, 1.0);
+}
+
+/** Generate improvement suggestions for a low-quality engram. */
+export function generateSuggestions(engram: Engram, result: QualityResult): string[] {
+  const suggestions: string[] = [];
+  if (result.factors.completeness <= 0.5) {
+    if (engram.wordCount <= MIN_WORD_COUNT)
+      suggestions.push(`Expand body (${engram.wordCount}/${MIN_WORD_COUNT} words)`);
+    if (engram.tags.length === 0) suggestions.push('Add at least one tag');
+    if (!engram.title || engram.title.trim().length === 0)
+      suggestions.push('Add a descriptive title');
+  }
+  if (result.factors.specificity < 0.3)
+    suggestions.push('Add specific details: dates, names, numbers, or references');
+  if (result.factors.linkDensity < 0.2) suggestions.push('Add cross-references to related engrams');
+  if (result.factors.templateFit < 0.3 && engram.template)
+    suggestions.push('Fill in template-suggested sections');
+  return suggestions;
+}
+
+function groupByTopScope(engrams: Engram[]): Map<string, Engram[]> {
+  const groups = new Map<string, Engram[]>();
+  for (const engram of engrams) {
+    for (const scope of engram.scopes) {
+      const top = topLevelScope(scope);
+      const group = groups.get(top) ?? [];
+      if (!group.some((e) => e.id === engram.id)) {
+        group.push(engram);
+        groups.set(top, group);
+      }
+    }
+  }
+  return groups;
+}
+
+function sharesTags(a: Engram, b: Engram): boolean {
+  const aTagSet = new Set(a.tags);
+  return b.tags.some((t) => aTagSet.has(t));
+}
+
+function collectGroupPairs(
+  group: Engram[],
+  seen: Set<string>,
+  pairs: Array<[Engram, Engram]>
+): void {
+  for (let i = 0; i < group.length; i++) {
+    for (let j = i + 1; j < group.length; j++) {
+      const a = group[i];
+      const b = group[j];
+      if (!a || !b) continue;
+      const key = [a.id, b.id].toSorted().join('::');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (sharesTags(a, b)) pairs.push([a, b]);
+    }
+  }
+}
+
+/** Build unique pairs of engrams that share tags within the same scope group. */
+export function buildTagSharedPairs(engrams: Engram[]): Array<[Engram, Engram]> {
+  const scopeGroups = groupByTopScope(engrams);
+  const seen = new Set<string>();
+  const pairs: Array<[Engram, Engram]> = [];
+  for (const group of scopeGroups.values()) {
+    collectGroupPairs(group, seen, pairs);
+  }
+  return pairs;
+}

--- a/pillars/cerebrum/src/api/modules/workers/auditor.ts
+++ b/pillars/cerebrum/src/api/modules/workers/auditor.ts
@@ -1,0 +1,194 @@
+/**
+ * Auditor Worker (US-04, PRD-085).
+ *
+ * Scores engram quality, detects contradictions within scopes, and identifies
+ * coverage gaps. The auditor is read-only — it surfaces issues but never
+ * modifies engrams directly.
+ */
+import {
+  buildTagSharedPairs,
+  computeQualityScore,
+  generateSuggestions,
+} from './auditor-helpers.js';
+import {
+  DEFAULT_AUDITOR_CONFIG,
+  type AuditorConfig,
+  type ContradictionPayload,
+  type CoverageGapPayload,
+  type GliaAction,
+  type GliaActionType,
+  type LowQualityPayload,
+  type QualityResult,
+  type TrustPhase,
+  type WorkerRunResult,
+} from './types.js';
+import { WorkerBase, type WorkerBaseDeps } from './worker-base.js';
+
+import type { Engram } from '../engrams/types.js';
+
+/** Interface for LLM-based contradiction detection. */
+export interface ContradictionDetector {
+  detectContradiction(bodyA: string, bodyB: string): Promise<string | null>;
+}
+
+/** Noop contradiction detector — returns null (no contradictions found). */
+class NoopContradictionDetector implements ContradictionDetector {
+  async detectContradiction(_bodyA: string, _bodyB: string): Promise<string | null> {
+    return null;
+  }
+}
+
+export interface AuditorDeps extends WorkerBaseDeps {
+  config?: Partial<AuditorConfig>;
+  contradictionDetector?: ContradictionDetector;
+}
+
+export class AuditorWorker extends WorkerBase {
+  protected readonly actionType: GliaActionType = 'audit';
+  private readonly config: AuditorConfig;
+  private readonly contradictionDetector: ContradictionDetector;
+
+  constructor(deps: AuditorDeps) {
+    super(deps);
+    this.config = { ...DEFAULT_AUDITOR_CONFIG, ...deps.config };
+    this.contradictionDetector = deps.contradictionDetector ?? new NoopContradictionDetector();
+  }
+
+  async run(dryRun = false): Promise<WorkerRunResult> {
+    const phase = this.resolvePhase(dryRun);
+    const engrams = this.listActiveEngrams();
+    const { qualityActions, processed, skipped } = this.scoreQuality(engrams, phase);
+    const contradictionActions = await this.detectContradictions(engrams, phase);
+    const gapActions = this.detectCoverageGaps(engrams, phase);
+    return {
+      actions: [...qualityActions, ...contradictionActions, ...gapActions],
+      processed,
+      skipped,
+    };
+  }
+
+  /** Compute the quality score for a single engram (public API). */
+  computeQuality(engram: Engram): QualityResult {
+    return computeQualityScore(engram, this.engramService);
+  }
+
+  private scoreQuality(
+    engrams: Engram[],
+    phase: TrustPhase
+  ): { qualityActions: GliaAction[]; processed: number; skipped: number } {
+    const qualityActions: GliaAction[] = [];
+    let processed = 0;
+    let skipped = 0;
+    for (const engram of engrams) {
+      processed++;
+      const result = this.computeQuality(engram);
+      if (result.score >= this.config.qualityThreshold) {
+        skipped++;
+        continue;
+      }
+      qualityActions.push(this.buildLowQualityAction(engram, result, phase));
+    }
+    return { qualityActions, processed, skipped };
+  }
+
+  private buildLowQualityAction(
+    engram: Engram,
+    result: QualityResult,
+    phase: TrustPhase
+  ): GliaAction {
+    const suggestions = generateSuggestions(engram, result);
+    const payload: LowQualityPayload = {
+      type: 'low_quality',
+      score: result.score,
+      factors: result.factors,
+      suggestions,
+    };
+    const action = this.createAction(
+      [engram.id],
+      `Low quality score (${result.score.toFixed(2)}): ${suggestions.join('; ')}`,
+      payload,
+      phase
+    );
+    if (phase !== 'propose') action.status = 'executed';
+    return action;
+  }
+
+  private async detectContradictions(engrams: Engram[], phase: TrustPhase): Promise<GliaAction[]> {
+    const pairs = buildTagSharedPairs(engrams);
+    const actions: GliaAction[] = [];
+    for (const [a, b] of pairs) {
+      const action = await this.comparePair(a, b, phase);
+      if (action) actions.push(action);
+    }
+    return actions;
+  }
+
+  private async comparePair(a: Engram, b: Engram, phase: TrustPhase): Promise<GliaAction | null> {
+    try {
+      const bodyA = this.engramService.read(a.id).body;
+      const bodyB = this.engramService.read(b.id).body;
+      const conflict = await this.contradictionDetector.detectContradiction(bodyA, bodyB);
+      if (!conflict) return null;
+      return this.buildContradictionAction(a, b, phase, conflict);
+    } catch {
+      return this.buildContradictionAction(a, b, phase);
+    }
+  }
+
+  private buildContradictionAction(
+    a: Engram,
+    b: Engram,
+    phase: TrustPhase,
+    conflict?: string
+  ): GliaAction {
+    const isError = conflict === undefined;
+    const summary = conflict ?? 'Comparison failed — will retry on next run';
+    const payload: ContradictionPayload = {
+      type: 'contradiction',
+      engramA: a.id,
+      engramB: b.id,
+      conflictSummary: summary,
+    };
+    const rationale = isError
+      ? `Contradiction check failed for "${a.title}" and "${b.title}"`
+      : `Contradiction detected between "${a.title}" and "${b.title}": ${conflict}`;
+    const action = this.createAction([a.id, b.id], rationale, payload, phase);
+    if (isError) {
+      action.status = 'error';
+    } else if (phase !== 'propose') {
+      action.status = 'executed';
+    }
+    return action;
+  }
+
+  private detectCoverageGaps(engrams: Engram[], phase: TrustPhase): GliaAction[] {
+    const tagCounts = new Map<string, { count: number; engramIds: string[] }>();
+    for (const engram of engrams) {
+      for (const tag of engram.tags) {
+        const entry = tagCounts.get(tag) ?? { count: 0, engramIds: [] };
+        entry.count++;
+        entry.engramIds.push(engram.id);
+        tagCounts.set(tag, entry);
+      }
+    }
+    const actions: GliaAction[] = [];
+    for (const [tag, { count, engramIds }] of tagCounts) {
+      if (count >= this.config.minEngramsPerTopic) continue;
+      const payload: CoverageGapPayload = {
+        type: 'gap',
+        topic: tag,
+        existingCount: count,
+        relatedEngrams: engramIds,
+      };
+      const action = this.createAction(
+        engramIds,
+        `Coverage gap: topic '${tag}' has only ${count} engram(s) (minimum: ${this.config.minEngramsPerTopic})`,
+        payload,
+        phase
+      );
+      if (phase !== 'propose') action.status = 'executed';
+      actions.push(action);
+    }
+    return actions;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/workers/consolidator-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/workers/consolidator-helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Consolidator worker helpers — scope grouping, cluster utilities, and merge planning.
+ * Extracted from consolidator.ts to respect max-lines-per-file.
+ */
+import { topLevelScope } from './worker-base.js';
+
+import type { EngramService } from '../engrams/service.js';
+import type { Engram } from '../engrams/types.js';
+import type { ConsolidatePayload } from './types.js';
+
+/** Group engrams by their top-level scope for scope-isolated clustering. */
+export function groupByTopLevelScope(engrams: Engram[]): Map<string, Engram[]> {
+  const groups = new Map<string, Engram[]>();
+  for (const engram of engrams) {
+    for (const scope of engram.scopes) {
+      const top = topLevelScope(scope);
+      const existing = groups.get(top) ?? [];
+      if (!existing.some((e) => e.id === engram.id)) {
+        existing.push(engram);
+        groups.set(top, existing);
+      }
+    }
+  }
+  return groups;
+}
+
+/** Deduplicate a string array. */
+export function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+/** Split an array into chunks of at most `size`. */
+export function chunk<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+/** BFS traversal to collect a connected component from an adjacency map. */
+export function bfsComponent(
+  startId: string,
+  adjacency: Map<string, Set<string>>,
+  visited: Set<string>,
+  engramById: Map<string, Engram>
+): Engram[] {
+  const component: Engram[] = [];
+  const queue = [startId];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || visited.has(current)) continue;
+    visited.add(current);
+
+    const e = engramById.get(current);
+    if (e) component.push(e);
+
+    const neighbours = adjacency.get(current) ?? new Set<string>();
+    for (const neighbour of neighbours) {
+      if (!visited.has(neighbour)) queue.push(neighbour);
+    }
+  }
+  return component;
+}
+
+/** Build a merge plan from a cluster of similar engrams. */
+export function buildMergePlan(
+  cluster: Engram[],
+  scope: string,
+  engramService: EngramService
+): ConsolidatePayload {
+  const allTags = dedupe(cluster.flatMap((e) => e.tags));
+  const clusterIds = new Set(cluster.map((e) => e.id));
+  const allLinks = dedupe(cluster.flatMap((e) => e.links).filter((link) => !clusterIds.has(link)));
+  const mergedTitle = `Consolidated: ${cluster[0]?.title ?? 'Untitled'}${cluster.length > 1 ? ` (+${cluster.length - 1} related)` : ''}`;
+
+  const bodyParts = cluster.map((e) => {
+    const { body } = engramService.read(e.id);
+    return `### From: ${e.title} (${e.id})\n\n${body}`;
+  });
+
+  const mergedBody = [
+    `# ${mergedTitle}`,
+    '',
+    ...bodyParts,
+    '',
+    '## Sources',
+    '',
+    ...cluster.map((e) => `- ${e.id}: ${e.title}`),
+  ].join('\n');
+
+  return {
+    type: 'merge',
+    clusterIds: [...clusterIds],
+    mergedTitle,
+    mergedTags: allTags,
+    mergedLinks: allLinks,
+    mergedBody,
+    scope,
+  };
+}
+
+/** Find the most common type within a cluster of engrams. */
+export function findDominantType(cluster: Engram[]): string {
+  const typeCounts = new Map<string, number>();
+  for (const e of cluster) {
+    typeCounts.set(e.type, (typeCounts.get(e.type) ?? 0) + 1);
+  }
+  let dominant = cluster[0]?.type ?? 'note';
+  let maxCount = 0;
+  for (const [type, cnt] of typeCounts) {
+    if (cnt > maxCount) {
+      dominant = type;
+      maxCount = cnt;
+    }
+  }
+  return dominant;
+}

--- a/pillars/cerebrum/src/api/modules/workers/consolidator.ts
+++ b/pillars/cerebrum/src/api/modules/workers/consolidator.ts
@@ -1,0 +1,153 @@
+/**
+ * Consolidator Worker (US-02, PRD-085).
+ *
+ * Detects clusters of 3+ engrams with cosine similarity > 0.85 within the
+ * same top-level scope. Produces merge plans that combine content, deduplicate
+ * tags/links, and archive originals. Large clusters (>10) are split.
+ */
+import {
+  bfsComponent,
+  buildMergePlan,
+  chunk,
+  findDominantType,
+  groupByTopLevelScope,
+} from './consolidator-helpers.js';
+import {
+  DEFAULT_CONSOLIDATOR_CONFIG,
+  type ConsolidatePayload,
+  type ConsolidatorConfig,
+  type GliaAction,
+  type GliaActionType,
+  type WorkerRunResult,
+} from './types.js';
+import { WorkerBase, type WorkerBaseDeps } from './worker-base.js';
+
+import type { Engram } from '../engrams/types.js';
+
+export interface ConsolidatorDeps extends WorkerBaseDeps {
+  config?: Partial<ConsolidatorConfig>;
+}
+
+export class ConsolidatorWorker extends WorkerBase {
+  protected readonly actionType: GliaActionType = 'consolidate';
+  private readonly config: ConsolidatorConfig;
+
+  constructor(deps: ConsolidatorDeps) {
+    super(deps);
+    this.config = { ...DEFAULT_CONSOLIDATOR_CONFIG, ...deps.config };
+  }
+
+  async run(dryRun = false): Promise<WorkerRunResult> {
+    const phase = this.resolvePhase(dryRun);
+    const engrams = this.listActiveEngrams();
+    const scopeGroups = groupByTopLevelScope(engrams);
+    const allActions = [];
+    let processed = 0;
+    let skipped = 0;
+
+    for (const [scope, scopeEngrams] of scopeGroups) {
+      const clusters = await this.detectClusters(scopeEngrams);
+
+      for (const rawCluster of clusters) {
+        const subClusters =
+          rawCluster.length > this.config.maxClusterSize
+            ? chunk(rawCluster, this.config.maxClusterSize)
+            : [rawCluster];
+
+        for (const cluster of subClusters) {
+          processed += cluster.length;
+          allActions.push(this.processCluster(cluster, scope, phase));
+        }
+      }
+
+      const clusteredIds = new Set(allActions.flatMap((a) => a.affectedIds));
+      skipped += scopeEngrams.filter((e) => !clusteredIds.has(e.id)).length;
+    }
+
+    return { actions: allActions, processed, skipped };
+  }
+
+  /** Detect clusters of semantically similar engrams within a scope group. */
+  private async detectClusters(engrams: Engram[]): Promise<Engram[][]> {
+    if (engrams.length < 3) return [];
+    const adjacency = await this.buildAdjacency(engrams);
+    return this.findClusters(engrams, adjacency, 3);
+  }
+
+  private async buildAdjacency(engrams: Engram[]): Promise<Map<string, Set<string>>> {
+    const adjacency = new Map<string, Set<string>>();
+    for (const engram of engrams) {
+      adjacency.set(engram.id, new Set());
+    }
+
+    for (const engram of engrams) {
+      const similar = await this.searchService.similar(engram.id, { status: ['active'] });
+      for (const result of similar) {
+        if (result.sourceType !== 'engram') continue;
+        if (result.score < this.config.similarityThreshold) continue;
+        if (!adjacency.has(result.sourceId)) continue;
+        adjacency.get(engram.id)?.add(result.sourceId);
+        adjacency.get(result.sourceId)?.add(engram.id);
+      }
+    }
+    return adjacency;
+  }
+
+  /** BFS to find connected components of at least `minSize`. */
+  private findClusters(
+    engrams: Engram[],
+    adjacency: Map<string, Set<string>>,
+    minSize: number
+  ): Engram[][] {
+    const visited = new Set<string>();
+    const engramById = new Map(engrams.map((e) => [e.id, e]));
+    const clusters: Engram[][] = [];
+
+    for (const engram of engrams) {
+      if (visited.has(engram.id)) continue;
+      const component = bfsComponent(engram.id, adjacency, visited, engramById);
+      if (component.length >= minSize) clusters.push(component);
+    }
+    return clusters;
+  }
+
+  private processCluster(cluster: Engram[], scope: string, phase: string): GliaAction {
+    const mergePlan = buildMergePlan(cluster, scope, this.engramService);
+    const action = this.createAction(
+      cluster.map((e) => e.id),
+      `Consolidating ${cluster.length} similar engrams in scope '${scope}': ${cluster.map((e) => `"${e.title}"`).join(', ')}`,
+      mergePlan,
+      phase
+    );
+    if (phase !== 'propose') {
+      const mergedId = this.executeMerge(cluster, mergePlan);
+      mergePlan.mergedEngramId = mergedId;
+      action.status = 'executed';
+    }
+    return action;
+  }
+
+  /**
+   * Execute a merge — create the consolidated engram and archive originals.
+   * Returns the merged engram's ID so the caller can record it on the action
+   * payload (needed for revert per PRD-086 US-04).
+   */
+  private executeMerge(cluster: Engram[], plan: ConsolidatePayload): string {
+    const dominantType = findDominantType(cluster);
+    const merged = this.engramService.create({
+      title: plan.mergedTitle,
+      body: plan.mergedBody,
+      type: dominantType,
+      scopes: [plan.scope],
+      tags: plan.mergedTags,
+      source: 'agent',
+    });
+    for (const linkTarget of plan.mergedLinks) {
+      this.engramService.link(merged.id, linkTarget);
+    }
+    for (const original of cluster) {
+      this.engramService.archive(original.id);
+    }
+    return merged.id;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/workers/linker.ts
+++ b/pillars/cerebrum/src/api/modules/workers/linker.ts
@@ -1,0 +1,142 @@
+import {
+  DEFAULT_LINKER_CONFIG,
+  type GliaAction,
+  type GliaActionType,
+  type LinkerConfig,
+  type LinkPayload,
+  type WorkerRunResult,
+} from './types.js';
+/**
+ * Linker Worker (US-03, PRD-085).
+ *
+ * Scans engrams with fewer than N outbound links, finds semantically similar
+ * engrams with shared entities, and proposes bidirectional links. Respects
+ * scope boundaries and avoids duplicate links.
+ */
+import { WorkerBase, shareTopLevelScope, type WorkerBaseDeps } from './worker-base.js';
+
+import type { Engram } from '../engrams/types.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+
+/** Shared context for evaluating link candidates within a single run. */
+interface LinkEvalContext {
+  allEngrams: Engram[];
+  phase: string;
+  proposedPairs: Set<string>;
+}
+
+export interface LinkerDeps extends WorkerBaseDeps {
+  config?: Partial<LinkerConfig>;
+}
+
+/** Check if a link already exists between two engrams (in either direction). */
+function linkExists(source: Engram, targetId: string, allEngrams: Engram[]): boolean {
+  if (source.links.includes(targetId)) return true;
+  const target = allEngrams.find((e) => e.id === targetId);
+  return target ? target.links.includes(source.id) : false;
+}
+
+/** Build a reason string describing why two engrams should be linked. */
+function buildLinkReason(
+  source: Engram,
+  target: Engram,
+  similarity: number,
+  sharedTags: string[]
+): string {
+  const parts: string[] = [];
+  if (similarity > 0) parts.push(`semantic similarity: ${similarity.toFixed(2)}`);
+  if (sharedTags.length > 0) parts.push(`shared tags: ${sharedTags.join(', ')}`);
+  return `"${source.title}" and "${target.title}" are related (${parts.join('; ')})`;
+}
+
+export class LinkerWorker extends WorkerBase {
+  protected readonly actionType: GliaActionType = 'link';
+  private readonly config: LinkerConfig;
+
+  constructor(deps: LinkerDeps) {
+    super(deps);
+    this.config = { ...DEFAULT_LINKER_CONFIG, ...deps.config };
+  }
+
+  async run(dryRun = false): Promise<WorkerRunResult> {
+    const phase = this.resolvePhase(dryRun);
+    const allEngrams = this.listActiveEngrams();
+    const candidates = allEngrams.filter((e) => e.links.length < this.config.minLinkThreshold);
+    const proposedPairs = new Set<string>();
+    const actions: GliaAction[] = [];
+    let processed = 0;
+    let skipped = 0;
+
+    const ctx: LinkEvalContext = { allEngrams, phase, proposedPairs };
+    for (const candidate of candidates) {
+      processed++;
+      const similar = await this.searchService.similar(candidate.id, { status: ['active'] });
+      const result = this.evaluateSimilarResults(candidate, similar, ctx);
+      actions.push(...result.actions);
+      skipped += result.skipped;
+    }
+    return { actions, processed, skipped };
+  }
+
+  private evaluateSimilarResults(
+    candidate: Engram,
+    similar: RetrievalResult[],
+    ctx: LinkEvalContext
+  ): { actions: GliaAction[]; skipped: number } {
+    const actions: GliaAction[] = [];
+    let proposals = 0;
+    let skipped = 0;
+
+    for (const result of similar) {
+      if (proposals >= this.config.maxProposalsPerEngram) break;
+      const action = this.evaluateCandidate(candidate, result, ctx);
+      if (action === 'skip') {
+        skipped++;
+        continue;
+      }
+      if (action === null) continue;
+      actions.push(action);
+      proposals++;
+    }
+    return { actions, skipped };
+  }
+
+  private evaluateCandidate(
+    candidate: Engram,
+    result: RetrievalResult,
+    ctx: LinkEvalContext
+  ): GliaAction | 'skip' | null {
+    const { allEngrams, phase, proposedPairs } = ctx;
+    if (result.sourceType !== 'engram' || result.score < this.config.similarityThreshold)
+      return null;
+    if (result.sourceId === candidate.id) return null;
+
+    const target = allEngrams.find((e) => e.id === result.sourceId);
+    if (!target || !shareTopLevelScope(candidate, target)) return null;
+    if (linkExists(candidate, result.sourceId, allEngrams)) return null;
+
+    const pairKey = [candidate.id, result.sourceId].toSorted().join('::');
+    if (proposedPairs.has(pairKey)) return null;
+
+    const sourceTags = new Set(candidate.tags);
+    const sharedTags = target.tags.filter((tag) => sourceTags.has(tag));
+    if (result.score < this.config.similarityThreshold && sharedTags.length === 0) return 'skip';
+
+    const reason = buildLinkReason(candidate, target, result.score, sharedTags);
+    const payload: LinkPayload = {
+      type: 'link',
+      sourceId: candidate.id,
+      targetId: result.sourceId,
+      reason,
+      similarityScore: result.score,
+    };
+    const action = this.createAction([candidate.id, result.sourceId], reason, payload, phase);
+    if (phase !== 'propose') {
+      this.engramService.link(candidate.id, result.sourceId);
+      this.engramService.link(result.sourceId, candidate.id);
+      action.status = 'executed';
+    }
+    proposedPairs.add(pairKey);
+    return action;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/workers/llm.ts
+++ b/pillars/cerebrum/src/api/modules/workers/llm.ts
@@ -1,0 +1,116 @@
+/**
+ * LLM-backed contradiction detector for the AuditorWorker.
+ *
+ * Lifts the monolith's pair-wise contradiction analyzer onto the
+ * {@link ContradictionDetector} port the auditor consumes (returns the conflict
+ * summary string, or null when there is no contradiction). The auditor only
+ * needs the summary; the verbatim-excerpt shape the nudges detector returns is
+ * not part of the worker action payload.
+ *
+ * Pillar deltas (parity with the ingest/ego slices): model is a hardcoded haiku
+ * constant with an optional `CEREBRUM_AUDITOR_MODEL` env override; no settings
+ * service, no `trackInference` — only the 429 backoff is retained. A missing
+ * `ANTHROPIC_API_KEY` yields null (no contradiction surfaced) rather than
+ * throwing. Tests inject a fake.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+import { withRateLimitRetry } from '../ingest/llm.js';
+
+import type { ContradictionDetector } from './auditor.js';
+
+export const DEFAULT_AUDITOR_MODEL = 'claude-haiku-4-5-20251001';
+
+const MAX_BODY_CHARS = 2000;
+const OPERATION = 'cerebrum.auditor.contradiction';
+
+const SYSTEM_PROMPT = `You are an impartial fact-checker comparing two passages that share a topic.
+
+Decide whether the passages express GENUINELY CONTRADICTORY positions on the same subject. A contradiction is when one passage asserts something that directly conflicts with what the other passage asserts. Differences in scope, complementary information, or thinking that has evolved over time are NOT contradictions.
+
+Be conservative — only flag clear, simultaneously-held conflicts.
+
+Respond with a single JSON object and nothing else. Two shapes are valid:
+
+When there is NO contradiction:
+{"contradiction": false}
+
+When there IS a contradiction:
+{
+  "contradiction": true,
+  "conflict": "<one concise sentence describing the conflict>"
+}`;
+
+const contradictionResultSchema = z.discriminatedUnion('contradiction', [
+  z.object({ contradiction: z.literal(false) }),
+  z.object({ contradiction: z.literal(true), conflict: z.string().trim().min(1) }),
+]);
+
+function envModel(): string {
+  const value = process.env['CEREBRUM_AUDITOR_MODEL'];
+  return value !== undefined && value !== '' ? value : DEFAULT_AUDITOR_MODEL;
+}
+
+function truncate(body: string): string {
+  return body.length <= MAX_BODY_CHARS ? body : body.slice(0, MAX_BODY_CHARS) + '...';
+}
+
+/**
+ * Extract the first JSON object embedded in a string and validate it. Returns
+ * the conflict summary on a contradiction, else null (no contradiction or any
+ * parse/schema failure).
+ */
+export function parseContradictionResponse(raw: string): string | null {
+  const trimmed = raw.trim();
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(trimmed.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  const result = contradictionResultSchema.safeParse(parsedJson);
+  if (!result.success || result.data.contradiction !== true) return null;
+  return result.data.conflict;
+}
+
+/** Anthropic-backed contradiction detector. */
+export class AnthropicContradictionDetector implements ContradictionDetector {
+  async detectContradiction(bodyA: string, bodyB: string): Promise<string | null> {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey === undefined || apiKey === '') {
+      console.warn('[cerebrum-auditor] ANTHROPIC_API_KEY not set — skipping contradiction check');
+      return null;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    const model = envModel();
+    const userMessage = `Passage A:\n${truncate(bodyA)}\n\nPassage B:\n${truncate(bodyB)}`;
+
+    try {
+      const response = await withRateLimitRetry(
+        () =>
+          client.messages.create({
+            model,
+            max_tokens: 500,
+            temperature: 0,
+            system: SYSTEM_PROMPT,
+            messages: [{ role: 'user', content: userMessage }],
+          }),
+        OPERATION
+      );
+      const first = response.content[0];
+      const text = first?.type === 'text' ? first.text : '';
+      return parseContradictionResponse(text);
+    } catch (err) {
+      console.warn(
+        `[cerebrum-auditor] contradiction check failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/workers/pruner-helpers.ts
+++ b/pillars/cerebrum/src/api/modules/workers/pruner-helpers.ts
@@ -1,0 +1,160 @@
+/**
+ * Pruner worker helpers — staleness scoring, orphan detection, and rationale building.
+ * Extracted from pruner.ts to respect max-lines-per-file.
+ */
+import type { Engram } from '../engrams/types.js';
+import type { StalenessFactors, StalenessResult } from './types.js';
+
+/** Weights for the staleness score computation. */
+const STALENESS_WEIGHTS = {
+  daysSinceModified: 0.3,
+  daysSinceReferenced: 0.3,
+  inboundLinkCount: 0.2,
+  queryHitCount: 0.2,
+} as const;
+
+/** Maximum days for capping the linear decay. */
+export const MAX_STALENESS_DAYS = 365;
+
+/** Maximum link/hit counts for normalization (inverse). */
+const MAX_LINK_COUNT = 20;
+const MAX_HIT_COUNT = 50;
+
+/** Days window for "recent" query activity check. */
+const RECENT_QUERY_WINDOW_DAYS = 7;
+
+/** Compute days between two dates (floored to whole days). */
+export function daysBetween(from: Date, to: Date): number {
+  return Math.max(0, Math.floor((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24)));
+}
+
+/** Normalise a days value to 0-1 range, capped at maxDays. */
+export function normaliseDays(days: number, maxDays: number): number {
+  return Math.min(days / maxDays, 1.0);
+}
+
+/** Normalise a count inversely — higher count = lower staleness. */
+export function normaliseCountInverse(count: number, maxCount: number): number {
+  return 1.0 - Math.min(count / maxCount, 1.0);
+}
+
+/** Default inbound link counter — counts how many other engrams link to this one. */
+export function defaultInboundLinkCount(engramId: string, allEngrams: Engram[]): number {
+  return allEngrams.filter((e) => e.links.includes(engramId)).length;
+}
+
+/** Lookup functions injected by the pruner worker. */
+export interface StalenessLookups {
+  getInboundLinkCount: (engramId: string, allEngrams: Engram[]) => number;
+  getQueryHitCount: (engramId: string) => number;
+  getLastQueriedAt: (engramId: string) => Date | undefined;
+}
+
+/** Compute the staleness score for a single engram. */
+export function computeStaleness(
+  engram: Engram,
+  allEngrams: Engram[],
+  now: Date,
+  lookups: StalenessLookups
+): StalenessResult {
+  const modifiedDate = new Date(engram.modified);
+  const daysSinceModified = daysBetween(modifiedDate, now);
+
+  const lastQueried = lookups.getLastQueriedAt(engram.id);
+  const daysSinceReferenced = lastQueried ? daysBetween(lastQueried, now) : MAX_STALENESS_DAYS;
+
+  const inboundLinkCount = lookups.getInboundLinkCount(engram.id, allEngrams);
+  const queryHitCount = lookups.getQueryHitCount(engram.id);
+
+  const recentQueryBoost = lastQueried && daysBetween(lastQueried, now) <= RECENT_QUERY_WINDOW_DAYS;
+
+  const factors: StalenessFactors = {
+    daysSinceModified,
+    daysSinceReferenced,
+    inboundLinkCount,
+    queryHitCount,
+  };
+
+  const normModified = normaliseDays(daysSinceModified, MAX_STALENESS_DAYS);
+  const normReferenced = normaliseDays(daysSinceReferenced, MAX_STALENESS_DAYS);
+  const normLinks = normaliseCountInverse(inboundLinkCount, MAX_LINK_COUNT);
+  const normHits = recentQueryBoost ? 0.0 : normaliseCountInverse(queryHitCount, MAX_HIT_COUNT);
+
+  const score =
+    STALENESS_WEIGHTS.daysSinceModified * normModified +
+    STALENESS_WEIGHTS.daysSinceReferenced * normReferenced +
+    STALENESS_WEIGHTS.inboundLinkCount * normLinks +
+    STALENESS_WEIGHTS.queryHitCount * normHits;
+
+  return { score: Math.min(1.0, Math.max(0.0, score)), factors };
+}
+
+/** Options for orphan detection. */
+export interface OrphanCheckOptions {
+  now: Date;
+  orphanDays: number;
+  getLastQueriedAt: (engramId: string) => Date | undefined;
+}
+
+/** Determine if an engram qualifies as an orphan. */
+export function isOrphan(
+  engram: Engram,
+  result: StalenessResult,
+  options: OrphanCheckOptions
+): boolean {
+  const lastQueried = options.getLastQueriedAt(engram.id);
+  const queryInWindow = lastQueried
+    ? daysBetween(lastQueried, options.now) <= options.orphanDays
+    : false;
+  return result.factors.inboundLinkCount === 0 && !queryInWindow;
+}
+
+/** Identify the factor contributing most to staleness. */
+export function getDominantFactor(result: StalenessResult): string {
+  const normModified = normaliseDays(result.factors.daysSinceModified, MAX_STALENESS_DAYS);
+  const normReferenced = normaliseDays(result.factors.daysSinceReferenced, MAX_STALENESS_DAYS);
+  const normLinks = normaliseCountInverse(result.factors.inboundLinkCount, MAX_LINK_COUNT);
+  const normHits = normaliseCountInverse(result.factors.queryHitCount, MAX_HIT_COUNT);
+
+  const contributions = [
+    { name: 'days since modified', value: STALENESS_WEIGHTS.daysSinceModified * normModified },
+    {
+      name: 'days since referenced',
+      value: STALENESS_WEIGHTS.daysSinceReferenced * normReferenced,
+    },
+    { name: 'low inbound links', value: STALENESS_WEIGHTS.inboundLinkCount * normLinks },
+    { name: 'low query hits', value: STALENESS_WEIGHTS.queryHitCount * normHits },
+  ];
+
+  contributions.sort((a, b) => b.value - a.value);
+  return contributions[0]?.name ?? 'unknown';
+}
+
+/** Build a human-readable rationale explaining why the engram is stale. */
+export function buildRationale(
+  engram: Engram,
+  result: StalenessResult,
+  orphan: boolean,
+  orphanDays: number
+): string {
+  const parts: string[] = [];
+
+  if (orphan) {
+    parts.push(
+      `Orphan engram: zero inbound links and no query hits in the last ${orphanDays} days.`
+    );
+  }
+
+  parts.push(`Staleness score: ${result.score.toFixed(2)}.`);
+
+  const dominantFactor = getDominantFactor(result);
+  parts.push(`Dominant factor: ${dominantFactor}.`);
+
+  parts.push(`Last modified: ${engram.modified}.`);
+
+  if (result.factors.inboundLinkCount === 0) {
+    parts.push('No inbound links from other engrams.');
+  }
+
+  return parts.join(' ');
+}

--- a/pillars/cerebrum/src/api/modules/workers/pruner.ts
+++ b/pillars/cerebrum/src/api/modules/workers/pruner.ts
@@ -1,0 +1,103 @@
+/**
+ * Pruner Worker (US-01, PRD-085).
+ *
+ * Computes staleness scores for engrams and detects orphans. Engrams above
+ * the staleness threshold are proposed for archival. Orphans (zero inbound
+ * links + zero query hits in the last N days) use a lower threshold.
+ */
+import {
+  buildRationale,
+  computeStaleness,
+  defaultInboundLinkCount,
+  isOrphan,
+  type StalenessLookups,
+} from './pruner-helpers.js';
+import {
+  DEFAULT_PRUNER_CONFIG,
+  type GliaActionType,
+  type PrunePayload,
+  type PrunerConfig,
+  type StalenessResult,
+  type WorkerRunResult,
+} from './types.js';
+import { WorkerBase, type WorkerBaseDeps } from './worker-base.js';
+
+import type { Engram } from '../engrams/types.js';
+
+export interface PrunerDeps extends WorkerBaseDeps {
+  config?: Partial<PrunerConfig>;
+  /** Lookup function for inbound link counts — defaults to searching the list. */
+  getInboundLinkCount?: (engramId: string, allEngrams: Engram[]) => number;
+  /** Lookup function for query hit counts — defaults to 0 (maximum staleness). */
+  getQueryHitCount?: (engramId: string) => number;
+  /** Lookup function for last queried date — defaults to undefined (max staleness). */
+  getLastQueriedAt?: (engramId: string) => Date | undefined;
+}
+
+export class PrunerWorker extends WorkerBase {
+  protected readonly actionType: GliaActionType = 'prune';
+  private readonly config: PrunerConfig;
+  private readonly lookups: StalenessLookups;
+
+  constructor(deps: PrunerDeps) {
+    super(deps);
+    this.config = { ...DEFAULT_PRUNER_CONFIG, ...deps.config };
+    this.lookups = {
+      getInboundLinkCount: deps.getInboundLinkCount ?? defaultInboundLinkCount,
+      getQueryHitCount: deps.getQueryHitCount ?? (() => 0),
+      getLastQueriedAt: deps.getLastQueriedAt ?? (() => undefined),
+    };
+  }
+
+  async run(dryRun = false): Promise<WorkerRunResult> {
+    const phase = this.resolvePhase(dryRun);
+    const engrams = this.listActiveEngrams();
+    const actions = [];
+    let skipped = 0;
+
+    for (let i = 0; i < engrams.length; i += this.config.batchSize) {
+      const batch = engrams.slice(i, i + this.config.batchSize);
+      for (const engram of batch) {
+        const result = this.computeStaleness(engram, engrams);
+        const orphan = isOrphan(engram, result, {
+          now: this.now(),
+          orphanDays: this.config.orphanDays,
+          getLastQueriedAt: this.lookups.getLastQueriedAt,
+        });
+        const threshold = orphan ? this.config.orphanThreshold : this.config.stalenessThreshold;
+
+        if (result.score < threshold) {
+          skipped++;
+          continue;
+        }
+
+        const rationale = buildRationale(engram, result, orphan, this.config.orphanDays);
+        const payload: PrunePayload = {
+          type: 'archive',
+          stalenessScore: result.score,
+          factors: result.factors,
+          isOrphan: orphan,
+        };
+
+        const action = this.createAction([engram.id], rationale, payload, phase);
+
+        if (phase !== 'propose') {
+          this.engramService.archive(engram.id);
+          action.status = 'executed';
+        }
+
+        actions.push(action);
+      }
+    }
+
+    return { actions, processed: engrams.length, skipped };
+  }
+
+  /**
+   * Compute the staleness score for a single engram.
+   * Exposed as a public method for the `getStalenessScore` API endpoint.
+   */
+  computeStaleness(engram: Engram, allEngrams: Engram[]): StalenessResult {
+    return computeStaleness(engram, allEngrams, this.now(), this.lookups);
+  }
+}

--- a/pillars/cerebrum/src/api/modules/workers/types.ts
+++ b/pillars/cerebrum/src/api/modules/workers/types.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared types for the Glia curation workers (PRD-085).
+ *
+ * All four workers (pruner, consolidator, linker, auditor) produce GliaAction
+ * records that flow through the trust graduation system (PRD-086).
+ */
+
+/** Trust phases that govern worker execution behaviour. */
+export type TrustPhase = 'propose' | 'act_report' | 'silent';
+
+/** Action types corresponding to the four curation workers. */
+export type GliaActionType = 'prune' | 'consolidate' | 'link' | 'audit';
+
+/** Status of a glia action through its lifecycle. */
+export type GliaActionStatus = 'proposed' | 'executed' | 'error';
+
+/**
+ * A uniform action record produced by any curation worker.
+ * Consumed by the trust graduation system (PRD-086).
+ */
+export interface GliaAction {
+  /** Unique action ID: `glia_{action_type}_{timestamp}_{short_hash}` */
+  id: string;
+  /** Which worker produced this action. */
+  actionType: GliaActionType;
+  /** Engram IDs affected by this action. */
+  affectedIds: string[];
+  /** Human-readable explanation of why this action is proposed. */
+  rationale: string;
+  /** Action-type-specific data (merge plan, link pairs, quality scores, etc.). */
+  payload: Record<string, unknown>;
+  /** Trust phase at time of creation. */
+  phase: TrustPhase;
+  /** Current status of the action. */
+  status: GliaActionStatus;
+  /** ISO 8601 timestamp. */
+  createdAt: string;
+}
+
+/** Staleness score breakdown for a single engram (Pruner). */
+export interface StalenessFactors {
+  daysSinceModified: number;
+  daysSinceReferenced: number;
+  inboundLinkCount: number;
+  queryHitCount: number;
+}
+
+export interface StalenessResult {
+  score: number;
+  factors: StalenessFactors;
+}
+
+/** Quality score breakdown for a single engram (Auditor). */
+export interface QualityFactors {
+  completeness: number;
+  specificity: number;
+  templateFit: number;
+  linkDensity: number;
+}
+
+export interface QualityResult {
+  score: number;
+  factors: QualityFactors;
+}
+
+/** Base index signature for payloads to satisfy Record<string, unknown>. */
+interface PayloadBase {
+  [key: string]: unknown;
+}
+
+/** Pruner-specific payload. */
+export interface PrunePayload extends PayloadBase {
+  type: 'archive';
+  stalenessScore: number;
+  factors: StalenessFactors;
+  isOrphan: boolean;
+}
+
+/** Consolidator-specific payload. */
+export interface ConsolidatePayload extends PayloadBase {
+  type: 'merge';
+  clusterIds: string[];
+  mergedTitle: string;
+  mergedTags: string[];
+  mergedLinks: string[];
+  mergedBody: string;
+  scope: string;
+  /**
+   * Engram ID of the merged file produced by `executeMerge`. Set only after
+   * the merge runs (non-propose phases). Required for `consolidate` revert
+   * to locate and remove the merged engram (PRD-086 US-04, #2576).
+   */
+  mergedEngramId?: string;
+}
+
+/** Linker-specific payload. */
+export interface LinkPayload extends PayloadBase {
+  type: 'link';
+  sourceId: string;
+  targetId: string;
+  reason: string;
+  similarityScore: number;
+}
+
+/** Auditor-specific payloads. */
+export interface ContradictionPayload extends PayloadBase {
+  type: 'contradiction';
+  engramA: string;
+  engramB: string;
+  conflictSummary: string;
+}
+
+export interface LowQualityPayload extends PayloadBase {
+  type: 'low_quality';
+  score: number;
+  factors: QualityFactors;
+  suggestions: string[];
+}
+
+export interface CoverageGapPayload extends PayloadBase {
+  type: 'gap';
+  topic: string;
+  existingCount: number;
+  relatedEngrams: string[];
+}
+
+export type AuditPayload = ContradictionPayload | LowQualityPayload | CoverageGapPayload;
+
+/** Result summary returned by each worker's run method. */
+export interface WorkerRunResult {
+  actions: GliaAction[];
+  processed: number;
+  skipped: number;
+}
+
+/** Configuration for the pruner worker. */
+export interface PrunerConfig {
+  stalenessThreshold: number;
+  orphanThreshold: number;
+  orphanDays: number;
+  batchSize: number;
+}
+
+/** Configuration for the consolidator worker. */
+export interface ConsolidatorConfig {
+  similarityThreshold: number;
+  maxClusterSize: number;
+}
+
+/** Configuration for the linker worker. */
+export interface LinkerConfig {
+  minLinkThreshold: number;
+  similarityThreshold: number;
+  maxProposalsPerEngram: number;
+}
+
+/** Configuration for the auditor worker. */
+export interface AuditorConfig {
+  qualityThreshold: number;
+  minEngramsPerTopic: number;
+}
+
+/** Default configurations — these would be read from glia.toml in production. */
+export const DEFAULT_PRUNER_CONFIG: PrunerConfig = {
+  stalenessThreshold: 0.7,
+  orphanThreshold: 0.5,
+  orphanDays: 90,
+  batchSize: 100,
+};
+
+export const DEFAULT_CONSOLIDATOR_CONFIG: ConsolidatorConfig = {
+  similarityThreshold: 0.85,
+  maxClusterSize: 10,
+};
+
+export const DEFAULT_LINKER_CONFIG: LinkerConfig = {
+  minLinkThreshold: 2,
+  similarityThreshold: 0.7,
+  maxProposalsPerEngram: 5,
+};
+
+export const DEFAULT_AUDITOR_CONFIG: AuditorConfig = {
+  qualityThreshold: 0.3,
+  minEngramsPerTopic: 2,
+};

--- a/pillars/cerebrum/src/api/modules/workers/worker-base.ts
+++ b/pillars/cerebrum/src/api/modules/workers/worker-base.ts
@@ -1,0 +1,125 @@
+/**
+ * Abstract base for Glia curation workers (PRD-085).
+ *
+ * Provides trust-phase checking, secret-scope filtering, action ID generation,
+ * and the common run-loop structure that all four workers share.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { EngramService } from '../engrams/service.js';
+import type { Engram } from '../engrams/types.js';
+import type { HybridSearchService } from '../retrieval/hybrid-search.js';
+import type { GliaAction, GliaActionType, TrustPhase, WorkerRunResult } from './types.js';
+
+/** Minimal interface for the trust phase lookup — stub until PRD-086 lands. */
+export interface TrustPhaseProvider {
+  getPhase(actionType: GliaActionType): TrustPhase;
+}
+
+/** Default trust phase provider — always proposes (safest default). */
+export class DefaultTrustPhaseProvider implements TrustPhaseProvider {
+  getPhase(_actionType: GliaActionType): TrustPhase {
+    return 'propose';
+  }
+}
+
+/** Check whether an engram's scope list contains a `.secret.` segment. */
+export function hasSecretScope(scopes: string[]): boolean {
+  return scopes.some((scope) => scope.split('.').includes('secret'));
+}
+
+/** Check whether an engram should be skipped by curation workers. */
+export function shouldSkipEngram(engram: Engram): boolean {
+  if (engram.status === 'archived' || engram.status === 'consolidated') return true;
+  return hasSecretScope(engram.scopes);
+}
+
+/** Extract top-level scope prefix (first segment before the first dot). */
+export function topLevelScope(scope: string): string {
+  const dot = scope.indexOf('.');
+  return dot === -1 ? scope : scope.slice(0, dot);
+}
+
+/** Check if two engrams share at least one top-level scope. */
+export function shareTopLevelScope(engramA: Engram, engramB: Engram): boolean {
+  const aTopScopes = new Set(engramA.scopes.map(topLevelScope));
+  return engramB.scopes.some((scope) => aTopScopes.has(topLevelScope(scope)));
+}
+
+export interface WorkerBaseDeps {
+  engramService: EngramService;
+  searchService: HybridSearchService;
+  trustProvider?: TrustPhaseProvider;
+  now?: () => Date;
+}
+
+/** Resolve a raw phase string to a TrustPhase value. */
+function resolveTrustPhase(phase: string): TrustPhase {
+  if (phase === 'act_report') return 'act_report';
+  if (phase === 'silent') return 'silent';
+  return 'propose';
+}
+
+export abstract class WorkerBase {
+  protected readonly engramService: EngramService;
+  protected readonly searchService: HybridSearchService;
+  protected readonly trustProvider: TrustPhaseProvider;
+  protected readonly now: () => Date;
+
+  constructor(deps: WorkerBaseDeps) {
+    this.engramService = deps.engramService;
+    this.searchService = deps.searchService;
+    this.trustProvider = deps.trustProvider ?? new DefaultTrustPhaseProvider();
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  /** Run the worker. If dryRun is true, force propose mode regardless of trust phase. */
+  abstract run(dryRun?: boolean): Promise<WorkerRunResult>;
+
+  /** The action type this worker produces. */
+  protected abstract readonly actionType: GliaActionType;
+
+  /** Resolve the effective trust phase — dryRun forces 'propose'. */
+  protected resolvePhase(dryRun: boolean): TrustPhase {
+    if (dryRun) return 'propose';
+    return this.trustProvider.getPhase(this.actionType);
+  }
+
+  /** Generate a unique action ID. */
+  protected generateActionId(): string {
+    const timestamp = this.now()
+      .toISOString()
+      .replace(/[-:T.Z]/g, '')
+      .slice(0, 14);
+    const hash = createHash('sha256').update(randomBytes(16)).digest('hex').slice(0, 8);
+    return `glia_${this.actionType}_${timestamp}_${hash}`;
+  }
+
+  /** Create a GliaAction record. */
+  protected createAction(
+    affectedIds: string[],
+    rationale: string,
+    payload: Record<string, unknown>,
+    phase: TrustPhase | string
+  ): GliaAction {
+    return {
+      id: this.generateActionId(),
+      actionType: this.actionType,
+      affectedIds,
+      rationale,
+      payload,
+      phase: resolveTrustPhase(phase),
+      status: 'proposed',
+      createdAt: this.now().toISOString(),
+    };
+  }
+
+  /** Fetch all active engrams, filtering out archived/consolidated/secret. */
+  protected listActiveEngrams(): Engram[] {
+    const { engrams } = this.engramService.list({
+      status: 'active',
+      limit: 10000,
+    });
+    return engrams.filter((e) => !shouldSkipEngram(e));
+  }
+}

--- a/pillars/cerebrum/src/api/rest/ego-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/ego-handlers.ts
@@ -1,0 +1,180 @@
+/**
+ * ts-rest handlers for `ego.*` (PRD-087).
+ *
+ * Conversation CRUD + context are thin adapters over {@link ConversationPersistence}.
+ * `chat` runs the lifted {@link ConversationEngine}: persist the user turn,
+ * call the engine (retrieval + injected LLM), then persist the assistant turn +
+ * engram context links. A pipeline failure persists a placeholder assistant
+ * message and rethrows so Express surfaces a 500.
+ *
+ * `getConversation`, `setScopes`, and `getActiveContext` map a missing
+ * conversation to 404 via the pillar {@link NotFoundError} + `runHttp`.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumEgoContract } from '../../contract/rest-ego.js';
+import { type CerebrumDb } from '../../db/index.js';
+import {
+  persistAssistantError,
+  persistAssistantTurn,
+  persistUserTurn,
+  resolveConversation,
+} from '../modules/ego/chat-helpers.js';
+import { ConversationEngine } from '../modules/ego/engine.js';
+import { ConversationPersistence } from '../modules/ego/persistence.js';
+import { EngramService } from '../modules/engrams/service.js';
+import { NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { EgoLlm } from '../modules/ego/llm.js';
+import type { AppContext } from '../modules/ego/types.js';
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface EgoHandlerDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  llm: EgoLlm;
+  peers: PeerClients;
+  embeddingClient?: EmbeddingClient;
+}
+
+export function makeEgoHandlers(
+  deps: EgoHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumEgoContract>> {
+  const persistence = (): ConversationPersistence => new ConversationPersistence({ db: deps.db });
+
+  const engine = (): ConversationEngine =>
+    new ConversationEngine({
+      llm: deps.llm,
+      search: {
+        db: deps.db,
+        raw: deps.raw,
+        vecAvailable: deps.vecAvailable,
+        peers: deps.peers,
+        embeddingClient: deps.embeddingClient,
+      },
+      engramService: new EngramService({
+        root: deps.engramRoot,
+        db: deps.db,
+        templates: deps.templates,
+      }),
+    });
+
+  return server.router(cerebrumEgoContract, {
+    chat: async ({ body }) => {
+      const store = persistence();
+      const scopes = body.scopes ?? [];
+      const appContext: AppContext | undefined = body.appContext ?? undefined;
+
+      const conversation = resolveConversation({
+        persistence: store,
+        conversationId: body.conversationId,
+        message: body.message,
+        scopes,
+        appContext,
+        model: deps.llm.model(),
+      });
+      const history = store.getConversation(conversation.id)?.messages ?? [];
+
+      persistUserTurn({
+        persistence: store,
+        conversationId: conversation.id,
+        userMessage: body.message,
+        storedAppContext: conversation.appContext as AppContext | undefined | null,
+        incomingAppContext: appContext,
+      });
+
+      let result;
+      try {
+        result = await engine().chat({
+          conversationId: conversation.id,
+          message: body.message,
+          history,
+          activeScopes: conversation.activeScopes,
+          appContext: appContext ?? (conversation.appContext as AppContext | undefined),
+          channel: body.channel ?? 'shell',
+          knownScopes: body.knownScopes,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        persistAssistantError(store, conversation.id, message);
+        throw err instanceof Error ? err : new Error(message);
+      }
+
+      const assistantMsg = persistAssistantTurn({
+        persistence: store,
+        conversationId: conversation.id,
+        result,
+      });
+
+      return {
+        status: 200 as const,
+        body: {
+          conversationId: conversation.id,
+          response: assistantMsg,
+          retrievedEngrams: result.retrievedEngrams,
+          scopeNegotiation: result.scopeNegotiation ?? null,
+        },
+      };
+    },
+
+    createConversation: async ({ body }) => ({
+      status: 200,
+      body: { conversation: persistence().createConversation(body) },
+    }),
+
+    listConversations: async ({ body }) => ({
+      status: 200,
+      body: persistence().listConversations(body),
+    }),
+
+    getConversation: async ({ params }) =>
+      runHttp(() => {
+        const result = persistence().getConversation(params.id);
+        if (!result) throw new NotFoundError('Conversation', params.id);
+        return { status: 200 as const, body: result };
+      }),
+
+    deleteConversation: async ({ params }) => {
+      persistence().deleteConversation(params.id);
+      return { status: 200, body: { success: true as const } };
+    },
+
+    setScopes: async ({ params, body }) =>
+      runHttp(() => {
+        const store = persistence();
+        if (!store.getConversation(params.id)) throw new NotFoundError('Conversation', params.id);
+        store.updateScopes(params.id, body.scopes);
+        return { status: 200 as const, body: { scopes: body.scopes } };
+      }),
+
+    getActiveContext: async ({ params }) =>
+      runHttp(() => {
+        const store = persistence();
+        const existing = store.getConversation(params.id);
+        if (!existing) throw new NotFoundError('Conversation', params.id);
+        const entries = store.getContextEntries(params.id);
+        return {
+          status: 200 as const,
+          body: {
+            scopes: existing.conversation.activeScopes,
+            appContext: existing.conversation.appContext,
+            engrams: entries.map((e) => ({
+              engramId: e.engramId,
+              relevanceScore: e.relevanceScore,
+              loadedAt: e.loadedAt,
+            })),
+          },
+        };
+      }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/ego-stream.ts
+++ b/pillars/cerebrum/src/api/rest/ego-stream.ts
@@ -1,0 +1,202 @@
+/**
+ * SSE route for streaming ego chat responses (PRD-087 US-01 AC #6).
+ *
+ * `POST /ego/chat/stream` — accepts the same body as `ego.chat` but returns a
+ * `text/event-stream`:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","conversationId":"...","citations":[...],...}
+ *
+ * ts-rest cannot model SSE, so this is mounted as a plain Express route in
+ * `app.ts` BEFORE `createExpressEndpoints`. The user turn is persisted before
+ * streaming; the assistant turn + engram context links are persisted after the
+ * `done` event (parity with `ego.chat`). A pre-stream failure emits an `error`
+ * frame; a mid-stream failure persists a placeholder assistant message and
+ * emits an `error` frame.
+ */
+import { Router, type Router as ExpressRouter, type Request, type Response } from 'express';
+
+import { egoChatBodySchema } from '../../contract/rest-ego-schemas.js';
+import {
+  persistAssistantError,
+  persistStreamResults,
+  persistUserTurn,
+  resolveConversation,
+} from '../modules/ego/chat-helpers.js';
+import { ConversationEngine } from '../modules/ego/engine.js';
+import { ConversationPersistence } from '../modules/ego/persistence.js';
+import { EngramService } from '../modules/engrams/service.js';
+
+import type { Conversation, Message } from '../modules/ego/persistence.js';
+import type { AppContext, ChatStreamPreparation } from '../modules/ego/types.js';
+import type { EgoHandlerDeps } from './ego-handlers.js';
+
+function setSseHeaders(res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+function writeSseEvent(res: Response, data: Record<string, unknown>): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+interface PipeStreamParams {
+  req: Request;
+  res: Response;
+  persistence: ConversationPersistence;
+  preparation: ChatStreamPreparation;
+  conversation: Conversation;
+}
+
+async function pipeStreamEvents(params: PipeStreamParams): Promise<void> {
+  const { req, res, persistence, preparation, conversation } = params;
+  let clientDisconnected = false;
+  req.on('close', () => {
+    clientDisconnected = true;
+  });
+
+  for await (const event of preparation.stream) {
+    if (clientDisconnected) break;
+
+    if (event.type === 'token') {
+      writeSseEvent(res, { type: 'token', text: event.text });
+    } else {
+      const assistantMsg = persistStreamResults({
+        persistence,
+        conversationId: conversation.id,
+        content: event.content,
+        citations: event.citations,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+        retrievedEngrams: preparation.retrievedEngrams,
+        scopeNegotiation: preparation.scopeNegotiation,
+      });
+
+      writeSseEvent(res, {
+        type: 'done',
+        conversationId: conversation.id,
+        messageId: assistantMsg.id,
+        citations: event.citations,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+        retrievedEngrams: preparation.retrievedEngrams,
+        scopeNegotiation: preparation.scopeNegotiation,
+      });
+    }
+  }
+}
+
+function buildEngine(deps: EgoHandlerDeps): ConversationEngine {
+  return new ConversationEngine({
+    llm: deps.llm,
+    search: {
+      db: deps.db,
+      raw: deps.raw,
+      vecAvailable: deps.vecAvailable,
+      peers: deps.peers,
+      embeddingClient: deps.embeddingClient,
+    },
+    engramService: new EngramService({
+      root: deps.engramRoot,
+      db: deps.db,
+      templates: deps.templates,
+    }),
+  });
+}
+
+interface ResolvedTurn {
+  conversation: Conversation;
+  history: Message[];
+}
+
+/**
+ * Resolve the conversation, snapshot the prior history, and persist the user
+ * turn. The history snapshot is taken BEFORE the user turn is appended so the
+ * engine sees the prior turns plus the new `message` arg. Emits an SSE `error`
+ * frame + ends the response on failure (returns null).
+ */
+function resolveAndPersistUserTurn(
+  deps: EgoHandlerDeps,
+  persistence: ConversationPersistence,
+  res: Response,
+  input: ReturnType<typeof egoChatBodySchema.parse>
+): ResolvedTurn | null {
+  const appContext: AppContext | undefined = input.appContext ?? undefined;
+  try {
+    const conversation = resolveConversation({
+      persistence,
+      conversationId: input.conversationId,
+      message: input.message,
+      scopes: input.scopes ?? [],
+      appContext,
+      model: deps.llm.model(),
+    });
+    const history = persistence.getConversation(conversation.id)?.messages ?? [];
+    persistUserTurn({
+      persistence,
+      conversationId: conversation.id,
+      userMessage: input.message,
+      storedAppContext: conversation.appContext as AppContext | undefined | null,
+      incomingAppContext: appContext,
+    });
+    return { conversation, history };
+  } catch (err) {
+    writeSseEvent(res, {
+      type: 'error',
+      message: err instanceof Error ? err.message : 'Internal server error',
+    });
+    res.end();
+    return null;
+  }
+}
+
+async function handleStreamRequest(
+  deps: EgoHandlerDeps,
+  req: Request,
+  res: Response
+): Promise<void> {
+  const parsed = egoChatBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Invalid request body', details: parsed.error.issues });
+    return;
+  }
+  const input = parsed.data;
+
+  setSseHeaders(res);
+
+  const persistence = new ConversationPersistence({ db: deps.db });
+  const resolved = resolveAndPersistUserTurn(deps, persistence, res, input);
+  if (!resolved) return;
+  const { conversation, history } = resolved;
+  const appContext: AppContext | undefined = input.appContext ?? undefined;
+
+  try {
+    const preparation = await buildEngine(deps).prepareStream({
+      conversationId: conversation.id,
+      message: input.message,
+      history,
+      activeScopes: conversation.activeScopes,
+      appContext: appContext ?? (conversation.appContext as AppContext | undefined),
+      channel: input.channel ?? 'shell',
+      knownScopes: input.knownScopes,
+    });
+    await pipeStreamEvents({ req, res, persistence, preparation, conversation });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    persistAssistantError(persistence, conversation.id, message);
+    writeSseEvent(res, { type: 'error', conversationId: conversation.id, message });
+  }
+
+  res.end();
+}
+
+/** Build the SSE router. Mount in `app.ts` before `createExpressEndpoints`. */
+export function makeEgoStreamRouter(deps: EgoHandlerDeps): ExpressRouter {
+  const router: ExpressRouter = Router();
+  router.post('/ego/chat/stream', (req: Request, res: Response) => {
+    void handleStreamRequest(deps, req, res);
+  });
+  return router;
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -8,9 +8,12 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumContract } from '../../contract/rest.js';
+import { AnthropicEgoLlm } from '../modules/ego/llm.js';
 import { resolveGliaConfigPath } from '../modules/glia/instance.js';
 import { AnthropicIngestLlm } from '../modules/ingest/llm.js';
 import { getCurationQueue } from '../modules/ingest/queue.js';
+import { AnthropicContradictionDetector } from '../modules/workers/llm.js';
+import { makeEgoHandlers } from './ego-handlers.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
 import { makeGliaHandlers } from './glia-handlers.js';
 import { makeIngestHandlers } from './ingest-handlers.js';
@@ -21,6 +24,7 @@ import { makeRetrievalHandlers } from './retrieval-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
 import { makeTagsHandlers } from './tags-handlers.js';
 import { makeTemplatesHandlers } from './templates-handlers.js';
+import { makeWorkersHandlers } from './workers-handlers.js';
 
 import type { CerebrumApiDeps } from '../handlers.js';
 
@@ -61,6 +65,27 @@ export function makeCerebrumRestHandlers(
       vecAvailable: deps.cerebrumDb.vecAvailable,
       peers: deps.peerClients,
       embeddingClient: deps.embeddingClient,
+    }),
+    ego: makeEgoHandlers({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      llm: deps.egoLlm ?? new AnthropicEgoLlm(),
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+    }),
+    workers: makeWorkersHandlers({
+      db: deps.cerebrumDb.db,
+      raw: deps.cerebrumDb.raw,
+      vecAvailable: deps.cerebrumDb.vecAvailable,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      peers: deps.peerClients,
+      embeddingClient: deps.embeddingClient,
+      contradictionDetector:
+        deps.auditorContradictionDetector ?? new AnthropicContradictionDetector(),
     }),
   });
 }

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -36,41 +36,30 @@ import type { CerebrumApiDeps } from '../handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
 
-type EngramDeps = {
-  db: CerebrumApiDeps['cerebrumDb']['db'];
-  engramRoot: string;
-  templates: CerebrumApiDeps['templateRegistry'];
-};
-
-function searchDeps(deps: CerebrumApiDeps) {
-  return {
-    db: deps.cerebrumDb.db,
+export function makeCerebrumRestHandlers(
+  deps: CerebrumApiDeps
+): ReturnType<typeof server.router<typeof cerebrumContract>> {
+  const db = deps.cerebrumDb.db;
+  const engramDeps = { db, engramRoot: deps.engramRoot, templates: deps.templateRegistry };
+  const base = {
+    db,
     raw: deps.cerebrumDb.raw,
     vecAvailable: deps.cerebrumDb.vecAvailable,
     peers: deps.peerClients,
     embeddingClient: deps.embeddingClient,
   };
-}
-
-function coreHandlerMap(deps: CerebrumApiDeps, engramDeps: EngramDeps) {
-  return {
+  return server.router(cerebrumContract, {
     templates: makeTemplatesHandlers(deps.templateRegistry),
     reflex: makeReflexHandlers(deps.reflexService),
-    plexus: makePlexusHandlers(deps.cerebrumDb.db),
+    plexus: makePlexusHandlers(db),
     engrams: makeEngramsHandlers(engramDeps),
     scopes: makeScopesHandlers(engramDeps),
-    tags: makeTagsHandlers(deps.cerebrumDb.db),
+    tags: makeTagsHandlers(db),
     glia: makeGliaHandlers({
       ...engramDeps,
       configPath: deps.gliaConfigPath ?? resolveGliaConfigPath(),
     }),
-    nudges: makeNudgesHandlers(deps.cerebrumDb.db),
-  };
-}
-
-function aiHandlerMap(deps: CerebrumApiDeps, engramDeps: EngramDeps) {
-  const base = searchDeps(deps);
-  return {
+    nudges: makeNudgesHandlers(db),
     retrieval: makeRetrievalHandlers(base),
     ingest: makeIngestHandlers({
       ...engramDeps,
@@ -96,19 +85,5 @@ function aiHandlerMap(deps: CerebrumApiDeps, engramDeps: EngramDeps) {
       contradictionDetector:
         deps.auditorContradictionDetector ?? new AnthropicContradictionDetector(),
     }),
-  };
-}
-
-export function makeCerebrumRestHandlers(
-  deps: CerebrumApiDeps
-): ReturnType<typeof server.router<typeof cerebrumContract>> {
-  const engramDeps: EngramDeps = {
-    db: deps.cerebrumDb.db,
-    engramRoot: deps.engramRoot,
-    templates: deps.templateRegistry,
-  };
-  return server.router(cerebrumContract, {
-    ...coreHandlerMap(deps, engramDeps),
-    ...aiHandlerMap(deps, engramDeps),
   });
 }

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -3,7 +3,9 @@
  *
  * Stitches the per-domain handler factories into the typed
  * `RouterImplementation<CerebrumRestContract>` that `createExpressEndpoints`
- * consumes in `app.ts`. Domains are added here as each migration slice lands.
+ * consumes in `app.ts`. The map is split into a `core` group (plain DB-backed
+ * domains) and an `ai` group (retrieval + the LLM-backed domains that share the
+ * vector-search dep bundle) so neither builder trips the per-function line cap.
  */
 import { initServer } from '@ts-rest/express';
 
@@ -34,15 +36,24 @@ import type { CerebrumApiDeps } from '../handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
 
-export function makeCerebrumRestHandlers(
-  deps: CerebrumApiDeps
-): ReturnType<typeof server.router<typeof cerebrumContract>> {
-  const engramDeps = {
+type EngramDeps = {
+  db: CerebrumApiDeps['cerebrumDb']['db'];
+  engramRoot: string;
+  templates: CerebrumApiDeps['templateRegistry'];
+};
+
+function searchDeps(deps: CerebrumApiDeps) {
+  return {
     db: deps.cerebrumDb.db,
-    engramRoot: deps.engramRoot,
-    templates: deps.templateRegistry,
+    raw: deps.cerebrumDb.raw,
+    vecAvailable: deps.cerebrumDb.vecAvailable,
+    peers: deps.peerClients,
+    embeddingClient: deps.embeddingClient,
   };
-  return server.router(cerebrumContract, {
+}
+
+function coreHandlerMap(deps: CerebrumApiDeps, engramDeps: EngramDeps) {
+  return {
     templates: makeTemplatesHandlers(deps.templateRegistry),
     reflex: makeReflexHandlers(deps.reflexService),
     plexus: makePlexusHandlers(deps.cerebrumDb.db),
@@ -50,63 +61,54 @@ export function makeCerebrumRestHandlers(
     scopes: makeScopesHandlers(engramDeps),
     tags: makeTagsHandlers(deps.cerebrumDb.db),
     glia: makeGliaHandlers({
-      db: deps.cerebrumDb.db,
-      engramRoot: deps.engramRoot,
-      templates: deps.templateRegistry,
+      ...engramDeps,
       configPath: deps.gliaConfigPath ?? resolveGliaConfigPath(),
     }),
     nudges: makeNudgesHandlers(deps.cerebrumDb.db),
+  };
+}
+
+function aiHandlerMap(deps: CerebrumApiDeps, engramDeps: EngramDeps) {
+  const base = searchDeps(deps);
+  return {
+    retrieval: makeRetrievalHandlers(base),
     ingest: makeIngestHandlers({
-      db: deps.cerebrumDb.db,
-      engramRoot: deps.engramRoot,
-      templates: deps.templateRegistry,
+      ...engramDeps,
       llm: deps.ingestLlm ?? new AnthropicIngestLlm(),
       curationQueue: deps.curationQueue ?? getCurationQueue,
     }),
-    retrieval: makeRetrievalHandlers({
-      db: deps.cerebrumDb.db,
-      raw: deps.cerebrumDb.raw,
-      vecAvailable: deps.cerebrumDb.vecAvailable,
-      peers: deps.peerClients,
-      embeddingClient: deps.embeddingClient,
-    }),
-    ego: makeEgoHandlers({
-      db: deps.cerebrumDb.db,
-      raw: deps.cerebrumDb.raw,
-      vecAvailable: deps.cerebrumDb.vecAvailable,
-      engramRoot: deps.engramRoot,
-      templates: deps.templateRegistry,
-      llm: deps.egoLlm ?? new AnthropicEgoLlm(),
-      peers: deps.peerClients,
-      embeddingClient: deps.embeddingClient,
-    }),
-    workers: makeWorkersHandlers({
-      db: deps.cerebrumDb.db,
-      raw: deps.cerebrumDb.raw,
-      vecAvailable: deps.cerebrumDb.vecAvailable,
-      engramRoot: deps.engramRoot,
-      templates: deps.templateRegistry,
-      peers: deps.peerClients,
-      embeddingClient: deps.embeddingClient,
-      contradictionDetector:
-        deps.auditorContradictionDetector ?? new AnthropicContradictionDetector(),
-    }),
-    emit: makeEmitHandlers({
-      db: deps.cerebrumDb.db,
-      raw: deps.cerebrumDb.raw,
-      vecAvailable: deps.cerebrumDb.vecAvailable,
-      peers: deps.peerClients,
-      embeddingClient: deps.embeddingClient,
-      llm: deps.emitLlm ?? new AnthropicGenerationLlm(),
-    }),
+    emit: makeEmitHandlers({ ...base, llm: deps.emitLlm ?? new AnthropicGenerationLlm() }),
     query: makeQueryHandlers({
-      db: deps.cerebrumDb.db,
-      raw: deps.cerebrumDb.raw,
-      vecAvailable: deps.cerebrumDb.vecAvailable,
-      peers: deps.peerClients,
-      embeddingClient: deps.embeddingClient,
+      ...base,
       llm: deps.queryLlm ?? new AnthropicQueryLlm(),
       streamLlm: deps.queryStreamLlm ?? new AnthropicQueryStreamLlm(),
     }),
+    ego: makeEgoHandlers({
+      ...base,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      llm: deps.egoLlm ?? new AnthropicEgoLlm(),
+    }),
+    workers: makeWorkersHandlers({
+      ...base,
+      engramRoot: deps.engramRoot,
+      templates: deps.templateRegistry,
+      contradictionDetector:
+        deps.auditorContradictionDetector ?? new AnthropicContradictionDetector(),
+    }),
+  };
+}
+
+export function makeCerebrumRestHandlers(
+  deps: CerebrumApiDeps
+): ReturnType<typeof server.router<typeof cerebrumContract>> {
+  const engramDeps: EngramDeps = {
+    db: deps.cerebrumDb.db,
+    engramRoot: deps.engramRoot,
+    templates: deps.templateRegistry,
+  };
+  return server.router(cerebrumContract, {
+    ...coreHandlerMap(deps, engramDeps),
+    ...aiHandlerMap(deps, engramDeps),
   });
 }

--- a/pillars/cerebrum/src/api/rest/workers-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/workers-handlers.ts
@@ -1,0 +1,145 @@
+/**
+ * ts-rest handlers for `workers.*` (PRD-085) — the Glia curation workers.
+ *
+ * Each `run*` builds a request-scoped worker bound to the in-pillar
+ * {@link EngramService} + {@link HybridSearchService} and runs it; `dryRun`
+ * defaults to true so a bare call never mutates engrams. The auditor's
+ * contradiction detector is the injected LLM port (fake in tests).
+ *
+ * `getStalenessScore` / `getQualityScore` read the engram via EngramService —
+ * a missing id throws the pillar `NotFoundError` → 404 via `runHttp`.
+ * `getOrphans` lists active engrams with zero inbound links.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumWorkersContract } from '../../contract/rest-workers.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { EngramService } from '../modules/engrams/service.js';
+import { HybridSearchService } from '../modules/retrieval/hybrid-search.js';
+import { AuditorWorker, type ContradictionDetector } from '../modules/workers/auditor.js';
+import { ConsolidatorWorker } from '../modules/workers/consolidator.js';
+import { LinkerWorker } from '../modules/workers/linker.js';
+import { PrunerWorker } from '../modules/workers/pruner.js';
+import { shouldSkipEngram, type WorkerBaseDeps } from '../modules/workers/worker-base.js';
+import { runHttp } from './error-mapping.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { OrphanEngramWire } from '../../contract/rest-workers-schemas.js';
+import type { Engram } from '../modules/engrams/types.js';
+import type { EmbeddingClient } from '../modules/retrieval/embedding-client.js';
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface WorkersHandlerDeps {
+  db: CerebrumDb;
+  raw: BetterSqlite3.Database;
+  vecAvailable: boolean;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  peers: PeerClients;
+  embeddingClient?: EmbeddingClient;
+  /** LLM-backed contradiction detector for the auditor (fake in tests). */
+  contradictionDetector: ContradictionDetector;
+}
+
+function toOrphanWire(engram: Engram): OrphanEngramWire {
+  return {
+    id: engram.id,
+    type: engram.type,
+    title: engram.title,
+    scopes: engram.scopes,
+    tags: engram.tags,
+    links: engram.links,
+    status: engram.status,
+    created: engram.created,
+    modified: engram.modified,
+    template: engram.template,
+    wordCount: engram.wordCount,
+  };
+}
+
+export function makeWorkersHandlers(
+  deps: WorkersHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumWorkersContract>> {
+  const engramService = (): EngramService =>
+    new EngramService({ root: deps.engramRoot, db: deps.db, templates: deps.templates });
+
+  const searchService = (): HybridSearchService =>
+    new HybridSearchService({
+      db: deps.db,
+      raw: deps.raw,
+      vecAvailable: deps.vecAvailable,
+      peers: deps.peers,
+      embeddingClient: deps.embeddingClient,
+    });
+
+  const baseDeps = (): WorkerBaseDeps => ({
+    engramService: engramService(),
+    searchService: searchService(),
+  });
+
+  return server.router(cerebrumWorkersContract, {
+    runPruner: async ({ body }) => ({
+      status: 200,
+      body: await new PrunerWorker(baseDeps()).run(body.dryRun ?? true),
+    }),
+
+    runConsolidator: async ({ body }) => ({
+      status: 200,
+      body: await new ConsolidatorWorker(baseDeps()).run(body.dryRun ?? true),
+    }),
+
+    runLinker: async ({ body }) => ({
+      status: 200,
+      body: await new LinkerWorker(baseDeps()).run(body.dryRun ?? true),
+    }),
+
+    runAuditor: async ({ body }) => ({
+      status: 200,
+      body: await new AuditorWorker({
+        ...baseDeps(),
+        contradictionDetector: deps.contradictionDetector,
+      }).run(body.dryRun ?? true),
+    }),
+
+    getStalenessScore: async ({ body }) =>
+      runHttp(() => {
+        const svc = engramService();
+        const worker = new PrunerWorker({ engramService: svc, searchService: searchService() });
+        const { engram } = svc.read(body.engramId);
+        const allEngrams = svc.list({ status: 'active', limit: 10000 }).engrams;
+        return { status: 200 as const, body: worker.computeStaleness(engram, allEngrams) };
+      }),
+
+    getQualityScore: async ({ body }) =>
+      runHttp(() => {
+        const svc = engramService();
+        const worker = new AuditorWorker({ engramService: svc, searchService: searchService() });
+        const { engram } = svc.read(body.engramId);
+        return { status: 200 as const, body: worker.computeQuality(engram) };
+      }),
+
+    getOrphans: async ({ query }) => {
+      const limit = query.limit ?? 50;
+      const { engrams } = engramService().list({ status: 'active', limit: 10000 });
+      const active = engrams.filter((e) => !shouldSkipEngram(e));
+
+      const inboundCounts = new Map<string, number>();
+      for (const e of active) {
+        for (const link of e.links) {
+          inboundCounts.set(link, (inboundCounts.get(link) ?? 0) + 1);
+        }
+      }
+
+      const orphans = active
+        .filter((e) => (inboundCounts.get(e.id) ?? 0) === 0)
+        .slice(0, limit)
+        .map(toOrphanWire);
+
+      return { status: 200, body: { engrams: orphans } };
+    },
+  });
+}

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -20,6 +20,7 @@ import { openCerebrumDb } from '../db/index.js';
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { buildCerebrumManifest } from './manifest.js';
+import { AnthropicEgoLlm } from './modules/ego/llm.js';
 import { resolveEngramRoot } from './modules/engrams/instance.js';
 import { AnthropicIngestLlm } from './modules/ingest/llm.js';
 import { closeCerebrumIngestQueue, getCurationQueue } from './modules/ingest/queue.js';
@@ -27,6 +28,7 @@ import { getReflexService } from './modules/reflex/instance.js';
 import { resolveEmbeddingClientFromEnv } from './modules/retrieval/embedding-client.js';
 import { resolvePeerClientsFromEnv } from './modules/retrieval/peer-clients.js';
 import { TemplateRegistry } from './modules/templates/registry.js';
+import { AnthropicContradictionDetector } from './modules/workers/llm.js';
 import { parseBareOrigin } from './pillars/env.js';
 
 function resolvePort(): number {
@@ -71,6 +73,8 @@ const app = createCerebrumApiApp({
   engramRoot,
   reflexService,
   ingestLlm: new AnthropicIngestLlm(),
+  egoLlm: new AnthropicEgoLlm(),
+  auditorContradictionDetector: new AnthropicContradictionDetector(),
   curationQueue: getCurationQueue,
   version,
   selfBaseUrl,

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -3,6 +3,109 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/cerebrum generate:api-types`.
  */
 export interface paths {
+  '/ego/chat': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run a chat turn: retrieve context, call the LLM, persist turns. */
+    post: operations['ego.chat'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ego/conversations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a new conversation. */
+    post: operations['ego.createConversation'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ego/conversations/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List conversations (paginated, optional title search). */
+    post: operations['ego.listConversations'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ego/conversations/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a conversation with all its messages. */
+    get: operations['ego.getConversation'];
+    put?: never;
+    post?: never;
+    /** Delete a conversation (cascades messages + context). */
+    delete: operations['ego.deleteConversation'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ego/conversations/{id}/context': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Return the current context state (scopes, app context, engrams). */
+    get: operations['ego.getActiveContext'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ego/conversations/{id}/scopes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Replace the active scopes for a conversation. */
+    post: operations['ego.setScopes'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/engrams': {
     parameters: {
       query?: never;
@@ -243,6 +346,57 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/glia/orphans': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List active engrams with no inbound links. */
+    get: operations['workers.getOrphans'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/scores/quality': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Compute the quality score for a single engram. */
+    post: operations['workers.getQualityScore'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/scores/staleness': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Compute the staleness score for a single engram. */
+    post: operations['workers.getStalenessScore'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/glia/trust-state': {
     parameters: {
       query?: never;
@@ -271,6 +425,74 @@ export interface paths {
     get: operations['glia.trustState.get'];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/workers/audit': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run the auditor worker (quality, contradiction, coverage-gap). */
+    post: operations['workers.runAuditor'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/workers/consolidate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run the consolidator worker (similar-engram merge proposals). */
+    post: operations['workers.runConsolidator'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/workers/link': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run the linker worker (cross-reference proposals). */
+    post: operations['workers.runLinker'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/glia/workers/prune': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run the pruner worker (staleness + orphan archival proposals). */
+    post: operations['workers.runPruner'];
     delete?: never;
     options?: never;
     head?: never;
@@ -902,6 +1124,359 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'ego.chat': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          appContext?: {
+            app: string;
+            entityId?: string;
+            entityType?: string;
+            route?: string;
+          };
+          /** @enum {string} */
+          channel?: 'shell' | 'moltbot' | 'mcp' | 'cli';
+          conversationId?: string;
+          knownScopes?: string[];
+          message: string;
+          scopes?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            conversationId: string;
+            response: {
+              citations: unknown;
+              content: string;
+              conversationId: string;
+              createdAt: string;
+              id: string;
+              role: string;
+              tokensIn: number | null;
+              tokensOut: number | null;
+              toolCalls: unknown;
+            };
+            retrievedEngrams: {
+              engramId: string;
+              relevanceScore: number;
+            }[];
+            scopeNegotiation: {
+              changed: boolean;
+              reason: string | null;
+              scopes: string[];
+              secretNotice: string | null;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ego.createConversation': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          appContext?: unknown;
+          model: string;
+          scopes?: string[];
+          title?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            conversation: {
+              activeScopes: string[];
+              appContext: unknown;
+              createdAt: string;
+              id: string;
+              model: string;
+              title: string | null;
+              updatedAt: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ego.listConversations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          offset?: number;
+          search?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            conversations: {
+              activeScopes: string[];
+              appContext: unknown;
+              createdAt: string;
+              id: string;
+              model: string;
+              title: string | null;
+              updatedAt: string;
+            }[];
+            total: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ego.getConversation': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            conversation: {
+              activeScopes: string[];
+              appContext: unknown;
+              createdAt: string;
+              id: string;
+              model: string;
+              title: string | null;
+              updatedAt: string;
+            };
+            messages: {
+              citations: unknown;
+              content: string;
+              conversationId: string;
+              createdAt: string;
+              id: string;
+              role: string;
+              tokensIn: number | null;
+              tokensOut: number | null;
+              toolCalls: unknown;
+            }[];
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ego.deleteConversation': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            success: true;
+          };
+        };
+      };
+    };
+  };
+  'ego.getActiveContext': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            appContext: unknown;
+            engrams: {
+              engramId: string;
+              loadedAt: string;
+              relevanceScore: number | null;
+            }[];
+            scopes: string[];
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ego.setScopes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          scopes: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            scopes: string[];
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'engrams.create': {
     parameters: {
       query?: never;
@@ -2010,6 +2585,138 @@ export interface operations {
       };
     };
   };
+  'workers.getOrphans': {
+    parameters: {
+      query?: {
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            engrams: {
+              created: string;
+              id: string;
+              links: string[];
+              modified: string;
+              scopes: string[];
+              status: string;
+              tags: string[];
+              template: string | null;
+              title: string;
+              type: string;
+              wordCount: number;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'workers.getQualityScore': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          engramId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            factors: {
+              completeness: number;
+              linkDensity: number;
+              specificity: number;
+              templateFit: number;
+            };
+            score: number;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'workers.getStalenessScore': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          engramId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            factors: {
+              daysSinceModified: number;
+              daysSinceReferenced: number;
+              inboundLinkCount: number;
+              queryHitCount: number;
+            };
+            score: number;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'glia.trustState.list': {
     parameters: {
       query?: never;
@@ -2088,6 +2795,186 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'workers.runAuditor': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dryRun?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              id: string;
+              payload: {
+                [key: string]: unknown;
+              };
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              /** @enum {string} */
+              status: 'proposed' | 'executed' | 'error';
+            }[];
+            processed: number;
+            skipped: number;
+          };
+        };
+      };
+    };
+  };
+  'workers.runConsolidator': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dryRun?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              id: string;
+              payload: {
+                [key: string]: unknown;
+              };
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              /** @enum {string} */
+              status: 'proposed' | 'executed' | 'error';
+            }[];
+            processed: number;
+            skipped: number;
+          };
+        };
+      };
+    };
+  };
+  'workers.runLinker': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dryRun?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              id: string;
+              payload: {
+                [key: string]: unknown;
+              };
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              /** @enum {string} */
+              status: 'proposed' | 'executed' | 'error';
+            }[];
+            processed: number;
+            skipped: number;
+          };
+        };
+      };
+    };
+  };
+  'workers.runPruner': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dryRun?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            actions: {
+              /** @enum {string} */
+              actionType: 'prune' | 'consolidate' | 'link' | 'audit';
+              affectedIds: string[];
+              createdAt: string;
+              id: string;
+              payload: {
+                [key: string]: unknown;
+              };
+              /** @enum {string} */
+              phase: 'propose' | 'act_report' | 'silent';
+              rationale: string;
+              /** @enum {string} */
+              status: 'proposed' | 'executed' | 'error';
+            }[];
+            processed: number;
+            skipped: number;
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-ego-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-ego-schemas.ts
@@ -1,0 +1,111 @@
+/**
+ * Wire schemas for `ego.*` (PRD-087) — conversations CRUD, chat, context.
+ *
+ * Lives in its own file (not the shared `rest-schemas.ts`) so that file stays
+ * under the oxlint `max-lines: 200` cap; no other domain consumes these. The
+ * conversation/message rows carry JSON-decoded `activeScopes` / `appContext` /
+ * `citations` / `toolCalls`, projected here as open `z.unknown()` bags where the
+ * shape is caller-defined.
+ */
+import { z } from 'zod';
+
+export const egoAppContextSchema = z.object({
+  app: z.string(),
+  route: z.string().optional(),
+  entityId: z.string().optional(),
+  entityType: z.string().optional(),
+});
+export type EgoAppContextWire = z.infer<typeof egoAppContextSchema>;
+
+export const egoChannelSchema = z.enum(['shell', 'moltbot', 'mcp', 'cli']);
+export type EgoChannelWire = z.infer<typeof egoChannelSchema>;
+
+export const conversationWire = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  activeScopes: z.array(z.string()),
+  appContext: z.unknown().nullable(),
+  model: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type ConversationWire = z.infer<typeof conversationWire>;
+
+export const conversationMessageWire = z.object({
+  id: z.string(),
+  conversationId: z.string(),
+  role: z.string(),
+  content: z.string(),
+  citations: z.unknown().nullable(),
+  toolCalls: z.unknown().nullable(),
+  tokensIn: z.number().nullable(),
+  tokensOut: z.number().nullable(),
+  createdAt: z.string(),
+});
+export type ConversationMessageWire = z.infer<typeof conversationMessageWire>;
+
+export const scopeNegotiationWire = z.object({
+  scopes: z.array(z.string()),
+  changed: z.boolean(),
+  reason: z.string().nullable(),
+  secretNotice: z.string().nullable(),
+});
+export type ScopeNegotiationWire = z.infer<typeof scopeNegotiationWire>;
+
+export const retrievedEngramWire = z.object({
+  engramId: z.string(),
+  relevanceScore: z.number(),
+});
+export type RetrievedEngramWire = z.infer<typeof retrievedEngramWire>;
+
+export const conversationContextEngramWire = z.object({
+  engramId: z.string(),
+  relevanceScore: z.number().nullable(),
+  loadedAt: z.string(),
+});
+export type ConversationContextEngramWire = z.infer<typeof conversationContextEngramWire>;
+
+export const egoChatBodySchema = z.object({
+  conversationId: z.string().min(1).optional(),
+  message: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  appContext: egoAppContextSchema.optional(),
+  channel: egoChannelSchema.optional(),
+  knownScopes: z.array(z.string().min(1)).optional(),
+});
+export type EgoChatBodyWire = z.infer<typeof egoChatBodySchema>;
+
+export const egoChatResponseSchema = z.object({
+  conversationId: z.string(),
+  response: conversationMessageWire,
+  retrievedEngrams: z.array(retrievedEngramWire),
+  scopeNegotiation: scopeNegotiationWire.nullable(),
+});
+export type EgoChatResponseWire = z.infer<typeof egoChatResponseSchema>;
+
+export const createConversationBodySchema = z.object({
+  title: z.string().min(1).optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  appContext: z.unknown().optional(),
+  model: z.string().min(1),
+});
+export type CreateConversationBodyWire = z.infer<typeof createConversationBodySchema>;
+
+export const listConversationsBodySchema = z.object({
+  limit: z.number().int().positive().max(200).optional(),
+  offset: z.number().int().nonnegative().optional(),
+  search: z.string().optional(),
+});
+export type ListConversationsBodyWire = z.infer<typeof listConversationsBodySchema>;
+
+export const setScopesBodySchema = z.object({
+  scopes: z.array(z.string()),
+});
+export type SetScopesBodyWire = z.infer<typeof setScopesBodySchema>;
+
+export const getActiveContextResponseSchema = z.object({
+  scopes: z.array(z.string()),
+  appContext: z.unknown().nullable(),
+  engrams: z.array(conversationContextEngramWire),
+});
+export type GetActiveContextResponseWire = z.infer<typeof getActiveContextResponseSchema>;

--- a/pillars/cerebrum/src/contract/rest-ego.ts
+++ b/pillars/cerebrum/src/contract/rest-ego.ts
@@ -1,0 +1,114 @@
+/**
+ * ts-rest contract for `ego.*` (PRD-087) — the conversational interface.
+ *
+ * Conversations are single-tenant at the row level (no per-user scoping today),
+ * so the surface is served on the docker-network trust boundary with no
+ * per-request auth (parity with the other migrated domains). The chat + context
+ * procedures carry their inputs as typed bodies; reads that take only an id use
+ * a path param.
+ *
+ * The SSE streaming endpoint (`POST /ego/chat/stream`) is NOT part of this
+ * ts-rest contract — it is mounted as a plain Express route in `app.ts` before
+ * `createExpressEndpoints` (ts-rest cannot model `text/event-stream`).
+ *
+ * The wire schemas live in the pure `rest-ego-schemas.ts` module so the contract
+ * and the lifted handlers share one source of truth.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  conversationMessageWire,
+  conversationWire,
+  createConversationBodySchema,
+  egoChatBodySchema,
+  egoChatResponseSchema,
+  getActiveContextResponseSchema,
+  listConversationsBodySchema,
+  scopeNegotiationWire,
+  setScopesBodySchema,
+} from './rest-ego-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const cerebrumEgoContract = c.router({
+  chat: {
+    method: 'POST',
+    path: '/ego/chat',
+    summary: 'Run a chat turn: retrieve context, call the LLM, persist turns.',
+    body: egoChatBodySchema,
+    responses: {
+      200: egoChatResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  createConversation: {
+    method: 'POST',
+    path: '/ego/conversations',
+    summary: 'Create a new conversation.',
+    body: createConversationBodySchema,
+    responses: {
+      200: z.object({ conversation: conversationWire }),
+      400: errorBodySchema,
+    },
+  },
+  listConversations: {
+    method: 'POST',
+    path: '/ego/conversations/search',
+    summary: 'List conversations (paginated, optional title search).',
+    body: listConversationsBodySchema,
+    responses: {
+      200: z.object({ conversations: z.array(conversationWire), total: z.number().int() }),
+      400: errorBodySchema,
+    },
+  },
+  getConversation: {
+    method: 'GET',
+    path: '/ego/conversations/:id',
+    summary: 'Get a conversation with all its messages.',
+    pathParams: z.object({ id: z.string().min(1) }),
+    responses: {
+      200: z.object({
+        conversation: conversationWire,
+        messages: z.array(conversationMessageWire),
+      }),
+      404: errorBodySchema,
+    },
+  },
+  deleteConversation: {
+    method: 'DELETE',
+    path: '/ego/conversations/:id',
+    summary: 'Delete a conversation (cascades messages + context).',
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: z.object({}).optional(),
+    responses: {
+      200: z.object({ success: z.literal(true) }),
+    },
+  },
+  setScopes: {
+    method: 'POST',
+    path: '/ego/conversations/:id/scopes',
+    summary: 'Replace the active scopes for a conversation.',
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: setScopesBodySchema,
+    responses: {
+      200: z.object({ scopes: z.array(z.string()) }),
+      404: errorBodySchema,
+    },
+  },
+  getActiveContext: {
+    method: 'GET',
+    path: '/ego/conversations/:id/context',
+    summary: 'Return the current context state (scopes, app context, engrams).',
+    pathParams: z.object({ id: z.string().min(1) }),
+    responses: {
+      200: getActiveContextResponseSchema,
+      404: errorBodySchema,
+    },
+  },
+});
+
+export type CerebrumEgoContract = typeof cerebrumEgoContract;
+
+export { scopeNegotiationWire };

--- a/pillars/cerebrum/src/contract/rest-workers-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-workers-schemas.ts
@@ -1,0 +1,93 @@
+/**
+ * Wire schemas for `workers.*` (PRD-085) — the Glia curation workers.
+ *
+ * Served under `/glia/workers/*` + `/glia/scores/*` + `/glia/orphans` to avoid
+ * colliding with the merged glia trust router (which owns `/glia/actions`,
+ * `/glia/trust-state`, `/glia/digest`). Kept under its own contract key
+ * (`workers`) so the operationIds stay `workers*`.
+ *
+ * The worker `run*` procedures return ephemeral `GliaAction` records (the
+ * proposal set) plus processed/skipped counts — they don't persist to
+ * `glia_actions` in propose/dryRun mode (parity with the monolith router). The
+ * `payload` is an open bag (merge plan / link pair / quality breakdown / …).
+ */
+import { z } from 'zod';
+
+export const workerDryRunBodySchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+export type WorkerDryRunBodyWire = z.infer<typeof workerDryRunBodySchema>;
+
+export const gliaActionWire = z.object({
+  id: z.string(),
+  actionType: z.enum(['prune', 'consolidate', 'link', 'audit']),
+  affectedIds: z.array(z.string()),
+  rationale: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  phase: z.enum(['propose', 'act_report', 'silent']),
+  status: z.enum(['proposed', 'executed', 'error']),
+  createdAt: z.string(),
+});
+export type GliaWorkerActionWire = z.infer<typeof gliaActionWire>;
+
+export const workerRunResultSchema = z.object({
+  actions: z.array(gliaActionWire),
+  processed: z.number().int(),
+  skipped: z.number().int(),
+});
+export type WorkerRunResultWire = z.infer<typeof workerRunResultSchema>;
+
+export const engramIdBodySchema = z.object({
+  engramId: z.string().min(1),
+});
+export type EngramIdBodyWire = z.infer<typeof engramIdBodySchema>;
+
+export const stalenessFactorsSchema = z.object({
+  daysSinceModified: z.number(),
+  daysSinceReferenced: z.number(),
+  inboundLinkCount: z.number(),
+  queryHitCount: z.number(),
+});
+
+export const stalenessResultSchema = z.object({
+  score: z.number(),
+  factors: stalenessFactorsSchema,
+});
+export type StalenessResultWire = z.infer<typeof stalenessResultSchema>;
+
+export const qualityFactorsSchema = z.object({
+  completeness: z.number(),
+  specificity: z.number(),
+  templateFit: z.number(),
+  linkDensity: z.number(),
+});
+
+export const qualityResultSchema = z.object({
+  score: z.number(),
+  factors: qualityFactorsSchema,
+});
+export type QualityResultWire = z.infer<typeof qualityResultSchema>;
+
+export const orphanEngramWire = z.object({
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+  scopes: z.array(z.string()),
+  tags: z.array(z.string()),
+  links: z.array(z.string()),
+  status: z.string(),
+  created: z.string(),
+  modified: z.string(),
+  template: z.string().nullable(),
+  wordCount: z.number().int(),
+});
+export type OrphanEngramWire = z.infer<typeof orphanEngramWire>;
+
+export const orphansResponseSchema = z.object({
+  engrams: z.array(orphanEngramWire),
+});
+export type OrphansResponseWire = z.infer<typeof orphansResponseSchema>;
+
+export const orphansQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(200).optional(),
+});

--- a/pillars/cerebrum/src/contract/rest-workers.ts
+++ b/pillars/cerebrum/src/contract/rest-workers.ts
@@ -1,0 +1,77 @@
+/**
+ * ts-rest contract for `workers.*` (PRD-085) — the Glia curation workers.
+ *
+ * Routed under `/glia/workers/*` + `/glia/scores/*` + `/glia/orphans` so paths
+ * never collide with the merged glia trust router. Non-identity domain — served
+ * on the docker-network trust boundary with no per-request auth. The auditor's
+ * contradiction check is LLM-backed (injectable; fake in tests); pruner /
+ * consolidator / linker are pure scoring + proposal logic.
+ */
+import { initContract } from '@ts-rest/core';
+
+import { errorBodySchema } from './rest-schemas.js';
+import {
+  engramIdBodySchema,
+  orphansQuerySchema,
+  orphansResponseSchema,
+  qualityResultSchema,
+  stalenessResultSchema,
+  workerDryRunBodySchema,
+  workerRunResultSchema,
+} from './rest-workers-schemas.js';
+
+const c = initContract();
+
+export const cerebrumWorkersContract = c.router({
+  runPruner: {
+    method: 'POST',
+    path: '/glia/workers/prune',
+    summary: 'Run the pruner worker (staleness + orphan archival proposals).',
+    body: workerDryRunBodySchema,
+    responses: { 200: workerRunResultSchema },
+  },
+  runConsolidator: {
+    method: 'POST',
+    path: '/glia/workers/consolidate',
+    summary: 'Run the consolidator worker (similar-engram merge proposals).',
+    body: workerDryRunBodySchema,
+    responses: { 200: workerRunResultSchema },
+  },
+  runLinker: {
+    method: 'POST',
+    path: '/glia/workers/link',
+    summary: 'Run the linker worker (cross-reference proposals).',
+    body: workerDryRunBodySchema,
+    responses: { 200: workerRunResultSchema },
+  },
+  runAuditor: {
+    method: 'POST',
+    path: '/glia/workers/audit',
+    summary: 'Run the auditor worker (quality, contradiction, coverage-gap).',
+    body: workerDryRunBodySchema,
+    responses: { 200: workerRunResultSchema },
+  },
+  getStalenessScore: {
+    method: 'POST',
+    path: '/glia/scores/staleness',
+    summary: 'Compute the staleness score for a single engram.',
+    body: engramIdBodySchema,
+    responses: { 200: stalenessResultSchema, 404: errorBodySchema },
+  },
+  getQualityScore: {
+    method: 'POST',
+    path: '/glia/scores/quality',
+    summary: 'Compute the quality score for a single engram.',
+    body: engramIdBodySchema,
+    responses: { 200: qualityResultSchema, 404: errorBodySchema },
+  },
+  getOrphans: {
+    method: 'GET',
+    path: '/glia/orphans',
+    summary: 'List active engrams with no inbound links.',
+    query: orphansQuerySchema,
+    responses: { 200: orphansResponseSchema },
+  },
+});
+
+export type CerebrumWorkersContract = typeof cerebrumWorkersContract;

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -12,6 +12,7 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { cerebrumEgoContract } from './rest-ego.js';
 import { cerebrumEngramsContract } from './rest-engrams.js';
 import { cerebrumGliaContract } from './rest-glia.js';
 import { cerebrumIngestContract } from './rest-ingest.js';
@@ -22,6 +23,7 @@ import { cerebrumRetrievalContract } from './rest-retrieval.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
 import { cerebrumTagsContract } from './rest-tags.js';
 import { cerebrumTemplatesContract } from './rest-templates.js';
+import { cerebrumWorkersContract } from './rest-workers.js';
 
 const c = initContract();
 
@@ -37,6 +39,8 @@ export const cerebrumContract = c.router(
     nudges: cerebrumNudgesContract,
     ingest: cerebrumIngestContract,
     retrieval: cerebrumRetrievalContract,
+    ego: cerebrumEgoContract,
+    workers: cerebrumWorkersContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Cerebrum REST migration — ego + workers (+ SSE)

Migrates the **ego** (user-facing chat) and **workers** (Glia curation) domains from the monolith onto the `@pops/cerebrum` pillar, alongside the 10 existing REST domains.

### EGO (`ego.*`, served at `/ego/*`)
- `POST /ego/chat` — retrieve context (HybridSearch) → injected LLM → persist user turn before / assistant turn + engram context links after.
- `POST /ego/conversations` (create), `POST /ego/conversations/search` (list), `GET /ego/conversations/:id` (get, 404), `DELETE /ego/conversations/:id`.
- `POST /ego/conversations/:id/scopes` (setScopes), `GET /ego/conversations/:id/context` (getActive).
- **SSE**: `POST /ego/chat/stream` — mounted as a plain Express route in `app.ts` before `createExpressEndpoints` (ts-rest can't model `text/event-stream`). Persists the user turn before streaming, the assistant turn + context links after the `done` event. Emits `token`/`done`/`error` frames; standard SSE headers.

### WORKERS (`workers.*`, served under `/glia/workers/*` + `/glia/scores/*` + `/glia/orphans`)
Routed to avoid collision with the merged glia trust router (`/glia/actions`, `/glia/trust-state`, `/glia/digest`).
- `POST /glia/workers/{prune,consolidate,link,audit}` (run*, `{dryRun?}`, default propose).
- `POST /glia/scores/{staleness,quality}`, `GET /glia/orphans`.
- Pruner/consolidator/linker are pure scoring/proposal logic; the auditor's contradiction detector is the injectable Anthropic LLM port.

### Injectable LLM
- `EgoLlm` port (chat + stream + summarise) — `AnthropicEgoLlm` default (`ANTHROPIC_API_KEY`, `claude-sonnet-4-6` / `CEREBRUM_EGO_MODEL`); offline fake in tests.
- `ContradictionDetector` port for the auditor — `AnthropicContradictionDetector` default (haiku / `CEREBRUM_AUDITOR_MODEL`); offline fake in tests.
- Dropped `getSettingValue` → constants and `trackInference` → retry-only, per the ingest-slice precedent. **No test hits a real API.**

### Deviations from the monolith
- `getCerebrumDrizzle()` AsyncLocalStorage + `getDrizzle()` replaced with the injected `deps.cerebrumDb.db` handle threaded through persistence + retrieval. Conversation reads/writes (incl. the auto-title read-after-write hop) and the append-message `updated_at` bump stay on one handle/transaction via `conversationsService`.
- The `query` citation-parser was lifted into ego (`ego/citation-parser.ts`) since the pillar has no query module yet; settings → constant excerpt budget, logger → console.warn.
- `ai-tools.ts` (MCP infra) skipped — not a wire proc, per the brief.

### Wiring
- Added `ego` + `workers` to `contract/rest.ts` + `rest/handlers.ts` alongside the 10 existing keys. New deps `egoLlm?` / `auditorContradictionDetector?` on `CerebrumApiDeps` (real in `server.ts`, fake in `test-utils.ts`). operationIds stay `ego.*` / `workers.*`.

### Prove green (all clean)
- `oxfmt --check` ✅ · `oxlint` 0 errors ✅ · `typecheck` ✅ · `build` ✅
- `generate:openapi && git diff --exit-code` clean ✅
- `vitest run` — **535 passed (37 files)**, incl. new `ego.test.ts` (CRUD / 404 / context / chat persistence / SSE token+done frames) + `workers.test.ts` (prune dryRun, auditor proposals, staleness/quality scores incl. 404, orphans + limit).
