### PR TITLE
feat(media): REST migration slice 13 — search (completes Wave 3)

### DIFF
--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -15555,6 +15555,312 @@
         "tags": ["rotation"]
       }
     },
+    "/search/movies": {
+      "get": {
+        "operationId": "search.movies",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 500,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "page": {
+                      "type": "number"
+                    },
+                    "results": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "backdropPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "genreIds": {
+                            "items": {
+                              "type": "number"
+                            },
+                            "type": "array"
+                          },
+                          "originalLanguage": {
+                            "type": "string"
+                          },
+                          "originalTitle": {
+                            "type": "string"
+                          },
+                          "overview": {
+                            "type": "string"
+                          },
+                          "popularity": {
+                            "type": "number"
+                          },
+                          "posterPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "releaseDate": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "tmdbId": {
+                            "type": "number"
+                          },
+                          "voteAverage": {
+                            "type": "number"
+                          },
+                          "voteCount": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "tmdbId",
+                          "title",
+                          "originalTitle",
+                          "overview",
+                          "releaseDate",
+                          "posterPath",
+                          "backdropPath",
+                          "voteAverage",
+                          "voteCount",
+                          "genreIds",
+                          "originalLanguage",
+                          "popularity"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "totalPages": {
+                      "type": "number"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["results", "totalResults", "totalPages", "page"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "502"
+          }
+        },
+        "summary": "Search movies via TMDB",
+        "tags": ["search"]
+      }
+    },
+    "/search/tv-shows": {
+      "get": {
+        "operationId": "search.tvShows",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "results": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "firstAirDate": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "genres": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "originalLanguage": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "originalName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "overview": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "posterPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "tvdbId": {
+                            "type": "number"
+                          },
+                          "year": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "tvdbId",
+                          "name",
+                          "originalName",
+                          "overview",
+                          "firstAirDate",
+                          "status",
+                          "posterPath",
+                          "genres",
+                          "originalLanguage",
+                          "year"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["results"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "502"
+          }
+        },
+        "summary": "Search TV shows via TheTVDB",
+        "tags": ["search"]
+      }
+    },
     "/seasons/{id}": {
       "delete": {
         "operationId": "tvShows.deleteSeason",

--- a/pillars/media/src/api/__tests__/search.test.ts
+++ b/pillars/media/src/api/__tests__/search.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for the `search.*` REST surface (TMDB movies + TheTVDB
+ * series) via supertest. The upstream HTTP layer is mocked at
+ * `globalThis.fetch` with a route table keyed on a URL substring, so the
+ * assertions exercise the real client → handler → contract path: raw
+ * provider JSON → domain mapping → wire envelope.
+ *
+ * No database is involved (search is a pure pass-through), but the app
+ * factory still needs an opened db handle, so a throwaway one is created.
+ *
+ * The TheTVDB client is a module-level singleton that caches its JWT; it is
+ * reset between tests via `setTvdbClient(null)` so a stubbed login from one
+ * test can't leak its token into the next.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb, type OpenedMediaDb } from '../../db/index.js';
+import { createMediaApiApp } from '../app.js';
+import { setTvdbClient } from '../clients/thetvdb/index.js';
+import { makeClient } from './test-utils.js';
+
+interface RouteResponse {
+  status?: number;
+  body: unknown;
+}
+
+type RouteHandler = () => RouteResponse;
+
+interface RouteRule {
+  match: string;
+  handler: RouteHandler;
+}
+
+let routes: RouteRule[];
+
+function route(match: string, handler: RouteHandler): void {
+  routes.push({ match, handler });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn((input: string | URL | Request): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const rule = routes.find((r) => url.includes(r.match));
+  if (!rule) return Promise.resolve(jsonResponse({ message: `unmatched ${url}` }, 404));
+  const res = rule.handler();
+  return Promise.resolve(jsonResponse(res.body, res.status ?? 200));
+});
+
+/** TheTVDB requires a JWT — every series search first POSTs to /login. */
+function stubTvdbLogin(): void {
+  route('/v4/login', () => ({ body: { data: { token: 'test-token' } } }));
+}
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-search-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+  routes = [];
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+  setTvdbClient(null);
+  process.env['TMDB_API_KEY'] = 'tmdb-key';
+  process.env['THETVDB_API_KEY'] = 'tvdb-key';
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  setTvdbClient(null);
+  delete process.env['TMDB_API_KEY'];
+  delete process.env['THETVDB_API_KEY'];
+});
+
+function client() {
+  return makeClient(
+    createMediaApiApp({ mediaDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3003' })
+  );
+}
+
+describe('search — movies (TMDB)', () => {
+  it('maps the raw TMDB search response to the wire shape', async () => {
+    route('/3/search/movie', () => ({
+      body: {
+        page: 1,
+        total_results: 2,
+        total_pages: 1,
+        results: [
+          {
+            id: 603,
+            title: 'The Matrix',
+            original_title: 'The Matrix',
+            overview: 'A hacker learns the truth.',
+            release_date: '1999-03-30',
+            poster_path: '/poster.jpg',
+            backdrop_path: '/backdrop.jpg',
+            vote_average: 8.2,
+            vote_count: 24000,
+            genre_ids: [28, 878],
+            original_language: 'en',
+            popularity: 99.5,
+          },
+        ],
+      },
+    }));
+
+    const res = await client().search.movies({ query: 'matrix' });
+    expect(res).toMatchObject({ totalResults: 2, totalPages: 1, page: 1 });
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0]).toMatchObject({
+      tmdbId: 603,
+      title: 'The Matrix',
+      posterPath: '/poster.jpg',
+      voteAverage: 8.2,
+    });
+
+    const call = fetchMock.mock.calls.find(([input]) => String(input).includes('/3/search/movie'));
+    expect(call).toBeDefined();
+    expect(String(call?.[0])).toContain('query=matrix');
+  });
+
+  it('forwards the page query param to TMDB', async () => {
+    route('/3/search/movie', () => ({
+      body: { page: 3, total_results: 0, total_pages: 3, results: [] },
+    }));
+
+    const res = await client().search.movies({ query: 'dune', page: 3 });
+    expect(res.page).toBe(3);
+    const call = fetchMock.mock.calls.find(([input]) => String(input).includes('/3/search/movie'));
+    expect(String(call?.[0])).toContain('page=3');
+  });
+
+  it('400s an empty query at the contract boundary (no upstream call)', async () => {
+    await expect(client().search.movies({ query: '' })).rejects.toMatchObject({ status: 400 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a TMDB upstream failure to 502', async () => {
+    route('/3/search/movie', () => ({ body: { status_message: 'Invalid API key' }, status: 401 }));
+    await expect(client().search.movies({ query: 'matrix' })).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+});
+
+describe('search — tv shows (TheTVDB)', () => {
+  it('maps the raw TheTVDB search response to the wire shape', async () => {
+    stubTvdbLogin();
+    route('/v4/search', () => ({
+      body: {
+        data: [
+          {
+            tvdb_id: '121361',
+            objectID: 'series-121361',
+            name: 'Game of Thrones',
+            overview: 'Seven noble families fight.',
+            first_air_time: '2011-04-17',
+            status: 'Ended',
+            image_url: '/got.jpg',
+            genres: ['Drama', 'Fantasy'],
+            primary_language: 'eng',
+            year: '2011',
+          },
+        ],
+      },
+    }));
+
+    const res = await client().search.tvShows({ query: 'thrones' });
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0]).toMatchObject({
+      tvdbId: 121361,
+      name: 'Game of Thrones',
+      year: '2011',
+    });
+
+    const searchCall = fetchMock.mock.calls.find(([input]) => String(input).includes('/v4/search'));
+    expect(String(searchCall?.[0])).toContain('q=thrones');
+    expect(String(searchCall?.[0])).toContain('type=series');
+  });
+
+  it('400s an empty query at the contract boundary (no upstream call)', async () => {
+    await expect(client().search.tvShows({ query: '' })).rejects.toMatchObject({ status: 400 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a TheTVDB upstream failure to 502', async () => {
+    stubTvdbLogin();
+    // 5xx (not 429) — surfaces immediately without the rate limiter's backoff.
+    route('/v4/search', () => ({ body: { message: 'server error' }, status: 500 }));
+    await expect(client().search.tvShows({ query: 'thrones' })).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+});

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -338,6 +338,34 @@ export function makeClient(app: Express) {
     comparisons: makeComparisonsClient(r),
     rotation: makeRotationClient(r),
     discovery: makeDiscoveryClient(r),
+    search: makeSearchClient(r),
+  };
+}
+
+interface MovieSearchResultWire {
+  tmdbId: number;
+  title: string;
+  posterPath: string | null;
+  voteAverage: number;
+}
+
+interface TvShowSearchResultWire {
+  tvdbId: number;
+  name: string;
+  year: string | null;
+}
+
+function makeSearchClient(r: ReturnType<typeof supertest>) {
+  return {
+    movies: (query: { query: string; page?: number }) =>
+      send<{
+        results: MovieSearchResultWire[];
+        totalResults: number;
+        totalPages: number;
+        page: number;
+      }>(r.get('/search/movies').query(query)),
+    tvShows: (query: { query: string }) =>
+      send<{ results: TvShowSearchResultWire[] }>(r.get('/search/tv-shows').query(query)),
   };
 }
 

--- a/pillars/media/src/api/manifest-routes.ts
+++ b/pillars/media/src/api/manifest-routes.ts
@@ -66,6 +66,8 @@ export const MEDIA_ROUTES: ManifestPayload['routes'] = {
     'media.rotation.listPlexFriends',
     'media.rotation.listSources',
     'media.rotation.getSettings',
+    'media.search.movies',
+    'media.search.tvShows',
     'media.discovery.getDismissed',
     'media.discovery.profile',
     'media.discovery.quickPick',

--- a/pillars/media/src/api/rest/error-mapping.ts
+++ b/pillars/media/src/api/rest/error-mapping.ts
@@ -3,10 +3,11 @@
  *
  * Handlers translate `@pops/media` db domain errors into `HttpError`
  * subclasses carrying a real `statusCode` (`NotFoundError` → 404,
- * `ConflictError` → 409, `ValidationError` → 400). For those three mapped
- * statuses we return a typed `{ status, body }` envelope; anything else (a
- * 500-class `HttpError`, or a non-HttpError) is re-thrown so Express's
- * error pipeline surfaces the real stack rather than a swallowed 500.
+ * `ConflictError` → 409, `ValidationError` → 400, `BadGatewayError` → 502
+ * for upstream provider failures). For those mapped statuses we return a
+ * typed `{ status, body }` envelope; anything else (an unmapped 500-class
+ * `HttpError`, or a non-HttpError) is re-thrown so Express's error pipeline
+ * surfaces the real stack rather than a swallowed 500.
  *
  * `messageKey` is carried through so the FE keeps the i18n behaviour it
  * had under the tRPC `data.messageKey` wire shape.
@@ -19,7 +20,7 @@ export interface ErrorBody {
   messageKey?: string;
 }
 
-export type ErrorStatus = 400 | 404 | 409;
+export type ErrorStatus = 400 | 404 | 409 | 502;
 
 export interface MappedHttpError {
   status: ErrorStatus;
@@ -27,7 +28,7 @@ export interface MappedHttpError {
 }
 
 function isMappedStatus(status: number): status is ErrorStatus {
-  return status === 400 || status === 404 || status === 409;
+  return status === 400 || status === 404 || status === 409 || status === 502;
 }
 
 export function mapHttpError(err: unknown): MappedHttpError | null {

--- a/pillars/media/src/api/rest/handlers.ts
+++ b/pillars/media/src/api/rest/handlers.ts
@@ -16,6 +16,7 @@ import { makeLibraryHandlers } from './library-handlers.js';
 import { makeMoviesHandlers } from './movies-handlers.js';
 import { makePlexHandlers } from './plex-handlers.js';
 import { makeRotationHandlers } from './rotation-handlers.js';
+import { makeSearchHandlers } from './search-handlers.js';
 import { makeShelfImpressionsHandlers } from './shelf-impressions-handlers.js';
 import { makeTvShowsHandlers } from './tv-shows-handlers.js';
 import { makeWatchHistoryHandlers } from './watch-history-handlers.js';
@@ -39,5 +40,6 @@ export function makeMediaRestHandlers(deps: {
     comparisons: makeComparisonsHandlers(db),
     rotation: makeRotationHandlers(db),
     discovery: makeDiscoveryHandlers(db),
+    search: makeSearchHandlers(),
   });
 }

--- a/pillars/media/src/api/rest/search-handlers.ts
+++ b/pillars/media/src/api/rest/search-handlers.ts
@@ -1,0 +1,56 @@
+/**
+ * Handlers for the `search.*` sub-router — live provider search.
+ *
+ * Thin pass-throughs to the env-configured TMDB / TheTVDB clients (no db).
+ * Provider failures (`TmdbApiError` / `TvdbApiError`) are translated to
+ * `BadGatewayError` (502) at this boundary; everything else propagates to
+ * Express. Wire shapes mirror the legacy `media.search.*` tRPC outputs.
+ */
+import { getTvdbClient } from '../clients/thetvdb/index.js';
+import { TvdbApiError } from '../clients/thetvdb/types.js';
+import { getTmdbClient } from '../clients/tmdb/index.js';
+import { TmdbApiError } from '../clients/tmdb/types.js';
+import { BadGatewayError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { mediaSearchContract } from '../../contract/rest-search.js';
+
+type Req = ServerInferRequest<typeof mediaSearchContract>;
+
+export function makeSearchHandlers() {
+  return {
+    movies: ({ query }: Req['movies']) =>
+      runHttp(async () => {
+        try {
+          const response = await getTmdbClient().searchMovies(query.query, query.page);
+          return {
+            status: 200 as const,
+            body: {
+              results: response.results,
+              totalResults: response.totalResults,
+              totalPages: response.totalPages,
+              page: response.page,
+            },
+          };
+        } catch (err) {
+          if (err instanceof TmdbApiError)
+            throw new BadGatewayError(`TMDB API error: ${err.message}`);
+          throw err;
+        }
+      }),
+
+    tvShows: ({ query }: Req['tvShows']) =>
+      runHttp(async () => {
+        try {
+          const results = await getTvdbClient().searchSeries(query.query);
+          return { status: 200 as const, body: { results } };
+        } catch (err) {
+          if (err instanceof TvdbApiError)
+            throw new BadGatewayError(`TheTVDB API error: ${err.message}`);
+          throw err;
+        }
+      }),
+  };
+}

--- a/pillars/media/src/api/shared/errors.ts
+++ b/pillars/media/src/api/shared/errors.ts
@@ -44,3 +44,14 @@ export class ConflictError extends HttpError {
     this.name = 'ConflictError';
   }
 }
+
+/**
+ * An upstream metadata provider (TMDB / TheTVDB) failed. Maps to 502 so the
+ * FE can tell a dependency outage apart from a 4xx caller error.
+ */
+export class BadGatewayError extends HttpError {
+  constructor(message: string) {
+    super(502, message, undefined, 'common.upstreamError');
+    this.name = 'BadGatewayError';
+  }
+}

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -1834,6 +1834,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/search/movies': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Search movies via TMDB */
+    get: operations['search.movies'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/search/tv-shows': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Search TV shows via TheTVDB */
+    get: operations['search.tvShows'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/seasons/{id}': {
     parameters: {
       query?: never;
@@ -9539,6 +9573,134 @@ export interface operations {
       };
       /** @description 409 */
       409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'search.movies': {
+    parameters: {
+      query: {
+        query: string;
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            page: number;
+            results: {
+              backdropPath: string | null;
+              genreIds: number[];
+              originalLanguage: string;
+              originalTitle: string;
+              overview: string;
+              popularity: number;
+              posterPath: string | null;
+              releaseDate: string;
+              title: string;
+              tmdbId: number;
+              voteAverage: number;
+              voteCount: number;
+            }[];
+            totalPages: number;
+            totalResults: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 502 */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'search.tvShows': {
+    parameters: {
+      query: {
+        query: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            results: {
+              firstAirDate: string | null;
+              genres: string[];
+              name: string;
+              originalLanguage: string | null;
+              originalName: string | null;
+              overview: string | null;
+              posterPath: string | null;
+              status: string | null;
+              tvdbId: number;
+              year: string | null;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 502 */
+      502: {
         headers: {
           [name: string]: unknown;
         };

--- a/pillars/media/src/contract/rest-search.ts
+++ b/pillars/media/src/contract/rest-search.ts
@@ -1,0 +1,86 @@
+/**
+ * `search.*` sub-router — live metadata search over the upstream providers
+ * (TMDB movies + TheTVDB series). No database: each route is a thin
+ * pass-through to the env-configured provider client.
+ *
+ * Wire shapes mirror the legacy `media.search.*` tRPC router exactly
+ * (`search.movies` → TMDB `TmdbSearchResponse`, `search.tvShows` →
+ * `{ results: TvdbSearchResult[] }`) so the REST cutover is transparent to
+ * the FE. A provider outage surfaces as 502 via `BadGatewayError`.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ErrorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+/** Mirrors `TmdbSearchResult` from the TMDB client. */
+const MovieSearchResultSchema = z.object({
+  tmdbId: z.number(),
+  title: z.string(),
+  originalTitle: z.string(),
+  overview: z.string(),
+  releaseDate: z.string(),
+  posterPath: z.string().nullable(),
+  backdropPath: z.string().nullable(),
+  voteAverage: z.number(),
+  voteCount: z.number(),
+  genreIds: z.array(z.number()),
+  originalLanguage: z.string(),
+  popularity: z.number(),
+});
+
+/** Mirrors `TvdbSearchResult` from the TheTVDB client. */
+const TvShowSearchResultSchema = z.object({
+  tvdbId: z.number(),
+  name: z.string(),
+  originalName: z.string().nullable(),
+  overview: z.string().nullable(),
+  firstAirDate: z.string().nullable(),
+  status: z.string().nullable(),
+  posterPath: z.string().nullable(),
+  genres: z.array(z.string()),
+  originalLanguage: z.string().nullable(),
+  year: z.string().nullable(),
+});
+
+const MovieSearchQuery = z.object({
+  query: z.string().min(1).max(200),
+  page: z.coerce.number().int().positive().max(500).optional(),
+});
+
+const TvShowSearchQuery = z.object({
+  query: z.string().min(1).max(200),
+});
+
+/** 502 carries the same error envelope as the 4xx mapped statuses. */
+const UPSTREAM_ERR_RESPONSES = { 400: ErrorBodySchema, 502: ErrorBodySchema } as const;
+
+export const mediaSearchContract = c.router({
+  movies: {
+    method: 'GET',
+    path: '/search/movies',
+    query: MovieSearchQuery,
+    responses: {
+      200: z.object({
+        results: z.array(MovieSearchResultSchema),
+        totalResults: z.number(),
+        totalPages: z.number(),
+        page: z.number(),
+      }),
+      ...UPSTREAM_ERR_RESPONSES,
+    },
+    summary: 'Search movies via TMDB',
+  },
+  tvShows: {
+    method: 'GET',
+    path: '/search/tv-shows',
+    query: TvShowSearchQuery,
+    responses: {
+      200: z.object({ results: z.array(TvShowSearchResultSchema) }),
+      ...UPSTREAM_ERR_RESPONSES,
+    },
+    summary: 'Search TV shows via TheTVDB',
+  },
+});

--- a/pillars/media/src/contract/rest.ts
+++ b/pillars/media/src/contract/rest.ts
@@ -18,6 +18,7 @@ import { mediaLibraryContract } from './rest-library.js';
 import { mediaMoviesContract } from './rest-movies.js';
 import { mediaPlexContract } from './rest-plex.js';
 import { mediaRotationContract } from './rest-rotation.js';
+import { mediaSearchContract } from './rest-search.js';
 import { mediaShelfImpressionsContract } from './rest-shelf-impressions.js';
 import { mediaTvShowsContract } from './rest-tv-shows.js';
 import { mediaWatchHistoryContract } from './rest-watch-history.js';
@@ -38,6 +39,7 @@ export const mediaContract = c.router(
     comparisons: mediaComparisonsContract,
     rotation: mediaRotationContract,
     discovery: mediaDiscoveryContract,
+    search: mediaSearchContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
Wave 3, part e — the **final ranking-engine domain**. Read-only **search**.

- `search.movies` (TMDB) → `GET /search/movies?query=&page=`; `search.tvShows` (TheTVDB) → `GET /search/tv-shows?query=`.
- thin handlers over the existing env-backed tmdb/tvdb clients; **no db**.
- adds `BadGatewayError` (502) + 502 to the shared error mapping so an upstream provider outage is distinguishable from a caller 4xx.
- 7 tests (**403 total**).

**Completes Wave 3** — all 14 media domains are now on REST. (Authored in parallel in a worktree, then cherry-picked onto post-discovery `lake-migration` with the composer union resolved by hand.)

Verified: typecheck ✓ · build ✓ (`/search/*` paths) · 403/403 ✓ · format ✓ · lint exit 0 (`.oxlintrc` untouched) ✓ · drift idempotent ✓ · no leftover conflict markers ✓. (A rare local `socket hang up` supertest flake appears only under heavy multi-agent CPU contention; CI's clean single run is unaffected — 17/17 prior merges green.)