### PR TITLE
feat(cerebrum): REST migration — thalamus index + cross-source

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -5395,6 +5395,294 @@
         "tags": ["workers"]
       }
     },
+    "/index/reconcile": {
+      "post": {
+        "operationId": "index.reconcile",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "missing": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "orphaned": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["missing", "orphaned", "dryRun"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Diff disk against the index; apply unless dryRun.",
+        "tags": ["index"]
+      }
+    },
+    "/index/reindex": {
+      "post": {
+        "operationId": "index.reindex",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "force": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "enqueued": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "indexed": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["indexed", "enqueued"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Rebuild the engram index from disk; force re-enqueues embeddings.",
+        "tags": ["index"]
+      }
+    },
+    "/index/reindex-sources": {
+      "post": {
+        "operationId": "index.reindexSources",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceTypes": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "enqueued": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "sourceTypes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["enqueued", "sourceTypes"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          }
+        },
+        "summary": "Scan peer pillars and enqueue embeddings for changed source rows.",
+        "tags": ["index"]
+      }
+    },
+    "/index/status": {
+      "get": {
+        "operationId": "index.status",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "embeddingsQueue": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "pendingCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["name", "pendingCount"],
+                      "type": "object"
+                    },
+                    "watcher": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "lastEventAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "watchedPaths": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "watching": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["watching", "lastEventAt", "watchedPaths"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["watcher", "embeddingsQueue"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Watcher health + embeddings-queue pending count.",
+        "tags": ["index"]
+      }
+    },
     "/ingest/classify": {
       "post": {
         "operationId": "ingest.classify",

--- a/pillars/cerebrum/src/api/__tests__/index.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/index.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Integration tests for `cerebrum.index.*` (thalamus) over REST.
+ *
+ * Boots the app against a per-test temp cerebrum.db + temp engram root with NO
+ * Redis (the embeddings-queue accessor is injected, either `() => null` for the
+ * soft no-queue path or a recording fake that captures `add` calls). The
+ * watcher is never started, so `status` reports `watching: false`.
+ * `reindexSources` is exercised with fully-injected fake peer clients so no real
+ * cross-pillar HTTP is ever made.
+ */
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { embeddings, openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { hashContent } from '../modules/thalamus/chunker.js';
+import { makeClient, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+
+import type { Queue } from 'bullmq';
+
+import type {
+  FinanceTransactionListRow,
+  InventoryItemListRow,
+  MediaMovieListRow,
+  MediaTvShowListRow,
+  PeerClients,
+  PeerPage,
+} from '../modules/retrieval/peer-clients.js';
+import type { EmbeddingJobData, EmbeddingsQueueAccessor } from '../modules/thalamus/queue.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-index-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-index-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+interface RecordingQueue {
+  accessor: EmbeddingsQueueAccessor;
+  jobs: EmbeddingJobData[];
+}
+
+/**
+ * A queue accessor that records every `add` payload without touching Redis. The
+ * recorded jobs let tests assert exactly which source rows / engrams were
+ * enqueued. Only `add` is exercised by the index procs; `getJobCounts` is
+ * stubbed so `status` can read a pending count.
+ */
+function recordingQueue(pending = 0): RecordingQueue {
+  const jobs: EmbeddingJobData[] = [];
+  const fake = {
+    add: (_name: string, data: EmbeddingJobData) => {
+      jobs.push(data);
+      return Promise.resolve({ id: String(jobs.length) });
+    },
+    getJobCounts: () => Promise.resolve({ waiting: pending, active: 0, delayed: 0 }),
+  } as unknown as Queue<EmbeddingJobData>;
+  return { accessor: () => fake, jobs };
+}
+
+const NULL_QUEUE: EmbeddingsQueueAccessor = () => null;
+
+function client(
+  opts: {
+    queueAccessor?: EmbeddingsQueueAccessor;
+    peerClients?: PeerClients;
+  } = {}
+) {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry: makeTemplateRegistry(),
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      curationQueue: () => null,
+      embeddingsQueue: opts.queueAccessor ?? NULL_QUEUE,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: opts.peerClients ?? {},
+    })
+  );
+}
+
+const ISO = '2026-06-17T00:00:00.000Z';
+
+function writeEngramFile(relPath: string, id: string, body: string, scope = 'work'): void {
+  const content = [
+    '---',
+    `id: ${id}`,
+    'type: note',
+    `scopes:\n  - ${scope}`,
+    `created: ${ISO}`,
+    `modified: ${ISO}`,
+    'source: manual',
+    'status: active',
+    '---',
+    '',
+    body,
+    '',
+  ].join('\n');
+  writeFileSync(join(engramRoot, relPath), content, 'utf8');
+}
+
+describe('GET /index/status', () => {
+  it('reports watching:false and a null pending count without Redis', async () => {
+    const status = await client().index.status();
+    expect(status.watcher).toEqual({ watching: false, lastEventAt: null, watchedPaths: 0 });
+    expect(status.embeddingsQueue.name).toBe('pops-embeddings');
+    expect(status.embeddingsQueue.pendingCount).toBeNull();
+  });
+
+  it('surfaces the queue pending count when a producer is present', async () => {
+    const queue = recordingQueue(7);
+    const status = await client({ queueAccessor: queue.accessor }).index.status();
+    expect(status.embeddingsQueue.pendingCount).toBe(7);
+  });
+});
+
+describe('POST /index/reindex', () => {
+  it('rebuilds the index from disk and reports enqueued:0 without Redis', async () => {
+    writeEngramFile('a.md', 'eng_20260617_0000_alpha', '# Alpha\n\nfirst body');
+    writeEngramFile('b.md', 'eng_20260617_0000_beta', '# Beta\n\nsecond body');
+
+    const result = await client().index.reindex();
+    expect(result.indexed).toBe(2);
+    expect(result.enqueued).toBe(0);
+
+    // The fs→index sync is observable: the engrams now resolve through search.
+    const found = await client().engrams.search({});
+    expect(found.total).toBe(2);
+  });
+
+  it('enqueues embeddings for every non-empty engram when force is set', async () => {
+    writeEngramFile('a.md', 'eng_20260617_0000_alpha', '# Alpha\n\nfirst body');
+    writeEngramFile('empty.md', 'eng_20260617_0000_empty', '   ');
+    const queue = recordingQueue();
+
+    const result = await client({ queueAccessor: queue.accessor }).index.reindex(true);
+    expect(result.indexed).toBe(2);
+    // Only the engram with a non-empty body is enqueued (empty body is skipped).
+    expect(result.enqueued).toBe(1);
+    expect(queue.jobs).toHaveLength(1);
+    expect(queue.jobs[0]).toMatchObject({
+      sourceType: 'engram',
+      sourceId: 'eng_20260617_0000_alpha',
+    });
+  });
+
+  it('force-reindex with no Redis still rebuilds and reports enqueued:0', async () => {
+    writeEngramFile('a.md', 'eng_20260617_0000_alpha', '# Alpha\n\nbody');
+    const result = await client().index.reindex(true);
+    expect(result.indexed).toBe(1);
+    expect(result.enqueued).toBe(0);
+  });
+});
+
+describe('POST /index/reconcile', () => {
+  it('detects a file on disk that is missing from the index (dryRun)', async () => {
+    writeEngramFile('orphan-on-disk.md', 'eng_20260617_0000_disk', '# Disk only\n\nbody');
+
+    const result = await client().index.reconcile(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.missing).toEqual(['orphan-on-disk.md']);
+    expect(result.orphaned).toEqual([]);
+
+    // dryRun must not mutate the index.
+    const found = await client().engrams.search({});
+    expect(found.total).toBe(0);
+  });
+
+  it('applies the sync for missing files when not a dryRun', async () => {
+    writeEngramFile('new.md', 'eng_20260617_0000_new', '# New\n\nbody');
+
+    const result = await client().index.reconcile(false);
+    expect(result.missing).toEqual(['new.md']);
+
+    const found = await client().engrams.search({});
+    expect(found.total).toBe(1);
+
+    // A second reconcile finds nothing missing — the first one persisted it.
+    const again = await client().index.reconcile(true);
+    expect(again.missing).toEqual([]);
+  });
+
+  it('detects an indexed engram whose file was deleted as orphaned', async () => {
+    writeEngramFile('gone.md', 'eng_20260617_0000_gone', '# Gone\n\nbody');
+    await client().index.reindex();
+
+    unlinkSync(join(engramRoot, 'gone.md'));
+
+    const result = await client().index.reconcile(false);
+    expect(result.orphaned).toEqual(['gone.md']);
+
+    // A re-run sees no orphans (the first marked it orphaned).
+    const again = await client().index.reconcile(true);
+    expect(again.orphaned).toEqual([]);
+  });
+
+  it('returns empty discrepancies when disk and index agree', async () => {
+    writeEngramFile('agree.md', 'eng_20260617_0000_agree', '# Agree\n\nbody');
+    await client().index.reindex();
+
+    const result = await client().index.reconcile(true);
+    expect(result.missing).toEqual([]);
+    expect(result.orphaned).toEqual([]);
+  });
+});
+
+describe('POST /index/reindex-sources', () => {
+  function singlePage<T>(rows: T[]): PeerPage<T> {
+    return { rows, hasMore: false };
+  }
+
+  function fakePeers(): PeerClients {
+    const tx: FinanceTransactionListRow = {
+      id: 'tx-1',
+      description: 'Coffee',
+      entityName: 'Cafe',
+      tags: ['food'],
+      notes: null,
+    };
+    const movie: MediaMovieListRow = { id: 42, title: 'Dune', overview: 'Sand', genres: ['scifi'] };
+    const show: MediaTvShowListRow = { id: 7, name: 'Severance', overview: 'Office', genres: [] };
+    const item: InventoryItemListRow = {
+      id: 'item-1',
+      itemName: 'Drill',
+      brand: 'Bosch',
+      type: 'tool',
+      location: 'Garage',
+    };
+    return {
+      finance: {
+        getTransaction: () => Promise.resolve(null),
+        listTransactions: () => Promise.resolve(singlePage([tx])),
+      },
+      media: {
+        getMovie: () => Promise.resolve(null),
+        getTvShow: () => Promise.resolve(null),
+        listMovies: () => Promise.resolve(singlePage([movie])),
+        listTvShows: () => Promise.resolve(singlePage([show])),
+      },
+      inventory: {
+        getItem: () => Promise.resolve(null),
+        listItems: () => Promise.resolve(singlePage([item])),
+      },
+    };
+  }
+
+  it('enqueues one job per changed peer row across all source types', async () => {
+    const queue = recordingQueue();
+    const result = await client({
+      queueAccessor: queue.accessor,
+      peerClients: fakePeers(),
+    }).index.reindexSources();
+
+    expect(result.sourceTypes).toEqual(['transaction', 'movie', 'tv_show', 'inventory']);
+    expect(result.enqueued).toBe(4);
+    expect(queue.jobs.map((j) => j.sourceType).toSorted()).toEqual([
+      'inventory',
+      'movie',
+      'transaction',
+      'tv_show',
+    ]);
+    const tx = queue.jobs.find((j) => j.sourceType === 'transaction');
+    expect(tx?.sourceId).toBe('tx-1');
+    expect(tx?.content).toContain('Coffee');
+  });
+
+  it('honours an explicit subset and ignores unknown source types', async () => {
+    const queue = recordingQueue();
+    const result = await client({
+      queueAccessor: queue.accessor,
+      peerClients: fakePeers(),
+    }).index.reindexSources(['movie', 'bogus']);
+
+    expect(result.sourceTypes).toEqual(['movie']);
+    expect(result.enqueued).toBe(1);
+    expect(queue.jobs).toHaveLength(1);
+    expect(queue.jobs[0]?.sourceType).toBe('movie');
+  });
+
+  it('skips a source row whose first-chunk hash is unchanged', async () => {
+    // Seed the embeddings table with the exact hash the movie row would produce.
+    const movieText = 'Title: Dune\nOverview: Sand\nGenres: scifi';
+    cerebrumDb.db
+      .insert(embeddings)
+      .values({
+        sourceType: 'movie',
+        sourceId: '42',
+        chunkIndex: 0,
+        contentHash: hashContent(movieText),
+        contentPreview: movieText.slice(0, 50),
+        model: 'fake',
+        dimensions: 3,
+        createdAt: ISO,
+      })
+      .run();
+
+    const queue = recordingQueue();
+    const result = await client({
+      queueAccessor: queue.accessor,
+      peerClients: fakePeers(),
+    }).index.reindexSources(['movie']);
+
+    expect(result.enqueued).toBe(0);
+    expect(queue.jobs).toHaveLength(0);
+  });
+
+  it('skips a source type whose peer is absent (enqueued:0, no crash)', async () => {
+    const queue = recordingQueue();
+    const result = await client({
+      queueAccessor: queue.accessor,
+      peerClients: {},
+    }).index.reindexSources(['transaction', 'movie']);
+
+    expect(result.enqueued).toBe(0);
+    expect(queue.jobs).toHaveLength(0);
+  });
+
+  it('reports enqueued:0 without Redis even when peers return rows', async () => {
+    const result = await client({
+      queueAccessor: NULL_QUEUE,
+      peerClients: fakePeers(),
+    }).index.reindexSources();
+    expect(result.enqueued).toBe(0);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -38,6 +38,12 @@ import type {
   GliaUserDecisionWire,
 } from '../../contract/rest-glia-schemas.js';
 import type {
+  IndexReconcileResponseWire,
+  IndexReindexResponseWire,
+  IndexReindexSourcesResponseWire,
+  IndexStatusResponseWire,
+} from '../../contract/rest-index-schemas.js';
+import type {
   ClassificationResultWire,
   IngestEnrichmentStatusResponseWire,
   IngestExtractEntitiesResponseWire,
@@ -589,6 +595,17 @@ export function makeClient(app: Express) {
         send<IngestRetryEnrichmentResponseWire>(
           r.post('/ingest/retry-enrichment').send({ engramId })
         ),
+    },
+    index: {
+      status: () => send<IndexStatusResponseWire>(r.get('/index/status')),
+      reindex: (force?: boolean) =>
+        send<IndexReindexResponseWire>(r.post('/index/reindex').send({ force })),
+      reindexSources: (sourceTypes?: string[]) =>
+        send<IndexReindexSourcesResponseWire>(
+          r.post('/index/reindex-sources').send(sourceTypes ? { sourceTypes } : {})
+        ),
+      reconcile: (dryRun?: boolean) =>
+        send<IndexReconcileResponseWire>(r.post('/index/reconcile').send({ dryRun })),
     },
     retrieval: {
       search: (body: RetrievalSearchBody = {}) =>

--- a/pillars/cerebrum/src/api/handlers.ts
+++ b/pillars/cerebrum/src/api/handlers.ts
@@ -19,6 +19,7 @@ import type { ReflexService } from './modules/reflex/reflex-service.js';
 import type { EmbeddingClient } from './modules/retrieval/embedding-client.js';
 import type { PeerClients } from './modules/retrieval/peer-clients.js';
 import type { TemplateRegistry } from './modules/templates/registry.js';
+import type { EmbeddingsQueueAccessor } from './modules/thalamus/queue.js';
 import type { ContradictionDetector } from './modules/workers/auditor.js';
 
 export interface CerebrumApiDeps {
@@ -64,6 +65,14 @@ export interface CerebrumApiDeps {
    * `() => null` accessor to exercise the no-Redis path.
    */
   curationQueue?: CurationQueueAccessor;
+  /**
+   * Accessor for the `pops-embeddings` BullMQ queue used by the thalamus index
+   * procs (`reindex --force` / `reindexSources`). Optional — defaults to the
+   * lazy `getEmbeddingsQueue()` singleton (returns `null` without Redis). Tests
+   * pass a `() => null` accessor to exercise the no-Redis path
+   * (`pendingCount: null`, `enqueued: 0`).
+   */
+  embeddingsQueue?: EmbeddingsQueueAccessor;
   /** Semver of the build, surfaced on the health response. */
   version: string;
   /**

--- a/pillars/cerebrum/src/api/modules/retrieval/peer-clients.ts
+++ b/pillars/cerebrum/src/api/modules/retrieval/peer-clients.ts
@@ -48,19 +48,71 @@ export interface InventoryItemRow {
   location?: string | null;
 }
 
+/** A page of rows returned by a peer LIST endpoint (`{ data, pagination }`). */
+export interface PeerPage<T> {
+  rows: T[];
+  hasMore: boolean;
+}
+
+/**
+ * Cross-source scan rows carry the owning-pillar primary key alongside the
+ * formatter fields. The thalamus cross-source indexer pages through these to
+ * enqueue embedding jobs for changed rows.
+ */
+export interface FinanceTransactionListRow extends FinanceTransactionRow {
+  id: string;
+}
+export interface MediaMovieListRow extends MediaMovieRow {
+  id: number;
+}
+export interface MediaTvShowListRow extends MediaTvShowRow {
+  id: number;
+}
+export interface InventoryItemListRow extends InventoryItemRow {
+  id: string;
+}
+
 export interface PeerClients {
-  finance?: { getTransaction(id: string): Promise<FinanceTransactionRow | null> };
+  finance?: {
+    getTransaction(id: string): Promise<FinanceTransactionRow | null>;
+    listTransactions(limit: number, offset: number): Promise<PeerPage<FinanceTransactionListRow>>;
+  };
   media?: {
     getMovie(id: number): Promise<MediaMovieRow | null>;
     getTvShow(id: number): Promise<MediaTvShowRow | null>;
+    listMovies(limit: number, offset: number): Promise<PeerPage<MediaMovieListRow>>;
+    listTvShows(limit: number, offset: number): Promise<PeerPage<MediaTvShowListRow>>;
   };
-  inventory?: { getItem(id: string): Promise<InventoryItemRow | null> };
+  inventory?: {
+    getItem(id: string): Promise<InventoryItemRow | null>;
+    listItems(limit: number, offset: number): Promise<PeerPage<InventoryItemListRow>>;
+  };
 }
 
 type FetchImpl = typeof globalThis.fetch;
 
+interface PeerPaginationEnvelope<T> {
+  data?: T[];
+  pagination?: { hasMore?: boolean };
+}
+
 function resolvePeerBaseUrl(id: string): string | undefined {
   return parsePillarsEnv(process.env['POPS_PILLARS']).find((p) => p.id === id)?.baseUrl;
+}
+
+async function fetchJson(
+  fetchImpl: FetchImpl,
+  baseUrl: string,
+  path: string,
+  label: string
+): Promise<{ status: number; text: string }> {
+  const res = await fetchImpl(`${baseUrl.replace(/\/$/, '')}${path}`, {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+  });
+  if (res.status === 404) return { status: 404, text: '' };
+  if (!res.ok) throw new Error(`${label} → HTTP ${res.status}`);
+  return { status: res.status, text: await res.text() };
 }
 
 async function getData<T>(
@@ -69,16 +121,90 @@ async function getData<T>(
   path: string,
   label: string
 ): Promise<T | null> {
-  const res = await fetchImpl(`${baseUrl.replace(/\/$/, '')}${path}`, {
-    method: 'GET',
-    headers: { 'content-type': 'application/json' },
-  });
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`${label} → HTTP ${res.status}`);
-  const text = await res.text();
-  if (text.length === 0) return null;
+  const { status, text } = await fetchJson(fetchImpl, baseUrl, path, label);
+  if (status === 404 || text.length === 0) return null;
   const json = JSON.parse(text) as { data?: T };
   return json.data ?? null;
+}
+
+interface ListRequest {
+  path: string;
+  label: string;
+  limit: number;
+  offset: number;
+}
+
+async function listData<T>(
+  fetchImpl: FetchImpl,
+  baseUrl: string,
+  req: ListRequest
+): Promise<PeerPage<T>> {
+  const query = `?limit=${req.limit}&offset=${req.offset}`;
+  const { status, text } = await fetchJson(fetchImpl, baseUrl, `${req.path}${query}`, req.label);
+  if (status === 404 || text.length === 0) return { rows: [], hasMore: false };
+  const json = JSON.parse(text) as PeerPaginationEnvelope<T>;
+  return { rows: json.data ?? [], hasMore: json.pagination?.hasMore ?? false };
+}
+
+function buildFinanceClient(fetchImpl: FetchImpl, baseUrl: string): PeerClients['finance'] {
+  return {
+    getTransaction: (id) =>
+      getData<FinanceTransactionRow>(
+        fetchImpl,
+        baseUrl,
+        `/transactions/${encodeURIComponent(id)}`,
+        'finance GET /transactions/:id'
+      ),
+    listTransactions: (limit, offset) =>
+      listData<FinanceTransactionListRow>(fetchImpl, baseUrl, {
+        path: '/transactions',
+        label: 'finance GET /transactions',
+        limit,
+        offset,
+      }),
+  };
+}
+
+function buildMediaClient(fetchImpl: FetchImpl, baseUrl: string): PeerClients['media'] {
+  return {
+    getMovie: (id) =>
+      getData<MediaMovieRow>(fetchImpl, baseUrl, `/movies/${id}`, 'media GET /movies/:id'),
+    getTvShow: (id) =>
+      getData<MediaTvShowRow>(fetchImpl, baseUrl, `/tv-shows/${id}`, 'media GET /tv-shows/:id'),
+    listMovies: (limit, offset) =>
+      listData<MediaMovieListRow>(fetchImpl, baseUrl, {
+        path: '/movies',
+        label: 'media GET /movies',
+        limit,
+        offset,
+      }),
+    listTvShows: (limit, offset) =>
+      listData<MediaTvShowListRow>(fetchImpl, baseUrl, {
+        path: '/tv-shows',
+        label: 'media GET /tv-shows',
+        limit,
+        offset,
+      }),
+  };
+}
+
+function buildInventoryClient(fetchImpl: FetchImpl, baseUrl: string): PeerClients['inventory'] {
+  return {
+    getItem: (id) =>
+      getData<InventoryItemRow>(
+        fetchImpl,
+        baseUrl,
+        `/items/${encodeURIComponent(id)}`,
+        'inventory GET /items/:id'
+      ),
+    listItems: (limit, offset) =>
+      listData<InventoryItemListRow>(fetchImpl, baseUrl, {
+        path: '/items',
+        label: 'inventory GET /items',
+        limit,
+        offset,
+      }),
+  };
 }
 
 /**
@@ -91,43 +217,9 @@ export function resolvePeerClientsFromEnv(fetchImpl: FetchImpl = globalThis.fetc
   const inventoryUrl = resolvePeerBaseUrl('inventory');
 
   return {
-    finance:
-      financeUrl === undefined
-        ? undefined
-        : {
-            getTransaction: (id) =>
-              getData<FinanceTransactionRow>(
-                fetchImpl,
-                financeUrl,
-                `/transactions/${encodeURIComponent(id)}`,
-                'finance GET /transactions/:id'
-              ),
-          },
-    media:
-      mediaUrl === undefined
-        ? undefined
-        : {
-            getMovie: (id) =>
-              getData<MediaMovieRow>(fetchImpl, mediaUrl, `/movies/${id}`, 'media GET /movies/:id'),
-            getTvShow: (id) =>
-              getData<MediaTvShowRow>(
-                fetchImpl,
-                mediaUrl,
-                `/tv-shows/${id}`,
-                'media GET /tv-shows/:id'
-              ),
-          },
+    finance: financeUrl === undefined ? undefined : buildFinanceClient(fetchImpl, financeUrl),
+    media: mediaUrl === undefined ? undefined : buildMediaClient(fetchImpl, mediaUrl),
     inventory:
-      inventoryUrl === undefined
-        ? undefined
-        : {
-            getItem: (id) =>
-              getData<InventoryItemRow>(
-                fetchImpl,
-                inventoryUrl,
-                `/items/${encodeURIComponent(id)}`,
-                'inventory GET /items/:id'
-              ),
-          },
+      inventoryUrl === undefined ? undefined : buildInventoryClient(fetchImpl, inventoryUrl),
   };
 }

--- a/pillars/cerebrum/src/api/modules/thalamus/chunker.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/chunker.ts
@@ -1,0 +1,54 @@
+/**
+ * Text chunking + content hashing for embedding generation, pillar-local.
+ *
+ * Lifted from the monolith `shared/chunker.ts` (the pillar container can't
+ * import pops-api). Uses a char-count token approximation (~4 chars/token).
+ * `cross-source.ts` hashes the first chunk of each row's embeddable text to
+ * detect whether content changed since the last embedding run.
+ */
+import { createHash } from 'node:crypto';
+
+const CHARS_PER_TOKEN = 4;
+const MAX_TOKENS = 512;
+const OVERLAP_TOKENS = 50;
+
+export const MAX_CHUNK_CHARS = MAX_TOKENS * CHARS_PER_TOKEN;
+export const OVERLAP_CHARS = OVERLAP_TOKENS * CHARS_PER_TOKEN;
+
+export interface TextChunk {
+  index: number;
+  text: string;
+}
+
+/**
+ * Split text into overlapping chunks of at most {@link MAX_CHUNK_CHARS}
+ * characters. Content shorter than the cap is returned as a single chunk at
+ * index 0; empty/whitespace input yields no chunks.
+ */
+export function chunkText(text: string): TextChunk[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.length <= MAX_CHUNK_CHARS) {
+    return [{ index: 0, text: trimmed }];
+  }
+
+  const chunks: TextChunk[] = [];
+  let start = 0;
+  let index = 0;
+
+  while (start < trimmed.length) {
+    const end = Math.min(start + MAX_CHUNK_CHARS, trimmed.length);
+    chunks.push({ index, text: trimmed.slice(start, end) });
+    index++;
+    if (end === trimmed.length) break;
+    start = end - OVERLAP_CHARS;
+  }
+
+  return chunks;
+}
+
+/** SHA-256 hex digest of a string. */
+export function hashContent(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/cross-source.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/cross-source.ts
@@ -1,0 +1,201 @@
+/**
+ * CrossSourceIndexer — scans non-engram source rows (transactions, movies,
+ * tv_shows, inventory items) and enqueues embedding jobs for rows whose content
+ * has changed since the last embedding run.
+ *
+ * The source rows no longer live in the cerebrum SQLite file; they are paged in
+ * over REST from the owning pillar via the injected {@link PeerClients} (the
+ * same clients that back retrieval enrichment, extended with paginated LIST
+ * methods). A peer absent from `POPS_PILLARS` yields an `undefined` client; that
+ * source type is skipped (no crash, contributes 0 to `enqueued`).
+ *
+ * Change detection is by SHA-256 of the first chunk of the embeddable text
+ * compared against the `content_hash` of the `chunk_index = 0` row in the
+ * cerebrum `embeddings` table. Rows never embedded are always enqueued.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { type CerebrumDb, embeddings } from '../../../db/index.js';
+import { chunkText, hashContent } from './chunker.js';
+import { EMBEDDINGS_JOB_OPTIONS, type EmbeddingsQueueAccessor } from './queue.js';
+
+import type {
+  FinanceTransactionListRow,
+  InventoryItemListRow,
+  MediaMovieListRow,
+  MediaTvShowListRow,
+  PeerClients,
+  PeerPage,
+} from '../retrieval/peer-clients.js';
+
+export const CROSS_SOURCE_TYPES = ['transaction', 'movie', 'tv_show', 'inventory'] as const;
+export type CrossSourceType = (typeof CROSS_SOURCE_TYPES)[number];
+
+export function toTransactionText(row: FinanceTransactionListRow): string {
+  const parts: string[] = [];
+  if (row.description) parts.push(`Description: ${row.description}`);
+  if (row.entityName) parts.push(`Merchant: ${row.entityName}`);
+  if (row.tags && row.tags.length > 0) parts.push(`Category: ${row.tags.join(', ')}`);
+  if (row.notes) parts.push(`Notes: ${row.notes}`);
+  return parts.join('\n');
+}
+
+export function toMovieText(row: MediaMovieListRow): string {
+  const parts: string[] = [];
+  if (row.title) parts.push(`Title: ${row.title}`);
+  if (row.overview) parts.push(`Overview: ${row.overview}`);
+  if (row.genres && row.genres.length > 0) parts.push(`Genres: ${row.genres.join(', ')}`);
+  return parts.join('\n');
+}
+
+export function toTvShowText(row: MediaTvShowListRow): string {
+  const parts: string[] = [];
+  if (row.name) parts.push(`Title: ${row.name}`);
+  if (row.overview) parts.push(`Overview: ${row.overview}`);
+  if (row.genres && row.genres.length > 0) parts.push(`Genres: ${row.genres.join(', ')}`);
+  return parts.join('\n');
+}
+
+export function toInventoryText(row: InventoryItemListRow): string {
+  const parts: string[] = [];
+  if (row.itemName) parts.push(`Name: ${row.itemName}`);
+  if (row.brand) parts.push(`Brand: ${row.brand}`);
+  if (row.type) parts.push(`Type: ${row.type}`);
+  if (row.location) parts.push(`Location: ${row.location}`);
+  return parts.join('\n');
+}
+
+const PAGE_SIZE = 100;
+
+interface ScanItem {
+  id: string;
+  text: string;
+}
+
+export interface CrossSourceIndexerDeps {
+  db: CerebrumDb;
+  peers: PeerClients;
+  queueAccessor: EmbeddingsQueueAccessor;
+}
+
+export class CrossSourceIndexer {
+  constructor(private readonly deps: CrossSourceIndexerDeps) {}
+
+  /**
+   * Scan the requested source types and enqueue embedding jobs for rows with
+   * missing or stale embeddings.
+   *
+   * @returns Total jobs enqueued. `0` for any type whose peer is absent or
+   *   whose queue producer is null (no Redis).
+   */
+  async scanAndEnqueue(
+    sourceTypes: CrossSourceType[] = [...CROSS_SOURCE_TYPES]
+  ): Promise<{ enqueued: number }> {
+    let enqueued = 0;
+    for (const sourceType of sourceTypes) {
+      enqueued += await this.processSourceType(sourceType);
+    }
+    return { enqueued };
+  }
+
+  private processSourceType(sourceType: CrossSourceType): Promise<number> {
+    switch (sourceType) {
+      case 'transaction':
+        return this.scanPeer('transaction', (limit, offset) =>
+          mapPage(this.deps.peers.finance?.listTransactions(limit, offset), (row) => ({
+            id: row.id,
+            text: toTransactionText(row),
+          }))
+        );
+      case 'movie':
+        return this.scanPeer('movie', (limit, offset) =>
+          mapPage(this.deps.peers.media?.listMovies(limit, offset), (row) => ({
+            id: String(row.id),
+            text: toMovieText(row),
+          }))
+        );
+      case 'tv_show':
+        return this.scanPeer('tv_show', (limit, offset) =>
+          mapPage(this.deps.peers.media?.listTvShows(limit, offset), (row) => ({
+            id: String(row.id),
+            text: toTvShowText(row),
+          }))
+        );
+      case 'inventory':
+        return this.scanPeer('inventory', (limit, offset) =>
+          mapPage(this.deps.peers.inventory?.listItems(limit, offset), (row) => ({
+            id: row.id,
+            text: toInventoryText(row),
+          }))
+        );
+    }
+  }
+
+  private async scanPeer(
+    sourceType: string,
+    fetchPage: (limit: number, offset: number) => Promise<PeerPage<ScanItem> | null>
+  ): Promise<number> {
+    let enqueued = 0;
+    let offset = 0;
+
+    for (;;) {
+      const page = await fetchPage(PAGE_SIZE, offset);
+      if (page === null) return 0;
+      if (page.rows.length > 0) {
+        enqueued += await this.enqueueChanged(sourceType, page.rows);
+      }
+      if (!page.hasMore || page.rows.length === 0) break;
+      offset += page.rows.length;
+    }
+
+    return enqueued;
+  }
+
+  private async enqueueChanged(sourceType: string, items: ScanItem[]): Promise<number> {
+    const queue = this.deps.queueAccessor();
+    if (!queue) return 0;
+
+    const ids = items.map((it) => it.id);
+    const existing = this.deps.db
+      .select({ sourceId: embeddings.sourceId, contentHash: embeddings.contentHash })
+      .from(embeddings)
+      .where(
+        and(
+          eq(embeddings.sourceType, sourceType),
+          inArray(embeddings.sourceId, ids),
+          eq(embeddings.chunkIndex, 0)
+        )
+      )
+      .all();
+    const chunk0HashBySourceId = new Map(existing.map((e) => [e.sourceId, e.contentHash]));
+
+    let enqueued = 0;
+    for (const item of items) {
+      if (!item.text.trim()) continue;
+      const firstChunk = chunkText(item.text)[0];
+      if (!firstChunk) continue;
+      if (chunk0HashBySourceId.get(item.id) === hashContent(firstChunk.text)) continue;
+
+      try {
+        await queue.add(
+          'embed',
+          { sourceType, sourceId: item.id, content: item.text },
+          EMBEDDINGS_JOB_OPTIONS
+        );
+        enqueued++;
+      } catch (err) {
+        console.error(`[thalamus] Failed to enqueue embedding for ${sourceType}/${item.id}:`, err);
+      }
+    }
+    return enqueued;
+  }
+}
+
+async function mapPage<T>(
+  pagePromise: Promise<PeerPage<T>> | undefined,
+  toItem: (row: T) => ScanItem
+): Promise<PeerPage<ScanItem> | null> {
+  if (pagePromise === undefined) return null;
+  const page = await pagePromise;
+  return { rows: page.rows.map(toItem), hasMore: page.hasMore };
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/embedding-trigger.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/embedding-trigger.ts
@@ -1,0 +1,68 @@
+/**
+ * EmbeddingTrigger — decides whether a synced engram should have its
+ * embeddings regenerated and enqueues the job.
+ *
+ * Rules:
+ *  - Skip if `wordCount === 0` (empty body — nothing to embed).
+ *  - Skip (unless `force`) if `contentHash === previousContentHash` (no change).
+ *  - Enqueue `{ sourceType: 'engram', sourceId, content }` to `pops-embeddings`.
+ *  - If the queue is unavailable (no Redis), report `action: 'skipped'` with a
+ *    queue-unavailable reason — a missing producer is soft, never an error.
+ */
+import { EMBEDDINGS_JOB_OPTIONS, type EmbeddingsQueueAccessor } from './queue.js';
+
+import type { SyncResult } from './sync.js';
+
+export interface TriggerResult {
+  engramId: string;
+  action: 'enqueued' | 'skipped' | 'error';
+  reason: string;
+}
+
+export class EmbeddingTrigger {
+  constructor(private readonly queueAccessor: EmbeddingsQueueAccessor) {}
+
+  async trigger(results: SyncResult[], force = false): Promise<TriggerResult[]> {
+    const output: TriggerResult[] = [];
+
+    for (const result of results) {
+      if (result.status !== 'synced' || result.engramId === undefined) continue;
+
+      const engramId = result.engramId;
+
+      if (result.wordCount === 0) {
+        output.push({ engramId, action: 'skipped', reason: 'empty body' });
+        continue;
+      }
+
+      if (!force && result.contentHash === result.previousContentHash) {
+        output.push({ engramId, action: 'skipped', reason: 'hash unchanged' });
+        continue;
+      }
+
+      const queue = this.queueAccessor();
+      if (!queue) {
+        output.push({
+          engramId,
+          action: 'skipped',
+          reason: 'embeddings queue unavailable — Redis not configured',
+        });
+        continue;
+      }
+
+      try {
+        await queue.add(
+          'embed',
+          { sourceType: 'engram', sourceId: engramId, content: result.bodyText },
+          EMBEDDINGS_JOB_OPTIONS
+        );
+        output.push({ engramId, action: 'enqueued', reason: 'content changed' });
+      } catch (err) {
+        console.error(`[thalamus] Failed to enqueue embedding job for ${engramId}:`, err);
+        output.push({ engramId, action: 'error', reason: (err as Error).message });
+      }
+    }
+
+    return output;
+  }
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/instance.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/instance.ts
@@ -1,0 +1,91 @@
+/**
+ * Thalamus watcher singleton — owns the optional file-watcher lifetime and
+ * wires it to the sync + embedding-trigger pipeline.
+ *
+ * The watcher is OPT-IN: `startThalamusWatcher` is a no-op unless
+ * `CEREBRUM_INDEX_WATCH=true`, and it returns without starting if the engram
+ * root does not exist. Tests never call it; `index.status` then reports
+ * `watching: false`. `getThalamusWatcher` exposes the running instance (or null)
+ * so the status proc can read its health.
+ */
+import { existsSync } from 'node:fs';
+
+import { eq } from 'drizzle-orm';
+
+import { type CerebrumDb, engramIndex } from '../../../db/index.js';
+import { EmbeddingTrigger } from './embedding-trigger.js';
+import { type EmbeddingsQueueAccessor } from './queue.js';
+import { FrontmatterSyncService } from './sync.js';
+import { FileWatcherService, type WatchEvent } from './watcher.js';
+
+export const INDEX_WATCH_ENV = 'CEREBRUM_INDEX_WATCH';
+
+export interface ThalamusWatcherDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  queueAccessor: EmbeddingsQueueAccessor;
+}
+
+let watcher: FileWatcherService | null = null;
+
+/** Returns the running watcher instance, or `null` when none is started. */
+export function getThalamusWatcher(): FileWatcherService | null {
+  return watcher;
+}
+
+/**
+ * Start the thalamus file watcher when `CEREBRUM_INDEX_WATCH=true`. No-op when
+ * the flag is unset/false, when a watcher is already running, or when the
+ * engram root does not exist (logged, not thrown).
+ */
+export function startThalamusWatcher(
+  deps: ThalamusWatcherDeps,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  if (watcher) return;
+  if (env[INDEX_WATCH_ENV] !== 'true') return;
+
+  if (!existsSync(deps.engramRoot)) {
+    console.warn(
+      `[thalamus] ${INDEX_WATCH_ENV}=true but engram root does not exist (${deps.engramRoot}) — ` +
+        'watcher disabled.'
+    );
+    return;
+  }
+
+  const existingPaths = new Set(
+    deps.db
+      .select({ filePath: engramIndex.filePath })
+      .from(engramIndex)
+      .where(eq(engramIndex.status, 'active'))
+      .all()
+      .map((r) => r.filePath)
+  );
+
+  const sync = new FrontmatterSyncService(deps.engramRoot, deps.db);
+  const trigger = new EmbeddingTrigger(deps.queueAccessor);
+
+  const instance = new FileWatcherService(deps.engramRoot);
+  instance.on('batch', (events: WatchEvent[]) => {
+    const results = sync.processEvents(events);
+    void trigger.trigger(results).catch((err: unknown) => {
+      console.error('[thalamus] Error triggering embeddings:', err);
+    });
+  });
+  instance.on('error', (err: Error) => {
+    console.error('[thalamus] Watcher error:', err);
+  });
+
+  instance.start(existingPaths);
+  watcher = instance;
+  console.warn(`[thalamus] File watcher started (root: ${deps.engramRoot})`);
+}
+
+/** Stop the thalamus file watcher if running. */
+export async function stopThalamusWatcher(): Promise<void> {
+  if (watcher) {
+    await watcher.stop();
+    watcher = null;
+    console.warn('[thalamus] File watcher stopped.');
+  }
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/queue.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/queue.ts
@@ -1,0 +1,75 @@
+/**
+ * BullMQ producer for the `pops-embeddings` queue, pillar-side.
+ *
+ * cerebrum-api is the *producer* — the thalamus index procs enqueue embedding
+ * jobs (one per changed engram on `reindex --force`, one per changed source row
+ * on `reindexSources`). The consumer (the embeddings worker) still runs in the
+ * monolith, so this file only declares the enqueue surface. Mirrors the ingest
+ * slice's lazy-singleton `queue.ts`: returns `null` when Redis is unconfigured
+ * so tests + dev runs without Redis don't blow up at module init. Closed on
+ * graceful shutdown via {@link closeCerebrumEmbeddingsQueue}.
+ */
+import { type DefaultJobOptions, Queue } from 'bullmq';
+import { Redis } from 'ioredis';
+
+/** Must match the monolith's `EMBEDDINGS_QUEUE` name so the worker picks jobs up. */
+export const EMBEDDINGS_QUEUE_NAME = 'pops-embeddings';
+
+/**
+ * Payload for an embedding job. `content` is optional — when omitted the worker
+ * fetches it from the source table. Kept minimal and local; the worker's full
+ * job-data union stays in the monolith.
+ */
+export interface EmbeddingJobData {
+  sourceType: string;
+  sourceId: string;
+  content?: string;
+}
+
+const ATTEMPTS = 3;
+const BACKOFF_DELAY_MS = 5_000;
+const REMOVE_KEEP_COUNT = 1_000;
+
+export const EMBEDDINGS_JOB_OPTIONS: DefaultJobOptions = {
+  attempts: ATTEMPTS,
+  backoff: { type: 'exponential', delay: BACKOFF_DELAY_MS },
+  removeOnComplete: { count: REMOVE_KEEP_COUNT },
+  removeOnFail: { count: REMOVE_KEEP_COUNT },
+};
+
+function resolveRedisUrl(): string | null {
+  const url = process.env['REDIS_URL'];
+  if (url !== undefined && url.length > 0) return url;
+  const host = process.env['REDIS_HOST'];
+  if (host === undefined || host.length === 0) return null;
+  return `redis://${host}:${process.env['REDIS_PORT'] ?? '6379'}`;
+}
+
+let queueSingleton: Queue<EmbeddingJobData> | null = null;
+let redisDisabled = false;
+
+/** Lazy embeddings-queue singleton. Returns `null` when Redis is unconfigured. */
+export function getEmbeddingsQueue(): Queue<EmbeddingJobData> | null {
+  if (redisDisabled) return null;
+  if (queueSingleton !== null) return queueSingleton;
+  const redisUrl = resolveRedisUrl();
+  if (redisUrl === null) {
+    redisDisabled = true;
+    return null;
+  }
+  const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
+  queueSingleton = new Queue<EmbeddingJobData>(EMBEDDINGS_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: EMBEDDINGS_JOB_OPTIONS,
+  });
+  return queueSingleton;
+}
+
+/** Accessor signature so tests can inject a `() => null` (no-Redis) producer. */
+export type EmbeddingsQueueAccessor = () => Queue<EmbeddingJobData> | null;
+
+export async function closeCerebrumEmbeddingsQueue(): Promise<void> {
+  await queueSingleton?.close();
+  queueSingleton = null;
+  redisDisabled = false;
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/service.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/service.ts
@@ -1,0 +1,159 @@
+/**
+ * IndexService — request-scoped orchestration for the `cerebrum.index.*` procs.
+ *
+ * Stateless and DB-bound (docker-net trust, no per-request auth). Owns the four
+ * index operations:
+ *
+ *  - `status`     — watcher health (reads the opt-in watcher singleton) +
+ *                   embeddings-queue pending count (`null` when no Redis).
+ *  - `reindex`    — full fs→index rebuild via the engrams `reindex` handler;
+ *                   `force` additionally re-enqueues embeddings for every
+ *                   indexed engram (soft-skipped when the queue is null).
+ *  - `reindexSources` — cross-source scan over peer pillars, enqueueing changed
+ *                   rows (`enqueued: 0` for an absent peer or null queue).
+ *  - `reconcile`  — diff disk vs. index, surfacing `missing` / `orphaned`;
+ *                   applied unless `dryRun`.
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { type CerebrumDb, engramIndex } from '../../../db/index.js';
+import { CROSS_SOURCE_TYPES, CrossSourceIndexer, type CrossSourceType } from './cross-source.js';
+import { EmbeddingTrigger } from './embedding-trigger.js';
+import { getThalamusWatcher } from './instance.js';
+import { EMBEDDINGS_QUEUE_NAME, type EmbeddingsQueueAccessor } from './queue.js';
+import { FrontmatterSyncService } from './sync.js';
+
+import type { EngramService } from '../engrams/service.js';
+import type { PeerClients } from '../retrieval/peer-clients.js';
+
+export interface IndexServiceDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  engramService: EngramService;
+  peers: PeerClients;
+  queueAccessor: EmbeddingsQueueAccessor;
+}
+
+export interface WatcherHealthWire {
+  watching: boolean;
+  lastEventAt: string | null;
+  watchedPaths: number;
+}
+
+export interface IndexStatus {
+  watcher: WatcherHealthWire;
+  embeddingsQueue: { name: string; pendingCount: number | null };
+}
+
+export interface ReindexResult {
+  indexed: number;
+  enqueued: number;
+}
+
+export interface ReindexSourcesResult {
+  enqueued: number;
+  sourceTypes: CrossSourceType[];
+}
+
+export interface ReconcileResult {
+  missing: string[];
+  orphaned: string[];
+  dryRun: boolean;
+}
+
+export class IndexService {
+  constructor(private readonly deps: IndexServiceDeps) {}
+
+  async status(): Promise<IndexStatus> {
+    const watcherHealth = getThalamusWatcher()?.health() ?? {
+      watching: false,
+      lastEventAt: null,
+      watchedPaths: 0,
+    };
+
+    let pendingCount: number | null = null;
+    const queue = this.deps.queueAccessor();
+    if (queue) {
+      try {
+        const counts = await queue.getJobCounts('waiting', 'active', 'delayed');
+        pendingCount =
+          (counts['waiting'] ?? 0) + (counts['active'] ?? 0) + (counts['delayed'] ?? 0);
+      } catch {
+        pendingCount = null;
+      }
+    }
+
+    return {
+      watcher: watcherHealth,
+      embeddingsQueue: { name: EMBEDDINGS_QUEUE_NAME, pendingCount },
+    };
+  }
+
+  async reindex(force: boolean): Promise<ReindexResult> {
+    const { indexed } = this.deps.engramService.reindex();
+    if (!force) return { indexed, enqueued: 0 };
+
+    const sync = new FrontmatterSyncService(this.deps.engramRoot, this.deps.db);
+    const trigger = new EmbeddingTrigger(this.deps.queueAccessor);
+    const rows = this.deps.db.select({ filePath: engramIndex.filePath }).from(engramIndex).all();
+    const syncResults = rows.map((row) => sync.syncFile(row.filePath));
+    const triggerResults = await trigger.trigger(syncResults, true);
+    const enqueued = triggerResults.filter((r) => r.action === 'enqueued').length;
+    return { indexed, enqueued };
+  }
+
+  async reindexSources(sourceTypes?: string[]): Promise<ReindexSourcesResult> {
+    const validTypes = (sourceTypes ?? [...CROSS_SOURCE_TYPES]).filter((t): t is CrossSourceType =>
+      (CROSS_SOURCE_TYPES as readonly string[]).includes(t)
+    );
+    const indexer = new CrossSourceIndexer({
+      db: this.deps.db,
+      peers: this.deps.peers,
+      queueAccessor: this.deps.queueAccessor,
+    });
+    const { enqueued } = await indexer.scanAndEnqueue(validTypes);
+    return { enqueued, sourceTypes: validTypes };
+  }
+
+  reconcile(dryRun: boolean): ReconcileResult {
+    const root = this.deps.engramRoot;
+    if (!existsSync(root)) return { missing: [], orphaned: [], dryRun };
+
+    const diskPaths = collectDiskPaths(root);
+    const indexedRows = this.deps.db
+      .select({ filePath: engramIndex.filePath, status: engramIndex.status })
+      .from(engramIndex)
+      .all();
+    const indexedPaths = new Map(indexedRows.map((r) => [r.filePath, r.status]));
+
+    const missing = [...diskPaths].filter((p) => !indexedPaths.has(p));
+    const orphaned = [...indexedPaths.entries()]
+      .filter(([p, status]) => !diskPaths.has(p) && status !== 'orphaned')
+      .map(([p]) => p);
+
+    if (!dryRun && (missing.length > 0 || orphaned.length > 0)) {
+      const sync = new FrontmatterSyncService(root, this.deps.db);
+      for (const relPath of missing) sync.syncFile(relPath);
+      for (const relPath of orphaned) sync.markOrphaned(relPath);
+    }
+
+    return { missing, orphaned, dryRun };
+  }
+}
+
+function collectDiskPaths(root: string): Set<string> {
+  const diskPaths = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith('.')) continue;
+        walk(join(dir, entry.name));
+      } else if (entry.name.endsWith('.md')) {
+        diskPaths.add(relative(root, join(dir, entry.name)).replaceAll('\\', '/'));
+      }
+    }
+  };
+  walk(root);
+  return diskPaths;
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/sync-junctions.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/sync-junctions.ts
@@ -1,0 +1,75 @@
+/**
+ * Junction-table sync helpers for the engram index.
+ *
+ * Each function diffs the current rows for an engram against the desired set
+ * and applies the minimal insert/delete pair inside the caller's transaction,
+ * so a re-sync of an unchanged engram touches no rows.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { type CerebrumDb, engramLinks, engramScopes, engramTags } from '../../../db/index.js';
+
+type Tx = Parameters<Parameters<CerebrumDb['transaction']>[0]>[0];
+
+export function syncEngramScopes(tx: Tx, engramId: string, newScopes: string[]): void {
+  const currentScopes = tx
+    .select({ scope: engramScopes.scope })
+    .from(engramScopes)
+    .where(eq(engramScopes.engramId, engramId))
+    .all()
+    .map((r) => r.scope);
+  const scopesToDelete = currentScopes.filter((s) => !newScopes.includes(s));
+  const scopesToAdd = newScopes.filter((s) => !currentScopes.includes(s));
+  if (scopesToDelete.length > 0) {
+    tx.delete(engramScopes)
+      .where(and(eq(engramScopes.engramId, engramId), inArray(engramScopes.scope, scopesToDelete)))
+      .run();
+  }
+  if (scopesToAdd.length > 0) {
+    tx.insert(engramScopes)
+      .values(scopesToAdd.map((scope) => ({ engramId, scope })))
+      .run();
+  }
+}
+
+export function syncEngramTags(tx: Tx, engramId: string, newTags: string[]): void {
+  const currentTags = tx
+    .select({ tag: engramTags.tag })
+    .from(engramTags)
+    .where(eq(engramTags.engramId, engramId))
+    .all()
+    .map((r) => r.tag);
+  const tagsToDelete = currentTags.filter((t) => !newTags.includes(t));
+  const tagsToAdd = newTags.filter((t) => !currentTags.includes(t));
+  if (tagsToDelete.length > 0) {
+    tx.delete(engramTags)
+      .where(and(eq(engramTags.engramId, engramId), inArray(engramTags.tag, tagsToDelete)))
+      .run();
+  }
+  if (tagsToAdd.length > 0) {
+    tx.insert(engramTags)
+      .values(tagsToAdd.map((tag) => ({ engramId, tag })))
+      .run();
+  }
+}
+
+export function syncEngramLinks(tx: Tx, engramId: string, newLinks: string[]): void {
+  const currentLinks = tx
+    .select({ targetId: engramLinks.targetId })
+    .from(engramLinks)
+    .where(eq(engramLinks.sourceId, engramId))
+    .all()
+    .map((r) => r.targetId);
+  const linksToDelete = currentLinks.filter((l) => !newLinks.includes(l));
+  const linksToAdd = newLinks.filter((l) => !currentLinks.includes(l));
+  if (linksToDelete.length > 0) {
+    tx.delete(engramLinks)
+      .where(and(eq(engramLinks.sourceId, engramId), inArray(engramLinks.targetId, linksToDelete)))
+      .run();
+  }
+  if (linksToAdd.length > 0) {
+    tx.insert(engramLinks)
+      .values(linksToAdd.map((targetId) => ({ sourceId: engramId, targetId })))
+      .run();
+  }
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/sync.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/sync.ts
@@ -1,0 +1,212 @@
+/**
+ * FrontmatterSyncService — reads an engram file from disk, parses its
+ * frontmatter, and upserts the index + junction tables atomically.
+ *
+ * The on-disk Markdown is the source of truth; this service keeps the SQLite
+ * index in step with a single file's frontmatter without the full-rebuild
+ * `reindexEngrams` does. `reconcile` / `reindex --force` drive it per-path.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+
+import { type CerebrumDb, engramIndex } from '../../../db/index.js';
+import { countWords, deriveTitle, parseEngramFile } from '../engrams/file.js';
+import { syncEngramLinks, syncEngramScopes, syncEngramTags } from './sync-junctions.js';
+
+export interface SyncResult {
+  filePath: string;
+  status: 'synced' | 'orphaned' | 'error';
+  engramId?: string;
+  contentHash?: string;
+  previousContentHash?: string;
+  wordCount?: number;
+  bodyText?: string;
+  error?: string;
+}
+
+const KNOWN_FRONTMATTER_KEYS = new Set<string>([
+  'id',
+  'type',
+  'scopes',
+  'created',
+  'modified',
+  'source',
+  'tags',
+  'links',
+  'status',
+  'template',
+]);
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function dedupe<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+function readFileContent(absPath: string): { content: string } | { error: string } {
+  if (!existsSync(absPath)) return { error: 'file not found' };
+  try {
+    return { content: readFileSync(absPath, 'utf8') };
+  } catch (err) {
+    return { error: (err as Error).message };
+  }
+}
+
+function extractCustomFields(frontmatter: Record<string, unknown>): Record<string, unknown> {
+  const customFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (!KNOWN_FRONTMATTER_KEYS.has(key)) customFields[key] = value;
+  }
+  return customFields;
+}
+
+interface IndexValues {
+  id: string;
+  filePath: string;
+  type: string;
+  source: string;
+  status: string;
+  template: string | null;
+  createdAt: string;
+  modifiedAt: string;
+  title: string;
+  contentHash: string;
+  bodyHash: string;
+  wordCount: number;
+  customFields: string | null;
+}
+
+function upsertIndexRow(
+  tx: Parameters<Parameters<CerebrumDb['transaction']>[0]>[0],
+  values: IndexValues
+): void {
+  tx.insert(engramIndex)
+    .values(values)
+    .onConflictDoUpdate({
+      target: engramIndex.id,
+      set: {
+        filePath: values.filePath,
+        type: values.type,
+        source: values.source,
+        status: values.status,
+        template: values.template,
+        modifiedAt: values.modifiedAt,
+        title: values.title,
+        contentHash: values.contentHash,
+        bodyHash: values.bodyHash,
+        wordCount: values.wordCount,
+        customFields: values.customFields,
+      },
+    })
+    .run();
+}
+
+export class FrontmatterSyncService {
+  constructor(
+    private readonly root: string,
+    private readonly db: CerebrumDb
+  ) {}
+
+  /**
+   * Process a batch of watch events. `delete` events mark the entry orphaned;
+   * `create` and `modify` events attempt a full sync.
+   */
+  processEvents(
+    events: { type: 'create' | 'modify' | 'delete'; filePath: string }[]
+  ): SyncResult[] {
+    const results: SyncResult[] = [];
+    for (const event of events) {
+      if (event.type === 'delete') {
+        this.markOrphaned(event.filePath);
+        results.push({ filePath: event.filePath, status: 'orphaned' });
+      } else {
+        results.push(this.syncFile(event.filePath));
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Sync a single file: read → parse → upsert index + junction tables.
+   */
+  syncFile(relPath: string): SyncResult {
+    const absPath = join(this.root, relPath);
+    const read = readFileContent(absPath);
+    if ('error' in read) return { filePath: relPath, status: 'error', error: read.error };
+
+    let parsed: ReturnType<typeof parseEngramFile>;
+    try {
+      parsed = parseEngramFile(read.content);
+    } catch (err) {
+      return { filePath: relPath, status: 'error', error: (err as Error).message };
+    }
+
+    const { frontmatter, body } = parsed;
+    const contentHash = sha256(read.content);
+    const wordCount = countWords(body);
+    const customFields = extractCustomFields(frontmatter as Record<string, unknown>);
+
+    const [existing] = this.db
+      .select({ contentHash: engramIndex.contentHash })
+      .from(engramIndex)
+      .where(eq(engramIndex.id, frontmatter.id))
+      .all();
+    const previousContentHash = existing?.contentHash ?? null;
+
+    const indexValues: IndexValues = {
+      id: frontmatter.id,
+      filePath: relPath,
+      type: frontmatter.type,
+      source: frontmatter.source,
+      status: frontmatter.status,
+      template: frontmatter.template ?? null,
+      createdAt: frontmatter.created,
+      modifiedAt: frontmatter.modified,
+      title: deriveTitle(body),
+      contentHash,
+      bodyHash: sha256(body),
+      wordCount,
+      customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+    };
+
+    this.db.transaction((tx) => {
+      upsertIndexRow(tx, indexValues);
+      syncEngramScopes(tx, frontmatter.id, dedupe(frontmatter.scopes));
+      syncEngramTags(tx, frontmatter.id, dedupe(frontmatter.tags ?? []));
+      syncEngramLinks(tx, frontmatter.id, dedupe(frontmatter.links ?? []));
+    });
+
+    return {
+      filePath: relPath,
+      status: 'synced',
+      engramId: frontmatter.id,
+      contentHash,
+      previousContentHash: previousContentHash ?? undefined,
+      wordCount,
+      bodyText: body,
+    };
+  }
+
+  /**
+   * Mark an indexed engram as orphaned (file was deleted from disk).
+   */
+  markOrphaned(relPath: string): void {
+    const rows = this.db
+      .update(engramIndex)
+      .set({ status: 'orphaned' })
+      .where(eq(engramIndex.filePath, relPath))
+      .returning({ id: engramIndex.id })
+      .all();
+
+    if (rows.length > 0) {
+      console.warn(
+        `[thalamus] Engram orphaned (file deleted): ${relPath} (id: ${rows[0]?.id ?? 'unknown'})`
+      );
+    }
+  }
+}

--- a/pillars/cerebrum/src/api/modules/thalamus/watcher.ts
+++ b/pillars/cerebrum/src/api/modules/thalamus/watcher.ts
@@ -1,0 +1,220 @@
+/**
+ * FileWatcherService — watches the engram root directory with chokidar and
+ * emits debounced `WatchEvent` batches so the sync pipeline can index changes
+ * incrementally without hammering the DB on every keystroke.
+ *
+ * Opt-in: started only by `instance.ts` when `CEREBRUM_INDEX_WATCH=true`. Tests
+ * never start a watcher; `index.status` reports `watching: false` when none is
+ * running. The `reindex` / `reconcile` procs operate on the engram root + index
+ * directly and do NOT require a live watcher.
+ *
+ * Reconciliation: on the `ready` event (after chokidar's initial scan) the
+ * service compares discovered paths to the `existingPaths` set provided by the
+ * caller. Any file present on disk but absent from the index gets a synthetic
+ * `create` event so it can be caught up.
+ */
+import EventEmitter from 'node:events';
+import { relative } from 'node:path';
+
+import { watch as chokidarWatch, type FSWatcher } from 'chokidar';
+
+export type WatchEventType = 'create' | 'modify' | 'delete';
+
+export interface WatchEvent {
+  type: WatchEventType;
+  filePath: string;
+}
+
+export interface WatcherHealth {
+  watching: boolean;
+  lastEventAt: string | null;
+  watchedPaths: number;
+}
+
+const EMFILE_POLL_INTERVAL_MS = 60_000;
+
+export class FileWatcherService extends EventEmitter {
+  private watcher: FSWatcher | null = null;
+  private readonly pendingEventTypes = new Map<string, WatchEventType>();
+  private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private lastEventAt: string | null = null;
+  private readonly root: string;
+  private readonly debounceMs: number;
+  private readonly discoveredPaths = new Set<string>();
+  private ready = false;
+
+  constructor(root: string, debounceMs = 500) {
+    super();
+    this.root = root;
+    this.debounceMs = debounceMs;
+  }
+
+  /**
+   * Start watching the root directory.
+   *
+   * @param existingPaths Relative paths currently indexed (used for
+   *   reconciliation: files on disk but not in this set get a `create` event).
+   */
+  start(existingPaths: Set<string>): void {
+    if (this.watcher) return;
+
+    const watchOptions: Parameters<typeof chokidarWatch>[1] = {
+      ignored: /(^|[/\\])\../,
+      persistent: true,
+      ignoreInitial: false,
+      awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+      usePolling: false,
+    };
+
+    let watcher: FSWatcher;
+    try {
+      watcher = chokidarWatch(this.root, watchOptions);
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    this.attachErrorHandler(watcher, watchOptions, existingPaths);
+    this.watcher = watcher;
+    this.attachHandlers(watcher, existingPaths);
+  }
+
+  /** Stop the watcher and clear all pending timers. */
+  async stop(): Promise<void> {
+    for (const timer of this.debounceTimers.values()) clearTimeout(timer);
+    this.debounceTimers.clear();
+    this.pendingEventTypes.clear();
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.ready = false;
+    this.discoveredPaths.clear();
+  }
+
+  health(): WatcherHealth {
+    const watchedPaths = this.watcher
+      ? Object.keys(this.watcher.getWatched()).reduce(
+          (sum, dir) => sum + (this.watcher?.getWatched()[dir]?.length ?? 0),
+          0
+        )
+      : 0;
+    return {
+      watching: this.watcher !== null,
+      lastEventAt: this.lastEventAt,
+      watchedPaths,
+    };
+  }
+
+  private attachErrorHandler(
+    w: FSWatcher,
+    watchOptions: Parameters<typeof chokidarWatch>[1],
+    existingPaths: Set<string>
+  ): void {
+    w.on('error', (err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if ((error as NodeJS.ErrnoException).code === 'EMFILE') {
+        console.error(
+          '[thalamus] EMFILE: too many open files — falling back to polling (interval: 60s)'
+        );
+        void w.close().then(() => {
+          this.watcher = null;
+          const pollingOptions = {
+            ...watchOptions,
+            usePolling: true,
+            interval: EMFILE_POLL_INTERVAL_MS,
+          };
+          const pollingWatcher = chokidarWatch(this.root, pollingOptions);
+          this.watcher = pollingWatcher;
+          this.attachErrorHandler(pollingWatcher, watchOptions, existingPaths);
+          this.attachHandlers(pollingWatcher, existingPaths);
+        });
+      } else {
+        this.emit('error', error);
+      }
+    });
+  }
+
+  private attachHandlers(watcher: FSWatcher, existingPaths: Set<string>): void {
+    watcher.on('add', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (!rel) return;
+      if (!this.ready) {
+        this.discoveredPaths.add(rel);
+      } else {
+        this.scheduleEvent(rel, 'create');
+      }
+    });
+
+    watcher.on('change', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (rel) this.scheduleEvent(rel, 'modify');
+    });
+
+    watcher.on('unlink', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (rel) this.scheduleEvent(rel, 'delete');
+    });
+
+    watcher.on('ready', () => {
+      this.ready = true;
+      this.reconcile(existingPaths);
+    });
+  }
+
+  private reconcile(existingPaths: Set<string>): void {
+    const toCreate = [...this.discoveredPaths].filter((p) => !existingPaths.has(p));
+    this.discoveredPaths.clear();
+
+    if (toCreate.length === 0) {
+      this.emit('reconciled');
+      return;
+    }
+
+    const BATCH = 100;
+    let offset = 0;
+
+    const flush = (): void => {
+      const slice = toCreate.slice(offset, offset + BATCH);
+      offset += BATCH;
+      for (const rel of slice) this.scheduleEvent(rel, 'create');
+      if (offset < toCreate.length) {
+        setImmediate(flush);
+      } else {
+        this.emit('reconciled');
+      }
+    };
+
+    setImmediate(flush);
+  }
+
+  private scheduleEvent(relPath: string, type: WatchEventType): void {
+    const current = this.pendingEventTypes.get(relPath);
+    if (current !== 'delete' && (type === 'delete' || current === undefined || type === 'create')) {
+      this.pendingEventTypes.set(relPath, type);
+    }
+    this.lastEventAt = new Date().toISOString();
+
+    const existing = this.debounceTimers.get(relPath);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(relPath);
+      const resolvedType = this.pendingEventTypes.get(relPath);
+      this.pendingEventTypes.delete(relPath);
+      if (resolvedType) {
+        this.emit('batch', [{ type: resolvedType, filePath: relPath }]);
+      }
+    }, this.debounceMs);
+
+    this.debounceTimers.set(relPath, timer);
+  }
+
+  /** Convert an absolute path to a root-relative forward-slash path. Only .md files pass. */
+  private toRel(absPath: string): string | null {
+    if (!absPath.endsWith('.md')) return null;
+    const rel = relative(this.root, absPath).replaceAll('\\', '/');
+    if (rel.startsWith('..') || rel.startsWith('.')) return null;
+    return rel;
+  }
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -16,11 +16,13 @@ import { resolveGliaConfigPath } from '../modules/glia/instance.js';
 import { AnthropicIngestLlm } from '../modules/ingest/llm.js';
 import { getCurationQueue } from '../modules/ingest/queue.js';
 import { AnthropicQueryLlm, AnthropicQueryStreamLlm } from '../modules/query/llm.js';
+import { getEmbeddingsQueue } from '../modules/thalamus/queue.js';
 import { AnthropicContradictionDetector } from '../modules/workers/llm.js';
 import { makeEgoHandlers } from './ego-handlers.js';
 import { makeEmitHandlers } from './emit-handlers.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
 import { makeGliaHandlers } from './glia-handlers.js';
+import { makeIndexHandlers } from './index-handlers.js';
 import { makeIngestHandlers } from './ingest-handlers.js';
 import { makeNudgesHandlers } from './nudges-handlers.js';
 import { makePlexusHandlers } from './plexus-handlers.js';
@@ -65,6 +67,11 @@ export function makeCerebrumRestHandlers(
       ...engramDeps,
       llm: deps.ingestLlm ?? new AnthropicIngestLlm(),
       curationQueue: deps.curationQueue ?? getCurationQueue,
+    }),
+    index: makeIndexHandlers({
+      ...engramDeps,
+      peers: deps.peerClients,
+      queueAccessor: deps.embeddingsQueue ?? getEmbeddingsQueue,
     }),
     emit: makeEmitHandlers({ ...base, llm: deps.emitLlm ?? new AnthropicGenerationLlm() }),
     query: makeQueryHandlers({

--- a/pillars/cerebrum/src/api/rest/index-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/index-handlers.ts
@@ -1,0 +1,72 @@
+/**
+ * ts-rest handlers for `cerebrum.index.*` (thalamus).
+ *
+ * Each handler builds a request-scoped {@link IndexService} bound to the pillar
+ * DB handle, engram root, a fresh {@link EngramService} (for the fs→index
+ * rebuild), the injected peer clients (cross-source scan), and the
+ * embeddings-queue accessor, then delegates. The service is stateless and never
+ * throws domain `HttpError`s, so the responses are plain 200 envelopes.
+ *
+ * Queue null path (no Redis): `status.embeddingsQueue.pendingCount` is `null`;
+ * `reindex` / `reindexSources` still run their non-enqueue work and report
+ * `enqueued: 0` — a missing producer is soft, never a 503.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumIndexContract } from '../../contract/rest-index.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { EngramService } from '../modules/engrams/service.js';
+import { IndexService } from '../modules/thalamus/service.js';
+
+import type { PeerClients } from '../modules/retrieval/peer-clients.js';
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+import type { EmbeddingsQueueAccessor } from '../modules/thalamus/queue.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export interface IndexHandlerDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  peers: PeerClients;
+  queueAccessor: EmbeddingsQueueAccessor;
+}
+
+export function makeIndexHandlers(
+  deps: IndexHandlerDeps
+): ReturnType<typeof server.router<typeof cerebrumIndexContract>> {
+  const service = (): IndexService =>
+    new IndexService({
+      db: deps.db,
+      engramRoot: deps.engramRoot,
+      engramService: new EngramService({
+        root: deps.engramRoot,
+        db: deps.db,
+        templates: deps.templates,
+      }),
+      peers: deps.peers,
+      queueAccessor: deps.queueAccessor,
+    });
+
+  return server.router(cerebrumIndexContract, {
+    status: async () => {
+      const body = await service().status();
+      return { status: 200 as const, body };
+    },
+
+    reindex: async ({ body }) => {
+      const result = await service().reindex(body.force ?? false);
+      return { status: 200 as const, body: result };
+    },
+
+    reindexSources: async ({ body }) => {
+      const result = await service().reindexSources(body.sourceTypes);
+      return { status: 200 as const, body: result };
+    },
+
+    reconcile: async ({ body }) => {
+      const result = service().reconcile(body.dryRun ?? false);
+      return { status: 200 as const, body: result };
+    },
+  });
+}

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -30,6 +30,8 @@ import { getReflexService } from './modules/reflex/instance.js';
 import { resolveEmbeddingClientFromEnv } from './modules/retrieval/embedding-client.js';
 import { resolvePeerClientsFromEnv } from './modules/retrieval/peer-clients.js';
 import { TemplateRegistry } from './modules/templates/registry.js';
+import { startThalamusWatcher, stopThalamusWatcher } from './modules/thalamus/instance.js';
+import { closeCerebrumEmbeddingsQueue, getEmbeddingsQueue } from './modules/thalamus/queue.js';
 import { AnthropicContradictionDetector } from './modules/workers/llm.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -78,6 +80,7 @@ const app = createCerebrumApiApp({
   egoLlm: new AnthropicEgoLlm(),
   auditorContradictionDetector: new AnthropicContradictionDetector(),
   curationQueue: getCurationQueue,
+  embeddingsQueue: getEmbeddingsQueue,
   version,
   selfBaseUrl,
   peerClients: resolvePeerClientsFromEnv(),
@@ -86,6 +89,8 @@ const app = createCerebrumApiApp({
   queryLlm: new AnthropicQueryLlm(),
   queryStreamLlm: new AnthropicQueryStreamLlm(),
 });
+
+startThalamusWatcher({ db: cerebrumDb.db, engramRoot, queueAccessor: getEmbeddingsQueue });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
@@ -105,7 +110,9 @@ function shutdown(signal: NodeJS.Signals): void {
   shuttingDown = true;
   console.warn(`[cerebrum-api] Shutting down (${signal})`);
   void (pillarHandle?.stop() ?? Promise.resolve())
+    .then(() => stopThalamusWatcher())
     .then(() => closeCerebrumIngestQueue())
+    .then(() => closeCerebrumEmbeddingsQueue())
     .finally(() => {
       server.close(() => {
         cerebrumDb.raw.close();

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -584,6 +584,74 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/index/reconcile': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Diff disk against the index; apply unless dryRun. */
+    post: operations['index.reconcile'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/index/reindex': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Rebuild the engram index from disk; force re-enqueues embeddings. */
+    post: operations['index.reindex'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/index/reindex-sources': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Scan peer pillars and enqueue embeddings for changed source rows. */
+    post: operations['index.reindexSources'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/index/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Watcher health + embeddings-queue pending count. */
+    get: operations['index.status'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/ingest/classify': {
     parameters: {
       query?: never;
@@ -3501,6 +3569,166 @@ export interface operations {
             }[];
             processed: number;
             skipped: number;
+          };
+        };
+      };
+    };
+  };
+  'index.reconcile': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dryRun?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            dryRun: boolean;
+            missing: string[];
+            orphaned: string[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'index.reindex': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          force?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            enqueued: number;
+            indexed: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'index.reindexSources': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceTypes?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            enqueued: number;
+            sourceTypes: string[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'index.status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            embeddingsQueue: {
+              name: string;
+              pendingCount: number | null;
+            };
+            watcher: {
+              lastEventAt: string | null;
+              watchedPaths: number;
+              watching: boolean;
+            };
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-index-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-index-schemas.ts
@@ -1,0 +1,57 @@
+/**
+ * Index (thalamus) wire schemas.
+ *
+ * PURE zod module — no ts-rest, no Express. Imported by BOTH the index contract
+ * (`rest-index.ts`) and the test client so the request/response shapes have a
+ * single source of truth (mirrors the ingest split). The `cerebrum.index.*`
+ * domain drives watcher health, on-demand reindex, cross-source re-embedding,
+ * and reconciliation dry-runs — all on the docker-net trust boundary.
+ */
+import { z } from 'zod';
+
+export const indexStatusResponseSchema = z.object({
+  watcher: z.object({
+    watching: z.boolean(),
+    lastEventAt: z.string().nullable(),
+    watchedPaths: z.number().int().nonnegative(),
+  }),
+  embeddingsQueue: z.object({
+    name: z.string(),
+    pendingCount: z.number().int().nonnegative().nullable(),
+  }),
+});
+export type IndexStatusResponseWire = z.infer<typeof indexStatusResponseSchema>;
+
+export const indexReindexBodySchema = z.object({
+  force: z.boolean().optional(),
+});
+export type IndexReindexBody = z.infer<typeof indexReindexBodySchema>;
+
+export const indexReindexResponseSchema = z.object({
+  indexed: z.number().int().nonnegative(),
+  enqueued: z.number().int().nonnegative(),
+});
+export type IndexReindexResponseWire = z.infer<typeof indexReindexResponseSchema>;
+
+export const indexReindexSourcesBodySchema = z.object({
+  sourceTypes: z.array(z.string().min(1)).optional(),
+});
+export type IndexReindexSourcesBody = z.infer<typeof indexReindexSourcesBodySchema>;
+
+export const indexReindexSourcesResponseSchema = z.object({
+  enqueued: z.number().int().nonnegative(),
+  sourceTypes: z.array(z.string()),
+});
+export type IndexReindexSourcesResponseWire = z.infer<typeof indexReindexSourcesResponseSchema>;
+
+export const indexReconcileBodySchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+export type IndexReconcileBody = z.infer<typeof indexReconcileBodySchema>;
+
+export const indexReconcileResponseSchema = z.object({
+  missing: z.array(z.string()),
+  orphaned: z.array(z.string()),
+  dryRun: z.boolean(),
+});
+export type IndexReconcileResponseWire = z.infer<typeof indexReconcileResponseSchema>;

--- a/pillars/cerebrum/src/contract/rest-index.ts
+++ b/pillars/cerebrum/src/contract/rest-index.ts
@@ -1,0 +1,72 @@
+/**
+ * ts-rest contract for `cerebrum.index.*` (thalamus).
+ *
+ * The engram-index maintenance surface: watcher health (`status`), full
+ * fs→index reindex (`reindex`), cross-source re-embedding over peer pillars
+ * (`reindexSources`), and disk↔index reconciliation (`reconcile`). Non-identity
+ * domain — served on the docker-network trust boundary with no per-request
+ * auth (parity with engrams / ingest). The mutations are queue- and peer-heavy;
+ * the container injects the embeddings-queue accessor + peer clients in
+ * `server.ts` and fakes/no-Redis in tests.
+ *
+ * `status` is the only GET (no body); the three mutations carry typed bodies.
+ * Wire schemas live in the pure `rest-index-schemas.ts` so the contract and the
+ * lifted service share one source of truth.
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  indexReconcileBodySchema,
+  indexReconcileResponseSchema,
+  indexReindexBodySchema,
+  indexReindexResponseSchema,
+  indexReindexSourcesBodySchema,
+  indexReindexSourcesResponseSchema,
+  indexStatusResponseSchema,
+} from './rest-index-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const cerebrumIndexContract = c.router({
+  status: {
+    method: 'GET',
+    path: '/index/status',
+    summary: 'Watcher health + embeddings-queue pending count.',
+    responses: {
+      200: indexStatusResponseSchema,
+    },
+  },
+  reindex: {
+    method: 'POST',
+    path: '/index/reindex',
+    summary: 'Rebuild the engram index from disk; force re-enqueues embeddings.',
+    body: indexReindexBodySchema,
+    responses: {
+      200: indexReindexResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  reindexSources: {
+    method: 'POST',
+    path: '/index/reindex-sources',
+    summary: 'Scan peer pillars and enqueue embeddings for changed source rows.',
+    body: indexReindexSourcesBodySchema,
+    responses: {
+      200: indexReindexSourcesResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+  reconcile: {
+    method: 'POST',
+    path: '/index/reconcile',
+    summary: 'Diff disk against the index; apply unless dryRun.',
+    body: indexReconcileBodySchema,
+    responses: {
+      200: indexReconcileResponseSchema,
+      400: errorBodySchema,
+    },
+  },
+});
+
+export type CerebrumIndexContract = typeof cerebrumIndexContract;

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -16,6 +16,7 @@ import { cerebrumEgoContract } from './rest-ego.js';
 import { cerebrumEmitContract } from './rest-emit.js';
 import { cerebrumEngramsContract } from './rest-engrams.js';
 import { cerebrumGliaContract } from './rest-glia.js';
+import { cerebrumIndexContract } from './rest-index.js';
 import { cerebrumIngestContract } from './rest-ingest.js';
 import { cerebrumNudgesContract } from './rest-nudges.js';
 import { cerebrumPlexusContract } from './rest-plexus.js';
@@ -40,6 +41,7 @@ export const cerebrumContract = c.router(
     glia: cerebrumGliaContract,
     nudges: cerebrumNudgesContract,
     ingest: cerebrumIngestContract,
+    index: cerebrumIndexContract,
     retrieval: cerebrumRetrievalContract,
     ego: cerebrumEgoContract,
     workers: cerebrumWorkersContract,


### PR DESCRIPTION
## Summary

Implements the **thalamus** (`cerebrum.index.*`) slice, completing the cerebrum REST-migration domain surface. Four `protectedProcedure`-equivalent procs on the docker-net trust boundary, served under `/index/*`, plus the lifted embeddings indexer machinery.

| proc | route | behaviour |
| --- | --- | --- |
| `index.status` | `GET /index/status` | watcher health + embeddings-queue pending count |
| `index.reindex` | `POST /index/reindex` | full fs→index rebuild; `force` re-enqueues embeddings |
| `index.reindexSources` | `POST /index/reindex-sources` | cross-source scan over peer pillars → enqueue changed rows |
| `index.reconcile` | `POST /index/reconcile` | diff disk vs index (`missing`/`orphaned`); applied unless `dryRun` |

Lifted into `src/api/modules/thalamus/`: `sync.ts` + `sync-junctions.ts` (engram fs→index upsert), `embedding-trigger.ts`, `watcher.ts` (chokidar), `instance.ts` (opt-in watcher singleton), `cross-source.ts` (CrossSourceIndexer), `service.ts` (proc orchestration), `queue.ts` (lazy `pops-embeddings` producer), `chunker.ts` (pillar-local). Wired into `rest.ts`, `rest/handlers.ts`, `handlers.ts` deps, `server.ts` (watcher start + queue close), and the `test-utils.ts` client.

## Deviations / notes

- **Peer LIST endpoints** — `reindexSources` no longer reads `@pops/{finance,media,inventory}-db` directly. The retrieval peer-clients were extended with paginated LIST methods (`listTransactions` / `listMovies` / `listTvShows` / `listItems`), each hitting the peer's `GET /transactions|/movies|/tv-shows|/items` (all return `{ data, pagination:{…,hasMore} }`). Clients stay injectable; an absent peer (not in `POPS_PILLARS`) yields `undefined` → that source type is skipped (`enqueued: 0`, no crash).
- **Queue null path** — `getEmbeddingsQueue()` returns `null` without `REDIS_URL`/`REDIS_HOST`. Then `status.embeddingsQueue.pendingCount = null`; `reindex --force` / `reindexSources` still run their non-enqueue work and report `enqueued: 0` (soft, no 503). `closeCerebrumEmbeddingsQueue()` runs on server shutdown.
- **Watcher opt-in** — `FileWatcherService` starts only in `server.ts` when `CEREBRUM_INDEX_WATCH=true`. Tests never start it; `status` reports `watching: false`. `reindex` / `reconcile` operate on the engram root + index directly, no live watcher needed.
- No `as any` / `as unknown as T` / suppressions in production code.

## Green proof

- `oxfmt --check pillars/cerebrum/` → clean
- `oxlint pillars/cerebrum/src` → exit 0 (no new errors)
- `pnpm --filter @pops/cerebrum typecheck` → pass
- `pnpm --filter @pops/cerebrum build` → pass
- `generate:openapi` → deterministic; operationIds `index.status` / `index.reindex` / `index.reindexSources` / `index.reconcile`
- `pnpm --filter @pops/cerebrum test` → 40 files, 566 tests pass (14 new in `index.test.ts`)

> Note: a parallel agent edits the same compose/handler files for nudges-write — edits here are additive (new `index:` entries); orchestrator resolves the merge.
