### PR TITLE
feat(media): Phase C — re-wire comparison-staleness reset into watch-history

### DIFF
--- a/pillars/media/src/api/__tests__/watch-history.test.ts
+++ b/pillars/media/src/api/__tests__/watch-history.test.ts
@@ -7,10 +7,8 @@
  * with no episodes), log with watchlist auto-removal (movie + fully-watched
  * show), batch-log season/show expansion with aired-only filtering and
  * already-watched skipping, delete, the 404 mapping, and contract-boundary
- * 400s.
- *
- * The comparison-staleness reset is deferred (comparisons not yet resident in
- * the pillar), so it is intentionally NOT asserted here.
+ * 400s. Also asserts the comparison-staleness reset on completion (movie →
+ * itself, episode → parent show; not reset when `completed = 0`).
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -18,7 +16,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { openMediaDb, type OpenedMediaDb } from '../../db/index.js';
+import { comparisonsService, openMediaDb, type OpenedMediaDb } from '../../db/index.js';
 import { createMediaApiApp } from '../app.js';
 import { makeClient } from './test-utils.js';
 
@@ -362,5 +360,73 @@ describe('watch-history — batch log', () => {
       watchedAt: '2024-10-05T10:00:00.000Z',
     });
     expect(data).toEqual({ logged: 0, skipped: 0 });
+  });
+});
+
+describe('watch-history — comparison staleness reset', () => {
+  it('resets a movie to fresh (1.0) once it is logged as completed', async () => {
+    const movie = await makeMovie();
+    comparisonsService.markStale(mediaDb.db, 'movie', movie.id);
+    expect(comparisonsService.getStaleness(mediaDb.db, 'movie', movie.id)).toBeLessThan(1);
+
+    await client().watchHistory.log({
+      mediaType: 'movie',
+      mediaId: movie.id,
+      watchedAt: '2024-11-01T10:00:00.000Z',
+      completed: 1,
+    });
+
+    expect(comparisonsService.getStaleness(mediaDb.db, 'movie', movie.id)).toBe(1.0);
+  });
+
+  it('resets the parent show (not the episode) when an episode is logged as completed', async () => {
+    const show = await makeShow();
+    const s1 = await makeSeason(show.id, 1);
+    const e1 = await makeEpisode(s1.id, 1, { airDate: PAST });
+
+    comparisonsService.markStale(mediaDb.db, 'tv_show', show.id);
+    comparisonsService.markStale(mediaDb.db, 'episode', e1.id);
+    expect(comparisonsService.getStaleness(mediaDb.db, 'tv_show', show.id)).toBeLessThan(1);
+
+    await client().watchHistory.log({
+      mediaType: 'episode',
+      mediaId: e1.id,
+      watchedAt: '2024-11-02T10:00:00.000Z',
+      completed: 1,
+    });
+
+    expect(comparisonsService.getStaleness(mediaDb.db, 'tv_show', show.id)).toBe(1.0);
+    expect(comparisonsService.getStaleness(mediaDb.db, 'episode', e1.id)).toBeLessThan(1);
+  });
+
+  it('does NOT reset staleness when the watch is logged with completed = 0', async () => {
+    const movie = await makeMovie();
+    const stale = comparisonsService.markStale(mediaDb.db, 'movie', movie.id);
+
+    await client().watchHistory.log({
+      mediaType: 'movie',
+      mediaId: movie.id,
+      watchedAt: '2024-11-03T10:00:00.000Z',
+      completed: 0,
+    });
+
+    expect(comparisonsService.getStaleness(mediaDb.db, 'movie', movie.id)).toBe(stale);
+  });
+
+  it('resets the parent show staleness once after a batch log', async () => {
+    const show = await makeShow();
+    const s1 = await makeSeason(show.id, 1);
+    await makeEpisode(s1.id, 1, { airDate: PAST });
+    await makeEpisode(s1.id, 2, { airDate: PAST });
+    comparisonsService.markStale(mediaDb.db, 'tv_show', show.id);
+    expect(comparisonsService.getStaleness(mediaDb.db, 'tv_show', show.id)).toBeLessThan(1);
+
+    await client().watchHistory.batchLog({
+      mediaType: 'show',
+      mediaId: show.id,
+      watchedAt: '2024-11-04T10:00:00.000Z',
+    });
+
+    expect(comparisonsService.getStaleness(mediaDb.db, 'tv_show', show.id)).toBe(1.0);
   });
 });

--- a/pillars/media/src/db/services/watch-history-batch.ts
+++ b/pillars/media/src/db/services/watch-history-batch.ts
@@ -6,18 +6,15 @@
  *
  * "Aired" means `air_date` is non-null and `<= today` (UTC date). Episodes
  * already completed (when `completed = 1`) and blacklisted episodes for the
- * same `watchedAt` are skipped. On a fully-watched show the watchlist row is
- * deleted and priorities resequenced. The whole thing runs in one
+ * same `watchedAt` are skipped. On a successful batch the parent show's
+ * comparison staleness is reset once; on a fully-watched show the watchlist
+ * row is deleted and priorities resequenced. The whole thing runs in one
  * `db.transaction(...)`.
- *
- * NOTE: the monolith also called `resetStaleness('tv_show', …)` (the
- * comparisons domain) on a successful batch. Comparisons is not resident in
- * this pillar yet — that side effect is deferred until the comparisons domain
- * is ported (wave 3). Everything else is preserved.
  */
 import { and, countDistinct, eq, inArray, isNotNull, lte } from 'drizzle-orm';
 
 import { episodes, mediaWatchlist, seasons, watchHistory } from '../schema.js';
+import { resetStaleness } from './comparisons/staleness.js';
 import { resequencePriorities } from './watchlist.js';
 
 import type { MediaDb } from './internal.js';
@@ -157,6 +154,7 @@ function maybeRemoveCompletedShowFromWatchlist(tx: Tx, tvShowId: number): void {
 function handleShowSideEffects(tx: Tx, input: BatchLogWatchInput): void {
   const tvShowId = resolveTvShowId(tx, input);
   if (tvShowId === undefined) return;
+  resetStaleness(tx, 'tv_show', tvShowId);
   maybeRemoveCompletedShowFromWatchlist(tx, tvShowId);
 }
 

--- a/pillars/media/src/db/services/watch-history-comp-target.ts
+++ b/pillars/media/src/db/services/watch-history-comp-target.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolve the comparison-staleness target for a watched media item.
+ *
+ * Comparison scores live at the comparable granularity: a movie is its own
+ * target, an episode rolls up to its parent TV show (episode → season →
+ * tv_show). The watch-history log/batchLog paths call this on completion to
+ * reset the right item's staleness. HTTP-free, `(db, …)`-arg; ported from the
+ * monolith `watch-history/handlers/log-watch-event.ts#resolveCompTarget`.
+ */
+import { eq } from 'drizzle-orm';
+
+import { episodes, seasons } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+export interface ComparisonTarget {
+  type: string;
+  id: number;
+}
+
+export function resolveComparisonTarget(
+  db: MediaDb,
+  mediaType: string,
+  mediaId: number
+): ComparisonTarget {
+  if (mediaType !== 'episode') return { type: mediaType, id: mediaId };
+
+  const episode = db
+    .select({ seasonId: episodes.seasonId })
+    .from(episodes)
+    .where(eq(episodes.id, mediaId))
+    .get();
+  if (!episode) return { type: mediaType, id: mediaId };
+
+  const season = db
+    .select({ tvShowId: seasons.tvShowId })
+    .from(seasons)
+    .where(eq(seasons.id, episode.seasonId))
+    .get();
+  if (!season) return { type: mediaType, id: mediaId };
+
+  return { type: 'tv_show', id: season.tvShowId };
+}

--- a/pillars/media/src/db/services/watch-history-log.ts
+++ b/pillars/media/src/db/services/watch-history-log.ts
@@ -3,18 +3,15 @@
  *
  * Lifted from the monolith `watch-history/handlers/log-watch-event.ts` +
  * `auto-remove-show.ts` and converted to the pillar's `(db, …)` arg-passing
- * pattern. All media-only writes (watch_history insert, watchlist removal,
- * priority resequence) run inside a single `db.transaction(...)`.
- *
- * NOTE: the monolith also called `resetStaleness(...)` (the comparisons
- * domain) on completion. Comparisons is not resident in this pillar yet —
- * that side effect is deferred until the comparisons domain is ported
- * (wave 3). Everything else (logging + watchlist auto-removal + resequence)
- * is preserved.
+ * pattern. All media-only writes (watch_history insert, comparison-staleness
+ * reset, watchlist removal, priority resequence) run inside a single
+ * `db.transaction(...)`.
  */
 import { and, countDistinct, eq, inArray } from 'drizzle-orm';
 
 import { episodes, mediaWatchlist, seasons, watchHistory } from '../schema.js';
+import { resetStaleness } from './comparisons/staleness.js';
+import { resolveComparisonTarget } from './watch-history-comp-target.js';
 import { resequencePriorities } from './watchlist.js';
 
 import type { MediaDb } from './internal.js';
@@ -167,6 +164,11 @@ function runMediaTx(
       .where(eq(watchHistory.id, Number(result.lastInsertRowid)))
       .get();
     if (!entry) throw new Error('Watch history entry not found after insert');
+
+    if (completed === 1) {
+      const target = resolveComparisonTarget(tx, input.mediaType, input.mediaId);
+      resetStaleness(tx, target.type, target.id);
+    }
 
     let watchlistRemoved = false;
     if (completed === 1 && input.source !== 'plex_sync') {


### PR DESCRIPTION
Phase C (fidelity). Completes the slice-4 deferral now that comparisons is merged: `logWatch`/`batchLogWatch` reset comparison staleness on a completed watch.

- `logWatch` (completed=1): resolve the comparison target (movie→movie; **episode→parent tv_show** via episode→season→tvShow) and `resetStaleness` on the same transaction.
- `batchLogWatch`: reset the parent tv_show once on a completed show/season log.
- new `watch-history-comp-target.ts` (`resolveComparisonTarget`, db-arg, HTTP-free); removes the `NOTE` deferral markers.
- 4 new staleness tests (**407 total**); **no contract/openapi change**.

Verified: typecheck ✓ · build ✓ · 407/407 ✓ · format ✓ · lint exit 0 (`.oxlintrc`/vitest config untouched) ✓ · openapi unchanged ✓. Stacks on #3398.