### PR TITLE
feat(cerebrum): REST migration — embeddings + debrief

### DIFF
--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -9,6 +9,749 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/debrief": {
+      "post": {
+        "operationId": "debrief.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "mediaId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mediaType": {
+                    "enum": ["movie", "episode"],
+                    "type": "string"
+                  },
+                  "watchHistoryId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["watchHistoryId", "mediaType", "mediaId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "mediaId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "mediaType": {
+                          "enum": ["movie", "episode"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "active", "complete"],
+                          "type": "string"
+                        },
+                        "watchHistoryId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "watchHistoryId",
+                        "mediaType",
+                        "mediaId",
+                        "status",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Create a debrief session; replaces any prior pending/active session for the media tuple.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/delete-by-watch-history": {
+      "post": {
+        "operationId": "debrief.deleteByWatchHistoryId",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "watchHistoryId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["watchHistoryId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "deletedResults": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "deletedSessions": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["deletedSessions", "deletedResults"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Cascade-delete debrief rows pinned to a watch_history id.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/get": {
+      "post": {
+        "operationId": "debrief.get",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sessionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["sessionId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "mediaId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "mediaType": {
+                          "enum": ["movie", "episode"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "active", "complete"],
+                          "type": "string"
+                        },
+                        "watchHistoryId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "watchHistoryId",
+                        "mediaType",
+                        "mediaId",
+                        "status",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Fetch a debrief session by id; null when absent.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/get-by-media": {
+      "post": {
+        "operationId": "debrief.getByMedia",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "mediaId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mediaType": {
+                    "enum": ["movie", "episode"],
+                    "type": "string"
+                  }
+                },
+                "required": ["mediaType", "mediaId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "mediaId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "mediaType": {
+                          "enum": ["movie", "episode"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "active", "complete"],
+                          "type": "string"
+                        },
+                        "watchHistoryId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "watchHistoryId",
+                        "mediaType",
+                        "mediaId",
+                        "status",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Most recent pending/active session for a media tuple; null when absent.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/list-pending": {
+      "post": {
+        "operationId": "debrief.listPending",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mediaId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mediaType": {
+                    "enum": ["movie", "episode"],
+                    "type": "string"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "mediaId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "mediaType": {
+                            "enum": ["movie", "episode"],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": ["pending", "active", "complete"],
+                            "type": "string"
+                          },
+                          "watchHistoryId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "watchHistoryId",
+                          "mediaType",
+                          "mediaId",
+                          "status",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "pagination": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "limit": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "total": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["limit", "offset", "total"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data", "pagination"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Paginated list of pending sessions, optionally narrowed by media tuple.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/log-watch-completion": {
+      "post": {
+        "operationId": "debrief.logWatchCompletion",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "mediaId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mediaType": {
+                    "enum": ["movie", "episode"],
+                    "type": "string"
+                  },
+                  "watchHistoryId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["watchHistoryId", "mediaType", "mediaId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dimensionsQueued": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "sessionId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["sessionId", "dimensionsQueued"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Option D entry point — creates a session; dimensionsQueued is 0.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/record": {
+      "post": {
+        "operationId": "debrief.record",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "comparisonId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "dimensionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "sessionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["sessionId", "dimensionId", "comparisonId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "comparisonId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "dimensionId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "sessionId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["id", "sessionId", "dimensionId", "comparisonId", "createdAt"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Record a per-dimension reflection result for a session.",
+        "tags": ["debrief"]
+      }
+    },
+    "/debrief/{sessionId}/dismiss": {
+      "post": {
+        "operationId": "debrief.dismiss",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sessionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "mediaId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "mediaType": {
+                          "enum": ["movie", "episode"],
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "active", "complete"],
+                          "type": "string"
+                        },
+                        "watchHistoryId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "watchHistoryId",
+                        "mediaType",
+                        "mediaId",
+                        "status",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Dismiss a session (status → complete); idempotent, 404 on unknown id.",
+        "tags": ["debrief"]
+      }
+    },
     "/ego/chat": {
       "post": {
         "operationId": "ego.chat",
@@ -810,6 +1553,110 @@
         },
         "summary": "Replace the active scopes for a conversation.",
         "tags": ["ego"]
+      }
+    },
+    "/embeddings/source-ids": {
+      "post": {
+        "operationId": "embeddings.listSourceIdsByType",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceType": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["sourceType"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "sourceIds": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["sourceIds"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Distinct source ids recorded against a given source type.",
+        "tags": ["embeddings"]
+      }
+    },
+    "/embeddings/status": {
+      "post": {
+        "operationId": "embeddings.getStatus",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "sourceType": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "pending": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "stale": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "total": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["total", "pending", "stale"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Embedded-row coverage stats, optionally scoped to a source type.",
+        "tags": ["embeddings"]
       }
     },
     "/emit/generate": {

--- a/pillars/cerebrum/src/api/__tests__/debrief.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/debrief.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for `cerebrum.debrief.*` over REST (PRD-248).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` (debrief tables present
+ * via migration 0055) and exercises the surface end-to-end through the REST
+ * client. Covers create→get round-trip, getByMedia, create idempotency,
+ * record (404 without a session), dismiss (idempotent + 404),
+ * deleteByWatchHistoryId cascade, and listPending pagination.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let templateRegistry: TemplateRegistry;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-debrief-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-debrief-root-'));
+  templateRegistry = makeTemplateRegistry();
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry,
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
+    })
+  );
+}
+
+describe('cerebrum.debrief.create + get', () => {
+  it('round-trips a created session by id', async () => {
+    const c = client();
+    const { data: created } = await c.debrief.create({
+      watchHistoryId: 10,
+      mediaType: 'movie',
+      mediaId: 42,
+    });
+    expect(created).toMatchObject({
+      watchHistoryId: 10,
+      mediaType: 'movie',
+      mediaId: 42,
+      status: 'pending',
+    });
+
+    const { data: fetched } = await c.debrief.get(created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it('returns null for an unknown session id (benign miss, not 404)', async () => {
+    const { data } = await client().debrief.get(99999);
+    expect(data).toBeNull();
+  });
+});
+
+describe('cerebrum.debrief.getByMedia', () => {
+  it('returns the most recent pending session for the media tuple', async () => {
+    const c = client();
+    await c.debrief.create({ watchHistoryId: 1, mediaType: 'episode', mediaId: 7 });
+
+    const { data } = await c.debrief.getByMedia('episode', 7);
+    expect(data).toMatchObject({ mediaType: 'episode', mediaId: 7, status: 'pending' });
+  });
+
+  it('returns null when no session exists for the tuple', async () => {
+    const { data } = await client().debrief.getByMedia('movie', 1234);
+    expect(data).toBeNull();
+  });
+});
+
+describe('cerebrum.debrief.create idempotency', () => {
+  it('replaces a prior pending/active session for the same media tuple', async () => {
+    const c = client();
+    const first = await c.debrief.create({ watchHistoryId: 1, mediaType: 'movie', mediaId: 5 });
+    const second = await c.debrief.create({ watchHistoryId: 2, mediaType: 'movie', mediaId: 5 });
+
+    expect(second.data.id).not.toBe(first.data.id);
+
+    const prior = await c.debrief.get(first.data.id);
+    expect(prior.data).toBeNull();
+
+    const byMedia = await c.debrief.getByMedia('movie', 5);
+    expect(byMedia.data?.id).toBe(second.data.id);
+    expect(byMedia.data?.watchHistoryId).toBe(2);
+  });
+});
+
+describe('cerebrum.debrief.record', () => {
+  it('records a result row against an existing session', async () => {
+    const c = client();
+    const { data: session } = await c.debrief.create({
+      watchHistoryId: 3,
+      mediaType: 'movie',
+      mediaId: 9,
+    });
+
+    const { data: result } = await c.debrief.record({
+      sessionId: session.id,
+      dimensionId: 11,
+      comparisonId: 22,
+    });
+    expect(result).toMatchObject({
+      sessionId: session.id,
+      dimensionId: 11,
+      comparisonId: 22,
+    });
+  });
+
+  it('accepts a null comparisonId (skipped dimension)', async () => {
+    const c = client();
+    const { data: session } = await c.debrief.create({
+      watchHistoryId: 4,
+      mediaType: 'movie',
+      mediaId: 8,
+    });
+
+    const { data: result } = await c.debrief.record({
+      sessionId: session.id,
+      dimensionId: 12,
+      comparisonId: null,
+    });
+    expect(result.comparisonId).toBeNull();
+  });
+
+  it('404s when the session does not exist', async () => {
+    await expect(
+      client().debrief.record({ sessionId: 77777, dimensionId: 1, comparisonId: null })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('cerebrum.debrief.dismiss', () => {
+  it('transitions a session to complete', async () => {
+    const c = client();
+    const { data: session } = await c.debrief.create({
+      watchHistoryId: 5,
+      mediaType: 'episode',
+      mediaId: 3,
+    });
+
+    const { data: dismissed } = await c.debrief.dismiss(session.id);
+    expect(dismissed.status).toBe('complete');
+  });
+
+  it('is idempotent — re-dismissing a complete session is a no-op', async () => {
+    const c = client();
+    const { data: session } = await c.debrief.create({
+      watchHistoryId: 6,
+      mediaType: 'episode',
+      mediaId: 4,
+    });
+
+    const first = await c.debrief.dismiss(session.id);
+    const second = await c.debrief.dismiss(session.id);
+    expect(second.data).toEqual(first.data);
+    expect(second.data.status).toBe('complete');
+  });
+
+  it('404s on an unknown session id', async () => {
+    await expect(client().debrief.dismiss(88888)).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('cerebrum.debrief.logWatchCompletion', () => {
+  it('creates a session and reports dimensionsQueued: 0', async () => {
+    const result = await client().debrief.logWatchCompletion({
+      watchHistoryId: 50,
+      mediaType: 'movie',
+      mediaId: 100,
+    });
+    expect(result.dimensionsQueued).toBe(0);
+    expect(result.sessionId).toBeGreaterThan(0);
+  });
+});
+
+describe('cerebrum.debrief.deleteByWatchHistoryId', () => {
+  it('cascade-deletes sessions and their results', async () => {
+    const c = client();
+    const { data: session } = await c.debrief.create({
+      watchHistoryId: 200,
+      mediaType: 'movie',
+      mediaId: 1,
+    });
+    await c.debrief.record({ sessionId: session.id, dimensionId: 1, comparisonId: 1 });
+    await c.debrief.record({ sessionId: session.id, dimensionId: 2, comparisonId: null });
+
+    const deleted = await c.debrief.deleteByWatchHistoryId(200);
+    expect(deleted).toEqual({ deletedSessions: 1, deletedResults: 2 });
+
+    const after = await c.debrief.get(session.id);
+    expect(after.data).toBeNull();
+  });
+
+  it('returns zero counts for a watch_history id with no debrief rows', async () => {
+    const deleted = await client().debrief.deleteByWatchHistoryId(999);
+    expect(deleted).toEqual({ deletedSessions: 0, deletedResults: 0 });
+  });
+});
+
+describe('cerebrum.debrief.listPending', () => {
+  it('paginates pending sessions newest-first and reports the unpaged total', async () => {
+    const c = client();
+    for (let i = 0; i < 5; i++) {
+      await c.debrief.create({ watchHistoryId: 300 + i, mediaType: 'movie', mediaId: 500 + i });
+    }
+
+    const page = await c.debrief.listPending({ limit: 2, offset: 1 });
+    expect(page.pagination).toEqual({ limit: 2, offset: 1, total: 5 });
+    expect(page.data).toHaveLength(2);
+  });
+
+  it('narrows by media tuple and excludes completed sessions', async () => {
+    const c = client();
+    const { data: keep } = await c.debrief.create({
+      watchHistoryId: 1,
+      mediaType: 'movie',
+      mediaId: 1,
+    });
+    const { data: dismissMe } = await c.debrief.create({
+      watchHistoryId: 2,
+      mediaType: 'episode',
+      mediaId: 2,
+    });
+    await c.debrief.dismiss(dismissMe.id);
+
+    const all = await c.debrief.listPending();
+    expect(all.pagination.total).toBe(1);
+    expect(all.data[0]?.id).toBe(keep.id);
+
+    const byMedia = await c.debrief.listPending({ mediaType: 'movie', mediaId: 1 });
+    expect(byMedia.pagination.total).toBe(1);
+
+    const otherMedia = await c.debrief.listPending({ mediaType: 'movie', mediaId: 999 });
+    expect(otherMedia.pagination.total).toBe(0);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/embeddings.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/embeddings.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for `cerebrum.embeddings.*` over REST (PRD-249).
+ *
+ * Boots the app against a per-test temp `cerebrum.db` (embeddings present via
+ * migration 0054) and seeds `embeddings` rows directly through the drizzle
+ * handle. Covers `getStatus` (total + optional source-type filter) and
+ * `listSourceIdsByType` (distinct ids).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type CerebrumDb,
+  embeddings,
+  openCerebrumDb,
+  type OpenedCerebrumDb,
+} from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import {
+  makeClient,
+  makeEmptyPeerClients,
+  makeReflexService,
+  makeTemplateRegistry,
+} from './test-utils.js';
+
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+interface SeedEmbedding {
+  sourceType: string;
+  sourceId: string;
+  chunkIndex?: number;
+}
+
+function seedEmbedding(db: CerebrumDb, e: SeedEmbedding): void {
+  db.insert(embeddings)
+    .values({
+      sourceType: e.sourceType,
+      sourceId: e.sourceId,
+      chunkIndex: e.chunkIndex ?? 0,
+      contentHash: `${e.sourceType}:${e.sourceId}:${e.chunkIndex ?? 0}`,
+      contentPreview: 'preview',
+      model: 'fake-embed',
+      dimensions: 3,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })
+    .run();
+}
+
+let tmpDir: string;
+let engramRoot: string;
+let templateRegistry: TemplateRegistry;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-embeddings-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-api-embeddings-root-'));
+  templateRegistry = makeTemplateRegistry();
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createCerebrumApiApp({
+      cerebrumDb,
+      templateRegistry,
+      engramRoot,
+      reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3007',
+      peerClients: makeEmptyPeerClients(),
+    })
+  );
+}
+
+describe('cerebrum.embeddings.getStatus', () => {
+  it('returns zero total on an empty table with pending/stale held at 0', async () => {
+    const status = await client().embeddings.getStatus();
+    expect(status).toEqual({ total: 0, pending: 0, stale: 0 });
+  });
+
+  it('counts every row when no source type is supplied', async () => {
+    const db = cerebrumDb.db;
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'a' });
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'b' });
+    seedEmbedding(db, { sourceType: 'note', sourceId: 'c' });
+
+    const status = await client().embeddings.getStatus();
+    expect(status).toEqual({ total: 3, pending: 0, stale: 0 });
+  });
+
+  it('scopes the count to the requested source type', async () => {
+    const db = cerebrumDb.db;
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'a' });
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'b' });
+    seedEmbedding(db, { sourceType: 'note', sourceId: 'c' });
+
+    const status = await client().embeddings.getStatus('engram');
+    expect(status).toEqual({ total: 2, pending: 0, stale: 0 });
+  });
+});
+
+describe('cerebrum.embeddings.listSourceIdsByType', () => {
+  it('returns the distinct source ids for a source type', async () => {
+    const db = cerebrumDb.db;
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'a', chunkIndex: 0 });
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'a', chunkIndex: 1 });
+    seedEmbedding(db, { sourceType: 'engram', sourceId: 'b' });
+    seedEmbedding(db, { sourceType: 'note', sourceId: 'c' });
+
+    const { sourceIds } = await client().embeddings.listSourceIdsByType('engram');
+    expect(sourceIds.toSorted()).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty list for a source type with no rows', async () => {
+    const { sourceIds } = await client().embeddings.listSourceIdsByType('absent');
+    expect(sourceIds).toEqual([]);
+  });
+});

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -14,12 +14,18 @@ import { TemplateRegistry } from '../modules/templates/registry.js';
 import type { Express } from 'express';
 
 import type {
+  DebriefMediaTypeWire,
+  DebriefResultWire,
+  DebriefSessionWire,
+} from '../../contract/rest-debrief-schemas.js';
+import type {
   ConversationMessageWire,
   ConversationWire,
   EgoChatBodyWire,
   EgoChatResponseWire,
   GetActiveContextResponseWire,
 } from '../../contract/rest-ego-schemas.js';
+import type { EmbeddingsStatusWire } from '../../contract/rest-embeddings.js';
 import type {
   EmitSourceCitationWire,
   GeneratedDocumentWire,
@@ -442,6 +448,30 @@ type QueryExplainResponse = {
   secretNotice: string | null;
 };
 
+export interface DebriefRecordInput {
+  sessionId: number;
+  dimensionId: number;
+  comparisonId: number | null;
+}
+
+export interface DebriefCreateInput {
+  watchHistoryId: number;
+  mediaType: DebriefMediaTypeWire;
+  mediaId: number;
+}
+
+export interface DebriefListPendingInput {
+  mediaType?: DebriefMediaTypeWire;
+  mediaId?: number;
+  limit?: number;
+  offset?: number;
+}
+
+type DebriefListPendingResponse = {
+  data: DebriefSessionWire[];
+  pagination: { limit: number; offset: number; total: number };
+};
+
 export function makeClient(app: Express) {
   const r = supertest.agent(app);
   return {
@@ -679,6 +709,38 @@ export function makeClient(app: Express) {
         send<{ sources: QuerySourceCitationWire[] }>(r.post('/query/retrieve').send(body)),
       explain: (question: string) =>
         send<QueryExplainResponse>(r.post('/query/explain').send({ question })),
+    },
+    embeddings: {
+      getStatus: (sourceType?: string) =>
+        send<EmbeddingsStatusWire>(
+          r.post('/embeddings/status').send(sourceType ? { sourceType } : {})
+        ),
+      listSourceIdsByType: (sourceType: string) =>
+        send<{ sourceIds: string[] }>(r.post('/embeddings/source-ids').send({ sourceType })),
+    },
+    debrief: {
+      get: (sessionId: number) =>
+        send<{ data: DebriefSessionWire | null }>(r.post('/debrief/get').send({ sessionId })),
+      getByMedia: (mediaType: DebriefMediaTypeWire, mediaId: number) =>
+        send<{ data: DebriefSessionWire | null }>(
+          r.post('/debrief/get-by-media').send({ mediaType, mediaId })
+        ),
+      listPending: (input: DebriefListPendingInput = {}) =>
+        send<DebriefListPendingResponse>(r.post('/debrief/list-pending').send(input)),
+      record: (input: DebriefRecordInput) =>
+        send<{ data: DebriefResultWire }>(r.post('/debrief/record').send(input)),
+      create: (input: DebriefCreateInput) =>
+        send<{ data: DebriefSessionWire }>(r.post('/debrief').send(input)),
+      logWatchCompletion: (input: DebriefCreateInput) =>
+        send<{ sessionId: number; dimensionsQueued: number }>(
+          r.post('/debrief/log-watch-completion').send(input)
+        ),
+      dismiss: (sessionId: number) =>
+        send<{ data: DebriefSessionWire }>(r.post(`/debrief/${sessionId}/dismiss`).send({})),
+      deleteByWatchHistoryId: (watchHistoryId: number) =>
+        send<{ deletedSessions: number; deletedResults: number }>(
+          r.post('/debrief/delete-by-watch-history').send({ watchHistoryId })
+        ),
     },
   };
 }

--- a/pillars/cerebrum/src/api/modules/debrief/service.ts
+++ b/pillars/cerebrum/src/api/modules/debrief/service.ts
@@ -1,0 +1,238 @@
+/**
+ * Query layer for the `cerebrum.debrief.*` surface (PRD-248).
+ *
+ * Reads/writes `debrief_sessions` + `debrief_results` through a drizzle
+ * handle. The media tuple, `watchHistoryId`, `dimensionId` and `comparisonId`
+ * are soft pointers into the media pillar (ADR-026) — no cross-DB FK and no
+ * cross-pillar call. `create` is idempotent (replaces any prior pending/active
+ * session for the media tuple); `deleteByWatchHistoryId` cascades results then
+ * sessions inside a single transaction.
+ *
+ * Rows are validated through the local wire schemas so the nullable-text
+ * `media_type` column is narrowed to the wire enum at the boundary; a row that
+ * fails validation surfaces as a thrown error rather than a silently widened
+ * shape.
+ */
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import {
+  debriefResultSchema,
+  debriefSessionSchema,
+  type DebriefMediaTypeWire,
+  type DebriefResultWire,
+  type DebriefSessionWire,
+} from '../../../contract/rest-debrief-schemas.js';
+import { type CerebrumDb, debriefResults, debriefSessions } from '../../../db/index.js';
+import { NotFoundError } from '../../shared/errors.js';
+
+const DEFAULT_LIST_PENDING_LIMIT = 50;
+
+export interface CreateSessionInput {
+  watchHistoryId: number;
+  mediaType: DebriefMediaTypeWire;
+  mediaId: number;
+}
+
+export interface RecordInput {
+  sessionId: number;
+  dimensionId: number;
+  comparisonId: number | null;
+}
+
+export interface ListPendingInput {
+  mediaType?: DebriefMediaTypeWire;
+  mediaId?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListPendingResult {
+  data: DebriefSessionWire[];
+  pagination: { limit: number; offset: number; total: number };
+}
+
+export interface DeleteByWatchHistoryResult {
+  deletedSessions: number;
+  deletedResults: number;
+}
+
+export interface DebriefService {
+  get: (sessionId: number) => DebriefSessionWire | null;
+  getByMedia: (mediaType: DebriefMediaTypeWire, mediaId: number) => DebriefSessionWire | null;
+  listPending: (input: ListPendingInput) => ListPendingResult;
+  record: (input: RecordInput) => DebriefResultWire;
+  create: (input: CreateSessionInput) => DebriefSessionWire;
+  dismiss: (sessionId: number) => DebriefSessionWire;
+  deleteByWatchHistoryId: (watchHistoryId: number) => DeleteByWatchHistoryResult;
+}
+
+function findSessionRow(db: CerebrumDb, sessionId: number): DebriefSessionWire | null {
+  const row = db.select().from(debriefSessions).where(eq(debriefSessions.id, sessionId)).get();
+  return row ? debriefSessionSchema.parse(row) : null;
+}
+
+function createOrReplacePendingSession(
+  db: CerebrumDb,
+  input: CreateSessionInput
+): DebriefSessionWire {
+  const row = db.transaction((tx) => {
+    tx.delete(debriefSessions)
+      .where(
+        and(
+          eq(debriefSessions.mediaType, input.mediaType),
+          eq(debriefSessions.mediaId, input.mediaId),
+          inArray(debriefSessions.status, ['pending', 'active'])
+        )
+      )
+      .run();
+    const inserted = tx
+      .insert(debriefSessions)
+      .values({
+        watchHistoryId: input.watchHistoryId,
+        mediaType: input.mediaType,
+        mediaId: input.mediaId,
+        status: 'pending',
+      })
+      .run();
+    const session = tx
+      .select()
+      .from(debriefSessions)
+      .where(eq(debriefSessions.id, Number(inserted.lastInsertRowid)))
+      .get();
+    if (!session) throw new Error('Failed to read back debrief session after insert');
+    return session;
+  });
+  return debriefSessionSchema.parse(row);
+}
+
+export function createDebriefService(db: CerebrumDb): DebriefService {
+  return {
+    get: (sessionId) => findSessionRow(db, sessionId),
+
+    getByMedia: (mediaType, mediaId) => {
+      const row = db
+        .select()
+        .from(debriefSessions)
+        .where(
+          and(
+            eq(debriefSessions.mediaType, mediaType),
+            eq(debriefSessions.mediaId, mediaId),
+            inArray(debriefSessions.status, ['pending', 'active'])
+          )
+        )
+        .orderBy(desc(debriefSessions.createdAt), desc(debriefSessions.id))
+        .get();
+      return row ? debriefSessionSchema.parse(row) : null;
+    },
+
+    listPending: (input) => listPending(db, input),
+
+    record: (input) => {
+      if (!findSessionRow(db, input.sessionId)) {
+        throw new NotFoundError('Debrief session', String(input.sessionId));
+      }
+      const inserted = db
+        .insert(debriefResults)
+        .values({
+          sessionId: input.sessionId,
+          dimensionId: input.dimensionId,
+          comparisonId: input.comparisonId,
+        })
+        .run();
+      const row = db
+        .select()
+        .from(debriefResults)
+        .where(eq(debriefResults.id, Number(inserted.lastInsertRowid)))
+        .get();
+      if (!row) throw new Error('Failed to read back debrief result after insert');
+      return debriefResultSchema.parse(row);
+    },
+
+    create: (input) => createOrReplacePendingSession(db, input),
+
+    dismiss: (sessionId) => dismiss(db, sessionId),
+
+    deleteByWatchHistoryId: (watchHistoryId) => deleteByWatchHistoryId(db, watchHistoryId),
+  };
+}
+
+function listPending(db: CerebrumDb, input: ListPendingInput): ListPendingResult {
+  const filters = [eq(debriefSessions.status, 'pending')];
+  if (input.mediaType !== undefined) filters.push(eq(debriefSessions.mediaType, input.mediaType));
+  if (input.mediaId !== undefined) filters.push(eq(debriefSessions.mediaId, input.mediaId));
+  const whereClause = and(...filters);
+
+  const limit = input.limit ?? DEFAULT_LIST_PENDING_LIMIT;
+  const offset = input.offset ?? 0;
+
+  const rows = db
+    .select()
+    .from(debriefSessions)
+    .where(whereClause)
+    .orderBy(desc(debriefSessions.createdAt), desc(debriefSessions.id))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const total = db
+    .select({ id: debriefSessions.id })
+    .from(debriefSessions)
+    .where(whereClause)
+    .all().length;
+
+  return {
+    data: rows.map((row) => debriefSessionSchema.parse(row)),
+    pagination: { limit, offset, total },
+  };
+}
+
+function dismiss(db: CerebrumDb, sessionId: number): DebriefSessionWire {
+  const row = db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(debriefSessions)
+      .where(eq(debriefSessions.id, sessionId))
+      .get();
+    if (!existing) throw new NotFoundError('Debrief session', String(sessionId));
+    if (existing.status === 'complete') return existing;
+    tx.update(debriefSessions)
+      .set({ status: 'complete' })
+      .where(eq(debriefSessions.id, sessionId))
+      .run();
+    const updated = tx
+      .select()
+      .from(debriefSessions)
+      .where(eq(debriefSessions.id, sessionId))
+      .get();
+    if (!updated) throw new Error('Failed to read back debrief session after dismiss');
+    return updated;
+  });
+  return debriefSessionSchema.parse(row);
+}
+
+function deleteByWatchHistoryId(
+  db: CerebrumDb,
+  watchHistoryId: number
+): DeleteByWatchHistoryResult {
+  return db.transaction((tx) => {
+    const sessionIds = tx
+      .select({ id: debriefSessions.id })
+      .from(debriefSessions)
+      .where(eq(debriefSessions.watchHistoryId, watchHistoryId))
+      .all()
+      .map((row) => row.id);
+    if (sessionIds.length === 0) return { deletedSessions: 0, deletedResults: 0 };
+
+    const resultsDelete = tx
+      .delete(debriefResults)
+      .where(inArray(debriefResults.sessionId, sessionIds))
+      .run();
+    const sessionsDelete = tx
+      .delete(debriefSessions)
+      .where(eq(debriefSessions.watchHistoryId, watchHistoryId))
+      .run();
+    return {
+      deletedSessions: Number(sessionsDelete.changes),
+      deletedResults: Number(resultsDelete.changes),
+    };
+  });
+}

--- a/pillars/cerebrum/src/api/modules/embeddings/service.ts
+++ b/pillars/cerebrum/src/api/modules/embeddings/service.ts
@@ -1,0 +1,40 @@
+/**
+ * Read-only query helpers for the `cerebrum.embeddings.*` surface (PRD-249).
+ *
+ * Thin wrappers over the `embeddings` metadata table bound to a drizzle
+ * handle. `getStatus` reports the embedded-row count (optionally scoped to a
+ * source type); `pending` / `stale` are held at `0` — per-source coverage
+ * tracking is out of scope for the current surface.
+ */
+import { eq, sql } from 'drizzle-orm';
+
+import { type CerebrumDb, embeddings } from '../../../db/index.js';
+
+import type { EmbeddingsStatusWire } from '../../../contract/rest-embeddings.js';
+
+export interface EmbeddingsReadService {
+  getStatus: (sourceType?: string) => EmbeddingsStatusWire;
+  listSourceIdsByType: (sourceType: string) => string[];
+}
+
+export function createEmbeddingsReadService(db: CerebrumDb): EmbeddingsReadService {
+  return {
+    getStatus: (sourceType?: string): EmbeddingsStatusWire => {
+      const baseQuery = db.select({ count: sql<number>`count(*)` }).from(embeddings);
+      const rows = sourceType
+        ? baseQuery.where(eq(embeddings.sourceType, sourceType)).all()
+        : baseQuery.all();
+      const total = rows[0]?.count ?? 0;
+      return { total, pending: 0, stale: 0 };
+    },
+
+    listSourceIdsByType: (sourceType: string): string[] => {
+      const rows = db
+        .selectDistinct({ sourceId: embeddings.sourceId })
+        .from(embeddings)
+        .where(eq(embeddings.sourceType, sourceType))
+        .all();
+      return rows.map((row) => row.sourceId);
+    },
+  };
+}

--- a/pillars/cerebrum/src/api/rest/debrief-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/debrief-handlers.ts
@@ -1,0 +1,67 @@
+/**
+ * ts-rest handlers for `cerebrum.debrief.*` (PRD-248).
+ *
+ * Thin adapter over {@link createDebriefService} bound to the pillar db handle.
+ * `get` / `getByMedia` return `{ data: null }` for a benign miss; `record` and
+ * `dismiss` surface a 404 for an unknown session via `runHttp` mapping the
+ * pillar `NotFoundError`. `create` is idempotent; `deleteByWatchHistoryId`
+ * cascades inside a transaction.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumDebriefContract } from '../../contract/rest-debrief.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { createDebriefService } from '../modules/debrief/service.js';
+import { runHttp } from './error-mapping.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export function makeDebriefHandlers(
+  db: CerebrumDb
+): ReturnType<typeof server.router<typeof cerebrumDebriefContract>> {
+  const service = createDebriefService(db);
+
+  return server.router(cerebrumDebriefContract, {
+    get: async ({ body }) => ({
+      status: 200,
+      body: { data: service.get(body.sessionId) },
+    }),
+
+    getByMedia: async ({ body }) => ({
+      status: 200,
+      body: { data: service.getByMedia(body.mediaType, body.mediaId) },
+    }),
+
+    listPending: async ({ body }) => ({
+      status: 200,
+      body: service.listPending(body),
+    }),
+
+    record: async ({ body }) =>
+      runHttp(() => ({
+        status: 200,
+        body: { data: service.record(body) },
+      })),
+
+    create: async ({ body }) => ({
+      status: 200,
+      body: { data: service.create(body) },
+    }),
+
+    logWatchCompletion: async ({ body }) => {
+      const session = service.create(body);
+      return { status: 200, body: { sessionId: session.id, dimensionsQueued: 0 } };
+    },
+
+    dismiss: async ({ params }) =>
+      runHttp(() => ({
+        status: 200,
+        body: { data: service.dismiss(params.sessionId) },
+      })),
+
+    deleteByWatchHistoryId: async ({ body }) => ({
+      status: 200,
+      body: service.deleteByWatchHistoryId(body.watchHistoryId),
+    }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/embeddings-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/embeddings-handlers.ts
@@ -1,0 +1,31 @@
+/**
+ * ts-rest handlers for `cerebrum.embeddings.*` (PRD-249).
+ *
+ * Thin adapter over {@link createEmbeddingsReadService} bound to the pillar
+ * db handle. Read-only — both procedures return a 200 with no error branch.
+ */
+import { initServer } from '@ts-rest/express';
+
+import { cerebrumEmbeddingsContract } from '../../contract/rest-embeddings.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { createEmbeddingsReadService } from '../modules/embeddings/service.js';
+
+const server: ReturnType<typeof initServer> = initServer();
+
+export function makeEmbeddingsHandlers(
+  db: CerebrumDb
+): ReturnType<typeof server.router<typeof cerebrumEmbeddingsContract>> {
+  const service = createEmbeddingsReadService(db);
+
+  return server.router(cerebrumEmbeddingsContract, {
+    getStatus: async ({ body }) => ({
+      status: 200,
+      body: service.getStatus(body.sourceType),
+    }),
+
+    listSourceIdsByType: async ({ body }) => ({
+      status: 200,
+      body: { sourceIds: service.listSourceIdsByType(body.sourceType) },
+    }),
+  });
+}

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -18,7 +18,9 @@ import { getCurationQueue } from '../modules/ingest/queue.js';
 import { AnthropicQueryLlm, AnthropicQueryStreamLlm } from '../modules/query/llm.js';
 import { getEmbeddingsQueue } from '../modules/thalamus/queue.js';
 import { AnthropicContradictionDetector } from '../modules/workers/llm.js';
+import { makeDebriefHandlers } from './debrief-handlers.js';
 import { makeEgoHandlers } from './ego-handlers.js';
+import { makeEmbeddingsHandlers } from './embeddings-handlers.js';
 import { makeEmitHandlers } from './emit-handlers.js';
 import { makeEngramsHandlers } from './engrams-handlers.js';
 import { makeGliaHandlers } from './glia-handlers.js';
@@ -92,5 +94,7 @@ export function makeCerebrumRestHandlers(
       contradictionDetector:
         deps.auditorContradictionDetector ?? new AnthropicContradictionDetector(),
     }),
+    embeddings: makeEmbeddingsHandlers(db),
+    debrief: makeDebriefHandlers(db),
   });
 }

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -3,6 +3,142 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/cerebrum generate:api-types`.
  */
 export interface paths {
+  '/debrief': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a debrief session; replaces any prior pending/active session for the media tuple. */
+    post: operations['debrief.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/delete-by-watch-history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Cascade-delete debrief rows pinned to a watch_history id. */
+    post: operations['debrief.deleteByWatchHistoryId'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Fetch a debrief session by id; null when absent. */
+    post: operations['debrief.get'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/get-by-media': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Most recent pending/active session for a media tuple; null when absent. */
+    post: operations['debrief.getByMedia'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/list-pending': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Paginated list of pending sessions, optionally narrowed by media tuple. */
+    post: operations['debrief.listPending'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/log-watch-completion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Option D entry point — creates a session; dimensionsQueued is 0. */
+    post: operations['debrief.logWatchCompletion'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/record': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Record a per-dimension reflection result for a session. */
+    post: operations['debrief.record'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/debrief/{sessionId}/dismiss': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dismiss a session (status → complete); idempotent, 404 on unknown id. */
+    post: operations['debrief.dismiss'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/ego/chat': {
     parameters: {
       query?: never;
@@ -100,6 +236,40 @@ export interface paths {
     put?: never;
     /** Replace the active scopes for a conversation. */
     post: operations['ego.setScopes'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/embeddings/source-ids': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Distinct source ids recorded against a given source type. */
+    post: operations['embeddings.listSourceIdsByType'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/embeddings/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Embedded-row coverage stats, optionally scoped to a source type. */
+    post: operations['embeddings.getStatus'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1328,6 +1498,336 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'debrief.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          mediaId: number;
+          /** @enum {string} */
+          mediaType: 'movie' | 'episode';
+          watchHistoryId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              id: number;
+              mediaId: number | null;
+              /** @enum {string|null} */
+              mediaType: 'movie' | 'episode' | null;
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'complete';
+              watchHistoryId: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'debrief.deleteByWatchHistoryId': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          watchHistoryId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            deletedResults: number;
+            deletedSessions: number;
+          };
+        };
+      };
+    };
+  };
+  'debrief.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sessionId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              id: number;
+              mediaId: number | null;
+              /** @enum {string|null} */
+              mediaType: 'movie' | 'episode' | null;
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'complete';
+              watchHistoryId: number;
+            } | null;
+          };
+        };
+      };
+    };
+  };
+  'debrief.getByMedia': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          mediaId: number;
+          /** @enum {string} */
+          mediaType: 'movie' | 'episode';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              id: number;
+              mediaId: number | null;
+              /** @enum {string|null} */
+              mediaType: 'movie' | 'episode' | null;
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'complete';
+              watchHistoryId: number;
+            } | null;
+          };
+        };
+      };
+    };
+  };
+  'debrief.listPending': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          mediaId?: number;
+          /** @enum {string} */
+          mediaType?: 'movie' | 'episode';
+          offset?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              id: number;
+              mediaId: number | null;
+              /** @enum {string|null} */
+              mediaType: 'movie' | 'episode' | null;
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'complete';
+              watchHistoryId: number;
+            }[];
+            pagination: {
+              limit: number;
+              offset: number;
+              total: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'debrief.logWatchCompletion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          mediaId: number;
+          /** @enum {string} */
+          mediaType: 'movie' | 'episode';
+          watchHistoryId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            dimensionsQueued: number;
+            sessionId: number;
+          };
+        };
+      };
+    };
+  };
+  'debrief.record': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          comparisonId: number | null;
+          dimensionId: number;
+          sessionId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              comparisonId: number | null;
+              createdAt: string;
+              dimensionId: number;
+              id: number;
+              sessionId: number;
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'debrief.dismiss': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        sessionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              id: number;
+              mediaId: number | null;
+              /** @enum {string|null} */
+              mediaType: 'movie' | 'episode' | null;
+              /** @enum {string} */
+              status: 'pending' | 'active' | 'complete';
+              watchHistoryId: number;
+            };
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'ego.chat': {
     parameters: {
       query?: never;
@@ -1676,6 +2176,66 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'embeddings.listSourceIdsByType': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceType: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            sourceIds: string[];
+          };
+        };
+      };
+    };
+  };
+  'embeddings.getStatus': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          sourceType?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            pending: number;
+            stale: number;
+            total: number;
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-debrief-schemas.ts
+++ b/pillars/cerebrum/src/contract/rest-debrief-schemas.ts
@@ -1,0 +1,100 @@
+/**
+ * Wire schemas for `cerebrum.debrief.*` (PRD-248).
+ *
+ * The cerebrum debrief subsystem stores a post-watch reflection session per
+ * (re-)watch and records per-dimension reflection outcomes. `watchHistoryId`,
+ * `mediaType`/`mediaId`, `dimensionId` and `comparisonId` are soft pointers
+ * into the media pillar (ADR-026) — no cross-DB FK, no cross-pillar call.
+ *
+ * The shapes mirror the cerebrum-db drizzle rows one-to-one (the contract is
+ * the wire shape, not a UI projection). Defined locally so the pillar contract
+ * stays self-contained; lives in its own file so the contract module stays
+ * under the oxlint `max-lines` cap.
+ */
+import { z } from 'zod';
+
+export const debriefMediaTypeSchema = z.enum(['movie', 'episode']);
+export type DebriefMediaTypeWire = z.infer<typeof debriefMediaTypeSchema>;
+
+export const debriefSessionStatusSchema = z.enum(['pending', 'active', 'complete']);
+export type DebriefSessionStatusWire = z.infer<typeof debriefSessionStatusSchema>;
+
+/** A single post-watch debrief session — one row per (re-)watch. */
+export const debriefSessionSchema = z.object({
+  id: z.number().int(),
+  watchHistoryId: z.number().int(),
+  mediaType: debriefMediaTypeSchema.nullable(),
+  mediaId: z.number().int().nullable(),
+  status: debriefSessionStatusSchema,
+  createdAt: z.string(),
+});
+export type DebriefSessionWire = z.infer<typeof debriefSessionSchema>;
+
+/** A per-session, per-dimension reflection outcome. */
+export const debriefResultSchema = z.object({
+  id: z.number().int(),
+  sessionId: z.number().int(),
+  dimensionId: z.number().int(),
+  comparisonId: z.number().int().nullable(),
+  createdAt: z.string(),
+});
+export type DebriefResultWire = z.infer<typeof debriefResultSchema>;
+
+export const debriefPaginationSchema = z.object({
+  limit: z.number().int().positive(),
+  offset: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+});
+
+export const debriefSessionResponseSchema = z.object({ data: debriefSessionSchema });
+export const debriefSessionNullableResponseSchema = z.object({
+  data: debriefSessionSchema.nullable(),
+});
+export const debriefResultResponseSchema = z.object({ data: debriefResultSchema });
+export const debriefListPendingResponseSchema = z.object({
+  data: z.array(debriefSessionSchema),
+  pagination: debriefPaginationSchema,
+});
+export const debriefLogWatchCompletionResponseSchema = z.object({
+  sessionId: z.number().int().positive(),
+  dimensionsQueued: z.number().int().nonnegative(),
+});
+export const debriefDeleteByWatchHistoryResponseSchema = z.object({
+  deletedSessions: z.number().int().nonnegative(),
+  deletedResults: z.number().int().nonnegative(),
+});
+
+export const debriefGetInputSchema = z.object({
+  sessionId: z.number().int().positive(),
+});
+export const debriefGetByMediaInputSchema = z.object({
+  mediaType: debriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+export const debriefListPendingInputSchema = z.object({
+  mediaType: debriefMediaTypeSchema.optional(),
+  mediaId: z.number().int().positive().optional(),
+  limit: z.number().int().positive().optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+export const debriefRecordInputSchema = z.object({
+  sessionId: z.number().int().positive(),
+  dimensionId: z.number().int().positive(),
+  comparisonId: z.number().int().positive().nullable(),
+});
+export const debriefCreateInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+  mediaType: debriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+export const debriefLogWatchCompletionInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+  mediaType: debriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+export const debriefSessionIdParamsSchema = z.object({
+  sessionId: z.coerce.number().int().positive(),
+});
+export const debriefDeleteByWatchHistoryInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+});

--- a/pillars/cerebrum/src/contract/rest-debrief.ts
+++ b/pillars/cerebrum/src/contract/rest-debrief.ts
@@ -1,0 +1,128 @@
+/**
+ * ts-rest contract for `cerebrum.debrief.*` (PRD-248).
+ *
+ * Read/write/delete surface over `debrief_sessions` + `debrief_results`. The
+ * media tuple (`mediaType`/`mediaId`), `watchHistoryId`, `dimensionId` and
+ * `comparisonId` are soft pointers into the media pillar (ADR-026) — no
+ * cross-DB FK and no cross-pillar call leaks into this surface.
+ *
+ *   - `get`                    → POST /debrief/get                  → { data: session | null }
+ *   - `getByMedia`             → POST /debrief/get-by-media         → { data: session | null }
+ *   - `listPending`            → POST /debrief/list-pending         → { data, pagination }
+ *   - `record`                 → POST /debrief/record               → { data: result } (404 no session)
+ *   - `create`                 → POST /debrief                      → { data: session } (idempotent)
+ *   - `logWatchCompletion`     → POST /debrief/log-watch-completion → { sessionId, dimensionsQueued }
+ *   - `dismiss`                → POST /debrief/:sessionId/dismiss   → { data: session } (idempotent, 404)
+ *   - `deleteByWatchHistoryId` → POST /debrief/delete-by-watch-history → { deletedSessions, deletedResults }
+ *
+ * `get` / `getByMedia` return `{ data: null }` for a benign miss rather than a
+ * 404 (parity with the in-monolith null shape over the wire). `record` /
+ * `dismiss` 404 on an unknown session — they are state-changing calls, so the
+ * typed 404 is the right shape.
+ *
+ * `dimensionsQueued` stays at `0`: the status fan-out needs the media pillar's
+ * `comparison_dimensions`, which the cerebrum container has no handle to. The
+ * field stays on the wire so a future US-05 call-site flip is a pure consumer
+ * move. Non-identity domain — docker-network trust, no per-request auth.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  debriefCreateInputSchema,
+  debriefDeleteByWatchHistoryInputSchema,
+  debriefDeleteByWatchHistoryResponseSchema,
+  debriefGetByMediaInputSchema,
+  debriefGetInputSchema,
+  debriefListPendingInputSchema,
+  debriefListPendingResponseSchema,
+  debriefLogWatchCompletionInputSchema,
+  debriefLogWatchCompletionResponseSchema,
+  debriefRecordInputSchema,
+  debriefResultResponseSchema,
+  debriefSessionIdParamsSchema,
+  debriefSessionNullableResponseSchema,
+  debriefSessionResponseSchema,
+} from './rest-debrief-schemas.js';
+import { errorBodySchema } from './rest-schemas.js';
+
+const c = initContract();
+
+export const cerebrumDebriefContract = c.router({
+  get: {
+    method: 'POST',
+    path: '/debrief/get',
+    summary: 'Fetch a debrief session by id; null when absent.',
+    body: debriefGetInputSchema,
+    responses: {
+      200: debriefSessionNullableResponseSchema,
+    },
+  },
+  getByMedia: {
+    method: 'POST',
+    path: '/debrief/get-by-media',
+    summary: 'Most recent pending/active session for a media tuple; null when absent.',
+    body: debriefGetByMediaInputSchema,
+    responses: {
+      200: debriefSessionNullableResponseSchema,
+    },
+  },
+  listPending: {
+    method: 'POST',
+    path: '/debrief/list-pending',
+    summary: 'Paginated list of pending sessions, optionally narrowed by media tuple.',
+    body: debriefListPendingInputSchema,
+    responses: {
+      200: debriefListPendingResponseSchema,
+    },
+  },
+  record: {
+    method: 'POST',
+    path: '/debrief/record',
+    summary: 'Record a per-dimension reflection result for a session.',
+    body: debriefRecordInputSchema,
+    responses: {
+      200: debriefResultResponseSchema,
+      404: errorBodySchema,
+    },
+  },
+  create: {
+    method: 'POST',
+    path: '/debrief',
+    summary:
+      'Create a debrief session; replaces any prior pending/active session for the media tuple.',
+    body: debriefCreateInputSchema,
+    responses: {
+      200: debriefSessionResponseSchema,
+    },
+  },
+  logWatchCompletion: {
+    method: 'POST',
+    path: '/debrief/log-watch-completion',
+    summary: 'Option D entry point — creates a session; dimensionsQueued is 0.',
+    body: debriefLogWatchCompletionInputSchema,
+    responses: {
+      200: debriefLogWatchCompletionResponseSchema,
+    },
+  },
+  dismiss: {
+    method: 'POST',
+    path: '/debrief/:sessionId/dismiss',
+    summary: 'Dismiss a session (status → complete); idempotent, 404 on unknown id.',
+    pathParams: debriefSessionIdParamsSchema,
+    body: z.object({}),
+    responses: {
+      200: debriefSessionResponseSchema,
+      404: errorBodySchema,
+    },
+  },
+  deleteByWatchHistoryId: {
+    method: 'POST',
+    path: '/debrief/delete-by-watch-history',
+    summary: 'Cascade-delete debrief rows pinned to a watch_history id.',
+    body: debriefDeleteByWatchHistoryInputSchema,
+    responses: {
+      200: debriefDeleteByWatchHistoryResponseSchema,
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest-embeddings.ts
+++ b/pillars/cerebrum/src/contract/rest-embeddings.ts
@@ -1,0 +1,56 @@
+/**
+ * ts-rest contract for `cerebrum.embeddings.*` (PRD-249 US-02).
+ *
+ * Read-only cross-pillar surface over the `embeddings` metadata table:
+ *
+ *   - `getStatus`            → POST /embeddings/status      → coverage stats
+ *   - `listSourceIdsByType`  → POST /embeddings/source-ids  → distinct ids
+ *
+ * `pending` / `stale` are held at `0` — per-source tracking is out of scope
+ * for the current surface (mirrors the in-monolith
+ * `core/embeddings/service.ts` note). Writes to `embeddings` belong to the
+ * cerebrum-internal embedding worker, not cross-pillar callers.
+ *
+ * Both procedures are POST-with-body rather than GET: the typed inputs keep
+ * parity with the in-monolith tRPC query shape and avoid query-string
+ * round-tripping. Non-identity domain — docker-network trust, no per-request
+ * auth (parity with templates / nudges). The wire schemas are defined locally
+ * so the pillar contract stays self-contained.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+export const embeddingsStatusSchema = z.object({
+  total: z.number().int().min(0),
+  pending: z.number().int().min(0),
+  stale: z.number().int().min(0),
+});
+export type EmbeddingsStatusWire = z.infer<typeof embeddingsStatusSchema>;
+
+export const embeddingsSourceIdsSchema = z.object({
+  sourceIds: z.array(z.string()),
+});
+export type EmbeddingsSourceIdsWire = z.infer<typeof embeddingsSourceIdsSchema>;
+
+export const cerebrumEmbeddingsContract = c.router({
+  getStatus: {
+    method: 'POST',
+    path: '/embeddings/status',
+    summary: 'Embedded-row coverage stats, optionally scoped to a source type.',
+    body: z.object({ sourceType: z.string().min(1).optional() }),
+    responses: {
+      200: embeddingsStatusSchema,
+    },
+  },
+  listSourceIdsByType: {
+    method: 'POST',
+    path: '/embeddings/source-ids',
+    summary: 'Distinct source ids recorded against a given source type.',
+    body: z.object({ sourceType: z.string().min(1) }),
+    responses: {
+      200: embeddingsSourceIdsSchema,
+    },
+  },
+});

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -12,7 +12,9 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { cerebrumDebriefContract } from './rest-debrief.js';
 import { cerebrumEgoContract } from './rest-ego.js';
+import { cerebrumEmbeddingsContract } from './rest-embeddings.js';
 import { cerebrumEmitContract } from './rest-emit.js';
 import { cerebrumEngramsContract } from './rest-engrams.js';
 import { cerebrumGliaContract } from './rest-glia.js';
@@ -47,6 +49,8 @@ export const cerebrumContract = c.router(
     workers: cerebrumWorkersContract,
     emit: cerebrumEmitContract,
     query: cerebrumQueryContract,
+    embeddings: cerebrumEmbeddingsContract,
+    debrief: cerebrumDebriefContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
Migrates the final two cerebrum domains — **embeddings** (2 procs) and **debrief** (8 procs) — from \`apps/pops-cerebrum-api\` onto the \`@pops/cerebrum\` ts-rest pillar contract, following the merged nudges/templates pattern.

## Surface

**embeddings** (read-only, docker-net trust):
- \`POST /embeddings/status\` → \`{ total, pending, stale }\` (pending/stale held at 0 per PRD-249 US-02)
- \`POST /embeddings/source-ids\` → \`{ sourceIds }\`

**debrief** (read/write/delete):
- \`POST /debrief/get\` / \`POST /debrief/get-by-media\` → \`{ data: session | null }\` (benign miss returns null, not 404)
- \`POST /debrief/list-pending\` → \`{ data, pagination }\`
- \`POST /debrief/record\` → \`{ data: result }\` (404 if session absent)
- \`POST /debrief\` → \`{ data: session }\` (idempotent: replaces prior pending/active for the media tuple)
- \`POST /debrief/log-watch-completion\` → \`{ sessionId, dimensionsQueued: 0 }\`
- \`POST /debrief/:sessionId/dismiss\` → \`{ data: session }\` (→ status complete; idempotent; 404 unknown)
- \`POST /debrief/delete-by-watch-history\` → \`{ deletedSessions, deletedResults }\` (cascade in a tx)

## Notes
- Self-contained contract: wire zod defined locally in \`rest-embeddings.ts\` / \`rest-debrief-schemas.ts\` (no \`@pops/cerebrum-contract/schemas\` import).
- tRPC error mapping replaced with pillar \`NotFoundError\` + \`runHttp\` (404). The \`get\`/\`getByMedia\` null path returns \`{ data: null }\`.
- \`create\` idempotency and \`deleteByWatchHistoryId\` cascade preserved in transactions; rows narrowed through the wire schemas at the boundary.
- Soft pointers to media (\`watchHistoryId\`, \`mediaType\`/\`mediaId\`, \`dimensionId\`, \`comparisonId\`) — no FK, no cross-pillar call, no LLM/SSE/queue.
- Composed into \`rest.ts\` + \`rest/handlers.ts\` alongside the existing 15 keys (additive — parallel nudges-write slice touches the same files).
- Dotted operationIds verified in the regenerated OpenAPI: \`embeddings.*\`, \`debrief.*\`.

## Verification (all green)
- oxfmt --check: pass
- oxlint: exit 0 (only a pre-existing warning in \`api/pillars/registry.ts\`, untouched)
- typecheck: pass
- build: pass
- generate:openapi: idempotent; new domains projected, no unrelated drift
- test: 587 passed (42 files), incl. new \`embeddings.test.ts\` + \`debrief.test.ts\` (27 cases covering round-trips, idempotency, 404s, cascade, pagination)