### PR TITLE
chore(cerebrum): Phase C — dep-cruiser ban no-dead-cerebrum-pkgs

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -2,2047 +2,562 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/db/backfill-cerebrum-from-shared.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/db/cerebrum-handle.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/jobs/handlers/embeddings-helpers.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/jobs/handlers/embeddings-source.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/ego/index.ts",
+    "to": "@pops/cerebrum-contract/settings",
+    "unresolvedTo": "@pops/cerebrum-contract/settings",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/ego/persistence.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/ego/types.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/archive-engram.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/fs-helpers.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/link-helpers.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/upsert-index.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/reclassify.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/service.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/tags-router.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/engrams/tags-router.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/glia/action-service.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/index.ts",
+    "to": "@pops/cerebrum-contract/settings",
+    "unresolvedTo": "@pops/cerebrum-contract/settings",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/ingest/pipeline-helpers.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/nudges/__tests__/nudge-service.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/nudges/detectors/citation-flush.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/plexus/router.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/reflex/reflex-io.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/reflex/reflex-queries.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/reflex/reflex-service.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/retrieval/router.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/retrieval/structured-query-conditions.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/instance.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/router.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "dynamic-import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/sync-junctions.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/sync.test.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/thalamus/sync.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts",
-    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "to": "@pops/cerebrum-db",
     "unresolvedTo": "@pops/cerebrum-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-cerebrum"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {
     "type": "dependency",
-    "from": "apps/pops-api/src/db.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
+    "from": "apps/pops-api/src/modules/core/embeddings/service.ts",
+    "to": "@pops/cerebrum-contract/schemas",
+    "unresolvedTo": "@pops/cerebrum-contract/schemas",
+    "dependencyTypes": ["unknown"],
     "rule": {
       "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/db/backfill-core-from-shared.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/jobs/handlers/embeddings-helpers.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/lib/inference-middleware.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/lib/inference-pricing.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/evaluator.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/evaluators/error-spike.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/mappers.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-alerts/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-budgets/enforcement.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-budgets/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/group-stats.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/history.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/retention-db.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/retention.test.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/retention.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-observability/summary.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-providers/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/ai-usage/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/corrections/handlers/ai-inference.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/entities/search-adapter.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/entities/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/entities/types.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/features/user-settings.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/settings/service.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/core/settings/types.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/finance/imports/router.test.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/finance/imports/service.test.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/finance/imports/types.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/finance/tag-suggester/index.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-config-router.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/scheduler.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/trpc.ts",
-    "to": "packages/core-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/core-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-core"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/db/backfill-media-from-shared.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/db/media-db-handle.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/arr/download-and-protect.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/dimensions.service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/global-count.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/batch-record.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/comparison-queries.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/dimension-exclusion.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/score-management.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/skip-cooloff.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/lib/submit-tier-list.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/pairs/movie-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/pairs/random-pair.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/pairs/smart-pair-fetch.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/rankings-overall.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/scores.service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/staleness.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/comparisons/types-domain.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/context-picks-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/flags.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/flags.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/plex-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/router-shelf.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/router-tmdb.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/router.assemble-session.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/service-library.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/service-preference-profile.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/service-rewatch.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/because-you-watched.shelf.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/credits-shelves.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/dimension-inspired.shelf.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-misc-shelves.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-runtime-shelves.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-score-shelves.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-shelves-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-watch-shelves.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/session.service.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/session.service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/shelf/top-dimension.shelf.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/discovery/tmdb-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/library/list-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/library/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/library/tv-show-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/movies/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/movies/types.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/router-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/router-sync.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-discover-check.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-discover-episode.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-discover-movie.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-discover-show.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-discover-watches.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-tv.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/plex/sync-watchlist.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/addition-gating.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/candidate-queue.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/download-candidate.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/exclusion-list.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/removal-selection.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-candidates-router.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-exclusions-router.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-log.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-log.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-scheduler-router.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/rotation-sources-router.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/selection-policy.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/selection-policy.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/source-crud.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/sync-all-sources.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/sync-source.test.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/rotation/sync-source.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/search/movies-adapter.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/search/tv-shows-adapter.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/thetvdb/refresh-episodes.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/thetvdb/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/thetvdb/types-inserts.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/tv-shows/episodes-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/tv-shows/seasons-service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/tv-shows/types-domain.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/tv-shows/types-mappers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/auto-remove-show.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/list-recent.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/log-watch-event.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/progress.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watch-history/types.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "type-only", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watchlist/plex-push.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watchlist/service.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "apps/pops-api/src/modules/media/watchlist/types.ts",
-    "to": "packages/media-db/dist/index.d.ts",
-    "unresolvedTo": "@pops/media-db",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-pillar-runtime-import-media"
+      "name": "no-dead-cerebrum-pkgs"
     }
   },
   {

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -74,6 +74,14 @@ module.exports = {
       from: { path: '.*' },
       to: { path: '^@pops/(app-finance-db|finance-db|finance-contract|finance-api)(/|$)' },
     },
+    {
+      name: 'no-dead-cerebrum-pkgs',
+      severity: 'error',
+      comment:
+        'Cerebrum has collapsed into `pillars/cerebrum/` — `@pops/cerebrum-db`, `@pops/cerebrum-contract`, and `@pops/cerebrum-api` are the retirement tombstone (deleted once the pops-api cerebrum module + pops-cerebrum-api are gone). No new code may import them; consumers go through `@pops/cerebrum` (contract types + api-types + openapi) and the cerebrum REST API for cross-pillar calls. Existing pops-api cerebrum-module imports are grandfathered in the known-violations baseline until they are removed.',
+      from: { path: '.*' },
+      to: { path: '^@pops/(cerebrum-db|cerebrum-contract|cerebrum-api)(/|$)' },
+    },
     ...contractBoundaryRules,
   ],
   options: {


### PR DESCRIPTION
Phase C (infra hygiene) of the cerebrum REST migration.

- Adds the `no-dead-cerebrum-pkgs` dep-cruiser rule banning imports of `@pops/(cerebrum-db|cerebrum-contract|cerebrum-api)` — cerebrum has collapsed into `pillars/cerebrum` (`@pops/cerebrum`). Mirrors the existing `no-dead-{lists,inventory,food,finance}-pkgs` bans.
- Existing monolith imports stay grandfathered via the known-violations baseline (`lint:boundaries` green: 0 unbaselined). They're removed in Phase E when the pops-api cerebrum module + `pops-cerebrum-api` are deleted.
- Synced the generated boundary-rules file (`lint:boundaries:verify` was reporting pre-existing drift).

The pops-api/shell Dockerfile `cerebrum-db`/`cerebrum-contract` COPY steps stay until Phase E (still imported by the live monolith cerebrum module).