### PR TITLE
feat(media/fe): rewire top-level hooks onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/hooks/discover-actions/discoverMutations.ts
+++ b/packages/app-media/src/hooks/discover-actions/discoverMutations.ts
@@ -1,61 +1,50 @@
-import { usePillarMutation } from '@pops/pillar-sdk/react';
+import { useMutation } from '@tanstack/react-query';
 
-interface AddMovieInput {
-  tmdbId: number;
-}
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  discoveryDismiss,
+  libraryAddMovie,
+  watchHistoryLog,
+  watchlistAdd,
+  watchlistRemove,
+} from '../../media-api/index.js';
 
-interface AddMovieResult {
-  created: boolean;
-  data: { id: number; title: string };
-}
+import type {
+  DiscoveryDismissData,
+  LibraryAddMovieData,
+  LibraryAddMovieResponses,
+  WatchHistoryLogData,
+  WatchHistoryLogResponses,
+  WatchlistAddData,
+  WatchlistAddResponses,
+  WatchlistRemoveData,
+} from '../../media-api/types.gen.js';
 
-interface AddWatchlistInput {
-  mediaType: 'movie';
-  mediaId: number;
-}
-
-interface AddWatchlistResult {
-  created: boolean;
-}
-
-interface RemoveWatchlistInput {
-  id: number;
-}
-
-interface LogWatchInput {
-  mediaType: 'movie';
-  mediaId: number;
-}
-
-interface LogWatchResult {
-  watchlistRemoved: boolean;
-}
-
-interface DismissInput {
-  tmdbId: number;
-}
+type AddMovieInput = NonNullable<LibraryAddMovieData['body']>;
+type AddMovieResult = LibraryAddMovieResponses[200];
+type AddWatchlistInput = NonNullable<WatchlistAddData['body']>;
+type AddWatchlistResult = WatchlistAddResponses[201];
+type RemoveWatchlistInput = WatchlistRemoveData['path'];
+type LogWatchInput = NonNullable<WatchHistoryLogData['body']>;
+type LogWatchResult = WatchHistoryLogResponses[201];
+type DismissInput = NonNullable<DiscoveryDismissData['body']>;
 
 export function useDiscoverMutations() {
-  const addMovieMutation = usePillarMutation<AddMovieInput, AddMovieResult>('media', [
-    'library',
-    'addMovie',
-  ]);
-  const addWatchlistMutation = usePillarMutation<AddWatchlistInput, AddWatchlistResult>('media', [
-    'watchlist',
-    'add',
-  ]);
-  const removeWatchlistMutation = usePillarMutation<RemoveWatchlistInput, unknown>('media', [
-    'watchlist',
-    'remove',
-  ]);
-  const logWatchMutation = usePillarMutation<LogWatchInput, LogWatchResult>('media', [
-    'watchHistory',
-    'log',
-  ]);
-  const dismissMutation = usePillarMutation<DismissInput, unknown>('media', [
-    'discovery',
-    'dismiss',
-  ]);
+  const addMovieMutation = useMutation<AddMovieResult, Error, AddMovieInput>({
+    mutationFn: async (body) => unwrap(await libraryAddMovie({ body })),
+  });
+  const addWatchlistMutation = useMutation<AddWatchlistResult, Error, AddWatchlistInput>({
+    mutationFn: async (body) => unwrap(await watchlistAdd({ body })),
+  });
+  const removeWatchlistMutation = useMutation<unknown, Error, RemoveWatchlistInput>({
+    mutationFn: async (path) => unwrap(await watchlistRemove({ path })),
+  });
+  const logWatchMutation = useMutation<LogWatchResult, Error, LogWatchInput>({
+    mutationFn: async (body) => unwrap(await watchHistoryLog({ body })),
+  });
+  const dismissMutation = useMutation<unknown, Error, DismissInput>({
+    mutationFn: async (body) => unwrap(await discoveryDismiss({ body })),
+  });
   return {
     addMovieMutation,
     addWatchlistMutation,

--- a/packages/app-media/src/hooks/discover-actions/handlers.ts
+++ b/packages/app-media/src/hooks/discover-actions/handlers.ts
@@ -1,7 +1,9 @@
+import { type QueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchlistStatus } from '../../media-api/index.js';
 
 import type { DiscoverActionResult } from '../useDiscoverCardActions';
 import type { useDiscoverMutations } from './discoverMutations';
@@ -9,17 +11,15 @@ import type { usePendingSet } from './usePendingSet';
 
 type Mutations = ReturnType<typeof useDiscoverMutations>;
 type Pending = ReturnType<typeof usePendingSet>;
-type PillarUtils = UsePillarUtilsResult;
-
-interface WatchlistStatusResponse {
-  onWatchlist: boolean;
-  entryId: number | null;
-}
 
 interface AddDeps {
   mutations: Mutations;
-  utils: PillarUtils;
+  queryClient: QueryClient;
   pending: Pending;
+}
+
+function invalidateWatchlist(queryClient: QueryClient) {
+  return queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'list'] });
 }
 
 export function useAddToLibrary({ mutations, pending }: AddDeps) {
@@ -42,7 +42,7 @@ export function useAddToLibrary({ mutations, pending }: AddDeps) {
   );
 }
 
-export function useAddToWatchlist({ mutations, utils, pending }: AddDeps) {
+export function useAddToWatchlist({ mutations, queryClient, pending }: AddDeps) {
   return useCallback(
     async (tmdbId: number): Promise<DiscoverActionResult> => {
       pending.add(tmdbId);
@@ -54,7 +54,7 @@ export function useAddToWatchlist({ mutations, utils, pending }: AddDeps) {
         });
         if (wlResult.created) toast.success(`Added "${libResult.data.title}" to watchlist`);
         else toast.info(`"${libResult.data.title}" is already on watchlist`);
-        void utils.invalidate(['watchlist', 'list']);
+        void invalidateWatchlist(queryClient);
         return { ok: true, inLibrary: true, onWatchlist: true };
       } catch {
         toast.error('Failed to add to watchlist');
@@ -63,27 +63,26 @@ export function useAddToWatchlist({ mutations, utils, pending }: AddDeps) {
         pending.remove(tmdbId);
       }
     },
-    [mutations, utils, pending]
+    [mutations, queryClient, pending]
   );
 }
 
-export function useRemoveFromWatchlist({ mutations, utils, pending }: AddDeps) {
+export function useRemoveFromWatchlist({ mutations, queryClient, pending }: AddDeps) {
   return useCallback(
     async (tmdbId: number): Promise<DiscoverActionResult> => {
       pending.add(tmdbId);
       try {
         const libResult = await mutations.addMovieMutation.mutateAsync({ tmdbId });
-        const status = await utils.fetchQuery<WatchlistStatusResponse>(['watchlist', 'status'], {
-          mediaType: 'movie',
-          mediaId: libResult.data.id,
-        });
+        const status = unwrap(
+          await watchlistStatus({ query: { mediaType: 'movie', mediaId: libResult.data.id } })
+        );
         if (!status.onWatchlist || status.entryId == null) {
           toast.info(`"${libResult.data.title}" is not on your watchlist`);
           return { ok: true, inLibrary: true, onWatchlist: false };
         }
         await mutations.removeWatchlistMutation.mutateAsync({ id: status.entryId });
         toast.success(`Removed "${libResult.data.title}" from watchlist`);
-        void utils.invalidate(['watchlist', 'list']);
+        void invalidateWatchlist(queryClient);
         return { ok: true, inLibrary: true, onWatchlist: false };
       } catch {
         toast.error('Failed to remove from watchlist');
@@ -92,11 +91,11 @@ export function useRemoveFromWatchlist({ mutations, utils, pending }: AddDeps) {
         pending.remove(tmdbId);
       }
     },
-    [mutations, utils, pending]
+    [mutations, queryClient, pending]
   );
 }
 
-export function useMarkWatched({ mutations, utils, pending }: AddDeps) {
+export function useMarkWatched({ mutations, queryClient, pending }: AddDeps) {
   return useCallback(
     async (tmdbId: number): Promise<DiscoverActionResult> => {
       pending.add(tmdbId);
@@ -105,10 +104,12 @@ export function useMarkWatched({ mutations, utils, pending }: AddDeps) {
         const watchResult = await mutations.logWatchMutation.mutateAsync({
           mediaType: 'movie',
           mediaId: libResult.data.id,
+          completed: 1,
+          source: 'manual',
         });
         toast.success(`Marked "${libResult.data.title}" as watched`);
         if (watchResult.watchlistRemoved) {
-          void utils.invalidate(['watchlist', 'list']);
+          void invalidateWatchlist(queryClient);
         }
         return {
           ok: true,
@@ -123,11 +124,11 @@ export function useMarkWatched({ mutations, utils, pending }: AddDeps) {
         pending.remove(tmdbId);
       }
     },
-    [mutations, utils, pending]
+    [mutations, queryClient, pending]
   );
 }
 
-export function useMarkRewatched({ mutations, utils, pending }: AddDeps) {
+export function useMarkRewatched({ mutations, pending }: AddDeps) {
   return useCallback(
     async (tmdbId: number): Promise<DiscoverActionResult> => {
       pending.add(tmdbId);
@@ -136,6 +137,8 @@ export function useMarkRewatched({ mutations, utils, pending }: AddDeps) {
         await mutations.logWatchMutation.mutateAsync({
           mediaType: 'movie',
           mediaId: libResult.data.id,
+          completed: 1,
+          source: 'manual',
         });
         toast.success(`Logged rewatch of "${libResult.data.title}"`);
         return { ok: true, inLibrary: true, isWatched: true };
@@ -146,18 +149,18 @@ export function useMarkRewatched({ mutations, utils, pending }: AddDeps) {
         pending.remove(tmdbId);
       }
     },
-    [mutations, utils, pending]
+    [mutations, pending]
   );
 }
 
 export function useNotInterested({
   mutations,
-  utils,
+  queryClient,
   dismissing,
   optimistic,
 }: {
   mutations: Mutations;
-  utils: PillarUtils;
+  queryClient: QueryClient;
   dismissing: Pending;
   optimistic: Pending;
 }) {
@@ -167,7 +170,7 @@ export function useNotInterested({
       dismissing.add(tmdbId);
       try {
         await mutations.dismissMutation.mutateAsync({ tmdbId });
-        void utils.invalidate(['discovery', 'getDismissed']);
+        void queryClient.invalidateQueries({ queryKey: ['media', 'discovery', 'getDismissed'] });
         return { ok: true };
       } catch {
         optimistic.remove(tmdbId);
@@ -177,6 +180,6 @@ export function useNotInterested({
         dismissing.remove(tmdbId);
       }
     },
-    [mutations, utils, dismissing, optimistic]
+    [mutations, queryClient, dismissing, optimistic]
   );
 }

--- a/packages/app-media/src/hooks/useDiscoverCardActions.ts
+++ b/packages/app-media/src/hooks/useDiscoverCardActions.ts
@@ -4,7 +4,7 @@
  * Encapsulates add-to-library, watchlist, watched, rewatch, and dismiss mutations
  * so they can be reused across the discover page and dynamic shelf sections.
  */
-import { usePillarUtils } from '@pops/pillar-sdk/react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { useDiscoverMutations } from './discover-actions/discoverMutations';
 import {
@@ -53,7 +53,7 @@ export interface DiscoverCardActions {
 }
 
 export function useDiscoverCardActions(): DiscoverCardActions {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const mutations = useDiscoverMutations();
 
   const addingToLibrary = usePendingSet();
@@ -72,15 +72,15 @@ export function useDiscoverCardActions(): DiscoverCardActions {
     markingRewatched: markingRewatched.set,
     dismissing: dismissing.set,
     optimisticDismissed: optimistic.set,
-    onAddToLibrary: useAddToLibrary({ mutations, utils, pending: addingToLibrary }),
-    onAddToWatchlist: useAddToWatchlist({ mutations, utils, pending: addingToWatchlist }),
+    onAddToLibrary: useAddToLibrary({ mutations, queryClient, pending: addingToLibrary }),
+    onAddToWatchlist: useAddToWatchlist({ mutations, queryClient, pending: addingToWatchlist }),
     onRemoveFromWatchlist: useRemoveFromWatchlist({
       mutations,
-      utils,
+      queryClient,
       pending: removingFromWatchlist,
     }),
-    onMarkWatched: useMarkWatched({ mutations, utils, pending: markingWatched }),
-    onMarkRewatched: useMarkRewatched({ mutations, utils, pending: markingRewatched }),
-    onNotInterested: useNotInterested({ mutations, utils, dismissing, optimistic }),
+    onMarkWatched: useMarkWatched({ mutations, queryClient, pending: markingWatched }),
+    onMarkRewatched: useMarkRewatched({ mutations, queryClient, pending: markingRewatched }),
+    onNotInterested: useNotInterested({ mutations, queryClient, dismissing, optimistic }),
   };
 }

--- a/packages/app-media/src/hooks/useMediaLibrary.ts
+++ b/packages/app-media/src/hooks/useMediaLibrary.ts
@@ -1,4 +1,7 @@
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { useQuery } from '@tanstack/react-query';
+
+import { unwrap } from '../media-api-helpers.js';
+import { libraryGenres, libraryList } from '../media-api/index.js';
 
 export type MediaType = 'all' | 'movie' | 'tv';
 export type SortOption = 'title' | 'dateAdded' | 'releaseDate' | 'rating';
@@ -58,17 +61,16 @@ function buildListInput(params: UseMediaLibraryParams) {
 }
 
 export function useMediaLibrary(params: UseMediaLibraryParams) {
-  const { data, isLoading, error, refetch } = usePillarQuery<LibraryListResult>(
-    'media',
-    ['library', 'list'],
-    buildListInput(params)
-  );
+  const listInput = buildListInput(params);
+  const { data, isLoading, error, refetch } = useQuery<LibraryListResult>({
+    queryKey: ['media', 'library', 'list', listInput],
+    queryFn: async () => unwrap(await libraryList({ query: listInput })),
+  });
 
-  const { data: genresData } = usePillarQuery<GenresResult>(
-    'media',
-    ['library', 'genres'],
-    undefined
-  );
+  const { data: genresData } = useQuery<GenresResult>({
+    queryKey: ['media', 'library', 'genres'],
+    queryFn: async () => unwrap(await libraryGenres()),
+  });
 
   const total = data?.pagination.total ?? 0;
   const isEmpty = !isLoading && !error && total === 0;

--- a/packages/app-media/src/hooks/useSyncJob.ts
+++ b/packages/app-media/src/hooks/useSyncJob.ts
@@ -4,10 +4,22 @@
  * Starts a job via mutation (returns immediately), polls for progress,
  * and auto-restores running jobs on mount (survives page navigation).
  */
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../media-api-helpers.js';
+import {
+  plexGetActiveSyncJobs,
+  plexGetLastSyncResults,
+  plexGetSyncJobStatus,
+  plexStartSyncJob,
+} from '../media-api/index.js';
+
+import type { PlexStartSyncJobData } from '../media-api/types.gen.js';
+
+type StartSyncJobBody = NonNullable<PlexStartSyncJobData['body']>;
+type WireJobType = StartSyncJobBody['jobType'];
 
 type SyncJobType =
   | 'plexSyncMovies'
@@ -16,6 +28,17 @@ type SyncJobType =
   | 'plexSyncWatchHistory'
   | 'plexSyncDiscoverWatches';
 
+const WIRE_JOB_TYPES: readonly WireJobType[] = [
+  'plexSyncMovies',
+  'plexSyncTvShows',
+  'plexSyncWatchlist',
+  'plexSyncWatchHistory',
+];
+
+function isWireJobType(jobType: SyncJobType): jobType is WireJobType {
+  return (WIRE_JOB_TYPES as readonly string[]).includes(jobType);
+}
+
 interface SyncJobProgress {
   processed: number;
   total: number;
@@ -23,7 +46,7 @@ interface SyncJobProgress {
 
 interface SyncJob {
   id: string;
-  jobType: SyncJobType;
+  jobType: string;
   status: 'running' | 'completed' | 'failed';
   startedAt: string;
   completedAt: string | null;
@@ -45,13 +68,6 @@ interface ActiveJobsResult {
 
 interface SyncJobStatusResult {
   data: SyncJob;
-}
-
-interface StartSyncJobInput {
-  jobType: SyncJobType;
-  sectionId?: string;
-  movieSectionId?: string;
-  tvSectionId?: string;
 }
 
 interface StartSyncJobResult {
@@ -98,15 +114,12 @@ function useRestoreActiveJob(
   setRestoredJob: (j: SyncJob) => void
 ) {
   const restoredRef = useRef(false);
-  const activeJobs = usePillarQuery<ActiveJobsResult>(
-    'media',
-    ['plex', 'getActiveSyncJobs'],
-    undefined,
-    {
-      enabled: !jobId && !restoredRef.current,
-      refetchOnWindowFocus: false,
-    }
-  );
+  const activeJobs = useQuery<ActiveJobsResult>({
+    queryKey: ['media', 'plex', 'getActiveSyncJobs'],
+    queryFn: async () => unwrap(await plexGetActiveSyncJobs()),
+    enabled: !jobId && !restoredRef.current,
+    refetchOnWindowFocus: false,
+  });
   const isRestoring = !restoredRef.current && !jobId && activeJobs.isLoading;
 
   useEffect(() => {
@@ -129,18 +142,15 @@ function useStatusPolling(
   restoredJob: SyncJob | null,
   clearRestored: () => void
 ) {
-  const statusQuery = usePillarQuery<SyncJobStatusResult>(
-    'media',
-    ['plex', 'getSyncJobStatus'],
-    { jobId: jobId ?? '' },
-    {
-      enabled: !!jobId,
-      refetchInterval: (query) => {
-        const status = query.state.data?.data?.status;
-        return status === 'running' ? 1500 : false;
-      },
-    }
-  );
+  const statusQuery = useQuery<SyncJobStatusResult>({
+    queryKey: ['media', 'plex', 'getSyncJobStatus', jobId],
+    queryFn: async () => unwrap(await plexGetSyncJobStatus({ path: { jobId: jobId ?? '' } })),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.data?.status;
+      return status === 'running' ? 1500 : false;
+    },
+  });
 
   useEffect(() => {
     if (statusQuery.data?.data && restoredJob) {
@@ -192,26 +202,27 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
   const { isRestoring } = useRestoreActiveJob(jobType, jobId, setJobId, setRestoredJob);
   const statusQuery = useStatusPolling(jobId, restoredJob, () => setRestoredJob(null));
 
-  const startMutation = usePillarMutation<StartSyncJobInput, StartSyncJobResult>(
-    'media',
-    ['plex', 'startSyncJob'],
-    {
-      onSuccess: (res) => {
-        setJobId(res.data.jobId);
-      },
-      onError: (err) => {
-        toast.error(`Failed to start ${label}: ${err.message}`);
-      },
-    }
-  );
+  const startMutation = useMutation<StartSyncJobResult, Error, StartSyncJobBody>({
+    mutationFn: async (body) => unwrap(await plexStartSyncJob({ body })),
+    onSuccess: (res) => {
+      setJobId(res.data.jobId);
+    },
+    onError: (err) => {
+      toast.error(`Failed to start ${label}: ${err.message}`);
+    },
+  });
 
   useCompletionToast(label, jobId, statusQuery.data?.data);
 
   const start = useCallback(
     (params?: SyncJobParams) => {
+      if (!isWireJobType(jobType)) {
+        toast.error(`${label} is not supported`);
+        return;
+      }
       startMutation.mutate({ jobType, ...params });
     },
-    [jobType, startMutation]
+    [jobType, label, startMutation]
   );
 
   const job = statusQuery.data?.data ?? restoredJob;
@@ -228,10 +239,9 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
 
 /** Hook to get "last synced" data for all sync types. */
 export function useLastSyncResults(): Record<string, SyncJob | null> {
-  const query = usePillarQuery<LastSyncResultsResult>(
-    'media',
-    ['plex', 'getLastSyncResults'],
-    undefined
-  );
+  const query = useQuery<LastSyncResultsResult>({
+    queryKey: ['media', 'plex', 'getLastSyncResults'],
+    queryFn: async () => unwrap(await plexGetLastSyncResults()),
+  });
   return query.data?.data ?? {};
 }

--- a/packages/app-media/src/hooks/useTierListSubmit.ts
+++ b/packages/app-media/src/hooks/useTierListSubmit.ts
@@ -4,9 +4,11 @@
  * Wraps the submitTierList pillar mutation with cache invalidation
  * and title enrichment for the summary display.
  */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 
-import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
+import { unwrap } from '../media-api-helpers.js';
+import { comparisonsSubmitTierList } from '../media-api/index.js';
 
 export type Tier = 'S' | 'A' | 'B' | 'C' | 'D';
 
@@ -51,28 +53,27 @@ interface SubmitTierListResponse {
 
 export function useTierListSubmit({ movieTitles, onSuccess }: UseTierListSubmitOptions) {
   const [result, setResult] = useState<TierListResult | null>(null);
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
 
-  const mutation = usePillarMutation<SubmitTierListInput, SubmitTierListResponse>(
-    'media',
-    ['comparisons', 'submitTierList'],
-    {
-      onSuccess: (response) => {
-        const enriched: TierListResult = {
-          comparisonsRecorded: response.data.comparisonsRecorded,
-          scoreChanges: response.data.scoreChanges.map((sc) => ({
-            ...sc,
-            title: movieTitles.get(sc.movieId) ?? `Movie #${sc.movieId}`,
-          })),
-        };
-        setResult(enriched);
-        void utils.invalidate(['comparisons', 'getTierListMovies']);
-        void utils.invalidate(['comparisons', 'listAll']);
-        void utils.invalidate(['comparisons', 'scores']);
-        onSuccess?.(enriched);
-      },
-    }
-  );
+  const mutation = useMutation<SubmitTierListResponse, Error, SubmitTierListInput>({
+    mutationFn: async (input) => unwrap(await comparisonsSubmitTierList({ body: input })),
+    onSuccess: (response) => {
+      const enriched: TierListResult = {
+        comparisonsRecorded: response.data.comparisonsRecorded,
+        scoreChanges: response.data.scoreChanges.map((sc) => ({
+          ...sc,
+          title: movieTitles.get(sc.movieId) ?? `Movie #${sc.movieId}`,
+        })),
+      };
+      setResult(enriched);
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getTierListMovies'],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons', 'listAll'] });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons', 'scores'] });
+      onSuccess?.(enriched);
+    },
+  });
 
   const submit = useCallback(
     (dimensionId: number, placements: TierPlacement[]) => {


### PR DESCRIPTION
Phase D tier-2. Rewires `packages/app-media/src/hooks/` (the shared top-level hooks) off `@pops/pillar-sdk/react` onto the generated Hey API SDK + react-query.

- `useMediaLibrary` (libraryList/libraryGenres), `useSyncJob`+`useLastSyncResults` (plex sync-job SDK fns), `useTierListSubmit` (comparisonsSubmitTierList), `useDiscoverCardActions` + its `discover-actions/{discoverMutations,handlers}` (library/watchlist/watch-history/dismiss).
- queryKey `['media',domain,op,input?]`; mutations invalidate `['media',domain]`; `unwrap` from media-api-helpers.
- **Divergences (honest, from backend changes):** `plexSyncDiscoverWatches` is type-guarded to a no-op (9b deferred Plex-Discover); `watchHistory.log` now supplies the required `completed:1, source:'manual'`.

Verified in ISOLATION (fe-quality red-by-design): zero type errors under src/hooks/, app-media tests no regression vs baseline, oxlint exit 0. Touches only `packages/app-media/src/hooks/**`.