### PR TITLE
feat(media/fe): rewire watchlist onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/components/WatchlistToggle.test.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.test.tsx
@@ -1,40 +1,17 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { WatchlistToggle } from './WatchlistToggle';
+const watchlistStatusMock = vi.hoisted(() => vi.fn());
+const watchlistAddMock = vi.hoisted(() => vi.fn());
+const watchlistRemoveMock = vi.hoisted(() => vi.fn());
 
-type MutationOpts = Record<string, (...args: unknown[]) => unknown>;
-
-let addMutationOpts: MutationOpts = {};
-let removeMutationOpts: MutationOpts = {};
-const mockAddMutate = vi.fn();
-const mockRemoveMutate = vi.fn();
-const mockInvalidate = vi.fn();
-const mockSetData = vi.fn();
-const mockStatusQuery = vi.fn();
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    if (path.join('.') === 'watchlist.status') return mockStatusQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (_pillarId: string, path: readonly string[], opts: MutationOpts) => {
-    const key = path.join('.');
-    if (key === 'watchlist.add') {
-      addMutationOpts = opts;
-      return { mutate: mockAddMutate, isPending: false };
-    }
-    if (key === 'watchlist.remove') {
-      removeMutationOpts = opts;
-      return { mutate: mockRemoveMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({
-    setData: mockSetData,
-    invalidate: mockInvalidate,
-  }),
+vi.mock('../media-api/index.js', () => ({
+  watchlistStatus: (...args: unknown[]) => watchlistStatusMock(...args),
+  watchlistAdd: (...args: unknown[]) => watchlistAddMock(...args),
+  watchlistRemove: (...args: unknown[]) => watchlistRemoveMock(...args),
 }));
 
 const mockToastSuccess = vi.fn();
@@ -48,25 +25,36 @@ vi.mock('sonner', () => ({
   },
 }));
 
-function setupNotOnWatchlist() {
-  mockStatusQuery.mockReturnValue({
-    data: { onWatchlist: false, entryId: null },
-    isLoading: false,
+import { WatchlistToggle } from './WatchlistToggle';
+
+type WatchlistStatus = { onWatchlist: boolean; entryId: number | null };
+
+function statusResult(data: WatchlistStatus) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+}
+
+function renderToggle(
+  props: { mediaType: 'movie' | 'tv'; mediaId: number },
+  queryClient = makeQueryClient()
+) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  const view = render(<WatchlistToggle {...props} />, { wrapper });
+  return { ...view, queryClient };
+}
+
+function setupNotOnWatchlist() {
+  watchlistStatusMock.mockResolvedValue(statusResult({ onWatchlist: false, entryId: null }));
 }
 
 function setupOnWatchlist() {
-  mockStatusQuery.mockReturnValue({
-    data: { onWatchlist: true, entryId: 42 },
-    isLoading: false,
-  });
-}
-
-function setupLoading() {
-  mockStatusQuery.mockReturnValue({
-    data: undefined,
-    isLoading: true,
-  });
+  watchlistStatusMock.mockResolvedValue(statusResult({ onWatchlist: true, entryId: 42 }));
 }
 
 afterEach(() => {
@@ -75,205 +63,201 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  addMutationOpts = {};
-  removeMutationOpts = {};
+  watchlistStatusMock.mockResolvedValue(statusResult({ onWatchlist: false, entryId: null }));
+  watchlistAddMock.mockResolvedValue({
+    data: { created: true, message: 'ok', data: { id: 1 } },
+    error: undefined,
+  });
+  watchlistRemoveMock.mockResolvedValue({ data: { message: 'ok' }, error: undefined });
 });
 
 describe('WatchlistToggle', () => {
   describe('initial state', () => {
     it('shows loading button while checking watchlist', () => {
-      setupLoading();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      watchlistStatusMock.mockReturnValue(new Promise(() => {}));
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
       expect(screen.getByLabelText('Checking watchlist status')).toBeInTheDocument();
     });
 
-    it("shows 'Add to Watchlist' when not on watchlist", () => {
+    it("shows 'Add to Watchlist' when not on watchlist", async () => {
       setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      expect(screen.getByText('Add to Watchlist')).toBeInTheDocument();
+      expect(await screen.findByText('Add to Watchlist')).toBeInTheDocument();
       expect(screen.getByLabelText('Add to watchlist')).toBeInTheDocument();
     });
 
-    it("shows 'On Watchlist' when on watchlist", () => {
+    it("shows 'On Watchlist' when on watchlist", async () => {
       setupOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      expect(screen.getByText('On Watchlist')).toBeInTheDocument();
+      expect(await screen.findByText('On Watchlist')).toBeInTheDocument();
       expect(screen.getByLabelText('Remove from watchlist')).toBeInTheDocument();
     });
   });
 
-  describe('optimistic add', () => {
-    it('calls addMutation.mutate on click when not on watchlist', async () => {
+  describe('add', () => {
+    it('calls watchlistAdd on click when not on watchlist', async () => {
       setupNotOnWatchlist();
       const user = userEvent.setup();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      await user.click(screen.getByRole('button', { name: 'Add to watchlist' }));
+      await user.click(await screen.findByRole('button', { name: 'Add to watchlist' }));
 
-      expect(mockAddMutate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
-    });
-
-    it('onMutate writes optimistic state via utils.setData and returns previous snapshot', () => {
-      setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
-
-      const previousData = { onWatchlist: false, entryId: null };
-      mockSetData.mockReturnValueOnce(previousData);
-
-      const context = addMutationOpts.onMutate!();
-
-      expect(mockSetData).toHaveBeenCalledWith(
-        ['watchlist', 'status'],
-        { mediaType: 'movie', mediaId: 550 },
-        expect.any(Function)
+      await waitFor(() =>
+        expect(watchlistAddMock).toHaveBeenCalledWith({
+          body: { mediaType: 'movie', mediaId: 550 },
+        })
       );
-      expect(context).toEqual({ previous: previousData });
-
-      const updater = mockSetData.mock.calls[0]![2] as (prev: unknown) => { onWatchlist: boolean };
-      expect(updater(previousData).onWatchlist).toBe(true);
     });
 
-    it('onSuccess shows success toast', () => {
+    it('optimistically flips the status before the request resolves', async () => {
       setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      let resolveAdd: ((value: unknown) => void) | undefined;
+      watchlistAddMock.mockReturnValue(
+        new Promise((resolve) => {
+          resolveAdd = resolve;
+        })
+      );
+      const user = userEvent.setup();
+      const { queryClient } = renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      addMutationOpts.onSuccess!();
+      await user.click(await screen.findByRole('button', { name: 'Add to watchlist' }));
 
-      expect(mockToastSuccess).toHaveBeenCalledWith('Added to watchlist');
+      await waitFor(() =>
+        expect(
+          queryClient.getQueryData<WatchlistStatus>([
+            'media',
+            'watchlist',
+            'status',
+            { mediaType: 'movie', mediaId: 550 },
+          ])
+        ).toEqual({ onWatchlist: true, entryId: -1 })
+      );
+      resolveAdd?.({ data: { created: true, message: 'ok', data: { id: 1 } }, error: undefined });
     });
 
-    it('onError rolls back cache via setData and shows error toast', () => {
+    it('shows a success toast when the add resolves', async () => {
       setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      const user = userEvent.setup();
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      const previous = { onWatchlist: false, entryId: null };
-      addMutationOpts.onError!({ message: 'Server error' }, {}, { previous });
+      await user.click(await screen.findByRole('button', { name: 'Add to watchlist' }));
 
-      const rollbackCall = mockSetData.mock.calls.at(-1)!;
-      expect(rollbackCall[0]).toEqual(['watchlist', 'status']);
-      expect(rollbackCall[1]).toEqual({ mediaType: 'movie', mediaId: 550 });
-      const rollbackUpdater = rollbackCall[2] as (prev: unknown) => unknown;
-      expect(rollbackUpdater(undefined)).toEqual(previous);
-      expect(mockToastError).toHaveBeenCalledWith('Failed to add: Server error');
+      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Added to watchlist'));
     });
 
-    it('onError without a context skips rollback and still toasts error', () => {
+    it('rolls back the optimistic status and toasts on error', async () => {
       setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      watchlistAddMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'Server error' },
+        response: { status: 500 },
+      });
+      const user = userEvent.setup();
+      const { queryClient } = renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      addMutationOpts.onError!({ message: 'Boom' }, {}, undefined);
+      await user.click(await screen.findByRole('button', { name: 'Add to watchlist' }));
 
-      expect(mockSetData).not.toHaveBeenCalled();
-      expect(mockToastError).toHaveBeenCalledWith('Failed to add: Boom');
-    });
-
-    it('onSettled invalidates the watchlist.status router slice', () => {
-      setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
-
-      addMutationOpts.onSettled!();
-
-      expect(mockInvalidate).toHaveBeenCalledWith(['watchlist', 'status']);
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith('Failed to add: Server error')
+      );
+      expect(
+        queryClient.getQueryData<WatchlistStatus>([
+          'media',
+          'watchlist',
+          'status',
+          { mediaType: 'movie', mediaId: 550 },
+        ])
+      ).toEqual({ onWatchlist: false, entryId: null });
+      expect(mockToastInfo).not.toHaveBeenCalled();
     });
   });
 
-  describe('optimistic remove', () => {
-    it('calls removeMutation.mutate on click when on watchlist', async () => {
+  describe('remove', () => {
+    it('calls watchlistRemove with the entry id on click when on watchlist', async () => {
       setupOnWatchlist();
       const user = userEvent.setup();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      await user.click(screen.getByRole('button', { name: 'Remove from watchlist' }));
+      await user.click(await screen.findByRole('button', { name: 'Remove from watchlist' }));
 
-      expect(mockRemoveMutate).toHaveBeenCalledWith({ id: 42 });
+      await waitFor(() => expect(watchlistRemoveMock).toHaveBeenCalledWith({ path: { id: 42 } }));
     });
 
-    it('onMutate writes cleared status via setData and returns previous snapshot', () => {
+    it('optimistically clears the status before the request resolves', async () => {
       setupOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
-
-      const previousData = { onWatchlist: true, entryId: 42 };
-      mockSetData.mockReturnValueOnce(previousData);
-
-      const context = removeMutationOpts.onMutate!();
-
-      expect(mockSetData).toHaveBeenCalledWith(
-        ['watchlist', 'status'],
-        { mediaType: 'movie', mediaId: 550 },
-        expect.any(Function)
+      let resolveRemove: ((value: unknown) => void) | undefined;
+      watchlistRemoveMock.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRemove = resolve;
+        })
       );
-      expect(context).toEqual({ previous: previousData });
+      const user = userEvent.setup();
+      const { queryClient } = renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      const updater = mockSetData.mock.calls[0]![2] as (prev: unknown) => {
-        onWatchlist: boolean;
-        entryId: number | null;
-      };
-      const result = updater(previousData);
-      expect(result.onWatchlist).toBe(false);
-      expect(result.entryId).toBeNull();
+      await user.click(await screen.findByRole('button', { name: 'Remove from watchlist' }));
+
+      await waitFor(() =>
+        expect(
+          queryClient.getQueryData<WatchlistStatus>([
+            'media',
+            'watchlist',
+            'status',
+            { mediaType: 'movie', mediaId: 550 },
+          ])
+        ).toEqual({ onWatchlist: false, entryId: null })
+      );
+      resolveRemove?.({ data: { message: 'ok' }, error: undefined });
     });
 
-    it('onSuccess shows success toast', () => {
+    it('shows a success toast when the remove resolves', async () => {
       setupOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      const user = userEvent.setup();
+      renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      removeMutationOpts.onSuccess!();
+      await user.click(await screen.findByRole('button', { name: 'Remove from watchlist' }));
 
-      expect(mockToastSuccess).toHaveBeenCalledWith('Removed from watchlist');
+      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Removed from watchlist'));
     });
 
-    it('onError rolls back cache and shows error toast', () => {
+    it('rolls back the optimistic status and toasts on error', async () => {
       setupOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      watchlistRemoveMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'Network error' },
+        response: { status: 500 },
+      });
+      const user = userEvent.setup();
+      const { queryClient } = renderToggle({ mediaType: 'movie', mediaId: 550 });
 
-      const previous = { onWatchlist: true, entryId: 42 };
-      removeMutationOpts.onError!({ message: 'Network error' }, {}, { previous });
+      await user.click(await screen.findByRole('button', { name: 'Remove from watchlist' }));
 
-      const rollbackCall = mockSetData.mock.calls.at(-1)!;
-      expect(rollbackCall[0]).toEqual(['watchlist', 'status']);
-      expect(rollbackCall[1]).toEqual({ mediaType: 'movie', mediaId: 550 });
-      const rollbackUpdater = rollbackCall[2] as (prev: unknown) => unknown;
-      expect(rollbackUpdater(undefined)).toEqual(previous);
-      expect(mockToastError).toHaveBeenCalledWith('Failed to remove: Network error');
-    });
-
-    it('onSettled invalidates the watchlist.status router slice', () => {
-      setupOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
-
-      removeMutationOpts.onSettled!();
-
-      expect(mockInvalidate).toHaveBeenCalledWith(['watchlist', 'status']);
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith('Failed to remove: Network error')
+      );
+      expect(
+        queryClient.getQueryData<WatchlistStatus>([
+          'media',
+          'watchlist',
+          'status',
+          { mediaType: 'movie', mediaId: 550 },
+        ])
+      ).toEqual({ onWatchlist: true, entryId: 42 });
     });
   });
 
   describe('media type conversion', () => {
-    it("converts 'tv' to 'tv_show' for API calls", () => {
-      mockStatusQuery.mockReturnValue({
-        data: { onWatchlist: false, entryId: null },
-        isLoading: false,
-      });
-      render(<WatchlistToggle mediaType="tv" mediaId={100} />);
-
-      expect(mockStatusQuery).toHaveBeenCalledWith({ mediaType: 'tv_show', mediaId: 100 });
-    });
-  });
-
-  describe('info toast', () => {
-    it('does not surface info toast (CONFLICT branch removed in SDK migration)', () => {
+    it("converts 'tv' to 'tv_show' for the status query", async () => {
       setupNotOnWatchlist();
-      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+      renderToggle({ mediaType: 'tv', mediaId: 100 });
 
-      addMutationOpts.onError!(
-        { message: 'Conflict' },
-        {},
-        { previous: { onWatchlist: false, entryId: null } }
+      await waitFor(() =>
+        expect(watchlistStatusMock).toHaveBeenCalledWith({
+          query: { mediaType: 'tv_show', mediaId: 100 },
+        })
       );
-
-      expect(mockToastInfo).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app-media/src/components/watchlist-toggle/useWatchlistToggleModel.ts
+++ b/packages/app-media/src/components/watchlist-toggle/useWatchlistToggleModel.ts
@@ -1,8 +1,8 @@
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
-
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchlistAdd, watchlistRemove, watchlistStatus } from '../../media-api/index.js';
 
 type ApiMediaType = 'movie' | 'tv_show';
 
@@ -10,94 +10,89 @@ type WatchlistStatus = { onWatchlist: boolean; entryId: number | null };
 
 type WatchlistMutationContext = { previous: WatchlistStatus | undefined };
 
-function snapshotAndApply(
-  utils: UsePillarUtilsResult,
+function statusQueryKey(apiMediaType: ApiMediaType, mediaId: number) {
+  return ['media', 'watchlist', 'status', { mediaType: apiMediaType, mediaId }] as const;
+}
+
+async function snapshotAndApply(
+  queryClient: QueryClient,
   apiMediaType: ApiMediaType,
   mediaId: number,
   next: WatchlistStatus
-): WatchlistMutationContext {
-  const previous = utils.setData<WatchlistStatus>(
-    ['watchlist', 'status'],
-    { mediaType: apiMediaType, mediaId },
-    () => next
-  );
+): Promise<WatchlistMutationContext> {
+  const key = statusQueryKey(apiMediaType, mediaId);
+  await queryClient.cancelQueries({ queryKey: key });
+  const previous = queryClient.getQueryData<WatchlistStatus>(key);
+  queryClient.setQueryData<WatchlistStatus>(key, next);
   return { previous };
 }
 
 function rollback(
-  utils: UsePillarUtilsResult,
+  queryClient: QueryClient,
   apiMediaType: ApiMediaType,
   mediaId: number,
   context: WatchlistMutationContext | undefined
 ) {
   if (!context) return;
-  utils.setData<WatchlistStatus | undefined>(
-    ['watchlist', 'status'],
-    { mediaType: apiMediaType, mediaId },
-    () => context.previous
+  queryClient.setQueryData<WatchlistStatus | undefined>(
+    statusQueryKey(apiMediaType, mediaId),
+    context.previous
   );
 }
 
-function useAddMutation(apiMediaType: ApiMediaType, mediaId: number, utils: UsePillarUtilsResult) {
-  return usePillarMutation<
-    { mediaType: ApiMediaType; mediaId: number },
-    unknown,
-    WatchlistMutationContext
-  >('media', ['watchlist', 'add'], {
+function useAddMutation(apiMediaType: ApiMediaType, mediaId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { mediaType: ApiMediaType; mediaId: number }) =>
+      unwrap(await watchlistAdd({ body: vars })),
     onMutate: () =>
-      snapshotAndApply(utils, apiMediaType, mediaId, { onWatchlist: true, entryId: -1 }),
+      snapshotAndApply(queryClient, apiMediaType, mediaId, { onWatchlist: true, entryId: -1 }),
     onSuccess: () => {
       toast.success('Added to watchlist');
     },
-    onError: (err, _vars, context) => {
-      rollback(utils, apiMediaType, mediaId, context);
+    onError: (err: Error, _vars, context) => {
+      rollback(queryClient, apiMediaType, mediaId, context);
       toast.error(`Failed to add: ${err.message}`);
     },
     onSettled: () => {
-      void utils.invalidate(['watchlist', 'status']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'status'] });
     },
   });
 }
 
-function useRemoveMutation(
-  apiMediaType: ApiMediaType,
-  mediaId: number,
-  utils: UsePillarUtilsResult
-) {
-  return usePillarMutation<{ id: number }, unknown, WatchlistMutationContext>(
-    'media',
-    ['watchlist', 'remove'],
-    {
-      onMutate: () =>
-        snapshotAndApply(utils, apiMediaType, mediaId, { onWatchlist: false, entryId: null }),
-      onSuccess: () => {
-        toast.success('Removed from watchlist');
-      },
-      onError: (err, _vars, context) => {
-        rollback(utils, apiMediaType, mediaId, context);
-        toast.error(`Failed to remove: ${err.message}`);
-      },
-      onSettled: () => {
-        void utils.invalidate(['watchlist', 'status']);
-      },
-    }
-  );
+function useRemoveMutation(apiMediaType: ApiMediaType, mediaId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { id: number }) =>
+      unwrap(await watchlistRemove({ path: { id: vars.id } })),
+    onMutate: () =>
+      snapshotAndApply(queryClient, apiMediaType, mediaId, { onWatchlist: false, entryId: null }),
+    onSuccess: () => {
+      toast.success('Removed from watchlist');
+    },
+    onError: (err: Error, _vars, context) => {
+      rollback(queryClient, apiMediaType, mediaId, context);
+      toast.error(`Failed to remove: ${err.message}`);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'status'] });
+    },
+  });
 }
 
 export function useWatchlistToggleModel(apiMediaType: ApiMediaType, mediaId: number) {
-  const utils = usePillarUtils('media');
-  const { data: statusData, isLoading: isChecking } = usePillarQuery<WatchlistStatus>(
-    'media',
-    ['watchlist', 'status'],
-    { mediaType: apiMediaType, mediaId },
-    { staleTime: 30_000 }
-  );
+  const { data: statusData, isLoading: isChecking } = useQuery({
+    queryKey: statusQueryKey(apiMediaType, mediaId),
+    queryFn: async () =>
+      unwrap(await watchlistStatus({ query: { mediaType: apiMediaType, mediaId } })),
+    staleTime: 30_000,
+  });
 
   const isOnWatchlist = statusData?.onWatchlist ?? false;
   const watchlistEntryId = statusData?.entryId ?? null;
 
-  const addMutation = useAddMutation(apiMediaType, mediaId, utils);
-  const removeMutation = useRemoveMutation(apiMediaType, mediaId, utils);
+  const addMutation = useAddMutation(apiMediaType, mediaId);
+  const removeMutation = useRemoveMutation(apiMediaType, mediaId);
 
   const isMutating = addMutation.isPending || removeMutation.isPending;
 

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
@@ -1,10 +1,11 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockStartMutate = vi.fn();
 const mockGetActive = vi.fn();
 const mockGetStatus = vi.fn();
-const mockInvalidateWatchlist = vi.fn();
 let capturedStartOpts: Record<string, (...args: unknown[]) => unknown> = {};
 
 vi.mock('@pops/pillar-sdk/react', () => ({
@@ -31,11 +32,6 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     }
     return { mutate: vi.fn(), isPending: false };
   },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: mockInvalidateWatchlist,
-    fetchQuery: vi.fn(),
-  }),
 }));
 
 const mockToastSuccess = vi.fn();
@@ -48,6 +44,15 @@ vi.mock('sonner', () => ({
 }));
 
 import { WatchlistPlexSyncButton } from './WatchlistPlexSyncButton';
+
+function renderButton() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<WatchlistPlexSyncButton />, { wrapper });
+}
 
 function setupIdle(): void {
   mockGetActive.mockReturnValue({ data: { data: [] }, isLoading: false });
@@ -82,7 +87,7 @@ describe('WatchlistPlexSyncButton', () => {
 
   it('renders the sync button with label "Sync with Plex" when idle', () => {
     setupIdle();
-    render(<WatchlistPlexSyncButton />);
+    renderButton();
     const button = screen.getByTestId('watchlist-plex-sync-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Sync with Plex');
@@ -91,13 +96,13 @@ describe('WatchlistPlexSyncButton', () => {
 
   it('exposes an aria-label for assistive tech', () => {
     setupIdle();
-    render(<WatchlistPlexSyncButton />);
+    renderButton();
     expect(screen.getByRole('button', { name: 'Sync watchlist with Plex' })).toBeInTheDocument();
   });
 
   it('triggers a plexSyncWatchlist mutation when clicked', () => {
     setupIdle();
-    render(<WatchlistPlexSyncButton />);
+    renderButton();
     fireEvent.click(screen.getByTestId('watchlist-plex-sync-button'));
     expect(mockStartMutate).toHaveBeenCalledTimes(1);
     expect(mockStartMutate).toHaveBeenCalledWith({ jobType: 'plexSyncWatchlist' });
@@ -105,7 +110,7 @@ describe('WatchlistPlexSyncButton', () => {
 
   it('disables the button and swaps copy to "Syncing…" while a job is running', () => {
     setupRunning();
-    render(<WatchlistPlexSyncButton />);
+    renderButton();
     const button = screen.getByTestId('watchlist-plex-sync-button');
     expect(button).toBeDisabled();
     expect(button).toHaveTextContent('Syncing…');
@@ -113,7 +118,7 @@ describe('WatchlistPlexSyncButton', () => {
 
   it('surfaces the start mutation error path via the hook (error toast)', () => {
     setupIdle();
-    render(<WatchlistPlexSyncButton />);
+    renderButton();
     const onError = capturedStartOpts.onError;
     expect(typeof onError).toBe('function');
     if (typeof onError !== 'function') return;

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.tsx
@@ -10,16 +10,16 @@
  * Toasts ("Watchlist sync complete" / "failed") are emitted by the hook
  * itself — this component owns only the UI affordance and cache invalidation.
  */
+import { useQueryClient } from '@tanstack/react-query';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
-import { usePillarUtils } from '@pops/pillar-sdk/react';
 import { Button } from '@pops/ui';
 
 import { useSyncJob } from '../../hooks/useSyncJob';
 
 export function WatchlistPlexSyncButton() {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const sync = useSyncJob('plexSyncWatchlist');
   const previousStatusRef = useRef(sync.status);
 
@@ -30,10 +30,10 @@ export function WatchlistPlexSyncButton() {
   // history.
   useEffect(() => {
     if (previousStatusRef.current === 'running' && sync.status === 'completed') {
-      void utils.invalidate(['watchlist', 'list']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'list'] });
     }
     previousStatusRef.current = sync.status;
-  }, [sync.status, utils]);
+  }, [sync.status, queryClient]);
 
   const busy = sync.isStarting || sync.isRunning;
 

--- a/packages/app-media/src/pages/watchlist/useWatchlistMutations.ts
+++ b/packages/app-media/src/pages/watchlist/useWatchlistMutations.ts
@@ -1,9 +1,9 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
-
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchlistRemove, watchlistReorder, watchlistUpdate } from '../../media-api/index.js';
 
 import type { WatchlistEntry } from './types';
 
@@ -25,14 +25,17 @@ interface ReorderInput {
   items: Array<{ id: number; priority: number }>;
 }
 
-function useRemoveMutation(utils: UsePillarUtilsResult, setRemovingId: (v: number | null) => void) {
-  return usePillarMutation<RemoveInput, unknown>('media', ['watchlist', 'remove'], {
+function useRemoveMutation(setRemovingId: (v: number | null) => void) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: RemoveInput) =>
+      unwrap(await watchlistRemove({ path: { id: input.id } })),
     onSuccess: () => {
       setRemovingId(null);
       toast.success('Removed from watchlist');
-      void utils.invalidate(['watchlist', 'list']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'list'] });
     },
-    onError: (err) => {
+    onError: (err: Error) => {
       setRemovingId(null);
       toast.error(`Failed to remove: ${err.message}`);
     },
@@ -40,31 +43,35 @@ function useRemoveMutation(utils: UsePillarUtilsResult, setRemovingId: (v: numbe
 }
 
 function useUpdateMutation(
-  utils: UsePillarUtilsResult,
   setUpdateErrorId: (v: number | null) => void,
   setUpdateErrorMsg: (v: string | null) => void
 ) {
-  return usePillarMutation<UpdateInput, unknown>('media', ['watchlist', 'update'], {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpdateInput) =>
+      unwrap(await watchlistUpdate({ path: { id: input.id }, body: input.data })),
     onSuccess: () => {
       setUpdateErrorId(null);
       setUpdateErrorMsg(null);
       toast.success('Notes saved');
-      void utils.invalidate(['watchlist', 'list']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'list'] });
     },
-    onError: (error) => {
+    onError: (error: Error) => {
       setUpdateErrorMsg(error.message ?? 'Failed to save notes');
       toast.error(`Failed to save notes: ${error.message}`);
     },
   });
 }
 
-function useReorderMutation(utils: UsePillarUtilsResult, args: MutationsArgs) {
-  return usePillarMutation<ReorderInput, unknown>('media', ['watchlist', 'reorder'], {
+function useReorderMutation(args: MutationsArgs) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: ReorderInput) => unwrap(await watchlistReorder({ body: input })),
     onSuccess: () => {
       args.setOptimisticOrder(null);
-      void utils.invalidate(['watchlist', 'list']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist', 'list'] });
     },
-    onError: (err) => {
+    onError: (err: Error) => {
       args.setOptimisticOrder(null);
       toast.error(`Failed to reorder: ${err.message}`);
     },
@@ -75,14 +82,13 @@ function useReorderMutation(utils: UsePillarUtilsResult, args: MutationsArgs) {
 }
 
 export function useWatchlistMutations(args: MutationsArgs) {
-  const utils = usePillarUtils('media');
   const [removingId, setRemovingId] = useState<number | null>(null);
   const [updateErrorId, setUpdateErrorId] = useState<number | null>(null);
   const [updateErrorMsg, setUpdateErrorMsg] = useState<string | null>(null);
 
-  const removeMutation = useRemoveMutation(utils, setRemovingId);
-  const updateMutation = useUpdateMutation(utils, setUpdateErrorId, setUpdateErrorMsg);
-  const reorderMutation = useReorderMutation(utils, args);
+  const removeMutation = useRemoveMutation(setRemovingId);
+  const updateMutation = useUpdateMutation(setUpdateErrorId, setUpdateErrorMsg);
+  const reorderMutation = useReorderMutation(args);
 
   return {
     removeMutation,

--- a/packages/app-media/src/pages/watchlist/useWatchlistPageModel.ts
+++ b/packages/app-media/src/pages/watchlist/useWatchlistPageModel.ts
@@ -1,40 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../../media-api-helpers.js';
+import { moviesList, tvShowsList, watchlistList } from '../../media-api/index.js';
 import { parseTypeParam, type WatchlistEntry, type WatchlistFilter } from './types';
 import { useWatchlistDnd } from './useWatchlistDnd';
 import { useWatchlistMediaMaps } from './useWatchlistMediaMaps';
 import { useWatchlistMutations } from './useWatchlistMutations';
-
-interface WatchlistListResponse {
-  data: WatchlistEntry[];
-}
-
-interface MovieRow {
-  id: number;
-  title: string;
-  releaseDate: string | null;
-  posterUrl: string | null;
-  rotationStatus?: 'leaving' | 'protected' | null;
-  rotationExpiresAt?: string | null;
-}
-
-interface TvRow {
-  id: number;
-  name: string;
-  firstAirDate: string | null;
-  posterUrl: string | null;
-}
-
-interface MoviesListResponse {
-  data: MovieRow[];
-}
-
-interface TvShowsListResponse {
-  data: TvRow[];
-}
 
 function useFilterState() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -49,24 +22,26 @@ function useFilterState() {
 }
 
 function useWatchlistData(filter: WatchlistFilter) {
+  const watchlistQueryInput = {
+    ...(filter !== 'all' ? { mediaType: filter } : {}),
+    limit: 500,
+  };
   const {
     data: watchlistData,
     isLoading,
     error: watchlistError,
-  } = usePillarQuery<WatchlistListResponse>('media', ['watchlist', 'list'], {
-    ...(filter !== 'all' ? { mediaType: filter } : {}),
-    limit: 500,
+  } = useQuery({
+    queryKey: ['media', 'watchlist', 'list', watchlistQueryInput],
+    queryFn: async () => unwrap(await watchlistList({ query: watchlistQueryInput })),
   });
-  const { data: moviesData, isLoading: moviesLoading } = usePillarQuery<MoviesListResponse>(
-    'media',
-    ['movies', 'list'],
-    { limit: 500 }
-  );
-  const { data: tvShowsData, isLoading: tvShowsLoading } = usePillarQuery<TvShowsListResponse>(
-    'media',
-    ['tvShows', 'list'],
-    { limit: 500 }
-  );
+  const { data: moviesData, isLoading: moviesLoading } = useQuery({
+    queryKey: ['media', 'movies', 'list', { limit: 500 }],
+    queryFn: async () => unwrap(await moviesList({ query: { limit: 500 } })),
+  });
+  const { data: tvShowsData, isLoading: tvShowsLoading } = useQuery({
+    queryKey: ['media', 'tvShows', 'list', { limit: 500 }],
+    queryFn: async () => unwrap(await tvShowsList({ query: { limit: 500 } })),
+  });
   return {
     watchlistData,
     isLoading,
@@ -134,7 +109,7 @@ export function useWatchlistPageModel() {
   const { getMetaForEntry } = useWatchlistMediaMaps(data.moviesData, data.tvShowsData);
   const mutations = useWatchlistMutations({ setIsReordering, setOptimisticOrder });
 
-  const entries = data.watchlistData?.data ?? [];
+  const entries: WatchlistEntry[] = data.watchlistData?.data ?? [];
   const sortedEntries = optimisticOrder ?? entries;
   const loading = data.isLoading || data.moviesLoading || data.tvShowsLoading;
 


### PR DESCRIPTION
Phase D tier-2. Rewires the **watchlist** area in app-media (`pages/watchlist/**` + `components/watchlist-toggle/**`, ~14 sites) onto the Hey API SDK + react-query, with optimistic cache updates in the toggle (cancel/get/set + rollback). SDK fns: watchlistList/Status/Add/Remove/Reorder/Update (+ moviesList/tvShowsList for the page model). queryKey `['media','watchlist',…]`. Verified in isolation (fe-quality red-by-design); the WatchlistPlexSyncButton test now passes since the hooks rewire (#3405, useSyncJob) is merged. Disjoint from hooks → clean.