### PR TITLE
feat(media/fe): rewire candidate-queue onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/candidate-queue/CandidateList.test.tsx
+++ b/packages/app-media/src/pages/candidate-queue/CandidateList.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rotationListCandidatesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../media-api/index.js', () => ({
+  rotationListCandidates: (...args: unknown[]) => rotationListCandidatesMock(...args),
+}));
+
+vi.mock('./CandidateCard', () => ({
+  CandidateCard: ({ candidate }: { candidate: { id: number; title: string } }) =>
+    createElement('div', { 'data-testid': `card-${candidate.id}` }, candidate.title),
+}));
+
+import { CandidateList } from './CandidateList';
+
+interface CandidateRow {
+  id: number;
+  tmdbId: number;
+  title: string;
+  year: number | null;
+  rating: number | null;
+  posterPath: string | null;
+  discoveredAt: string;
+  sourceId: number;
+  sourceName: string | null;
+  sourcePriority: number | null;
+  status: string;
+}
+
+function row(id: number, title: string): CandidateRow {
+  return {
+    id,
+    tmdbId: id * 10,
+    title,
+    year: 2024,
+    rating: 7.5,
+    posterPath: null,
+    discoveredAt: '2026-01-01T00:00:00Z',
+    sourceId: 1,
+    sourceName: 'Manual',
+    sourcePriority: 1,
+    status: 'pending',
+  };
+}
+
+function listResult(items: CandidateRow[], total: number) {
+  return { data: { data: { items, total } }, error: undefined };
+}
+
+function renderList(props?: {
+  status?: 'pending' | 'added' | 'excluded';
+  actions?: 'pending' | 'excluded' | 'none';
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(
+    <CandidateList status={props?.status ?? 'pending'} actions={props?.actions ?? 'pending'} />,
+    { wrapper }
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CandidateList', () => {
+  it('queries rotationListCandidates with the status filter and page-zero offset', async () => {
+    rotationListCandidatesMock.mockResolvedValue(listResult([row(1, 'Dune')], 1));
+    renderList({ status: 'added' });
+
+    await waitFor(() =>
+      expect(rotationListCandidatesMock).toHaveBeenCalledWith({
+        query: { status: 'added', search: undefined, limit: 20, offset: 0 },
+      })
+    );
+  });
+
+  it('renders a card per returned candidate', async () => {
+    rotationListCandidatesMock.mockResolvedValue(
+      listResult([row(1, 'Dune'), row(2, 'Arrival')], 2)
+    );
+    renderList();
+
+    expect(await screen.findByTestId('card-1')).toHaveTextContent('Dune');
+    expect(screen.getByTestId('card-2')).toHaveTextContent('Arrival');
+  });
+
+  it('shows the empty-state copy when the list is empty', async () => {
+    rotationListCandidatesMock.mockResolvedValue(listResult([], 0));
+    renderList();
+
+    expect(await screen.findByText('No candidates found')).toBeInTheDocument();
+  });
+
+  it('surfaces the unwrapped error rather than rendering stale data', async () => {
+    rotationListCandidatesMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'rotation down' },
+      response: { status: 500 },
+    });
+    renderList();
+
+    await waitFor(() => expect(screen.getByText('No candidates found')).toBeInTheDocument());
+    expect(screen.queryByTestId('card-1')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/pages/candidate-queue/CandidateList.tsx
+++ b/packages/app-media/src/pages/candidate-queue/CandidateList.tsx
@@ -1,9 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
 import { Search } from 'lucide-react';
 import { useState } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
+import { unwrap } from '../../media-api-helpers.js';
+import { rotationListCandidates } from '../../media-api/index.js';
 import { CandidateCard } from './CandidateCard';
 import { Pagination } from './Pagination';
 
@@ -42,42 +44,39 @@ function CandidateLoading() {
   );
 }
 
-interface ListCandidatesResult {
-  items: Candidate[];
-  total: number;
-}
-
 export function CandidateList({ status, actions }: CandidateListProps) {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
 
-  const query = usePillarQuery<ListCandidatesResult>('media', ['rotation', 'listCandidates'], {
+  const queryInput = {
     status,
     search: search || undefined,
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
+  };
+  const query = useQuery({
+    queryKey: ['media', 'rotation', 'listCandidates', queryInput],
+    queryFn: async () => unwrap(await rotationListCandidates({ query: queryInput })),
   });
 
-  const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
+  const result = query.data?.data;
+  const items: Candidate[] = result?.items ?? [];
+  const total = result?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   function renderBody() {
     if (query.isLoading) return <CandidateLoading />;
-    if (!query.data?.items.length) {
+    if (!items.length) {
       return <p className="text-sm text-muted-foreground py-8 text-center">No candidates found</p>;
     }
     return (
       <>
         <div className="space-y-2">
-          {query.data.items.map((c) => (
+          {items.map((c) => (
             <CandidateCard key={c.id} candidate={c} actions={actions} />
           ))}
         </div>
-        <Pagination
-          page={page}
-          totalPages={totalPages}
-          total={query.data.total}
-          onPageChange={setPage}
-        />
+        <Pagination page={page} totalPages={totalPages} total={total} onPageChange={setPage} />
       </>
     );
   }

--- a/packages/app-media/src/pages/candidate-queue/useCardMutations.test.tsx
+++ b/packages/app-media/src/pages/candidate-queue/useCardMutations.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rotationDownloadCandidateMock = vi.hoisted(() => vi.fn());
+const rotationAddExclusionMock = vi.hoisted(() => vi.fn());
+const rotationRemoveExclusionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../media-api/index.js', () => ({
+  rotationDownloadCandidate: (...args: unknown[]) => rotationDownloadCandidateMock(...args),
+  rotationAddExclusion: (...args: unknown[]) => rotationAddExclusionMock(...args),
+  rotationRemoveExclusion: (...args: unknown[]) => rotationRemoveExclusionMock(...args),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { useCardMutations } from './useCardMutations';
+
+import type { Candidate } from './CandidateCard';
+
+const candidate: Candidate = {
+  id: 7,
+  tmdbId: 550,
+  title: 'Fight Club',
+  year: 1999,
+  rating: 8.4,
+  posterPath: null,
+  discoveredAt: '2026-01-01T00:00:00Z',
+  sourceName: 'Manual',
+  sourcePriority: 1,
+};
+
+function setupHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const setPopoverOpen = vi.fn();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  const { result } = renderHook(() => useCardMutations(candidate, setPopoverOpen), { wrapper });
+  return { result, invalidateSpy, setPopoverOpen };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rotationDownloadCandidateMock.mockResolvedValue({
+    data: { data: { success: true, alreadyInRadarr: false } },
+    error: undefined,
+  });
+  rotationAddExclusionMock.mockResolvedValue({ data: { message: 'ok' }, error: undefined });
+  rotationRemoveExclusionMock.mockResolvedValue({
+    data: { data: { success: true } },
+    error: undefined,
+  });
+});
+
+describe('useCardMutations', () => {
+  describe('download', () => {
+    it('downloads by candidate id and invalidates the candidates list', async () => {
+      const { result, invalidateSpy } = setupHook();
+
+      result.current.downloadMutation.mutate({ candidateId: 7 });
+
+      await waitFor(() => expect(result.current.downloadMutation.isSuccess).toBe(true));
+      expect(rotationDownloadCandidateMock).toHaveBeenCalledWith({ path: { candidateId: 7 } });
+      expect(mockToastSuccess).toHaveBeenCalledWith('Downloading "Fight Club"');
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'rotation', 'listCandidates'],
+      });
+    });
+
+    it('toasts the error message when the download fails', async () => {
+      rotationDownloadCandidateMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'radarr offline' },
+        response: { status: 500 },
+      });
+      const { result } = setupHook();
+
+      result.current.downloadMutation.mutate({ candidateId: 7 });
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('radarr offline'));
+    });
+  });
+
+  describe('exclude', () => {
+    it('sends only tmdbId + reason (title is resolved server-side) and closes the popover', async () => {
+      const { result, invalidateSpy, setPopoverOpen } = setupHook();
+
+      result.current.excludeMutation.mutate({
+        tmdbId: 550,
+        title: 'Fight Club',
+        reason: 'seen it',
+      });
+
+      await waitFor(() => expect(result.current.excludeMutation.isSuccess).toBe(true));
+      expect(rotationAddExclusionMock).toHaveBeenCalledWith({
+        body: { tmdbId: 550, reason: 'seen it' },
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith('Excluded "Fight Club"');
+      expect(setPopoverOpen).toHaveBeenCalledWith(false);
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'rotation', 'listCandidates'],
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'rotation', 'listExclusions'],
+      });
+    });
+  });
+
+  describe('unexclude', () => {
+    it('removes the exclusion by tmdbId and invalidates both lists', async () => {
+      const { result, invalidateSpy } = setupHook();
+
+      result.current.unexcludeMutation.mutate({ tmdbId: 550 });
+
+      await waitFor(() => expect(result.current.unexcludeMutation.isSuccess).toBe(true));
+      expect(rotationRemoveExclusionMock).toHaveBeenCalledWith({ path: { tmdbId: 550 } });
+      expect(mockToastSuccess).toHaveBeenCalledWith('Restored "Fight Club" to queue');
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'rotation', 'listCandidates'],
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'rotation', 'listExclusions'],
+      });
+    });
+  });
+});

--- a/packages/app-media/src/pages/candidate-queue/useCardMutations.ts
+++ b/packages/app-media/src/pages/candidate-queue/useCardMutations.ts
@@ -1,6 +1,12 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  rotationAddExclusion,
+  rotationDownloadCandidate,
+  rotationRemoveExclusion,
+} from '../../media-api/index.js';
 
 import type { Candidate } from './CandidateCard';
 
@@ -19,42 +25,45 @@ interface UnexcludeInput {
 }
 
 export function useCardMutations(candidate: Candidate, setPopoverOpen: (v: boolean) => void) {
-  const utils = usePillarUtils('media');
-  const downloadMutation = usePillarMutation<DownloadInput, unknown>(
-    'media',
-    ['rotation', 'downloadCandidate'],
-    {
-      onSuccess: () => {
-        toast.success(`Downloading "${candidate.title}"`);
-        void utils.invalidate(['rotation', 'listCandidates']);
-      },
-      onError: (err) => toast.error(err.message || 'Failed to download'),
-    }
-  );
-  const excludeMutation = usePillarMutation<ExcludeInput, unknown>(
-    'media',
-    ['rotation', 'excludeCandidate'],
-    {
-      onSuccess: () => {
-        toast.success(`Excluded "${candidate.title}"`);
-        void utils.invalidate(['rotation', 'listCandidates']);
-        void utils.invalidate(['rotation', 'listExclusions']);
-        setPopoverOpen(false);
-      },
-      onError: (err) => toast.error(err.message || 'Failed to exclude'),
-    }
-  );
-  const unexcludeMutation = usePillarMutation<UnexcludeInput, unknown>(
-    'media',
-    ['rotation', 'removeExclusion'],
-    {
-      onSuccess: () => {
-        toast.success(`Restored "${candidate.title}" to queue`);
-        void utils.invalidate(['rotation', 'listCandidates']);
-        void utils.invalidate(['rotation', 'listExclusions']);
-      },
-      onError: (err) => toast.error(err.message || 'Failed to restore'),
-    }
-  );
+  const queryClient = useQueryClient();
+
+  const invalidateCandidates = () =>
+    queryClient.invalidateQueries({ queryKey: ['media', 'rotation', 'listCandidates'] });
+  const invalidateExclusions = () =>
+    queryClient.invalidateQueries({ queryKey: ['media', 'rotation', 'listExclusions'] });
+
+  const downloadMutation = useMutation({
+    mutationFn: async (input: DownloadInput) =>
+      unwrap(await rotationDownloadCandidate({ path: { candidateId: input.candidateId } })),
+    onSuccess: () => {
+      toast.success(`Downloading "${candidate.title}"`);
+      void invalidateCandidates();
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to download'),
+  });
+
+  const excludeMutation = useMutation({
+    mutationFn: async (input: ExcludeInput) =>
+      unwrap(await rotationAddExclusion({ body: { tmdbId: input.tmdbId, reason: input.reason } })),
+    onSuccess: () => {
+      toast.success(`Excluded "${candidate.title}"`);
+      void invalidateCandidates();
+      void invalidateExclusions();
+      setPopoverOpen(false);
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to exclude'),
+  });
+
+  const unexcludeMutation = useMutation({
+    mutationFn: async (input: UnexcludeInput) =>
+      unwrap(await rotationRemoveExclusion({ path: { tmdbId: input.tmdbId } })),
+    onSuccess: () => {
+      toast.success(`Restored "${candidate.title}" to queue`);
+      void invalidateCandidates();
+      void invalidateExclusions();
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to restore'),
+  });
+
   return { downloadMutation, excludeMutation, unexcludeMutation };
 }


### PR DESCRIPTION
Phase D tier-2. Rewires candidate-queue (`useCardMutations`, `CandidateList`; 8 sites) onto the Hey API SDK + react-query (rotationListCandidates/DownloadCandidate/AddExclusion/RemoveExclusion). Verified in isolation (fe-quality red-by-design), no regression.

**Known gap (follow-up):** `ExclusionList.tsx` stays on pillar-sdk — it needs a paginated `rotation.listExclusions` REST endpoint that the rotation pillar slice never added (only single-entry getExclusion exists). Must add that backend endpoint + migrate ExclusionList **before** the routing cutover removes /trpc-media.