### PR TITLE
feat(media/fe): rewire compare-arena onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,30 +8,19 @@ import { TooltipProvider } from '@pops/ui';
 
 const mockDimensionsQuery = vi.fn();
 const mockPairQuery = vi.fn();
-const mockRecordMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
 const mockRefetchPair = vi.fn();
-const mockScoresFetch = vi.fn();
-const mockWatchlistListQuery = vi.fn();
-const mockWatchlistAddMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
-const mockWatchlistRemoveMutate = vi.fn();
-const mockSkipMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
-const mockMarkStaleMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
-const mockExcludeMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
-const mockBlacklistMutate = vi.fn() as ReturnType<typeof vi.fn> & {
-  _opts?: Record<string, unknown>;
-};
-const mockListForMediaQuery = vi.fn();
-const mockInvalidate = vi.fn();
+const mockPageInvalidate = vi.fn();
+
+const mockComparisonsRecord = vi.fn();
+const mockComparisonsRecordSkip = vi.fn();
+const mockComparisonsMarkStale = vi.fn();
+const mockComparisonsExcludeFromDimension = vi.fn();
+const mockComparisonsBlacklistMovie = vi.fn();
+const mockComparisonsListForMedia = vi.fn();
+const mockComparisonsScores = vi.fn();
+const mockWatchlistList = vi.fn();
+const mockWatchlistAdd = vi.fn();
+const mockWatchlistRemove = vi.fn();
 
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
@@ -39,52 +30,38 @@ vi.mock('@pops/pillar-sdk/react', () => ({
       const result = mockPairQuery(input);
       return { ...result, refetch: mockRefetchPair };
     }
-    if (key === 'comparisons.listForMedia') return mockListForMediaQuery(input);
-    if (key === 'watchlist.list') return mockWatchlistListQuery(input);
     return { data: undefined, isLoading: false, error: null };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts?: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'comparisons.record') {
-      mockRecordMutate._opts = opts;
-      return { mutate: mockRecordMutate, isPending: false };
-    }
-    if (key === 'comparisons.recordSkip') {
-      mockSkipMutate._opts = opts;
-      return { mutate: mockSkipMutate, isPending: false };
-    }
-    if (key === 'comparisons.markStale') {
-      mockMarkStaleMutate._opts = opts;
-      return { mutate: mockMarkStaleMutate, isPending: false };
-    }
-    if (key === 'comparisons.excludeFromDimension') {
-      return { mutate: mockExcludeMutate, isPending: false };
-    }
-    if (key === 'comparisons.blacklistMovie') {
-      mockBlacklistMutate._opts = opts;
-      return { mutate: mockBlacklistMutate, isPending: false };
-    }
-    if (key === 'watchlist.add') {
-      mockWatchlistAddMutate._opts = opts;
-      return { mutate: mockWatchlistAddMutate, isPending: false };
-    }
-    if (key === 'watchlist.remove') {
-      return { mutate: mockWatchlistRemoveMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
   },
   usePillarUtils: () => ({
     setData: vi.fn(),
     invalidate: (path?: readonly string[]) => {
-      mockInvalidate(path?.join('.') ?? '');
+      mockPageInvalidate(path?.join('.') ?? '');
       return Promise.resolve();
     },
-    fetchQuery: mockScoresFetch,
+    fetchQuery: vi.fn(),
   }),
+}));
+
+vi.mock('../media-api/index.js', () => ({
+  comparisonsRecord: (opts: unknown) => mockComparisonsRecord(opts),
+  comparisonsRecordSkip: (opts: unknown) => mockComparisonsRecordSkip(opts),
+  comparisonsMarkStale: (opts: unknown) => mockComparisonsMarkStale(opts),
+  comparisonsExcludeFromDimension: (opts: unknown) => mockComparisonsExcludeFromDimension(opts),
+  comparisonsBlacklistMovie: (opts: unknown) => mockComparisonsBlacklistMovie(opts),
+  comparisonsListForMedia: (opts: unknown) => mockComparisonsListForMedia(opts),
+  comparisonsScores: (opts: unknown) => mockComparisonsScores(opts),
+  watchlistList: (opts: unknown) => mockWatchlistList(opts),
+  watchlistAdd: (opts: unknown) => mockWatchlistAdd(opts),
+  watchlistRemove: (opts: unknown) => mockWatchlistRemove(opts),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
 }));
 
 vi.mock('../components/DimensionManager', () => ({
@@ -100,14 +77,19 @@ const dim3 = { id: 3, name: 'Soundtrack', active: true, description: null, sortO
 const movieA = { id: 10, title: 'The Matrix', posterPath: null, posterUrl: null };
 const movieB = { id: 20, title: 'Inception', posterPath: null, posterUrl: null };
 
-function renderPage() {
-  return render(
-    <MemoryRouter>
-      <TooltipProvider>
-        <CompareArenaPage />
-      </TooltipProvider>
-    </MemoryRouter>
-  );
+function renderPage(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, null, createElement(TooltipProvider, null, children))
+    );
+  return render(<CompareArenaPage />, { wrapper });
 }
 
 function setupArena() {
@@ -120,27 +102,21 @@ function setupArena() {
     isLoading: false,
     error: null,
   });
-  mockWatchlistListQuery.mockReturnValue({
-    data: { data: [] },
-    isLoading: false,
-  });
-  mockListForMediaQuery.mockReturnValue({
-    data: null,
-    isLoading: false,
-  });
 }
 
 describe('CompareArenaPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockWatchlistListQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-    });
-    mockListForMediaQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-    });
+    mockWatchlistList.mockResolvedValue({ data: { data: [] } });
+    mockComparisonsListForMedia.mockResolvedValue({ data: null });
+    mockComparisonsRecord.mockResolvedValue({ data: { data: {} } });
+    mockComparisonsRecordSkip.mockResolvedValue({ data: {} });
+    mockComparisonsMarkStale.mockResolvedValue({ data: { data: { staleness: 0.5 } } });
+    mockComparisonsExcludeFromDimension.mockResolvedValue({ data: { comparisonsDeleted: 0 } });
+    mockComparisonsBlacklistMovie.mockResolvedValue({ data: { data: {} } });
+    mockComparisonsScores.mockResolvedValue({ data: { data: [] } });
+    mockWatchlistAdd.mockResolvedValue({ data: { data: {} } });
+    mockWatchlistRemove.mockResolvedValue({ data: {} });
   });
 
   it('renders pair with movie titles', () => {
@@ -160,36 +136,42 @@ describe('CompareArenaPage', () => {
     expect((select as HTMLSelectElement).value).toBe('1');
   });
 
-  it('calls record mutation when picking a winner', () => {
+  it('calls record mutation when picking a winner', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getAllByText('The Matrix')[0]!);
 
-    expect(mockRecordMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dimensionId: 1,
-        mediaAId: 10,
-        mediaBId: 20,
-        winnerId: 10,
-      })
-    );
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          dimensionId: 1,
+          mediaAId: 10,
+          mediaBId: 20,
+          winnerId: 10,
+        }),
+      });
+    });
   });
 
-  it('skip button calls recordSkip mutation', () => {
+  it('skip button calls recordSkip mutation', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Skip this pair'));
 
-    expect(mockRecordMutate).not.toHaveBeenCalled();
-    expect(mockSkipMutate).toHaveBeenCalledWith({
-      dimensionId: 1,
-      mediaAType: 'movie',
-      mediaAId: 10,
-      mediaBType: 'movie',
-      mediaBId: 20,
+    await waitFor(() => {
+      expect(mockComparisonsRecordSkip).toHaveBeenCalledWith({
+        body: {
+          dimensionId: 1,
+          mediaAType: 'movie',
+          mediaAId: 10,
+          mediaBType: 'movie',
+          mediaBId: 20,
+        },
+      });
     });
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
   it('shows minimum threshold message when pair data is null', () => {
@@ -201,10 +183,6 @@ describe('CompareArenaPage', () => {
       data: { data: null },
       isLoading: false,
       error: null,
-    });
-    mockWatchlistListQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
     });
 
     renderPage();
@@ -222,32 +200,36 @@ describe('CompareArenaPage', () => {
       isLoading: false,
       error: null,
     });
-    mockWatchlistListQuery.mockReturnValue({
-      data: {
-        data: [
-          { id: 1, mediaType: 'movie', mediaId: 10, title: 'The Matrix', addedAt: '2026-01-01' },
-        ],
-      },
-      isLoading: false,
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['media', 'watchlist', 'list', { mediaType: 'movie' }], {
+      data: [
+        { id: 1, mediaType: 'movie', mediaId: 10, title: 'The Matrix', addedAt: '2026-01-01' },
+      ],
     });
 
-    renderPage();
+    renderPage(queryClient);
 
     expect(screen.getByText('Not enough movies')).toBeTruthy();
     expect(screen.getByText('Some are on your watchlist.')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'View watchlist' })).toBeTruthy();
   });
 
-  it('calls record mutation with correct dimension', () => {
+  it('calls record mutation with correct dimension', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getAllByText('The Matrix')[0]!);
 
-    expect(mockRecordMutate).toHaveBeenCalledWith(expect.objectContaining({ dimensionId: 1 }));
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledWith({
+        body: expect.objectContaining({ dimensionId: 1 }),
+      });
+    });
   });
 
-  it('watchlist button calls watchlist.add without comparison side effects', () => {
+  it('watchlist button calls watchlist add without comparison side effects', async () => {
     setupArena();
     renderPage();
 
@@ -255,23 +237,20 @@ describe('CompareArenaPage', () => {
     expect(bookmarkButtons.length).toBeGreaterThan(0);
     fireEvent.click(bookmarkButtons[0]!);
 
-    expect(mockWatchlistAddMutate).toHaveBeenCalledWith({
-      mediaType: 'movie',
-      mediaId: 10,
+    await waitFor(() => {
+      expect(mockWatchlistAdd).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 10 },
+      });
     });
 
-    expect(mockRecordMutate).not.toHaveBeenCalled();
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
     expect(mockRefetchPair).not.toHaveBeenCalled();
 
-    const onSuccess = mockWatchlistAddMutate._opts?.onSuccess as (
-      data: unknown,
-      variables: { mediaType: string; mediaId: number }
-    ) => void;
-    onSuccess(undefined, { mediaType: 'movie', mediaId: 10 });
-
-    expect(mockInvalidate).toHaveBeenCalledWith('watchlist');
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('The Matrix added to watchlist');
+    });
     expect(mockRefetchPair).not.toHaveBeenCalled();
-    expect(mockRecordMutate).not.toHaveBeenCalled();
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
   it('renders loading skeletons when pair is loading', () => {
@@ -318,63 +297,70 @@ describe('CompareArenaPage', () => {
     expect(screen.getByLabelText('Mark Inception as stale')).toBeTruthy();
   });
 
-  it('calls markStale mutation when clicking stale button for movie A', () => {
+  it('calls markStale mutation when clicking stale button for movie A', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Mark The Matrix as stale'));
 
-    expect(mockMarkStaleMutate).toHaveBeenCalledWith({
-      mediaType: 'movie',
-      mediaId: 10,
+    await waitFor(() => {
+      expect(mockComparisonsMarkStale).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 10 },
+      });
     });
   });
 
-  it('calls markStale mutation when clicking stale button for movie B', () => {
+  it('calls markStale mutation when clicking stale button for movie B', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Mark Inception as stale'));
 
-    expect(mockMarkStaleMutate).toHaveBeenCalledWith({
-      mediaType: 'movie',
-      mediaId: 20,
+    await waitFor(() => {
+      expect(mockComparisonsMarkStale).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 20 },
+      });
     });
   });
 
-  it('does not record a comparison when marking stale', () => {
+  it('does not record a comparison when marking stale', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Mark The Matrix as stale'));
 
-    expect(mockRecordMutate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockComparisonsMarkStale).toHaveBeenCalled();
+    });
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
-  it('N/A button for movie A calls excludeFromDimension with movie A id only', () => {
+  it('N/A button for movie A calls excludeFromDimension with movie A id only', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('N/A: The Matrix'));
 
-    expect(mockExcludeMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ mediaType: 'movie', mediaId: 10, dimensionId: 1 }),
-      expect.objectContaining({ onSuccess: expect.any(Function) })
-    );
-    expect(mockRecordMutate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockComparisonsExcludeFromDimension).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 10, dimensionId: 1 },
+      });
+    });
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
-  it('N/A button for movie B calls excludeFromDimension with movie B id only', () => {
+  it('N/A button for movie B calls excludeFromDimension with movie B id only', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('N/A: Inception'));
 
-    expect(mockExcludeMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ mediaType: 'movie', mediaId: 20, dimensionId: 1 }),
-      expect.objectContaining({ onSuccess: expect.any(Function) })
-    );
-    expect(mockRecordMutate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockComparisonsExcludeFromDimension).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 20, dimensionId: 1 },
+      });
+    });
+    expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
   it('renders Not Watched buttons on both cards', () => {
@@ -396,28 +382,31 @@ describe('CompareArenaPage', () => {
     expect(screen.getByRole('button', { name: 'Not watched' })).toBeTruthy();
   });
 
-  it('shows comparison count in confirmation dialog', () => {
+  it('shows comparison count in confirmation dialog', async () => {
     setupArena();
-    mockListForMediaQuery.mockReturnValue({
+    mockComparisonsListForMedia.mockResolvedValue({
       data: { data: [], pagination: { total: 5 } },
-      isLoading: false,
     });
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Not watched The Matrix'));
 
-    expect(screen.getByText('5')).toBeTruthy();
+    expect(await screen.findByText('5')).toBeTruthy();
     expect(screen.getByText(/comparisons involving/)).toBeTruthy();
   });
 
-  it('calls blacklistMovie mutation on confirm', () => {
+  it('calls blacklistMovie mutation on confirm', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Not watched Inception'));
     fireEvent.click(screen.getByRole('button', { name: 'Not watched' }));
 
-    expect(mockBlacklistMutate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 20 });
+    await waitFor(() => {
+      expect(mockComparisonsBlacklistMovie).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 20 },
+      });
+    });
   });
 
   it('closes dialog on cancel without calling blacklist', () => {
@@ -428,7 +417,7 @@ describe('CompareArenaPage', () => {
     expect(screen.getByText('Mark as not watched?')).toBeTruthy();
 
     fireEvent.click(screen.getByText('Cancel'));
-    expect(mockBlacklistMutate).not.toHaveBeenCalled();
+    expect(mockComparisonsBlacklistMovie).not.toHaveBeenCalled();
   });
 
   it('renders draw tier buttons with tooltips', () => {
@@ -440,59 +429,69 @@ describe('CompareArenaPage', () => {
     expect(screen.getByLabelText('Equally poor')).toBeTruthy();
   });
 
-  it('draw high button records comparison with drawTier high', () => {
+  it('draw high button records comparison with drawTier high', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Equally great'));
 
-    expect(mockRecordMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dimensionId: 1,
-        mediaAId: 10,
-        mediaBId: 20,
-        winnerId: 0,
-        drawTier: 'high',
-      })
-    );
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          dimensionId: 1,
+          mediaAId: 10,
+          mediaBId: 20,
+          winnerId: 0,
+          drawTier: 'high',
+        }),
+      });
+    });
   });
 
-  it('draw mid button records comparison with drawTier mid', () => {
+  it('draw mid button records comparison with drawTier mid', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Equally average'));
 
-    expect(mockRecordMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        winnerId: 0,
-        drawTier: 'mid',
-      })
-    );
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          winnerId: 0,
+          drawTier: 'mid',
+        }),
+      });
+    });
   });
 
-  it('draw low button records comparison with drawTier low', () => {
+  it('draw low button records comparison with drawTier low', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Equally poor'));
 
-    expect(mockRecordMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        winnerId: 0,
-        drawTier: 'low',
-      })
-    );
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          winnerId: 0,
+          drawTier: 'low',
+        }),
+      });
+    });
   });
 
-  it('draw buttons do not record a winner', () => {
+  it('draw buttons do not record a winner', async () => {
     setupArena();
     renderPage();
 
     fireEvent.click(screen.getByLabelText('Equally great'));
 
-    expect(mockRecordMutate).toHaveBeenCalledTimes(1);
-    expect(mockRecordMutate).toHaveBeenCalledWith(expect.objectContaining({ winnerId: 0 }));
+    await waitFor(() => {
+      expect(mockComparisonsRecord).toHaveBeenCalledTimes(1);
+    });
+    expect(mockComparisonsRecord).toHaveBeenCalledWith({
+      body: expect.objectContaining({ winnerId: 0 }),
+    });
   });
 
   it('renders history link in header', () => {

--- a/packages/app-media/src/pages/compare-arena/useArenaActions.ts
+++ b/packages/app-media/src/pages/compare-arena/useArenaActions.ts
@@ -1,6 +1,5 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-
-import { usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { useArenaRecord } from './useArenaRecord';
 import { useFetchScoreDelta, useScoreDeltaTimer } from './useScoreDelta';
@@ -26,15 +25,15 @@ export function useArenaActions({
   resolveTitle,
   onAfterAction,
 }: UseArenaActionsArgs) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const [sessionCount, setSessionCount] = useState(0);
   const { scoreDelta, setScoreDelta, scheduleClear } = useScoreDeltaTimer();
-  const fetchScoreDelta = useFetchScoreDelta(dimensionId, utils, setScoreDelta);
+  const fetchScoreDelta = useFetchScoreDelta(dimensionId, queryClient, setScoreDelta);
 
   const { recordMutation, skipMutation, handlePick, handleSkip, handleDraw } = useArenaRecord({
     pair,
     dimensionId,
-    utils,
+    queryClient,
     fetchScoreDelta,
     onAfterAction,
     setSessionCount,
@@ -44,7 +43,7 @@ export function useArenaActions({
   const { markStaleMutation, handleMarkStale, excludeMutation, handleNA } =
     useStaleAndExcludeMutations({
       dimensionId,
-      utils,
+      queryClient,
       resolveTitle,
       onAfterAction,
     });

--- a/packages/app-media/src/pages/compare-arena/useArenaBlacklist.ts
+++ b/packages/app-media/src/pages/compare-arena/useArenaBlacklist.ts
@@ -1,15 +1,13 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsBlacklistMovie, comparisonsListForMedia } from '../../media-api/index.js';
 
 interface UseArenaBlacklistArgs {
   resolveTitle: (mediaId: number) => string;
   onAfterAction: () => void;
-}
-
-interface ComparisonsListResult {
-  pagination?: { total: number };
 }
 
 interface BlacklistInput {
@@ -22,29 +20,33 @@ interface BlacklistInput {
  * the target movie, comparison-count lookup, and the destructive mutation.
  */
 export function useArenaBlacklist({ resolveTitle, onAfterAction }: UseArenaBlacklistArgs) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const [target, setTarget] = useState<{ id: number; title: string } | null>(null);
 
-  const { data: blacklistComparisonData } = usePillarQuery<ComparisonsListResult>(
-    'media',
-    ['comparisons', 'listForMedia'],
-    { mediaType: 'movie', mediaId: target?.id ?? 0, limit: 1 },
-    { enabled: target !== null }
-  );
+  const listForMediaInput = {
+    mediaType: 'movie' as const,
+    mediaId: target?.id ?? 0,
+    limit: 1,
+  };
+  const { data: blacklistComparisonData } = useQuery({
+    queryKey: ['media', 'comparisons', 'listForMedia', listForMediaInput],
+    queryFn: async () => unwrap(await comparisonsListForMedia({ query: listForMediaInput })),
+    enabled: target !== null,
+  });
   const comparisonsToPurge = blacklistComparisonData?.pagination?.total ?? null;
 
-  const blacklistMutation = usePillarMutation<BlacklistInput, unknown>(
-    'media',
-    ['comparisons', 'blacklistMovie'],
-    {
-      onSuccess: (_data, variables) => {
-        toast.success(`${resolveTitle(variables.mediaId)} marked as not watched`);
-        setTarget(null);
-        onAfterAction();
-        void utils.invalidate(['comparisons', 'getSmartPair']);
-      },
-    }
-  );
+  const blacklistMutation = useMutation({
+    mutationFn: async (variables: BlacklistInput) =>
+      unwrap(await comparisonsBlacklistMovie({ body: variables })),
+    onSuccess: (_data, variables) => {
+      toast.success(`${resolveTitle(variables.mediaId)} marked as not watched`);
+      setTarget(null);
+      onAfterAction();
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getSmartPair'],
+      });
+    },
+  });
 
   const open = useCallback((movie: { id: number; title: string }) => {
     setTarget(movie);

--- a/packages/app-media/src/pages/compare-arena/useArenaRecord.ts
+++ b/packages/app-media/src/pages/compare-arena/useArenaRecord.ts
@@ -1,10 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsRecord, comparisonsRecordSkip } from '../../media-api/index.js';
 
 import type { DrawTier, PairData } from './types';
-import type { MediaUtils, RecordVariables } from './useScoreDelta';
+import type { MediaQueryClient, RecordVariables } from './useScoreDelta';
 
 interface RecordInput {
   dimensionId: number;
@@ -28,7 +30,7 @@ interface SkipInput {
 interface RecordArgs {
   pair: PairData | null | undefined;
   dimensionId: number | null;
-  utils: MediaUtils;
+  queryClient: MediaQueryClient;
   fetchScoreDelta: (v: RecordVariables) => Promise<void>;
   onAfterAction: () => void;
   setSessionCount: React.Dispatch<React.SetStateAction<number>>;
@@ -36,37 +38,37 @@ interface RecordArgs {
 }
 
 function useArenaMutations({
-  utils,
+  queryClient,
   fetchScoreDelta,
   onAfterAction,
   setSessionCount,
   scheduleClear,
 }: Omit<RecordArgs, 'pair' | 'dimensionId'>) {
-  const recordMutation = usePillarMutation<RecordInput, unknown>(
-    'media',
-    ['comparisons', 'record'],
-    {
-      onSuccess: async (_data, variables) => {
-        await fetchScoreDelta(variables);
-        setSessionCount((c) => c + 1);
-        onAfterAction();
-        void utils.invalidate(['comparisons', 'getSmartPair']);
-        scheduleClear();
-      },
-    }
-  );
+  const recordMutation = useMutation({
+    mutationFn: async (variables: RecordInput) =>
+      unwrap(await comparisonsRecord({ body: variables })),
+    onSuccess: async (_data, variables) => {
+      await fetchScoreDelta(variables);
+      setSessionCount((c) => c + 1);
+      onAfterAction();
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getSmartPair'],
+      });
+      scheduleClear();
+    },
+  });
 
-  const skipMutation = usePillarMutation<SkipInput, unknown>(
-    'media',
-    ['comparisons', 'recordSkip'],
-    {
-      onSuccess: () => {
-        toast.success('Pair skipped');
-        onAfterAction();
-        void utils.invalidate(['comparisons', 'getSmartPair']);
-      },
-    }
-  );
+  const skipMutation = useMutation({
+    mutationFn: async (variables: SkipInput) =>
+      unwrap(await comparisonsRecordSkip({ body: variables })),
+    onSuccess: () => {
+      toast.success('Pair skipped');
+      onAfterAction();
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getSmartPair'],
+      });
+    },
+  });
 
   return { recordMutation, skipMutation };
 }

--- a/packages/app-media/src/pages/compare-arena/useArenaWatchlist.ts
+++ b/packages/app-media/src/pages/compare-arena/useArenaWatchlist.ts
@@ -1,21 +1,13 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchlistAdd, watchlistList, watchlistRemove } from '../../media-api/index.js';
 
 interface UseArenaWatchlistArgs {
   enabled: boolean;
   resolveTitle: (mediaId: number) => string;
-}
-
-interface WatchlistEntry {
-  id: number;
-  mediaType: string;
-  mediaId: number;
-}
-
-interface WatchlistListResult {
-  data: WatchlistEntry[];
 }
 
 interface AddInput {
@@ -28,14 +20,14 @@ interface AddInput {
  * watchlisted movies and a toggle that mutates add/remove with toasts.
  */
 export function useArenaWatchlist({ enabled, resolveTitle }: UseArenaWatchlistArgs) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
 
-  const { data: watchlistData } = usePillarQuery<WatchlistListResult>(
-    'media',
-    ['watchlist', 'list'],
-    { mediaType: 'movie' },
-    { enabled }
-  );
+  const watchlistQueryInput = { mediaType: 'movie' as const };
+  const { data: watchlistData } = useQuery({
+    queryKey: ['media', 'watchlist', 'list', watchlistQueryInput],
+    queryFn: async () => unwrap(await watchlistList({ query: watchlistQueryInput })),
+    enabled,
+  });
 
   const watchlistedMovies = useMemo(
     () =>
@@ -47,28 +39,29 @@ export function useArenaWatchlist({ enabled, resolveTitle }: UseArenaWatchlistAr
     [watchlistData]
   );
 
-  const addMutation = usePillarMutation<AddInput, unknown>('media', ['watchlist', 'add'], {
+  const invalidateWatchlist = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+  }, [queryClient]);
+
+  const addMutation = useMutation({
+    mutationFn: async (variables: AddInput) => unwrap(await watchlistAdd({ body: variables })),
     onSuccess: (_data, variables) => {
-      void utils.invalidate(['watchlist']);
+      invalidateWatchlist();
       toast.success(`${resolveTitle(variables.mediaId)} added to watchlist`);
     },
   });
 
-  const removeMutation = usePillarMutation<{ id: number }, unknown>(
-    'media',
-    ['watchlist', 'remove'],
-    {
-      onSuccess: (_data, variables) => {
-        void utils.invalidate(['watchlist']);
-        const mediaId = [...watchlistedMovies.entries()].find(
-          ([, entryId]) => entryId === variables.id
-        )?.[0];
-        toast.success(
-          `${mediaId != null ? resolveTitle(mediaId) : 'Movie'} removed from watchlist`
-        );
-      },
-    }
-  );
+  const removeMutation = useMutation({
+    mutationFn: async (variables: { id: number }) =>
+      unwrap(await watchlistRemove({ path: { id: variables.id } })),
+    onSuccess: (_data, variables) => {
+      invalidateWatchlist();
+      const mediaId = [...watchlistedMovies.entries()].find(
+        ([, entryId]) => entryId === variables.id
+      )?.[0];
+      toast.success(`${mediaId != null ? resolveTitle(mediaId) : 'Movie'} removed from watchlist`);
+    },
+  });
 
   const handleToggleWatchlist = useCallback(
     (movieId: number) => {

--- a/packages/app-media/src/pages/compare-arena/useScoreDelta.ts
+++ b/packages/app-media/src/pages/compare-arena/useScoreDelta.ts
@@ -1,14 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsScores } from '../../media-api/index.js';
 import { buildScoreDelta } from './scoreDelta';
 
-import type { usePillarUtils } from '@pops/pillar-sdk/react';
+import type { QueryClient } from '@tanstack/react-query';
 
 import type { DrawTier, ScoreDelta } from './types';
 
 const DELTA_DISPLAY_MS = 1500;
 
-export type MediaUtils = ReturnType<typeof usePillarUtils>;
+export type MediaQueryClient = QueryClient;
 
 export interface RecordVariables {
   mediaAId: number;
@@ -24,29 +26,37 @@ interface ScoresResult {
 interface FetchScoresArgs {
   variables: RecordVariables;
   dimensionId: number | null;
-  utils: MediaUtils;
+  queryClient: MediaQueryClient;
 }
 
 function getScoreFor(data: ScoresResult | undefined, dimensionId: number | null): number {
   return data?.data?.find((s) => s.dimensionId === dimensionId)?.score ?? 1500;
 }
 
-async function fetchPairScores({ variables, dimensionId, utils }: FetchScoresArgs) {
+function fetchScoresFor(
+  queryClient: MediaQueryClient,
+  mediaId: number,
+  dimensionId: number | null
+): Promise<ScoresResult> {
+  const query = {
+    mediaType: 'movie' as const,
+    mediaId,
+    ...(dimensionId !== null ? { dimensionId } : {}),
+  };
+  return queryClient.fetchQuery({
+    queryKey: ['media', 'comparisons', 'scores', query],
+    queryFn: async () => unwrap(await comparisonsScores({ query })),
+  });
+}
+
+async function fetchPairScores({ variables, dimensionId, queryClient }: FetchScoresArgs) {
   const isDraw = variables.winnerId === 0;
   const winnerId = isDraw ? variables.mediaAId : variables.winnerId;
   const loserId = variables.mediaAId === winnerId ? variables.mediaBId : variables.mediaAId;
 
   const [scoresA, scoresB] = await Promise.all([
-    utils.fetchQuery<ScoresResult>(['comparisons', 'scores'], {
-      mediaType: 'movie',
-      mediaId: winnerId,
-      dimensionId: dimensionId ?? undefined,
-    }),
-    utils.fetchQuery<ScoresResult>(['comparisons', 'scores'], {
-      mediaType: 'movie',
-      mediaId: loserId,
-      dimensionId: dimensionId ?? undefined,
-    }),
+    fetchScoresFor(queryClient, winnerId, dimensionId),
+    fetchScoresFor(queryClient, loserId, dimensionId),
   ]);
 
   return {
@@ -85,13 +95,13 @@ export function useScoreDeltaTimer() {
 
 export function useFetchScoreDelta(
   dimensionId: number | null,
-  utils: MediaUtils,
+  queryClient: MediaQueryClient,
   setScoreDelta: (d: ScoreDelta) => void
 ) {
   return useCallback(
     async (variables: RecordVariables): Promise<void> => {
       try {
-        const result = await fetchPairScores({ variables, dimensionId, utils });
+        const result = await fetchPairScores({ variables, dimensionId, queryClient });
         setScoreDelta(
           buildScoreDelta({
             ...result,
@@ -102,6 +112,6 @@ export function useFetchScoreDelta(
         // Score fetch failed — skip animation
       }
     },
-    [utils, dimensionId, setScoreDelta]
+    [queryClient, dimensionId, setScoreDelta]
   );
 }

--- a/packages/app-media/src/pages/compare-arena/useStaleAndExclude.ts
+++ b/packages/app-media/src/pages/compare-arena/useStaleAndExclude.ts
@@ -1,17 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsExcludeFromDimension, comparisonsMarkStale } from '../../media-api/index.js';
 
-import type { MediaUtils } from './useScoreDelta';
+import type { MediaQueryClient } from './useScoreDelta';
 
 interface MarkStaleInput {
   mediaType: 'movie';
   mediaId: number;
-}
-
-interface MarkStaleResult {
-  data: { staleness: number };
 }
 
 interface ExcludeInput {
@@ -22,30 +20,30 @@ interface ExcludeInput {
 
 interface Args {
   dimensionId: number | null;
-  utils: MediaUtils;
+  queryClient: MediaQueryClient;
   resolveTitle: (id: number) => string;
   onAfterAction: () => void;
 }
 
 export function useStaleAndExcludeMutations({
   dimensionId,
-  utils,
+  queryClient,
   resolveTitle,
   onAfterAction,
 }: Args) {
-  const markStaleMutation = usePillarMutation<MarkStaleInput, MarkStaleResult>(
-    'media',
-    ['comparisons', 'markStale'],
-    {
-      onSuccess: (data, variables) => {
-        const staleness = data.data.staleness;
-        const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
-        toast.success(`${resolveTitle(variables.mediaId)} marked stale (×${timesMarked})`);
-        onAfterAction();
-        void utils.invalidate(['comparisons', 'getSmartPair']);
-      },
-    }
-  );
+  const markStaleMutation = useMutation({
+    mutationFn: async (variables: MarkStaleInput) =>
+      unwrap(await comparisonsMarkStale({ body: variables })),
+    onSuccess: (data, variables) => {
+      const staleness = data.data.staleness;
+      const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
+      toast.success(`${resolveTitle(variables.mediaId)} marked stale (×${timesMarked})`);
+      onAfterAction();
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getSmartPair'],
+      });
+    },
+  });
 
   const handleMarkStale = useCallback(
     (movieId: number) => {
@@ -55,10 +53,10 @@ export function useStaleAndExcludeMutations({
     [markStaleMutation]
   );
 
-  const excludeMutation = usePillarMutation<ExcludeInput, unknown>('media', [
-    'comparisons',
-    'excludeFromDimension',
-  ]);
+  const excludeMutation = useMutation({
+    mutationFn: async (variables: ExcludeInput) =>
+      unwrap(await comparisonsExcludeFromDimension({ body: variables })),
+  });
 
   const handleNA = useCallback(
     (movieId: number) => {
@@ -68,12 +66,14 @@ export function useStaleAndExcludeMutations({
         {
           onSuccess: () => {
             toast.success(`${resolveTitle(movieId)} excluded from this dimension`);
-            void utils.invalidate(['comparisons', 'getSmartPair']);
+            void queryClient.invalidateQueries({
+              queryKey: ['media', 'comparisons', 'getSmartPair'],
+            });
           },
         }
       );
     },
-    [dimensionId, excludeMutation, resolveTitle, utils]
+    [dimensionId, excludeMutation, resolveTitle, queryClient]
   );
 
   return { markStaleMutation, handleMarkStale, excludeMutation, handleNA };


### PR DESCRIPTION
Phase D tier-2. Rewires compare-arena (19 sites: useArena{Actions,Record,Blacklist,Watchlist,ScoreDelta},useStaleAndExclude) onto the Hey API SDK + react-query (comparisonsRecord/RecordSkip/MarkStale/ExcludeFromDimension/BlacklistMovie/ListForMedia/Scores + watchlistList/Add/Remove). Verified in isolation (fe-quality red-by-design): 449==449 tsc errors (no new), CompareArenaPage test 27/27, no suite regression, oxlint exit 0.