### PR TITLE
feat(media/fe): rewire season-detail onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/SeasonDetailPage.test.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.test.tsx
@@ -1,126 +1,68 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { PillarCallError } from '@pops/pillar-sdk/client';
-
-import { SeasonDetailPage } from './SeasonDetailPage';
-
 const {
-  mockShowQuery,
-  mockSeasonsQuery,
-  mockEpisodesQuery,
-  mockWatchHistoryQuery,
-  mockProgressQuery,
-  mockCheckSeriesQuery,
-  mockSonarrEpisodesQuery,
-  mockBatchLogMutation,
-  mockLogMutation,
-  mockDeleteMutation,
-  mockSeasonMonitorMutation,
-  mockEpisodeMonitorMutation,
-  mockInvalidate,
-  mockSetData,
+  tvShowsGetMock,
+  tvShowsListSeasonsMock,
+  tvShowsListEpisodesMock,
+  watchHistoryListMock,
+  watchHistoryProgressMock,
+  arrCheckSeriesMock,
+  arrGetSeriesEpisodesMock,
+  watchHistoryBatchLogMock,
+  watchHistoryLogMock,
+  watchHistoryDeleteMock,
+  arrUpdateSeasonMonitoringMock,
+  arrUpdateEpisodeMonitoringMock,
 } = vi.hoisted(() => ({
-  mockShowQuery: vi.fn(),
-  mockSeasonsQuery: vi.fn(),
-  mockEpisodesQuery: vi.fn(),
-  mockWatchHistoryQuery: vi.fn(),
-  mockProgressQuery: vi.fn(),
-  mockCheckSeriesQuery: vi.fn(),
-  mockSonarrEpisodesQuery: vi.fn(),
-  mockBatchLogMutation: vi.fn(),
-  mockLogMutation: vi.fn(),
-  mockDeleteMutation: vi.fn(),
-  mockSeasonMonitorMutation: vi.fn(),
-  mockEpisodeMonitorMutation: vi.fn(),
-  mockInvalidate: vi.fn(),
-  mockSetData: vi.fn(),
+  tvShowsGetMock: vi.fn(),
+  tvShowsListSeasonsMock: vi.fn(),
+  tvShowsListEpisodesMock: vi.fn(),
+  watchHistoryListMock: vi.fn(),
+  watchHistoryProgressMock: vi.fn(),
+  arrCheckSeriesMock: vi.fn(),
+  arrGetSeriesEpisodesMock: vi.fn(),
+  watchHistoryBatchLogMock: vi.fn(),
+  watchHistoryLogMock: vi.fn(),
+  watchHistoryDeleteMock: vi.fn(),
+  arrUpdateSeasonMonitoringMock: vi.fn(),
+  arrUpdateEpisodeMonitoringMock: vi.fn(),
 }));
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'tvShows.get') return mockShowQuery(input);
-    if (key === 'tvShows.listSeasons') return mockSeasonsQuery(input);
-    if (key === 'tvShows.listEpisodes') return mockEpisodesQuery(input);
-    if (key === 'watchHistory.list') return mockWatchHistoryQuery(input);
-    if (key === 'watchHistory.progress') return mockProgressQuery(input);
-    if (key === 'arr.checkSeries') return mockCheckSeriesQuery(input);
-    if (key === 'arr.getSeriesEpisodes') return mockSonarrEpisodesQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'watchHistory.batchLog') {
-      mockBatchLogMutation.mockImplementation(() => {
-        if (typeof opts.onMutate === 'function') (opts.onMutate as () => void)();
-        if (typeof opts.onSuccess === 'function')
-          (opts.onSuccess as (r: { data: { logged: number } }) => void)({ data: { logged: 5 } });
-        if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
-      });
-      return { mutate: mockBatchLogMutation, isPending: false };
-    }
-    if (key === 'watchHistory.log') {
-      mockLogMutation.mockImplementation(() => {
-        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-      });
-      return { mutate: mockLogMutation, isPending: false };
-    }
-    if (key === 'watchHistory.delete') {
-      mockDeleteMutation.mockImplementation(() => {
-        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-      });
-      return { mutate: mockDeleteMutation, isPending: false };
-    }
-    if (key === 'arr.updateSeasonMonitoring') {
-      mockSeasonMonitorMutation.mockImplementation(() => {
-        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-      });
-      return { mutate: mockSeasonMonitorMutation, isPending: false };
-    }
-    if (key === 'arr.updateEpisodeMonitoring') {
-      mockEpisodeMonitorMutation.mockImplementation(
-        (variables: { episodeIds: number[]; monitored: boolean }) => {
-          if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-          if (typeof opts.onSettled === 'function')
-            (opts.onSettled as (d: unknown, e: unknown, v: typeof variables) => void)(
-              undefined,
-              undefined,
-              variables
-            );
-        }
-      );
-      return { mutate: mockEpisodeMonitorMutation, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({ setData: mockSetData, invalidate: mockInvalidate }),
+vi.mock('../media-api/index.js', () => ({
+  tvShowsGet: (...args: unknown[]) => tvShowsGetMock(...args),
+  tvShowsListSeasons: (...args: unknown[]) => tvShowsListSeasonsMock(...args),
+  tvShowsListEpisodes: (...args: unknown[]) => tvShowsListEpisodesMock(...args),
+  watchHistoryList: (...args: unknown[]) => watchHistoryListMock(...args),
+  watchHistoryProgress: (...args: unknown[]) => watchHistoryProgressMock(...args),
+  arrCheckSeries: (...args: unknown[]) => arrCheckSeriesMock(...args),
+  arrGetSeriesEpisodes: (...args: unknown[]) => arrGetSeriesEpisodesMock(...args),
+  watchHistoryBatchLog: (...args: unknown[]) => watchHistoryBatchLogMock(...args),
+  watchHistoryLog: (...args: unknown[]) => watchHistoryLogMock(...args),
+  watchHistoryDelete: (...args: unknown[]) => watchHistoryDeleteMock(...args),
+  arrUpdateSeasonMonitoring: (...args: unknown[]) => arrUpdateSeasonMonitoringMock(...args),
+  arrUpdateEpisodeMonitoring: (...args: unknown[]) => arrUpdateEpisodeMonitoringMock(...args),
 }));
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+import { SeasonDetailPage } from './SeasonDetailPage';
+
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
 const SHOW = {
   id: 1,
   tvdbId: 81189,
   name: 'Breaking Bad',
   overview: 'A chemistry teacher turned meth cook.',
-  firstAirDate: '2008-01-20',
-  lastAirDate: '2013-09-29',
-  status: 'Ended',
-  originalLanguage: 'en',
   posterUrl: '/poster.jpg',
-  backdropUrl: '/backdrop.jpg',
-  voteAverage: 9.5,
-  voteCount: 10000,
-  genres: ['Drama'],
-  networks: ['AMC'],
 };
 
 const SEASONS = [
@@ -128,7 +70,6 @@ const SEASONS = [
     id: 11,
     seasonNumber: 1,
     name: 'Season 1',
-    episodeCount: 3,
     posterUrl: '/s1-poster.jpg',
     overview: 'The beginning.',
     airDate: '2008-01-20',
@@ -137,7 +78,6 @@ const SEASONS = [
     id: 12,
     seasonNumber: 2,
     name: 'Season 2',
-    episodeCount: 5,
     posterUrl: null,
     overview: null,
     airDate: '2009-03-08',
@@ -186,15 +126,15 @@ const PROGRESS = {
   nextEpisode: { seasonNumber: 1, episodeNumber: 3, episodeName: "...And the Bag's in the River" },
 };
 
-function renderPage(showId = '1', seasonNum = '1') {
-  return render(
-    <MemoryRouter initialEntries={[`/media/tv/${showId}/season/${seasonNum}`]}>
-      <Routes>
-        <Route path="/media/tv/:id/season/:num" element={<SeasonDetailPage />} />
-      </Routes>
-    </MemoryRouter>
-  );
-}
+const SONARR_SERIES = {
+  exists: true,
+  sonarrId: 42,
+  monitored: true,
+  seasons: [
+    { seasonNumber: 1, monitored: true },
+    { seasonNumber: 2, monitored: true },
+  ],
+};
 
 const SONARR_EPISODES = [
   {
@@ -235,205 +175,211 @@ const SONARR_EPISODES = [
   },
 ];
 
-function setupQueries(
-  overrides: {
-    show?: Record<string, unknown>;
-    seasons?: typeof SEASONS;
-    episodes?: typeof EPISODES;
-    progress?: typeof PROGRESS | null;
-    sonarr?: {
-      exists: boolean;
-      sonarrId?: number;
-      monitored?: boolean;
-      seasons?: Array<{ seasonNumber: number; monitored: boolean }>;
-    } | null;
-    sonarrEpisodes?: typeof SONARR_EPISODES | null;
-    watchHistory?: Array<{ id: number; mediaId: number }>;
-  } = {}
-) {
-  mockShowQuery.mockReturnValue({
-    data: { data: { ...SHOW, ...overrides.show } },
-    isLoading: false,
-    error: null,
+type Overrides = {
+  show?: Record<string, unknown>;
+  seasons?: typeof SEASONS;
+  episodes?: typeof EPISODES;
+  progress?: typeof PROGRESS | null;
+  sonarr?: {
+    exists: boolean;
+    sonarrId?: number;
+    monitored?: boolean;
+    seasons?: Array<{ seasonNumber: number; monitored: boolean }>;
+  };
+  sonarrEpisodes?: typeof SONARR_EPISODES | null;
+  watchHistory?: Array<{ id: number; mediaId: number }>;
+};
+
+function setupQueries(overrides: Overrides = {}) {
+  tvShowsGetMock.mockResolvedValue(ok({ data: { ...SHOW, ...overrides.show } }));
+  tvShowsListSeasonsMock.mockResolvedValue(ok({ data: overrides.seasons ?? SEASONS, total: 2 }));
+  tvShowsListEpisodesMock.mockResolvedValue(ok({ data: overrides.episodes ?? EPISODES }));
+  watchHistoryListMock.mockResolvedValue(
+    ok({
+      data: (
+        overrides.watchHistory ?? [
+          { id: 1001, mediaId: 101 },
+          { id: 1002, mediaId: 102 },
+        ]
+      ).map((e) => ({ ...e, mediaType: 'episode', watchedAt: '2026-01-01', completed: 1 })),
+      pagination: { hasMore: false, limit: 500, offset: 0, total: 2 },
+    })
+  );
+  watchHistoryProgressMock.mockResolvedValue(ok({ data: overrides.progress ?? PROGRESS }));
+  arrCheckSeriesMock.mockResolvedValue(ok({ data: overrides.sonarr ?? SONARR_SERIES }));
+  arrGetSeriesEpisodesMock.mockResolvedValue(
+    ok({ data: overrides.sonarrEpisodes ?? SONARR_EPISODES })
+  );
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  mockSeasonsQuery.mockReturnValue({
-    data: { data: overrides.seasons ?? SEASONS },
-    isLoading: false,
-  });
-  mockEpisodesQuery.mockReturnValue({
-    data: { data: overrides.episodes ?? EPISODES },
-    isLoading: false,
-  });
-  mockWatchHistoryQuery.mockReturnValue({
-    data: {
-      data: overrides.watchHistory ?? [
-        { id: 1001, mediaId: 101 },
-        { id: 1002, mediaId: 102 },
-      ],
-    },
-    isLoading: false,
-  });
-  mockProgressQuery.mockReturnValue({
-    data: { data: overrides.progress ?? PROGRESS },
-    isLoading: false,
-  });
-  mockCheckSeriesQuery.mockReturnValue({
-    data: {
-      data: overrides.sonarr ?? {
-        exists: true,
-        sonarrId: 42,
-        monitored: true,
-        seasons: [
-          { seasonNumber: 1, monitored: true },
-          { seasonNumber: 2, monitored: true },
-        ],
-      },
-    },
-    isLoading: false,
-  });
-  mockSonarrEpisodesQuery.mockReturnValue({
-    data: {
-      data: overrides.sonarrEpisodes ?? SONARR_EPISODES,
-    },
-    isLoading: false,
-  });
+}
+
+function renderPage(showId = '1', seasonNum = '1', queryClient = makeQueryClient()) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  const view = render(
+    <MemoryRouter initialEntries={[`/media/tv/${showId}/season/${seasonNum}`]}>
+      <Routes>
+        <Route path="/media/tv/:id/season/:num" element={<SeasonDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper }
+  );
+  return { ...view, queryClient };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockShowQuery.mockReturnValue({ data: null, isLoading: false, error: null });
-  mockSeasonsQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockWatchHistoryQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockProgressQuery.mockReturnValue({ data: null, isLoading: false });
-  mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: false });
-  mockSonarrEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+  watchHistoryBatchLogMock.mockResolvedValue(
+    ok({ data: { logged: 5, skipped: 0 }, message: 'ok' })
+  );
+  watchHistoryLogMock.mockResolvedValue(
+    ok({
+      data: { completed: 1, id: 9, mediaId: 0, mediaType: 'episode', watchedAt: '' },
+      message: 'ok',
+      watchlistRemoved: false,
+    })
+  );
+  watchHistoryDeleteMock.mockResolvedValue(ok({ message: 'ok' }));
+  arrUpdateSeasonMonitoringMock.mockResolvedValue(ok({ message: 'ok' }));
+  arrUpdateEpisodeMonitoringMock.mockResolvedValue(ok({ message: 'ok' }));
 });
 
 describe('SeasonDetailPage — monitoring', () => {
   describe('season monitoring toggle', () => {
-    it('shows monitoring toggle when series exists in Sonarr', () => {
+    it('shows monitoring toggle when series exists in Sonarr', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByRole('switch', { name: 'Monitor Season 1' })).toBeInTheDocument();
+      expect(await screen.findByRole('switch', { name: 'Monitor Season 1' })).toBeInTheDocument();
     });
 
-    it('hides monitoring toggle when series is not in Sonarr', () => {
+    it('hides monitoring toggle when series is not in Sonarr', async () => {
       setupQueries({ sonarr: { exists: false } });
       renderPage();
+      expect(await screen.findByText('Pilot')).toBeInTheDocument();
       expect(screen.queryByRole('switch', { name: 'Monitor Season 1' })).not.toBeInTheDocument();
     });
 
-    it('hides monitoring toggle when Sonarr data is not loaded', () => {
-      setupQueries({ sonarr: null });
-      mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: true });
-      renderPage();
-      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    });
-
-    it("shows 'Monitored' label when toggle is on", () => {
+    it("shows 'Monitored' label when toggle is on", async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByText('Monitored')).toBeInTheDocument();
+      expect(await screen.findByText('Monitored')).toBeInTheDocument();
     });
 
-    it('calls updateSeasonMonitoring when toggle is clicked', () => {
+    it('calls arrUpdateSeasonMonitoring when toggle is clicked', async () => {
       setupQueries();
       renderPage();
-      const toggle = screen.getByRole('switch', { name: 'Monitor Season 1' });
+      const toggle = await screen.findByRole('switch', { name: 'Monitor Season 1' });
       fireEvent.click(toggle);
-      expect(mockSeasonMonitorMutation).toHaveBeenCalledWith({
-        sonarrId: 42,
-        seasonNumber: 1,
-        monitored: false,
-      });
+      await waitFor(() =>
+        expect(arrUpdateSeasonMonitoringMock).toHaveBeenCalledWith({
+          path: { sonarrId: 42, seasonNumber: 1 },
+          body: { monitored: false },
+        })
+      );
     });
 
-    it("shows 'Unmonitored' label after toggling off", () => {
+    it("shows 'Unmonitored' label after toggling off", async () => {
       setupQueries();
       renderPage();
-      const toggle = screen.getByRole('switch', { name: 'Monitor Season 1' });
+      const toggle = await screen.findByRole('switch', { name: 'Monitor Season 1' });
       fireEvent.click(toggle);
-      expect(screen.getByText('Unmonitored')).toBeInTheDocument();
+      expect(await screen.findByText('Unmonitored')).toBeInTheDocument();
     });
   });
 
   describe('rendering', () => {
-    it('renders season header with name and episode count', () => {
+    it('renders season header with name and episode count', async () => {
       setupQueries();
       renderPage();
-      const headings = screen.getAllByRole('heading', { level: 1 });
-      expect(headings.some((h) => h.textContent === 'Season 1')).toBe(true);
-      expect(screen.getByText('4 episodes')).toBeInTheDocument();
+      await waitFor(() => {
+        const headings = screen.getAllByRole('heading', { level: 1 });
+        expect(headings.some((h) => h.textContent === 'Season 1')).toBe(true);
+      });
+      expect(await screen.findByText('4 episodes')).toBeInTheDocument();
     });
 
-    it('renders episodes section', () => {
+    it('renders episodes section', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByRole('heading', { name: 'Episodes' })).toBeInTheDocument();
-      expect(screen.getByText('Pilot')).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: 'Episodes' })).toBeInTheDocument();
+      expect(await screen.findByText('Pilot')).toBeInTheDocument();
       expect(screen.getByText("Cat's in the Bag")).toBeInTheDocument();
     });
 
-    it('renders progress bar when progress data exists', () => {
+    it('renders progress bar when progress data exists', async () => {
       setupQueries();
       const { container } = renderPage();
-      const bar = container.querySelector('[aria-valuenow="67"]');
-      expect(bar).toBeInTheDocument();
+      await waitFor(() =>
+        expect(container.querySelector('[aria-valuenow="67"]')).toBeInTheDocument()
+      );
     });
   });
 
   describe('upcoming episodes', () => {
-    it('dims future episodes and shows Upcoming label', () => {
+    it('dims future episodes and shows Upcoming label', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByText('Upcoming')).toBeInTheDocument();
+      expect(await screen.findByText('Upcoming')).toBeInTheDocument();
     });
 
-    it('disables watch toggle for upcoming episodes', () => {
+    it('disables watch toggle for upcoming episodes', async () => {
       setupQueries();
       renderPage();
-      const upcomingButton = screen.getByLabelText('Episode 4 upcoming');
+      const upcomingButton = await screen.findByLabelText('Episode 4 upcoming');
       expect(upcomingButton).toBeDisabled();
     });
   });
 
   describe('batch mark watched', () => {
-    it('shows Mark Season Watched button when not all watched', () => {
+    it('shows Mark Season Watched button when not all watched', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByText('Mark Season Watched')).toBeInTheDocument();
+      expect(await screen.findByText('Mark Season Watched')).toBeInTheDocument();
     });
 
-    it('calls batchLogMutation on Mark Season Watched click', () => {
+    it('calls watchHistoryBatchLog on Mark Season Watched click', async () => {
       setupQueries();
       renderPage();
-      fireEvent.click(screen.getByText('Mark Season Watched'));
-      expect(mockBatchLogMutation).toHaveBeenCalledWith({
-        mediaType: 'season',
-        mediaId: 11,
-      });
-    });
-
-    it('writes optimistic progress via SDK setData on batch mark', () => {
-      setupQueries();
-      renderPage();
-      fireEvent.click(screen.getByText('Mark Season Watched'));
-      expect(mockSetData).toHaveBeenCalledWith(
-        ['watchHistory', 'progress'],
-        { tvShowId: 1 },
-        expect.any(Function)
+      fireEvent.click(await screen.findByText('Mark Season Watched'));
+      await waitFor(() =>
+        expect(watchHistoryBatchLogMock).toHaveBeenCalledWith({
+          body: { mediaType: 'season', mediaId: 11, completed: 1 },
+        })
       );
     });
 
-    it('invalidates watchHistory after settle', () => {
+    it('writes optimistic progress into the cache on batch mark', async () => {
       setupQueries();
-      renderPage();
-      fireEvent.click(screen.getByText('Mark Season Watched'));
-      expect(mockInvalidate).toHaveBeenCalledWith(['watchHistory']);
+      const { queryClient } = renderPage();
+      fireEvent.click(await screen.findByText('Mark Season Watched'));
+      await waitFor(() => {
+        const cached = queryClient.getQueryData<typeof PROGRESS>([
+          'media',
+          'watchHistory',
+          'progress',
+          { tvShowId: 1 },
+        ]);
+        const season1 = cached?.seasons?.find((s) => s.seasonNumber === 1);
+        expect(season1?.watched).toBe(season1?.total);
+      });
     });
 
-    it('shows All Watched when season is complete', () => {
+    it('invalidates watchHistory queries after settle', async () => {
+      setupQueries();
+      const { queryClient } = renderPage();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      fireEvent.click(await screen.findByText('Mark Season Watched'));
+      await waitFor(() =>
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['media', 'watchHistory'] })
+      );
+    });
+
+    it('shows All Watched when season is complete', async () => {
       setupQueries({
         progress: {
           tvShowId: 1,
@@ -443,7 +389,7 @@ describe('SeasonDetailPage — monitoring', () => {
         },
       });
       renderPage();
-      expect(screen.getByText('All Watched')).toBeInTheDocument();
+      expect(await screen.findByText('All Watched')).toBeInTheDocument();
       expect(screen.queryByText('Mark Season Watched')).not.toBeInTheDocument();
     });
   });
@@ -454,113 +400,117 @@ describe('SeasonDetailPage — monitoring', () => {
       expect(screen.getByText('Invalid parameters')).toBeInTheDocument();
     });
 
-    it('shows not found for missing show', () => {
-      mockShowQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
+    it('shows not found for missing show', async () => {
+      setupQueries();
+      tvShowsGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'not found' },
+        response: { status: 404 },
       });
       renderPage('999');
-      expect(screen.getByText('Show not found')).toBeInTheDocument();
+      expect(await screen.findByText('Show not found')).toBeInTheDocument();
     });
   });
 
   describe('episode monitoring toggles', () => {
-    it('shows monitoring toggle for each episode when series exists in Sonarr', () => {
+    it('shows monitoring toggle for each episode when series exists in Sonarr', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByRole('switch', { name: 'Monitor episode 1' })).toBeInTheDocument();
+      expect(await screen.findByRole('switch', { name: 'Monitor episode 1' })).toBeInTheDocument();
       expect(screen.getByRole('switch', { name: 'Monitor episode 2' })).toBeInTheDocument();
       expect(screen.getByRole('switch', { name: 'Monitor episode 3' })).toBeInTheDocument();
     });
 
-    it('reflects monitoring state from Sonarr data', () => {
+    it('reflects monitoring state from Sonarr data', async () => {
       setupQueries();
       renderPage();
-      const ep1Toggle = screen.getByRole('switch', { name: 'Monitor episode 1' });
+      const ep1Toggle = await screen.findByRole('switch', { name: 'Monitor episode 1' });
       const ep3Toggle = screen.getByRole('switch', { name: 'Monitor episode 3' });
       expect(ep1Toggle).toBeChecked();
       expect(ep3Toggle).not.toBeChecked();
     });
 
-    it('hides monitoring toggles when series is not in Sonarr', () => {
-      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: null });
-      mockSonarrEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+    it('hides monitoring toggles when series is not in Sonarr', async () => {
+      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: [] });
       renderPage();
+      expect(await screen.findByText('Pilot')).toBeInTheDocument();
       expect(screen.queryByRole('switch', { name: /Monitor episode/ })).not.toBeInTheDocument();
     });
 
-    it('calls updateEpisodeMonitoring when episode toggle is clicked', () => {
+    it('calls arrUpdateEpisodeMonitoring when episode toggle is clicked', async () => {
       setupQueries();
       renderPage();
-      const ep1Toggle = screen.getByRole('switch', { name: 'Monitor episode 1' });
+      const ep1Toggle = await screen.findByRole('switch', { name: 'Monitor episode 1' });
       fireEvent.click(ep1Toggle);
-      expect(mockEpisodeMonitorMutation).toHaveBeenCalledWith({
-        episodeIds: [5001],
-        monitored: false,
-      });
+      await waitFor(() =>
+        expect(arrUpdateEpisodeMonitoringMock).toHaveBeenCalledWith({
+          body: { episodeIds: [5001], monitored: false },
+        })
+      );
     });
 
-    it('optimistically updates toggle state on click', () => {
+    it('optimistically updates toggle state on click', async () => {
       setupQueries();
       renderPage();
-      const ep1Toggle = screen.getByRole('switch', { name: 'Monitor episode 1' });
+      const ep1Toggle = await screen.findByRole('switch', { name: 'Monitor episode 1' });
       fireEvent.click(ep1Toggle);
-      expect(ep1Toggle).not.toBeChecked();
+      await waitFor(() => expect(ep1Toggle).not.toBeChecked());
     });
   });
 
   describe('downloaded indicator', () => {
-    it('shows download icon for episodes with files', () => {
+    it('shows download icon for episodes with files', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByLabelText('Episode 1 downloaded')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Episode 1 downloaded')).toBeInTheDocument();
       expect(screen.getByLabelText('Episode 2 downloaded')).toBeInTheDocument();
     });
 
-    it('does not show download icon for episodes without files', () => {
+    it('does not show download icon for episodes without files', async () => {
       setupQueries();
       renderPage();
+      await screen.findByLabelText('Episode 1 downloaded');
       expect(screen.queryByLabelText('Episode 3 downloaded')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Episode 4 downloaded')).not.toBeInTheDocument();
     });
 
-    it('hides download icons when series is not in Sonarr', () => {
-      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: null });
-      mockSonarrEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+    it('hides download icons when series is not in Sonarr', async () => {
+      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: [] });
       renderPage();
+      expect(await screen.findByText('Pilot')).toBeInTheDocument();
       expect(screen.queryByLabelText(/downloaded/)).not.toBeInTheDocument();
     });
   });
 
   describe('batch monitor toggle', () => {
-    it('shows Monitor All button when not all episodes are monitored', () => {
+    it('shows Monitor All button when not all episodes are monitored', async () => {
       setupQueries();
       renderPage();
-      expect(screen.getByRole('button', { name: 'Monitor All' })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Monitor All' })).toBeInTheDocument();
     });
 
-    it('shows Unmonitor All button when all episodes are monitored', () => {
+    it('shows Unmonitor All button when all episodes are monitored', async () => {
       const allMonitored = SONARR_EPISODES.map((ep) => ({ ...ep, monitored: true }));
       setupQueries({ sonarrEpisodes: allMonitored });
       renderPage();
-      expect(screen.getByRole('button', { name: 'Unmonitor All' })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Unmonitor All' })).toBeInTheDocument();
     });
 
-    it('calls updateEpisodeMonitoring with all episode IDs when batch button clicked', () => {
+    it('calls arrUpdateEpisodeMonitoring with all episode IDs when batch button clicked', async () => {
       setupQueries();
       renderPage();
-      fireEvent.click(screen.getByRole('button', { name: 'Monitor All' }));
-      expect(mockEpisodeMonitorMutation).toHaveBeenCalledWith({
-        episodeIds: [5001, 5002, 5003, 5004],
-        monitored: true,
-      });
+      fireEvent.click(await screen.findByRole('button', { name: 'Monitor All' }));
+      await waitFor(() =>
+        expect(arrUpdateEpisodeMonitoringMock).toHaveBeenCalledWith({
+          body: { episodeIds: [5001, 5002, 5003, 5004], monitored: true },
+        })
+      );
     });
 
-    it('hides batch toggle when series is not in Sonarr', () => {
-      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: null });
-      mockSonarrEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+    it('hides batch toggle when series is not in Sonarr', async () => {
+      setupQueries({ sonarr: { exists: false }, sonarrEpisodes: [] });
       renderPage();
+      expect(await screen.findByText('Pilot')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /Monitor All/ })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /Unmonitor All/ })).not.toBeInTheDocument();
     });

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -1,9 +1,9 @@
 import { Link, useParams } from 'react-router';
 
-import { isNotFound as isPillarNotFound } from '@pops/pillar-sdk/client';
 import { PageHeader, Skeleton } from '@pops/ui';
 
 import { EpisodeList } from '../components/EpisodeList';
+import { isNotFoundError } from '../media-api-helpers.js';
 import {
   InvalidParamsError,
   SeasonNotFoundError,
@@ -68,7 +68,7 @@ export function SeasonDetailPage() {
   if (Number.isNaN(showId) || Number.isNaN(seasonNum)) return <InvalidParamsError />;
   if (m.showLoading || m.seasonsLoading) return <SeasonDetailSkeleton />;
   if (m.showError) {
-    const is404 = isPillarNotFound(m.showError);
+    const is404 = isNotFoundError(m.showError);
     return <ShowError is404={is404} message={m.showError.message} />;
   }
 

--- a/packages/app-media/src/pages/season-detail/useBatchSeasonLog.ts
+++ b/packages/app-media/src/pages/season-detail/useBatchSeasonLog.ts
@@ -1,9 +1,9 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
-
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchHistoryBatchLog } from '../../media-api/index.js';
 
 interface UseBatchSeasonLogArgs {
   showId: number;
@@ -47,6 +47,20 @@ type BatchLogContext = {
 
 const LIST_INPUT = { mediaType: 'episode' as const, limit: 500 };
 
+const PROGRESS_KEY = (showId: number) =>
+  ['media', 'watchHistory', 'progress', { tvShowId: showId }] as const;
+const LIST_KEY = ['media', 'watchHistory', 'list', LIST_INPUT] as const;
+
+function writeCache<TData>(
+  queryClient: QueryClient,
+  key: readonly unknown[],
+  updater: (previous: TData | undefined) => TData | undefined
+): TData | undefined {
+  const previous = queryClient.getQueryData<TData>(key);
+  queryClient.setQueryData<TData>(key, updater(previous));
+  return previous;
+}
+
 function buildProgressUpdater(seasonNum: number) {
   return (envelope: ProgressEnvelope | undefined): ProgressEnvelope | undefined => {
     if (!envelope?.data) return envelope;
@@ -88,21 +102,21 @@ function buildListUpdater(episodes: Array<{ id: number }>) {
 }
 
 function applyOptimistic(
-  utils: UsePillarUtilsResult,
+  queryClient: QueryClient,
   showId: number,
   seasonNum: number,
   episodes: Array<{ id: number }>
 ): BatchLogContext {
-  const previousProgress = utils.setData<ProgressEnvelope>(
-    ['watchHistory', 'progress'],
-    { tvShowId: showId },
+  const previousProgress = writeCache<ProgressEnvelope>(
+    queryClient,
+    PROGRESS_KEY(showId),
     buildProgressUpdater(seasonNum)
   );
   let previousList: WatchHistoryEnvelope | undefined;
   if (episodes.length > 0) {
-    previousList = utils.setData<WatchHistoryEnvelope>(
-      ['watchHistory', 'list'],
-      LIST_INPUT,
+    previousList = writeCache<WatchHistoryEnvelope>(
+      queryClient,
+      LIST_KEY,
       buildListUpdater(episodes)
     );
   }
@@ -110,48 +124,56 @@ function applyOptimistic(
 }
 
 function rollbackOptimistic(
-  utils: UsePillarUtilsResult,
+  queryClient: QueryClient,
   showId: number,
   context: BatchLogContext | undefined
 ) {
   if (!context) return;
   if (context.previousProgress !== undefined) {
-    utils.setData<ProgressEnvelope | undefined>(
-      ['watchHistory', 'progress'],
-      { tvShowId: showId },
+    writeCache<ProgressEnvelope | undefined>(
+      queryClient,
+      PROGRESS_KEY(showId),
       () => context.previousProgress
     );
   }
   if (context.previousList !== undefined) {
-    utils.setData<WatchHistoryEnvelope | undefined>(
-      ['watchHistory', 'list'],
-      LIST_INPUT,
-      () => context.previousList
-    );
+    writeCache<WatchHistoryEnvelope | undefined>(queryClient, LIST_KEY, () => context.previousList);
   }
 }
 
-export function useBatchSeasonLog({ showId, seasonNum, season, episodes }: UseBatchSeasonLogArgs) {
-  const utils = usePillarUtils('media');
+interface BatchLogInput {
+  mediaType: 'season';
+  mediaId: number;
+}
 
-  const batchLogMutation = usePillarMutation<
-    { mediaType: 'season'; mediaId: number },
+export function useBatchSeasonLog({ showId, seasonNum, season, episodes }: UseBatchSeasonLogArgs) {
+  const queryClient = useQueryClient();
+
+  const batchLogMutation = useMutation<
     { data: { logged: number } },
+    Error,
+    BatchLogInput,
     BatchLogContext
-  >('media', ['watchHistory', 'batchLog'], {
-    onMutate: () => applyOptimistic(utils, showId, seasonNum, episodes),
+  >({
+    mutationFn: async (variables) =>
+      unwrap(
+        await watchHistoryBatchLog({
+          body: { mediaType: variables.mediaType, mediaId: variables.mediaId, completed: 1 },
+        })
+      ),
+    onMutate: () => applyOptimistic(queryClient, showId, seasonNum, episodes),
     onSuccess: (result) => {
       toast.success(
         `Marked ${result.data.logged} episode${result.data.logged !== 1 ? 's' : ''} as watched`
       );
     },
     onError: (err, _vars, context) => {
-      rollbackOptimistic(utils, showId, context);
+      rollbackOptimistic(queryClient, showId, context);
       toast.error(`Failed to mark season: ${err.message}`);
     },
     onSettled: () => {
-      void utils.invalidate(['watchHistory']);
-      void utils.invalidate(['tvShows', 'listSeasons']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'tvShows', 'listSeasons'] });
     },
   });
 

--- a/packages/app-media/src/pages/season-detail/useEpisodeMonitoring.ts
+++ b/packages/app-media/src/pages/season-detail/useEpisodeMonitoring.ts
@@ -1,7 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { arrUpdateEpisodeMonitoring } from '../../media-api/index.js';
 
 interface SonarrEpisode {
   id: number;
@@ -44,34 +46,32 @@ function useMonitorMutation(
   setOptimisticEpMonitoring: React.Dispatch<React.SetStateAction<Map<number, boolean>>>,
   setPendingEpMonitoring: React.Dispatch<React.SetStateAction<Set<number>>>
 ) {
-  return usePillarMutation<UpdateEpisodeMonitoringInput, unknown>(
-    'media',
-    ['arr', 'updateEpisodeMonitoring'],
-    {
-      onError: (err, variables) => {
-        setOptimisticEpMonitoring((prev) => {
-          const next = new Map(prev);
-          const affectedIds = new Set(variables.episodeIds);
-          for (const ep of sonarrEpisodes) {
-            if (affectedIds.has(ep.id)) next.set(ep.episodeNumber, !variables.monitored);
-          }
-          return next;
-        });
-        toast.error(`Failed to update monitoring: ${err.message}`);
-      },
-      onSettled: (_data, _err, variables) => {
-        if (!variables) return;
-        setPendingEpMonitoring((prev) => {
-          const next = new Set(prev);
-          const affectedIds = new Set(variables.episodeIds);
-          for (const ep of sonarrEpisodes) {
-            if (affectedIds.has(ep.id)) next.delete(ep.episodeNumber);
-          }
-          return next;
-        });
-      },
-    }
-  );
+  return useMutation({
+    mutationFn: async (variables: UpdateEpisodeMonitoringInput) =>
+      unwrap(await arrUpdateEpisodeMonitoring({ body: variables })),
+    onError: (err: Error, variables) => {
+      setOptimisticEpMonitoring((prev) => {
+        const next = new Map(prev);
+        const affectedIds = new Set(variables.episodeIds);
+        for (const ep of sonarrEpisodes) {
+          if (affectedIds.has(ep.id)) next.set(ep.episodeNumber, !variables.monitored);
+        }
+        return next;
+      });
+      toast.error(`Failed to update monitoring: ${err.message}`);
+    },
+    onSettled: (_data, _err, variables) => {
+      if (!variables) return;
+      setPendingEpMonitoring((prev) => {
+        const next = new Set(prev);
+        const affectedIds = new Set(variables.episodeIds);
+        for (const ep of sonarrEpisodes) {
+          if (affectedIds.has(ep.id)) next.delete(ep.episodeNumber);
+        }
+        return next;
+      });
+    },
+  });
 }
 
 export function useEpisodeMonitoring(sonarrEpisodes: SonarrEpisode[]) {

--- a/packages/app-media/src/pages/season-detail/useEpisodeToggle.ts
+++ b/packages/app-media/src/pages/season-detail/useEpisodeToggle.ts
@@ -1,9 +1,9 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
-
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { watchHistoryDelete, watchHistoryLog } from '../../media-api/index.js';
 
 interface UseEpisodeToggleArgs {
   watchHistory: Array<{ id: number; mediaId: number }> | undefined;
@@ -18,12 +18,23 @@ interface DeleteInput {
   id: number;
 }
 
-function useLogMutation(utils: UsePillarUtilsResult, removeToggling: (id: number) => void) {
-  return usePillarMutation<LogInput, unknown>('media', ['watchHistory', 'log'], {
+function useLogMutation(queryClient: QueryClient, removeToggling: (id: number) => void) {
+  return useMutation({
+    mutationFn: async (variables: LogInput) =>
+      unwrap(
+        await watchHistoryLog({
+          body: {
+            mediaType: variables.mediaType,
+            mediaId: variables.mediaId,
+            completed: 1,
+            source: 'manual',
+          },
+        })
+      ),
     onSuccess: () => {
-      void utils.invalidate(['tvShows', 'listSeasons']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'tvShows', 'listSeasons'] });
     },
-    onError: (err) => {
+    onError: (err: Error) => {
       toast.error(`Failed to log watch: ${err.message}`);
     },
     onSettled: (_data, _err, variables) => {
@@ -33,15 +44,17 @@ function useLogMutation(utils: UsePillarUtilsResult, removeToggling: (id: number
 }
 
 function useDeleteMutation(
-  utils: UsePillarUtilsResult,
+  queryClient: QueryClient,
   deleteEntryToEpisode: React.RefObject<Map<number, number>>,
   removeToggling: (id: number) => void
 ) {
-  return usePillarMutation<DeleteInput, unknown>('media', ['watchHistory', 'delete'], {
+  return useMutation({
+    mutationFn: async (variables: DeleteInput) =>
+      unwrap(await watchHistoryDelete({ path: { id: variables.id } })),
     onSuccess: () => {
-      void utils.invalidate(['tvShows', 'listSeasons']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'tvShows', 'listSeasons'] });
     },
-    onError: (err) => {
+    onError: (err: Error) => {
       toast.error(`Failed to remove watch: ${err.message}`);
     },
     onSettled: (_data, _err, variables) => {
@@ -54,7 +67,7 @@ function useDeleteMutation(
 }
 
 export function useEpisodeToggle({ watchHistory }: UseEpisodeToggleArgs) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
   const deleteEntryToEpisode = useRef<Map<number, number>>(new Map());
 
@@ -66,8 +79,8 @@ export function useEpisodeToggle({ watchHistory }: UseEpisodeToggleArgs) {
     });
   }, []);
 
-  const logMutation = useLogMutation(utils, removeToggling);
-  const deleteMutation = useDeleteMutation(utils, deleteEntryToEpisode, removeToggling);
+  const logMutation = useLogMutation(queryClient, removeToggling);
+  const deleteMutation = useDeleteMutation(queryClient, deleteEntryToEpisode, removeToggling);
 
   const handleToggleWatched = useCallback(
     (episodeId: number, watched: boolean) => {

--- a/packages/app-media/src/pages/season-detail/useSeasonDetailModel.ts
+++ b/packages/app-media/src/pages/season-detail/useSeasonDetailModel.ts
@@ -1,8 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { useSetPageContext } from '@pops/navigation';
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  tvShowsGet,
+  tvShowsListEpisodes,
+  tvShowsListSeasons,
+  watchHistoryList,
+  watchHistoryProgress,
+} from '../../media-api/index.js';
 import { useEpisodeWatchState } from './useEpisodeWatchState';
 import { useSonarrMonitoring } from './useSonarrMonitoring';
 
@@ -13,7 +21,7 @@ interface ShowEnvelope {
 interface SeasonItem {
   id: number;
   seasonNumber: number;
-  name: string;
+  name: string | null;
   posterUrl: string | null;
   airDate: string | null;
   overview: string | null;
@@ -59,41 +67,40 @@ interface ProgressEnvelope {
 
 function useSeasonQueries(showId: number, seasonNum: number) {
   const enabled = !Number.isNaN(showId);
-  const showQuery = usePillarQuery<ShowEnvelope>(
-    'media',
-    ['tvShows', 'get'],
-    { id: showId },
-    { enabled }
-  );
-  const seasonsQuery = usePillarQuery<SeasonsEnvelope>(
-    'media',
-    ['tvShows', 'listSeasons'],
-    { tvShowId: showId },
-    { enabled }
-  );
+  const showQuery = useQuery({
+    queryKey: ['media', 'tvShows', 'get', { id: showId }],
+    queryFn: async (): Promise<ShowEnvelope> => unwrap(await tvShowsGet({ path: { id: showId } })),
+    enabled,
+  });
+  const seasonsQuery = useQuery({
+    queryKey: ['media', 'tvShows', 'listSeasons', { tvShowId: showId }],
+    queryFn: async (): Promise<SeasonsEnvelope> =>
+      unwrap(await tvShowsListSeasons({ path: { tvShowId: showId } })),
+    enabled,
+  });
   const season = seasonsQuery.data?.data?.find((s) => s.seasonNumber === seasonNum);
-  const episodesQuery = usePillarQuery<EpisodesEnvelope>(
-    'media',
-    ['tvShows', 'listEpisodes'],
-    { seasonId: season?.id ?? 0 },
-    { enabled: !!season?.id }
-  );
+  const episodesQuery = useQuery({
+    queryKey: ['media', 'tvShows', 'listEpisodes', { seasonId: season?.id ?? 0 }],
+    queryFn: async (): Promise<EpisodesEnvelope> =>
+      unwrap(await tvShowsListEpisodes({ path: { seasonId: season?.id ?? 0 } })),
+    enabled: !!season?.id,
+  });
   return { showQuery, seasonsQuery, season, episodesQuery };
 }
 
 function useWatchHistoryAndProgress(showId: number, episodeIds: number[]) {
-  const watchHistoryQuery = usePillarQuery<WatchHistoryEnvelope>(
-    'media',
-    ['watchHistory', 'list'],
-    { mediaType: 'episode', limit: 500 },
-    { enabled: episodeIds.length > 0 }
-  );
-  const progressQuery = usePillarQuery<ProgressEnvelope>(
-    'media',
-    ['watchHistory', 'progress'],
-    { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) }
-  );
+  const watchHistoryQuery = useQuery({
+    queryKey: ['media', 'watchHistory', 'list', { mediaType: 'episode', limit: 500 }],
+    queryFn: async (): Promise<WatchHistoryEnvelope> =>
+      unwrap(await watchHistoryList({ query: { mediaType: 'episode', limit: 500 } })),
+    enabled: episodeIds.length > 0,
+  });
+  const progressQuery = useQuery({
+    queryKey: ['media', 'watchHistory', 'progress', { tvShowId: showId }],
+    queryFn: async (): Promise<ProgressEnvelope> =>
+      unwrap(await watchHistoryProgress({ path: { tvShowId: showId } })),
+    enabled: !Number.isNaN(showId),
+  });
   return { watchHistoryQuery, progressQuery };
 }
 

--- a/packages/app-media/src/pages/season-detail/useSonarrMonitoring.ts
+++ b/packages/app-media/src/pages/season-detail/useSonarrMonitoring.ts
@@ -1,8 +1,13 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  arrCheckSeries,
+  arrGetSeriesEpisodes,
+  arrUpdateSeasonMonitoring,
+} from '../../media-api/index.js';
 import { useEpisodeMonitoring } from './useEpisodeMonitoring';
 
 interface SonarrSeries {
@@ -41,36 +46,49 @@ interface UseSonarrMonitoringArgs {
  * Hook owning Sonarr (Arr) monitoring state for a single season.
  */
 export function useSonarrMonitoring({ tvdbId, seasonNum }: UseSonarrMonitoringArgs) {
-  const { data: sonarrData } = usePillarQuery<CheckSeriesEnvelope>(
-    'media',
-    ['arr', 'checkSeries'],
-    { tvdbId: tvdbId ?? 0 },
-    { enabled: !!tvdbId }
-  );
+  const { data: sonarrData } = useQuery({
+    queryKey: ['media', 'arr', 'checkSeries', { tvdbId: tvdbId ?? 0 }],
+    queryFn: async (): Promise<CheckSeriesEnvelope> =>
+      unwrap(await arrCheckSeries({ path: { tvdbId: tvdbId ?? 0 } })),
+    enabled: !!tvdbId,
+  });
 
   const sonarrSeries: SonarrSeries | undefined = sonarrData?.data;
   const sonarrSeasonData = sonarrSeries?.seasons?.find((s) => s.seasonNumber === seasonNum);
   const [seasonMonitored, setSeasonMonitored] = useState<boolean | null>(null);
   const effectiveMonitored = seasonMonitored ?? sonarrSeasonData?.monitored ?? false;
 
-  const seasonMonitorMutation = usePillarMutation<UpdateSeasonMonitoringInput, unknown>(
-    'media',
-    ['arr', 'updateSeasonMonitoring'],
-    {
-      onError: (err) => {
-        setSeasonMonitored((prev) => (prev != null ? !prev : null));
-        toast.error(`Failed to update monitoring: ${err.message}`);
-      },
-    }
-  );
+  const seasonMonitorMutation = useMutation({
+    mutationFn: async (variables: UpdateSeasonMonitoringInput) =>
+      unwrap(
+        await arrUpdateSeasonMonitoring({
+          path: { sonarrId: variables.sonarrId, seasonNumber: variables.seasonNumber },
+          body: { monitored: variables.monitored },
+        })
+      ),
+    onError: (err: Error) => {
+      setSeasonMonitored((prev) => (prev != null ? !prev : null));
+      toast.error(`Failed to update monitoring: ${err.message}`);
+    },
+  });
 
   const sonarrId = sonarrSeries?.sonarrId;
-  const { data: sonarrEpisodesData } = usePillarQuery<GetSeriesEpisodesEnvelope>(
-    'media',
-    ['arr', 'getSeriesEpisodes'],
-    { sonarrId: sonarrId ?? 0, seasonNumber: seasonNum },
-    { enabled: !!sonarrId }
-  );
+  const { data: sonarrEpisodesData } = useQuery({
+    queryKey: [
+      'media',
+      'arr',
+      'getSeriesEpisodes',
+      { sonarrId: sonarrId ?? 0, seasonNumber: seasonNum },
+    ],
+    queryFn: async (): Promise<GetSeriesEpisodesEnvelope> =>
+      unwrap(
+        await arrGetSeriesEpisodes({
+          path: { sonarrId: sonarrId ?? 0 },
+          query: { seasonNumber: seasonNum },
+        })
+      ),
+    enabled: !!sonarrId,
+  });
 
   const sonarrEpisodes = sonarrEpisodesData?.data ?? [];
   const monitoring = useEpisodeMonitoring(sonarrEpisodes);


### PR DESCRIPTION
Phase D tier-2. Rewires season-detail (19 sites: useSeasonDetailModel/useSonarrMonitoring/useEpisodeMonitoring/useEpisodeToggle/useBatchSeasonLog) onto the Hey API SDK + react-query (tvShows*/watchHistory*/arr* fns). Optimistic batch-log cache writes preserved. Verified in isolation (fe-quality red-by-design): no new tsc errors in scope, SeasonDetailPage test 29/29, no suite regression, oxlint exit 0. Honest deviations: log/batchLog bodies pass completed:1(+source:'manual'); arrUpdateSeasonMonitoring path/body split; SeasonItem.name typed string|null; isNotFoundError from media-api-helpers.