### PR TITLE
feat(media): add rotation.listExclusions endpoint

### DIFF
--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -13323,6 +13323,152 @@
       }
     },
     "/rotation/exclusions": {
+      "get": {
+        "operationId": "rotation.listExclusions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "items": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "excludedAt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "number"
+                              },
+                              "reason": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "tmdbId": {
+                                "type": "number"
+                              }
+                            },
+                            "required": ["id", "tmdbId", "title", "reason", "excludedAt"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "total": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["items", "total"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List exclusion entries, most-recent first, with pagination",
+        "tags": ["rotation"]
+      },
       "post": {
         "operationId": "rotation.addExclusion",
         "parameters": [],

--- a/pillars/media/src/api/__tests__/rotation.test.ts
+++ b/pillars/media/src/api/__tests__/rotation.test.ts
@@ -11,11 +11,13 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   moviesService,
   openMediaDb,
+  rotationExclusions,
   rotationSourcesService,
   type OpenedMediaDb,
 } from '../../db/index.js';
@@ -203,6 +205,68 @@ describe('rotation — exclusions', () => {
   it('returns success:false when removing a non-existent exclusion', async () => {
     const res = await client().rotation.removeExclusion(nextTmdb());
     expect(res.data.success).toBe(false);
+  });
+});
+
+describe('rotation — list exclusions', () => {
+  it('returns an empty list with total 0 when none are excluded', async () => {
+    const { data } = await client().rotation.listExclusions();
+    expect(data.items).toEqual([]);
+    expect(data.total).toBe(0);
+  });
+
+  it('lists an exclusion right after it is added', async () => {
+    const tmdbId = nextTmdb();
+    await client().rotation.addExclusion({ tmdbId, reason: 'meh' });
+
+    const { data } = await client().rotation.listExclusions();
+    expect(data.total).toBe(1);
+    expect(data.items).toHaveLength(1);
+    expect(data.items[0]).toMatchObject({ tmdbId, reason: 'meh', title: String(tmdbId) });
+  });
+
+  it('paginates with limit/offset while reporting the full total', async () => {
+    const ids = [nextTmdb(), nextTmdb(), nextTmdb(), nextTmdb(), nextTmdb()];
+    for (const tmdbId of ids) await client().rotation.addExclusion({ tmdbId });
+
+    const page1 = await client().rotation.listExclusions({ limit: 2, offset: 0 });
+    expect(page1.data.total).toBe(5);
+    expect(page1.data.items).toHaveLength(2);
+
+    const page2 = await client().rotation.listExclusions({ limit: 2, offset: 2 });
+    expect(page2.data.total).toBe(5);
+    expect(page2.data.items).toHaveLength(2);
+
+    const page3 = await client().rotation.listExclusions({ limit: 2, offset: 4 });
+    expect(page3.data.items).toHaveLength(1);
+
+    const seen = [...page1.data.items, ...page2.data.items, ...page3.data.items].map(
+      (e) => e.tmdbId
+    );
+    expect(seen.toSorted()).toEqual(ids.toSorted());
+  });
+
+  it('orders most-recently-excluded first', async () => {
+    const older = nextTmdb();
+    const newer = nextTmdb();
+    await client().rotation.addExclusion({ tmdbId: older });
+    await client().rotation.addExclusion({ tmdbId: newer });
+
+    // excludedAt defaults to second-granularity datetime('now'); pin distinct
+    // values so the DESC ordering assertion is deterministic rather than a tie.
+    mediaDb.db
+      .update(rotationExclusions)
+      .set({ excludedAt: '2020-01-01 00:00:00' })
+      .where(eq(rotationExclusions.tmdbId, older))
+      .run();
+    mediaDb.db
+      .update(rotationExclusions)
+      .set({ excludedAt: '2024-01-01 00:00:00' })
+      .where(eq(rotationExclusions.tmdbId, newer))
+      .run();
+
+    const { data } = await client().rotation.listExclusions();
+    expect(data.items.map((e) => e.tmdbId)).toEqual([newer, older]);
   });
 });
 

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -642,6 +642,10 @@ function makeRotationClient(r: ReturnType<typeof supertest>) {
       ),
     addExclusion: (body: Record<string, unknown>) =>
       send<{ message: string }>(r.post('/rotation/exclusions').send(body)),
+    listExclusions: (query: { limit?: number; offset?: number } = {}) =>
+      send<{ data: { items: ExclusionWire[]; total: number } }>(
+        r.get('/rotation/exclusions').query(query)
+      ),
     getExclusion: (tmdbId: number) =>
       send<{ data: ExclusionWire | null }>(r.get(`/rotation/exclusions/${tmdbId}`)),
     removeExclusion: (tmdbId: number) =>

--- a/pillars/media/src/api/manifest-routes.ts
+++ b/pillars/media/src/api/manifest-routes.ts
@@ -61,6 +61,7 @@ export const MEDIA_ROUTES: ManifestPayload['routes'] = {
     'media.comparisons.getTierListMovies',
     'media.rotation.listCandidates',
     'media.rotation.getCandidateStatus',
+    'media.rotation.listExclusions',
     'media.rotation.getExclusion',
     'media.rotation.sourceTypes',
     'media.rotation.listPlexFriends',

--- a/pillars/media/src/api/rest/rotation-candidate-handlers.ts
+++ b/pillars/media/src/api/rest/rotation-candidate-handlers.ts
@@ -63,6 +63,12 @@ export function makeRotationCandidateHandlers(db: MediaDb) {
         return { status: 200 as const, body: { message: 'Excluded from rotation' } };
       }),
 
+    listExclusions: ({ query }: Req['listExclusions']) =>
+      runHttp(() => {
+        const { rows, total } = rotationExclusionsService.listExclusions(db, query);
+        return { status: 200 as const, body: { data: { items: rows, total } } };
+      }),
+
     getExclusion: ({ params }: Req['getExclusion']) =>
       runHttp(() => ({
         status: 200 as const,

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -1548,7 +1548,8 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /** List exclusion entries, most-recent first, with pagination */
+    get: operations['rotation.listExclusions'];
     put?: never;
     /** Exclude a movie from rotation */
     post: operations['rotation.addExclusion'];
@@ -8403,6 +8404,79 @@ export interface operations {
           'application/json': {
             data: {
               success: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'rotation.listExclusions': {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              items: {
+                excludedAt: string;
+                id: number;
+                reason: string | null;
+                title: string;
+                tmdbId: number;
+              }[];
+              total: number;
             };
           };
         };

--- a/pillars/media/src/contract/rest-rotation-schemas.ts
+++ b/pillars/media/src/contract/rest-rotation-schemas.ts
@@ -69,6 +69,16 @@ export const ExclusionSchema = z.object({
   excludedAt: z.string(),
 });
 
+export const ListExclusionsQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+export const ListExclusionsResultSchema = z.object({
+  items: z.array(ExclusionSchema),
+  total: z.number(),
+});
+
 export const SourceSchema = z.object({
   id: z.number(),
   type: z.string(),

--- a/pillars/media/src/contract/rest-rotation.ts
+++ b/pillars/media/src/contract/rest-rotation.ts
@@ -27,6 +27,8 @@ import {
   ExclusionSchema,
   ListCandidatesQuery,
   ListCandidatesResultSchema,
+  ListExclusionsQuery,
+  ListExclusionsResultSchema,
   PlexFriendsResultSchema,
   SaveSettingsBody,
   SaveSettingsResultSchema,
@@ -87,6 +89,13 @@ export const mediaRotationContract = c.router({
     body: AddExclusionBody,
     responses: { 200: MessageSchema, ...ERR_RESPONSES },
     summary: 'Exclude a movie from rotation',
+  },
+  listExclusions: {
+    method: 'GET',
+    path: '/rotation/exclusions',
+    query: ListExclusionsQuery,
+    responses: { 200: z.object({ data: ListExclusionsResultSchema }), ...ERR_RESPONSES },
+    summary: 'List exclusion entries, most-recent first, with pagination',
   },
   getExclusion: {
     method: 'GET',

--- a/pillars/media/src/db/services/rotation/exclusions.ts
+++ b/pillars/media/src/db/services/rotation/exclusions.ts
@@ -10,7 +10,7 @@
  * existing candidate or library row, falling back to the tmdbId string so the
  * NOT NULL constraint always holds.
  */
-import { eq } from 'drizzle-orm';
+import { count, desc, eq } from 'drizzle-orm';
 
 import { movies, rotationCandidates, rotationExclusions } from '../../schema.js';
 
@@ -21,6 +21,16 @@ export type RotationExclusionRow = typeof rotationExclusions.$inferSelect;
 export interface AddExclusionInput {
   tmdbId: number;
   reason?: string | null;
+}
+
+export interface ListExclusionsInput {
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListExclusionsResult {
+  rows: RotationExclusionRow[];
+  total: number;
 }
 
 /** Resolve a display title for an exclusion from existing candidate/movie rows. */
@@ -56,6 +66,21 @@ export function addExclusion(db: MediaDb, input: AddExclusionInput): void {
       .where(eq(rotationCandidates.tmdbId, input.tmdbId))
       .run();
   });
+}
+
+/** List exclusion entries, most-recent first, with pagination. Defaults match the monolith. */
+export function listExclusions(db: MediaDb, input: ListExclusionsInput = {}): ListExclusionsResult {
+  const limit = input.limit ?? 50;
+  const offset = input.offset ?? 0;
+  const rows = db
+    .select()
+    .from(rotationExclusions)
+    .orderBy(desc(rotationExclusions.excludedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const totalRow = db.select({ value: count() }).from(rotationExclusions).get();
+  return { rows, total: totalRow?.value ?? 0 };
 }
 
 /** Fetch an exclusion by tmdbId, or `null` when absent. */


### PR DESCRIPTION
Fills the gap the FE rewire surfaced: the rotation data plane shipped only single `getExclusion`/`addExclusion`/`removeExclusion`, but `app-media`'s ExclusionList needs a paginated list. Adds `GET /rotation/exclusions` → `{ items, total }` (rows {id,tmdbId,title,reason,excludedAt}, excludedAt DESC, limit/offset). SDK fn `rotationListExclusions`. 4 tests (**411 total**). Verified: typecheck ✓ build ✓ 411/411 ✓ lint exit 0 ✓ idempotent ✓.