### PR TITLE
feat(media/fe): rewire search/history/rankings onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/HistoryPage.test.tsx
+++ b/packages/app-media/src/pages/HistoryPage.test.tsx
@@ -1,9 +1,10 @@
-import { act, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock sonner toast
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock('sonner', () => ({
@@ -13,49 +14,31 @@ vi.mock('sonner', () => ({
   },
 }));
 
-const mockListRecentQuery = vi.fn();
-const mockDeleteMutate = vi.fn();
-let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
-let deleteMutationPending = false;
-const mockInvalidateWatchHistory = vi.fn();
-const mockInvalidateWatchlist = vi.fn();
+const mockWatchHistoryListRecent = vi.fn();
+const mockWatchHistoryDelete = vi.fn();
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'watchHistory.listRecent') return mockListRecentQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, (...args: unknown[]) => unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'watchHistory.delete') {
-      deleteMutationOpts = opts;
-      return { mutate: mockDeleteMutate, isPending: deleteMutationPending };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: (path?: readonly string[]) => {
-      const key = path?.join('.') ?? '';
-      if (key === 'watchHistory') mockInvalidateWatchHistory();
-      if (key === 'watchlist') mockInvalidateWatchlist();
-    },
-  }),
+vi.mock('../media-api/index.js', () => ({
+  watchHistoryListRecent: (opts: unknown) => mockWatchHistoryListRecent(opts),
+  watchHistoryDelete: (opts: unknown) => mockWatchHistoryDelete(opts),
 }));
 
 import { HistoryPage } from './HistoryPage';
 
 function renderPage() {
-  return render(
-    <MemoryRouter initialEntries={['/media/history']}>
-      <HistoryPage />
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, { initialEntries: ['/media/history'] }, children)
+    );
+  return render(<HistoryPage />, { wrapper });
+}
+
+function listResult(data: unknown[], total: number) {
+  return { data: { data, pagination: { total } } };
 }
 
 const episodeEntry = {
@@ -103,73 +86,55 @@ const episodeNoShow = {
 describe('HistoryPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    deleteMutationPending = false;
-    deleteMutationOpts = {};
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeEntry, movieEntry], pagination: { total: 2 } },
-      isLoading: false,
-      error: null,
-    });
+    mockWatchHistoryListRecent.mockResolvedValue(listResult([episodeEntry, movieEntry], 2));
+    mockWatchHistoryDelete.mockResolvedValue({ data: { id: 1 } });
   });
 
   describe('episode enrichment', () => {
-    it('renders episode subtitle in S02E10 format with em-dash', () => {
+    it('renders episode subtitle in S02E10 format with em-dash', async () => {
       renderPage();
-      expect(screen.getAllByText('Breaking Bad').length).toBeGreaterThan(0);
+      expect((await screen.findAllByText('Breaking Bad')).length).toBeGreaterThan(0);
       expect(screen.getAllByText('S02E10').length).toBeGreaterThan(0);
     });
 
-    it('renders show name as link to show detail page', () => {
+    it('renders show name as link to show detail page', async () => {
       renderPage();
-      const showLinks = screen.getAllByText('Breaking Bad');
+      const showLinks = await screen.findAllByText('Breaking Bad');
       const showLink = showLinks.find(
         (el) => el.closest('a')?.getAttribute('href') === '/media/tv/7'
       );
       expect(showLink).toBeTruthy();
     });
 
-    it('renders season code as link to season detail page', () => {
+    it('renders season code as link to season detail page', async () => {
       renderPage();
-      const codeLinks = screen.getAllByText('S02E10');
+      const codeLinks = await screen.findAllByText('S02E10');
       const seasonLink = codeLinks.find(
         (el) => el.closest('a')?.getAttribute('href') === '/media/tv/7?season=2'
       );
       expect(seasonLink).toBeTruthy();
     });
 
-    it('renders movie entries with no subtitle', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [movieEntry], pagination: { total: 1 } },
-        isLoading: false,
-        error: null,
-      });
+    it('renders movie entries with no subtitle', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([movieEntry], 1));
       renderPage();
-      expect(screen.getAllByText('The Matrix').length).toBeGreaterThan(0);
+      expect((await screen.findAllByText('The Matrix')).length).toBeGreaterThan(0);
       expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
     });
 
-    it('renders episode with missing show data as title only (graceful fallback)', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [episodeNoShow], pagination: { total: 1 } },
-        isLoading: false,
-        error: null,
-      });
+    it('renders episode with missing show data as title only (graceful fallback)', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([episodeNoShow], 1));
       renderPage();
-      expect(screen.getAllByText('Mystery Episode').length).toBeGreaterThan(0);
+      expect((await screen.findAllByText('Mystery Episode')).length).toBeGreaterThan(0);
       expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
     });
 
-    it('renders mixed entries correctly', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: {
-          data: [episodeEntry, movieEntry, episodeNoShow],
-          pagination: { total: 3 },
-        },
-        isLoading: false,
-        error: null,
-      });
+    it('renders mixed entries correctly', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(
+        listResult([episodeEntry, movieEntry, episodeNoShow], 3)
+      );
       renderPage();
-      expect(screen.getAllByText('Breaking Bad').length).toBeGreaterThan(0);
+      expect((await screen.findAllByText('Breaking Bad')).length).toBeGreaterThan(0);
       expect(screen.getAllByText('S02E10').length).toBeGreaterThan(0);
       expect(screen.getAllByText('The Matrix').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Mystery Episode').length).toBeGreaterThan(0);
@@ -177,9 +142,9 @@ describe('HistoryPage', () => {
   });
 
   describe('delete button visibility', () => {
-    it('renders delete buttons with correct aria-label', () => {
+    it('renders delete buttons with correct aria-label', async () => {
       renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
       expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
     });
   });
@@ -188,7 +153,7 @@ describe('HistoryPage', () => {
     it('opens confirmation dialog when delete is clicked', async () => {
       const user = userEvent.setup();
       renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
       await user.click(deleteButtons[0]!);
       expect(screen.getByText('Remove watch event?')).toBeInTheDocument();
       expect(screen.getByText(/This cannot be undone/)).toBeInTheDocument();
@@ -197,7 +162,7 @@ describe('HistoryPage', () => {
     it('shows cancel and remove buttons in dialog', async () => {
       const user = userEvent.setup();
       renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
       await user.click(deleteButtons[0]!);
       expect(screen.getByText('Cancel')).toBeInTheDocument();
       expect(screen.getByText('Remove')).toBeInTheDocument();
@@ -206,141 +171,128 @@ describe('HistoryPage', () => {
     it('calls delete mutation when confirmed', async () => {
       const user = userEvent.setup();
       renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
       await user.click(deleteButtons[0]!);
       await user.click(screen.getByText('Remove'));
-      expect(mockDeleteMutate).toHaveBeenCalledWith({ id: episodeEntry.id });
+      await waitFor(() =>
+        expect(mockWatchHistoryDelete).toHaveBeenCalledWith({ path: { id: episodeEntry.id } })
+      );
     });
 
     it('closes dialog on cancel without calling delete', async () => {
       const user = userEvent.setup();
       renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
       await user.click(deleteButtons[0]!);
       await user.click(screen.getByText('Cancel'));
-      expect(mockDeleteMutate).not.toHaveBeenCalled();
+      expect(mockWatchHistoryDelete).not.toHaveBeenCalled();
       expect(screen.queryByText('Remove watch event?')).not.toBeInTheDocument();
     });
   });
 
   describe('delete success', () => {
-    it('shows success toast on deletion', () => {
+    it('shows success toast on deletion', async () => {
+      const user = userEvent.setup();
       renderPage();
-      deleteMutationOpts.onSuccess?.();
-      expect(mockToastSuccess).toHaveBeenCalledWith('Watch event removed');
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText('Remove'));
+      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Watch event removed'));
     });
 
-    it('invalidates queries on success', () => {
+    it('refetches history after a successful deletion', async () => {
+      const user = userEvent.setup();
       renderPage();
-      deleteMutationOpts.onSuccess?.();
-      expect(mockInvalidateWatchHistory).toHaveBeenCalled();
-      expect(mockInvalidateWatchlist).toHaveBeenCalled();
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
+      const callsBefore = mockWatchHistoryListRecent.mock.calls.length;
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText('Remove'));
+      await waitFor(() =>
+        expect(mockWatchHistoryListRecent.mock.calls.length).toBeGreaterThan(callsBefore)
+      );
     });
   });
 
   describe('delete error', () => {
-    it('shows error toast on failure', () => {
+    it('shows error toast on failure', async () => {
+      mockWatchHistoryDelete.mockResolvedValue({ error: { message: 'Server error' } });
+      const user = userEvent.setup();
       renderPage();
-      deleteMutationOpts.onError?.({ message: 'Server error' });
-      expect(mockToastError).toHaveBeenCalledWith('Failed to delete watch event: Server error');
-    });
-  });
-
-  describe('delete disabled while in flight', () => {
-    it('disables delete buttons while mutation is pending', () => {
-      deleteMutationPending = true;
-      renderPage();
-      const deleteButtons = screen.getAllByLabelText('Delete watch event');
-      deleteButtons.forEach((btn) => expect(btn).toBeDisabled());
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText('Remove'));
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith('Failed to delete watch event: Server error')
+      );
     });
   });
 
   describe('delete pagination edge case', () => {
     it('goes to previous page when last entry on a non-first page is deleted', async () => {
-      // Single entry with total > PAGE_SIZE so Next button is visible on page 1.
-      // After clicking Next (offset → 50), triggering onSuccess with 1 entry should
-      // reset offset back to 0.
       const singleEntry = { ...movieEntry, id: 99 };
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [singleEntry], pagination: { total: 51 } },
-        isLoading: false,
-        error: null,
-      });
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([singleEntry], 51));
       const user = userEvent.setup();
       renderPage();
 
-      // Page 1: Next should be visible because total (51) > PAGE_SIZE (50)
-      await user.click(screen.getByText('Next'));
-
-      // Now at offset 50 with 1 entry — trigger onSuccess inside act to simulate delete
-      await act(async () => {
-        deleteMutationOpts.onSuccess?.();
+      await user.click(await screen.findByText('Next'));
+      await waitFor(() => {
+        const calls = mockWatchHistoryListRecent.mock.calls as Array<
+          [{ query: { offset: number } }]
+        >;
+        expect(calls.some((args) => args[0]?.query.offset === 50)).toBe(true);
       });
 
-      // Offset should have been reset to 0 — verify via subsequent query call args
-      const calls = mockListRecentQuery.mock.calls as Array<[{ offset: number }]>;
-      const resetCall = calls.find((args) => args[0]?.offset === 0);
-      expect(resetCall).toBeDefined();
+      const deleteButtons = await screen.findAllByLabelText('Delete watch event');
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText('Remove'));
+
+      await waitFor(() => {
+        const calls = mockWatchHistoryListRecent.mock.calls as Array<
+          [{ query: { offset: number } }]
+        >;
+        const resetCall = calls.find((args) => args[0]?.query.offset === 0);
+        expect(resetCall).toBeDefined();
+      });
     });
   });
 
   describe('empty state', () => {
-    it('shows empty state when no entries', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [], pagination: { total: 0 } },
-        isLoading: false,
-        error: null,
-      });
+    it('shows empty state when no entries', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([], 0));
       renderPage();
       expect(
-        screen.getByText('No watch history yet. Start watching something!')
+        await screen.findByText('No watch history yet. Start watching something!')
       ).toBeInTheDocument();
     });
 
     it('shows filtered empty state for movies', async () => {
       const user = userEvent.setup();
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [], pagination: { total: 0 } },
-        isLoading: false,
-        error: null,
-      });
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([], 0));
       renderPage();
-      await user.click(screen.getByText('Movies'));
-      expect(screen.getByText('No movies in your history.')).toBeInTheDocument();
+      await user.click(await screen.findByText('Movies'));
+      expect(await screen.findByText('No movies in your history.')).toBeInTheDocument();
     });
 
-    it('shows browse library link in empty state', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: { data: [], pagination: { total: 0 } },
-        isLoading: false,
-        error: null,
-      });
+    it('shows browse library link in empty state', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(listResult([], 0));
       renderPage();
-      expect(screen.getByText('Browse library')).toHaveAttribute('href', '/media');
+      expect(await screen.findByText('Browse library')).toHaveAttribute('href', '/media');
     });
   });
 
   describe('loading state', () => {
     it('shows skeleton when loading', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: null,
-        isLoading: true,
-        error: null,
-      });
+      mockWatchHistoryListRecent.mockReturnValue(new Promise(() => {}));
       const { container } = renderPage();
       expect(container.querySelectorAll("[data-slot='skeleton']").length).toBeGreaterThan(0);
     });
   });
 
   describe('error state', () => {
-    it('shows error alert on query error', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: { message: 'Failed to fetch' },
-      });
+    it('shows error alert on query error', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue({ error: { message: 'Failed to fetch' } });
       renderPage();
-      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(await screen.findByText('Error')).toBeInTheDocument();
       expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
     });
   });
@@ -349,47 +301,53 @@ describe('HistoryPage', () => {
     it('passes mediaType filter when Movies tab is selected', async () => {
       const user = userEvent.setup();
       renderPage();
-      await user.click(screen.getByText('Movies'));
-      const lastCall = mockListRecentQuery.mock.calls.at(-1);
-      expect(lastCall?.[0]).toMatchObject({ mediaType: 'movie' });
+      await user.click(await screen.findByText('Movies'));
+      await waitFor(() => {
+        const lastCall = mockWatchHistoryListRecent.mock.calls.at(-1);
+        expect(lastCall?.[0]).toMatchObject({ query: { mediaType: 'movie' } });
+      });
     });
 
     it('passes mediaType filter when Episodes tab is selected', async () => {
       const user = userEvent.setup();
       renderPage();
-      await user.click(screen.getByText('Episodes'));
-      const lastCall = mockListRecentQuery.mock.calls.at(-1);
-      expect(lastCall?.[0]).toMatchObject({ mediaType: 'episode' });
+      await user.click(await screen.findByText('Episodes'));
+      await waitFor(() => {
+        const lastCall = mockWatchHistoryListRecent.mock.calls.at(-1);
+        expect(lastCall?.[0]).toMatchObject({ query: { mediaType: 'episode' } });
+      });
     });
 
-    it('does not pass mediaType filter when All tab is selected', () => {
+    it('does not pass mediaType filter when All tab is selected', async () => {
       renderPage();
-      const lastCall = mockListRecentQuery.mock.calls.at(-1);
-      expect(lastCall?.[0]).not.toHaveProperty('mediaType');
+      await screen.findAllByText('Breaking Bad');
+      const lastCall = mockWatchHistoryListRecent.mock.calls.at(-1);
+      const opts = lastCall?.[0] as { query: Record<string, unknown> } | undefined;
+      expect(opts).toBeDefined();
+      expect(opts?.query).not.toHaveProperty('mediaType');
     });
   });
 
   describe('pagination', () => {
-    it('shows pagination info', () => {
+    it('shows pagination info', async () => {
       renderPage();
-      expect(screen.getByText('Showing 2 of 2')).toBeInTheDocument();
+      expect(await screen.findByText('Showing 2 of 2')).toBeInTheDocument();
     });
 
-    it('shows Next button when there are more pages', () => {
-      mockListRecentQuery.mockReturnValue({
-        data: {
-          data: Array.from({ length: 50 }, (_, i) => ({ ...movieEntry, id: i + 1 })),
-          pagination: { total: 100 },
-        },
-        isLoading: false,
-        error: null,
-      });
+    it('shows Next button when there are more pages', async () => {
+      mockWatchHistoryListRecent.mockResolvedValue(
+        listResult(
+          Array.from({ length: 50 }, (_, i) => ({ ...movieEntry, id: i + 1 })),
+          100
+        )
+      );
       renderPage();
-      expect(screen.getByText('Next')).toBeInTheDocument();
+      expect(await screen.findByText('Next')).toBeInTheDocument();
     });
 
-    it('hides Previous button on first page', () => {
+    it('hides Previous button on first page', async () => {
       renderPage();
+      await screen.findAllByText('Breaking Bad');
       expect(screen.queryByText('Previous')).not.toBeInTheDocument();
     });
   });

--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -1,28 +1,42 @@
-import { render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockRankingsQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
+const mockComparisonsRankings = vi.fn();
 
 vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
     const key = path.join('.');
-    if (key === 'comparisons.rankings') return mockRankingsQuery(input);
     if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
     return { data: undefined, isLoading: false };
   },
 }));
 
+vi.mock('../media-api/index.js', () => ({
+  comparisonsRankings: (opts: unknown) => mockComparisonsRankings(opts),
+}));
+
 import { RankingsPage } from './RankingsPage';
 
 function renderPage(initialRoute = '/media/rankings') {
-  return render(
-    <MemoryRouter initialEntries={[initialRoute]}>
-      <RankingsPage />
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, { initialEntries: [initialRoute] }, children)
+    );
+  return render(<RankingsPage />, { wrapper });
+}
+
+function rankingsResult(data: unknown[], pagination: Record<string, number | boolean>) {
+  return { data: { data, pagination } };
 }
 
 const rankedEntries = [
@@ -74,14 +88,9 @@ function setupDefaults() {
     data: { data: dimensions },
     isLoading: false,
   });
-  mockRankingsQuery.mockReturnValue({
-    data: {
-      data: rankedEntries,
-      pagination: { total: 2, limit: 25, offset: 0, hasMore: false },
-    },
-    isLoading: false,
-    error: null,
-  });
+  mockComparisonsRankings.mockResolvedValue(
+    rankingsResult(rankedEntries, { total: 2, limit: 25, offset: 0, hasMore: false })
+  );
 }
 
 beforeEach(() => {
@@ -90,9 +99,9 @@ beforeEach(() => {
 });
 
 describe('RankingsPage', () => {
-  it('renders the page heading', () => {
+  it('renders the page heading', async () => {
     renderPage();
-    expect(screen.getByRole('heading', { name: 'Rankings' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Rankings' })).toBeInTheDocument();
   });
 
   it('shows loading skeleton when dimensions are loading', () => {
@@ -101,9 +110,9 @@ describe('RankingsPage', () => {
     expect(screen.queryByRole('list', { name: 'Rankings' })).not.toBeInTheDocument();
   });
 
-  it('renders ranked items in order', () => {
+  it('renders ranked items in order', async () => {
     renderPage();
-    const list = screen.getByRole('list', { name: 'Rankings' });
+    const list = await screen.findByRole('list', { name: 'Rankings' });
     const items = within(list).getAllByText(/Movie/);
     expect(items.length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('Alpha Movie')).toBeInTheDocument();
@@ -124,42 +133,36 @@ describe('RankingsPage', () => {
     const storyTab = screen.getByRole('tab', { name: 'Story' });
     await user.click(storyTab);
 
-    // After clicking Story, the rankings query should have been called with dimensionId: 1
-    expect(mockRankingsQuery).toHaveBeenCalledWith(expect.objectContaining({ dimensionId: 1 }));
+    await waitFor(() =>
+      expect(mockComparisonsRankings).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ dimensionId: 1 }) })
+      )
+    );
   });
 
-  it('shows empty state when no rankings', () => {
-    mockRankingsQuery.mockReturnValue({
-      data: {
-        data: [],
-        pagination: { total: 0, limit: 25, offset: 0, hasMore: false },
-      },
-      isLoading: false,
-      error: null,
-    });
+  it('shows empty state when no rankings', async () => {
+    mockComparisonsRankings.mockResolvedValue(
+      rankingsResult([], { total: 0, limit: 25, offset: 0, hasMore: false })
+    );
 
     renderPage();
-    expect(screen.getByText(/No rankings yet/)).toBeInTheDocument();
+    expect(await screen.findByText(/No rankings yet/)).toBeInTheDocument();
   });
 
-  it('shows error alert on query failure', () => {
-    mockRankingsQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('fail'),
-    });
+  it('shows error alert on query failure', async () => {
+    mockComparisonsRankings.mockResolvedValue({ error: { message: 'fail' } });
 
     renderPage();
-    expect(screen.getByText('Failed to load rankings.')).toBeInTheDocument();
+    expect(await screen.findByText('Failed to load rankings.')).toBeInTheDocument();
   });
 
-  it('renders score and match count', () => {
+  it('renders score and match count', async () => {
     renderPage();
-    expect(screen.getByText('1532')).toBeInTheDocument();
+    expect(await screen.findByText('1532')).toBeInTheDocument();
     expect(screen.getAllByText('5 matches')).toHaveLength(2);
   });
 
-  it('shows pagination when total exceeds page size', () => {
+  it('shows pagination when total exceeds page size', async () => {
     const manyEntries = Array.from({ length: 25 }, (_, i) => ({
       rank: i + 1,
       mediaType: 'movie',
@@ -172,17 +175,12 @@ describe('RankingsPage', () => {
       confidence: 0.5,
     }));
 
-    mockRankingsQuery.mockReturnValue({
-      data: {
-        data: manyEntries,
-        pagination: { total: 30, limit: 25, offset: 0, hasMore: true },
-      },
-      isLoading: false,
-      error: null,
-    });
+    mockComparisonsRankings.mockResolvedValue(
+      rankingsResult(manyEntries, { total: 30, limit: 25, offset: 0, hasMore: true })
+    );
 
     renderPage();
-    expect(screen.getByText(/Showing 1–25 of 30/)).toBeInTheDocument();
+    expect(await screen.findByText(/Showing 1–25 of 30/)).toBeInTheDocument();
     expect(screen.getByText('Next')).toBeInTheDocument();
   });
 
@@ -206,7 +204,7 @@ describe('RankingsPage', () => {
     expect(overallTab).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('displays medal colors for top 3 ranks', () => {
+  it('displays medal colors for top 3 ranks', async () => {
     const top3 = [
       {
         rank: 1,
@@ -243,32 +241,26 @@ describe('RankingsPage', () => {
       },
     ];
 
-    mockRankingsQuery.mockReturnValue({
-      data: {
-        data: top3,
-        pagination: { total: 3, limit: 25, offset: 0, hasMore: false },
-      },
-      isLoading: false,
-      error: null,
-    });
+    mockComparisonsRankings.mockResolvedValue(
+      rankingsResult(top3, { total: 3, limit: 25, offset: 0, hasMore: false })
+    );
 
     renderPage();
-    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(await screen.findByText('#1')).toBeInTheDocument();
     expect(screen.getByText('#2')).toBeInTheDocument();
     expect(screen.getByText('#3')).toBeInTheDocument();
   });
 
-  it('displays confidence percentage for items with comparisons', () => {
+  it('displays confidence percentage for items with comparisons', async () => {
     renderPage();
-    // Both entries have confidence 0.59 → 59% conf
-    const confLabels = screen.getAllByText('59% conf');
+    const confLabels = await screen.findAllByText('59% conf');
     expect(confLabels).toHaveLength(2);
   });
 
-  it("shows 'Unknown' for media without metadata", () => {
-    mockRankingsQuery.mockReturnValue({
-      data: {
-        data: [
+  it("shows 'Unknown' for media without metadata", async () => {
+    mockComparisonsRankings.mockResolvedValue(
+      rankingsResult(
+        [
           {
             rank: 1,
             mediaType: 'movie',
@@ -281,14 +273,12 @@ describe('RankingsPage', () => {
             confidence: 0.29,
           },
         ],
-        pagination: { total: 1, limit: 25, offset: 0, hasMore: false },
-      },
-      isLoading: false,
-      error: null,
-    });
+        { total: 1, limit: 25, offset: 0, hasMore: false }
+      )
+    );
 
     renderPage();
-    const unknowns = screen.getAllByText('Unknown');
+    const unknowns = await screen.findAllByText('Unknown');
     expect(unknowns.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -1,30 +1,30 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// ── Hoisted mocks ──────────────────────────────────────────────────────────
 
 const {
   mockMovieSearch,
   mockTvSearch,
-  mockLibraryMovies,
-  mockLibraryTv,
-  mockAddMovieMutation,
-  mockAddTvMutation,
-  mockWatchlistAddMutation,
-  mockWatchHistoryLogMutation,
+  mockMoviesList,
+  mockTvShowsList,
+  mockLibraryAddMovie,
+  mockLibraryAddTvShow,
+  mockWatchlistAdd,
+  mockWatchHistoryLog,
   mockMovieRefetch,
   mockTvRefetch,
 } = vi.hoisted(() => ({
   mockMovieSearch: vi.fn(),
   mockTvSearch: vi.fn(),
-  mockLibraryMovies: vi.fn(),
-  mockLibraryTv: vi.fn(),
-  mockAddMovieMutation: vi.fn(),
-  mockAddTvMutation: vi.fn(),
-  mockWatchlistAddMutation: vi.fn(),
-  mockWatchHistoryLogMutation: vi.fn(),
+  mockMoviesList: vi.fn(),
+  mockTvShowsList: vi.fn(),
+  mockLibraryAddMovie: vi.fn(),
+  mockLibraryAddTvShow: vi.fn(),
+  mockWatchlistAdd: vi.fn(),
+  mockWatchHistoryLog: vi.fn(),
   mockMovieRefetch: vi.fn(),
   mockTvRefetch: vi.fn(),
 }));
@@ -39,27 +39,19 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     const key = path.join('.');
     if (key === 'search.movies') return mockMovieSearch(input, options);
     if (key === 'search.tvShows') return mockTvSearch(input, options);
-    if (key === 'movies.list') return mockLibraryMovies(input, options);
-    if (key === 'tvShows.list') return mockLibraryTv(input, options);
     return { data: undefined, isLoading: false, error: null };
   },
-  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
-    const key = path.join('.');
-    if (key === 'library.addMovie') return { mutate: mockAddMovieMutation, isPending: false };
-    if (key === 'library.addTvShow') return { mutate: mockAddTvMutation, isPending: false };
-    if (key === 'watchlist.add') return { mutate: mockWatchlistAddMutation, isPending: false };
-    if (key === 'watchHistory.log')
-      return { mutate: mockWatchHistoryLogMutation, isPending: false };
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: vi.fn(),
-    fetchQuery: vi.fn(),
-  }),
 }));
 
-// Capture props passed to SearchResultCard for assertion
+vi.mock('../media-api/index.js', () => ({
+  moviesList: (opts: unknown) => mockMoviesList(opts),
+  tvShowsList: (opts: unknown) => mockTvShowsList(opts),
+  libraryAddMovie: (opts: unknown) => mockLibraryAddMovie(opts),
+  libraryAddTvShow: (opts: unknown) => mockLibraryAddTvShow(opts),
+  watchlistAdd: (opts: unknown) => mockWatchlistAdd(opts),
+  watchHistoryLog: (opts: unknown) => mockWatchHistoryLog(opts),
+}));
+
 let lastMovieCardProps: Record<string, unknown>[] = [];
 let lastTvCardProps: Record<string, unknown>[] = [];
 
@@ -93,8 +85,6 @@ vi.mock('../components/MovieActionButtons', () => ({
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
-
-// ── Test data ──────────────────────────────────────────────────────────────
 
 const MOVIE_RESULTS = [
   {
@@ -145,10 +135,8 @@ const LIBRARY_MOVIES = [
     rotationStatus: 'leaving' as const,
     rotationExpiresAt: '2026-05-01T00:00:00Z',
   },
-]; // Inception is in library with leaving rotation
-const LIBRARY_TV = [{ id: 2, tvdbId: 201 }]; // Breaking Bad is in library
-
-// ── Helpers ────────────────────────────────────────────────────────────────
+];
+const LIBRARY_TV = [{ id: 2, tvdbId: 201 }];
 
 function setupMovieResults(overrides = {}) {
   mockMovieSearch.mockReturnValue({
@@ -171,28 +159,46 @@ function setupTvResults(overrides = {}) {
 }
 
 function setupLibrary() {
-  mockLibraryMovies.mockReturnValue({ data: { data: LIBRARY_MOVIES } });
-  mockLibraryTv.mockReturnValue({ data: { data: LIBRARY_TV } });
+  mockMoviesList.mockResolvedValue({ data: { data: LIBRARY_MOVIES } });
+  mockTvShowsList.mockResolvedValue({ data: { data: LIBRARY_TV } });
 }
 
 function setupEmptyLibrary() {
-  mockLibraryMovies.mockReturnValue({ data: { data: [] } });
-  mockLibraryTv.mockReturnValue({ data: { data: [] } });
+  mockMoviesList.mockResolvedValue({ data: { data: [] } });
+  mockTvShowsList.mockResolvedValue({ data: { data: [] } });
 }
 
 function renderPage(path = '/media/search?q=inception') {
-  return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/media/search" element={<SearchPage />} />
-      </Routes>
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(
+        MemoryRouter,
+        { initialEntries: [path] },
+        createElement(
+          Routes,
+          null,
+          createElement(Route, { path: '/media/search', element: children })
+        )
+      )
+    );
+  return render(<SearchPage />, { wrapper });
 }
 
 import { SearchPage } from './SearchPage';
 
-// ── Tests ──────────────────────────────────────────────────────────────────
+async function findInLibraryMovieCard(title: string) {
+  await screen.findByTestId(`card-movie-${title}`);
+  return waitFor(() => {
+    const card = lastMovieCardProps.findLast((p) => p.title === title);
+    expect(card?.inLibrary).toBe(true);
+    return card;
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -204,10 +210,10 @@ beforeEach(() => {
 });
 
 describe('SearchPage — both sections render independently', () => {
-  it("shows movie results and TV results simultaneously in 'Both' mode", () => {
+  it("shows movie results and TV results simultaneously in 'Both' mode", async () => {
     renderPage();
 
-    expect(screen.getByTestId('card-movie-Inception')).toBeInTheDocument();
+    expect(await screen.findByTestId('card-movie-Inception')).toBeInTheDocument();
     expect(screen.getByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
   });
 
@@ -234,11 +240,8 @@ describe('SearchPage — both sections render independently', () => {
     setupTvResults();
     renderPage();
 
-    // TV results visible
     expect(screen.getByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
-    // Movie skeleton visible (skeleton divs in movie section)
     expect(screen.getByText('Breaking Bad')).toBeInTheDocument();
-    // No movie cards
     expect(screen.queryByTestId('card-movie-Inception')).not.toBeInTheDocument();
   });
 
@@ -305,8 +308,9 @@ describe('SearchPage — no results message', () => {
     expect(screen.getByText(/inception/i)).toBeInTheDocument();
   });
 
-  it('does not show no-results message when results are present', () => {
+  it('does not show no-results message when results are present', async () => {
     renderPage();
+    await screen.findByTestId('card-movie-Inception');
     expect(screen.queryByText(/No results found for/)).not.toBeInTheDocument();
   });
 
@@ -317,286 +321,295 @@ describe('SearchPage — no results message', () => {
 });
 
 describe('SearchPage — In Library badge', () => {
-  it('passes inLibrary=true for movies already in library (by tmdbId)', () => {
+  it('passes inLibrary=true for movies already in library (by tmdbId)', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.inLibrary).toBe(true);
   });
 
-  it('passes inLibrary=false for movies not in library', () => {
+  it('passes inLibrary=false for movies not in library', async () => {
     renderPage();
-
-    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    await findInLibraryMovieCard('Inception');
+    const interstellarCard = lastMovieCardProps.findLast((p) => p.title === 'Interstellar');
     expect(interstellarCard?.inLibrary).toBe(false);
   });
 
-  it('passes inLibrary=true for TV shows already in library (by tvdbId)', () => {
+  it('passes inLibrary=true for TV shows already in library (by tvdbId)', async () => {
     renderPage();
-
-    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
-    expect(bbCard?.inLibrary).toBe(true);
+    await waitFor(() => {
+      const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
+      expect(bbCard?.inLibrary).toBe(true);
+    });
   });
 
-  it('passes inLibrary=false for TV shows not in library', () => {
+  it('passes inLibrary=false for TV shows not in library', async () => {
     renderPage();
-
-    const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
+    await waitFor(() => {
+      const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
+      expect(bbCard?.inLibrary).toBe(true);
+    });
+    const severanceCard = lastTvCardProps.findLast((p) => p.title === 'Severance');
     expect(severanceCard?.inLibrary).toBe(false);
   });
 
-  it('all items show inLibrary=false when library is empty', () => {
+  it('all items show inLibrary=false when library is empty', async () => {
     setupEmptyLibrary();
     renderPage();
-
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => {
+      expect(mockMoviesList).toHaveBeenCalled();
+      expect(mockTvShowsList).toHaveBeenCalled();
+    });
     expect(lastMovieCardProps.every((p) => p.inLibrary === false)).toBe(true);
     expect(lastTvCardProps.every((p) => p.inLibrary === false)).toBe(true);
   });
 });
 
 describe('SearchPage — poster fallback (via card props)', () => {
-  it('passes null posterUrl when posterPath is null (movie)', () => {
+  it('passes null posterUrl when posterPath is null (movie)', async () => {
     renderPage();
-
-    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    await screen.findByTestId('card-movie-Inception');
+    const interstellarCard = lastMovieCardProps.findLast((p) => p.title === 'Interstellar');
     expect(interstellarCard?.posterUrl).toBeNull();
   });
 
-  it('passes constructed posterUrl for TMDB relative paths', () => {
+  it('passes constructed posterUrl for TMDB relative paths', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(inceptionCard?.posterUrl).toBe('https://image.tmdb.org/t/p/w342/inception.jpg');
   });
 
-  it('passes null posterUrl when TV show has no poster', () => {
+  it('passes null posterUrl when TV show has no poster', async () => {
     renderPage();
-
-    const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
+    await screen.findByTestId('card-tv-Severance');
+    const severanceCard = lastTvCardProps.findLast((p) => p.title === 'Severance');
     expect(severanceCard?.posterUrl).toBeNull();
   });
 
-  it('passes full TVDB URL when TV show has poster', () => {
+  it('passes full TVDB URL when TV show has poster', async () => {
     renderPage();
-
-    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
+    await screen.findByTestId('card-tv-Breaking Bad');
+    const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
     expect(bbCard?.posterUrl).toBe('https://cdn.tvdb.com/bb.jpg');
   });
 });
 
 describe('SearchPage — rotation fields passed to in-library movie cards', () => {
-  it('passes rotationStatus and rotationExpiresAt for in-library movies', () => {
+  it('passes rotationStatus and rotationExpiresAt for in-library movies', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.rotationStatus).toBe('leaving');
     expect(inceptionCard?.rotationExpiresAt).toBe('2026-05-01T00:00:00Z');
   });
 
-  it('passes undefined rotationStatus and rotationExpiresAt for movies not in library', () => {
+  it('passes undefined rotationStatus and rotationExpiresAt for movies not in library', async () => {
     renderPage();
-
-    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    await findInLibraryMovieCard('Inception');
+    const interstellarCard = lastMovieCardProps.findLast((p) => p.title === 'Interstellar');
     expect(interstellarCard?.rotationStatus).toBeUndefined();
     expect(interstellarCard?.rotationExpiresAt).toBeUndefined();
   });
 
-  it('passes no rotation fields when library is empty', () => {
+  it('passes no rotation fields when library is empty', async () => {
     setupEmptyLibrary();
     renderPage();
-
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
     expect(lastMovieCardProps.every((p) => p.rotationStatus === undefined)).toBe(true);
     expect(lastMovieCardProps.every((p) => p.rotationExpiresAt === undefined)).toBe(true);
   });
 });
 
 describe('SearchPage — overview passed to cards', () => {
-  it('passes overview text to movie card', () => {
+  it('passes overview text to movie card', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(inceptionCard?.overview).toContain('dream-sharing');
   });
 
-  it('passes null overview for TV shows with no overview', () => {
+  it('passes null overview for TV shows with no overview', async () => {
     renderPage();
-
-    const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
+    await screen.findByTestId('card-tv-Severance');
+    const severanceCard = lastTvCardProps.findLast((p) => p.title === 'Severance');
     expect(severanceCard?.overview).toBeNull();
   });
 });
 
 describe('SearchPage — clickable links for in-library items (#1913)', () => {
-  it('passes href to in-library movie card pointing to detail page', () => {
+  it('passes href to in-library movie card pointing to detail page', async () => {
     renderPage();
-
-    // Inception (tmdbId=101) maps to localId=1 from LIBRARY_MOVIES
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.href).toBe('/media/movies/1');
   });
 
-  it('does not pass href to not-in-library movie card', () => {
+  it('does not pass href to not-in-library movie card', async () => {
     renderPage();
-
-    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    await findInLibraryMovieCard('Inception');
+    const interstellarCard = lastMovieCardProps.findLast((p) => p.title === 'Interstellar');
     expect(interstellarCard?.href).toBeUndefined();
   });
 
-  it('passes href to in-library TV card pointing to detail page', () => {
+  it('passes href to in-library TV card pointing to detail page', async () => {
     renderPage();
-
-    // Breaking Bad (tvdbId=201) maps to localId=2 from LIBRARY_TV
-    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
-    expect(bbCard?.href).toBe('/media/tv/2');
+    await waitFor(() => {
+      const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
+      expect(bbCard?.href).toBe('/media/tv/2');
+    });
   });
 
-  it('does not pass href to not-in-library TV card', () => {
+  it('does not pass href to not-in-library TV card', async () => {
     renderPage();
-
-    const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
+    await waitFor(() => {
+      const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
+      expect(bbCard?.inLibrary).toBe(true);
+    });
+    const severanceCard = lastTvCardProps.findLast((p) => p.title === 'Severance');
     expect(severanceCard?.href).toBeUndefined();
   });
 
-  it('passes mediaId to in-library movie card', () => {
+  it('passes mediaId to in-library movie card', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.mediaId).toBe(1);
   });
 
-  it('passes mediaId to in-library TV card', () => {
+  it('passes mediaId to in-library TV card', async () => {
     renderPage();
-
-    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
-    expect(bbCard?.mediaId).toBe(2);
+    await waitFor(() => {
+      const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
+      expect(bbCard?.mediaId).toBe(2);
+    });
   });
 
-  it('does not pass mediaId to not-in-library movie card', () => {
+  it('does not pass mediaId to not-in-library movie card', async () => {
     setupEmptyLibrary();
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(inceptionCard?.mediaId).toBeUndefined();
   });
 });
 
 describe('SearchPage — compound actions (#1912)', () => {
-  it('passes onAddToWatchlistAndLibrary to not-in-library movie cards', () => {
+  it('passes onAddToWatchlistAndLibrary to not-in-library movie cards', async () => {
     setupEmptyLibrary();
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(typeof inceptionCard?.onAddToWatchlistAndLibrary).toBe('function');
   });
 
-  it('does not pass onAddToWatchlistAndLibrary to in-library movie cards', () => {
+  it('does not pass onAddToWatchlistAndLibrary to in-library movie cards', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.onAddToWatchlistAndLibrary).toBeUndefined();
   });
 
-  it('passes onMarkWatchedAndLibrary to not-in-library movie cards', () => {
+  it('passes onMarkWatchedAndLibrary to not-in-library movie cards', async () => {
     setupEmptyLibrary();
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(typeof inceptionCard?.onMarkWatchedAndLibrary).toBe('function');
   });
 
-  it('does not pass onMarkWatchedAndLibrary to in-library movie cards', () => {
+  it('does not pass onMarkWatchedAndLibrary to in-library movie cards', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(inceptionCard?.onMarkWatchedAndLibrary).toBeUndefined();
   });
 
-  it('passes onMarkWatched to in-library movie cards', () => {
+  it('passes onMarkWatched to in-library movie cards', async () => {
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     expect(typeof inceptionCard?.onMarkWatched).toBe('function');
   });
 
-  it('does not pass onMarkWatched to not-in-library movie cards (no localId)', () => {
+  it('does not pass onMarkWatched to not-in-library movie cards (no localId)', async () => {
     setupEmptyLibrary();
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     expect(inceptionCard?.onMarkWatched).toBeUndefined();
   });
 
-  it('calling onAddToWatchlistAndLibrary triggers addMovie then watchlist.add', () => {
+  it('calling onAddToWatchlistAndLibrary triggers addMovie then watchlist.add', async () => {
     setupEmptyLibrary();
+    mockLibraryAddMovie.mockResolvedValue({
+      data: { created: true, data: { id: 99, title: 'Inception' } },
+    });
+    mockWatchlistAdd.mockResolvedValue({ data: {} });
     renderPage();
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
 
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     const handler = inceptionCard?.onAddToWatchlistAndLibrary as (() => void) | undefined;
     expect(handler).toBeDefined();
 
     handler?.();
 
-    expect(mockAddMovieMutation).toHaveBeenCalledWith(
-      { tmdbId: 101 },
-      expect.objectContaining({ onSuccess: expect.any(Function) })
+    await waitFor(() =>
+      expect(mockLibraryAddMovie).toHaveBeenCalledWith({ body: { tmdbId: 101 } })
     );
-
-    // Simulate addMovie success with local id
-    const onSuccess = mockAddMovieMutation.mock.calls[0]?.[1]?.onSuccess;
-    onSuccess?.({ data: { id: 99 }, created: true, message: 'Movie added to library' });
-
-    expect(mockWatchlistAddMutation).toHaveBeenCalledWith(
-      { mediaType: 'movie', mediaId: 99 },
-      expect.objectContaining({ onSuccess: expect.any(Function) })
+    await waitFor(() =>
+      expect(mockWatchlistAdd).toHaveBeenCalledWith({ body: { mediaType: 'movie', mediaId: 99 } })
     );
   });
 
-  it('calling onMarkWatchedAndLibrary triggers addMovie then watchHistory.log', () => {
+  it('calling onMarkWatchedAndLibrary triggers addMovie then watchHistory.log', async () => {
     setupEmptyLibrary();
+    mockLibraryAddMovie.mockResolvedValue({
+      data: { created: true, data: { id: 99, title: 'Inception' } },
+    });
+    mockWatchHistoryLog.mockResolvedValue({ data: {} });
     renderPage();
+    await screen.findByTestId('card-movie-Inception');
+    await waitFor(() => expect(mockMoviesList).toHaveBeenCalled());
 
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = lastMovieCardProps.findLast((p) => p.title === 'Inception');
     const handler = inceptionCard?.onMarkWatchedAndLibrary as (() => void) | undefined;
     expect(handler).toBeDefined();
 
     handler?.();
 
-    expect(mockAddMovieMutation).toHaveBeenCalledWith(
-      { tmdbId: 101 },
-      expect.objectContaining({ onSuccess: expect.any(Function) })
+    await waitFor(() =>
+      expect(mockLibraryAddMovie).toHaveBeenCalledWith({ body: { tmdbId: 101 } })
     );
-
-    const onSuccess = mockAddMovieMutation.mock.calls[0]?.[1]?.onSuccess;
-    onSuccess?.({ data: { id: 99 }, created: true, message: 'Movie added to library' });
-
-    expect(mockWatchHistoryLogMutation).toHaveBeenCalledWith(
-      { mediaType: 'movie', mediaId: 99 },
-      expect.objectContaining({ onSuccess: expect.any(Function) })
+    await waitFor(() =>
+      expect(mockWatchHistoryLog).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 99, completed: 1, source: 'manual' },
+      })
     );
   });
 
-  it('calling onMarkWatched for in-library movie triggers watchHistory.log directly', () => {
+  it('calling onMarkWatched for in-library movie triggers watchHistory.log directly', async () => {
+    mockWatchHistoryLog.mockResolvedValue({ data: {} });
     renderPage();
-
-    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const inceptionCard = await findInLibraryMovieCard('Inception');
     const handler = inceptionCard?.onMarkWatched as (() => void) | undefined;
     expect(handler).toBeDefined();
 
     handler?.();
 
-    expect(mockWatchHistoryLogMutation).toHaveBeenCalledWith(
-      { mediaType: 'movie', mediaId: 1 },
-      expect.objectContaining({ onSuccess: expect.any(Function) })
+    await waitFor(() =>
+      expect(mockWatchHistoryLog).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 1, completed: 1, source: 'manual' },
+      })
     );
-    // addMovie should NOT be called for an in-library item
-    expect(mockAddMovieMutation).not.toHaveBeenCalled();
+    expect(mockLibraryAddMovie).not.toHaveBeenCalled();
   });
 
-  it('does not pass onAddToWatchlistAndLibrary to TV cards', () => {
+  it('does not pass onAddToWatchlistAndLibrary to TV cards', async () => {
     renderPage();
-
-    // TV compound watchlist action not supported (no episode-level tracking)
-    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
+    await screen.findByTestId('card-tv-Breaking Bad');
+    const bbCard = lastTvCardProps.findLast((p) => p.title === 'Breaking Bad');
     expect(bbCard?.onAddToWatchlistAndLibrary).toBeUndefined();
   });
 });

--- a/packages/app-media/src/pages/history/useHistoryPageModel.ts
+++ b/packages/app-media/src/pages/history/useHistoryPageModel.ts
@@ -1,8 +1,9 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../../media-api-helpers.js';
+import { watchHistoryDelete, watchHistoryListRecent } from '../../media-api/index.js';
 import { PAGE_SIZE, type HistoryEntry, type MediaTypeFilter } from './types';
 
 interface WatchHistoryListResult {
@@ -19,26 +20,24 @@ function useDeleteFlow({
   offset: number;
   setOffset: React.Dispatch<React.SetStateAction<number>>;
 }) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
 
-  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
-    'media',
-    ['watchHistory', 'delete'],
-    {
-      onSuccess: () => {
-        toast.success('Watch event removed');
-        void utils.invalidate(['watchHistory']);
-        void utils.invalidate(['watchlist']);
-        if (entriesLength === 1 && offset > 0) {
-          setOffset(Math.max(0, offset - PAGE_SIZE));
-        }
-      },
-      onError: (err) => {
-        toast.error(`Failed to delete watch event: ${err.message}`);
-      },
-    }
-  );
+  const deleteMutation = useMutation({
+    mutationFn: async (input: { id: number }) =>
+      unwrap(await watchHistoryDelete({ path: { id: input.id } })),
+    onSuccess: () => {
+      toast.success('Watch event removed');
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+      if (entriesLength === 1 && offset > 0) {
+        setOffset(Math.max(0, offset - PAGE_SIZE));
+      }
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to delete watch event: ${err.message}`);
+    },
+  });
 
   const handleDeleteClick = useCallback((id: number) => setDeleteTarget(id), []);
   const handleDeleteConfirm = useCallback(() => {
@@ -60,11 +59,10 @@ export function useHistoryPageModel() {
     offset,
   };
 
-  const { data, isLoading, error } = usePillarQuery<WatchHistoryListResult>(
-    'media',
-    ['watchHistory', 'listRecent'],
-    queryInput
-  );
+  const { data, isLoading, error } = useQuery<WatchHistoryListResult>({
+    queryKey: ['media', 'watchHistory', 'listRecent', queryInput],
+    queryFn: async () => unwrap(await watchHistoryListRecent({ query: queryInput })),
+  });
 
   const entries = data?.data ?? [];
   const total = data?.pagination?.total ?? 0;

--- a/packages/app-media/src/pages/rankings/RankingsList.tsx
+++ b/packages/app-media/src/pages/rankings/RankingsList.tsx
@@ -1,9 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
 import { Trophy } from 'lucide-react';
 import { useState } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsRankings } from '../../media-api/index.js';
 import { RankingRow } from './RankingRow';
 import { RankingsSkeleton } from './RankingsSkeleton';
 
@@ -80,11 +82,11 @@ interface RankingsResult {
 export function RankingsList({ dimensionId }: { dimensionId?: number }) {
   const [offset, setOffset] = useState(0);
 
-  const { data, isLoading, error } = usePillarQuery<RankingsResult>(
-    'media',
-    ['comparisons', 'rankings'],
-    { dimensionId, limit: PAGE_SIZE, offset }
-  );
+  const queryInput = { dimensionId, limit: PAGE_SIZE, offset };
+  const { data, isLoading, error } = useQuery<RankingsResult>({
+    queryKey: ['media', 'comparisons', 'rankings', queryInput],
+    queryFn: async () => unwrap(await comparisonsRankings({ query: queryInput })),
+  });
 
   if (error) {
     return (

--- a/packages/app-media/src/pages/search/useLibraryLookups.ts
+++ b/packages/app-media/src/pages/search/useLibraryLookups.ts
@@ -1,6 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { moviesList, tvShowsList } from '../../media-api/index.js';
 
 import type { RotationInfo } from './types';
 
@@ -9,47 +11,27 @@ interface UseLibraryLookupsArgs {
   shouldSearchTv: boolean;
 }
 
-interface LibraryMovie {
-  id: number;
-  tmdbId: number;
-  rotationStatus?: 'leaving' | 'protected' | null;
-  rotationExpiresAt?: string | null;
-}
-
-interface LibraryTvShow {
-  id: number;
-  tvdbId: number;
-}
-
-interface LibraryMoviesEnvelope {
-  data: LibraryMovie[];
-}
-
-interface LibraryTvShowsEnvelope {
-  data: LibraryTvShow[];
-}
-
 /**
  * Fetches existing-library movies and TV shows so the search results can
  * mark items as "in library" and link to their detail pages.
  */
 export function useLibraryLookups({ shouldSearchMovies, shouldSearchTv }: UseLibraryLookupsArgs) {
-  const libraryMovies = usePillarQuery<LibraryMoviesEnvelope>(
-    'media',
-    ['movies', 'list'],
-    { limit: 1000 },
-    { enabled: shouldSearchMovies, staleTime: 30_000 }
-  );
-  const libraryTvShows = usePillarQuery<LibraryTvShowsEnvelope>(
-    'media',
-    ['tvShows', 'list'],
-    { limit: 1000 },
-    { enabled: shouldSearchTv, staleTime: 30_000 }
-  );
+  const libraryMovies = useQuery({
+    queryKey: ['media', 'movies', 'list', { limit: 1000 }],
+    queryFn: async () => unwrap(await moviesList({ query: { limit: 1000 } })),
+    enabled: shouldSearchMovies,
+    staleTime: 30_000,
+  });
+  const libraryTvShows = useQuery({
+    queryKey: ['media', 'tvShows', 'list', { limit: 1000 }],
+    queryFn: async () => unwrap(await tvShowsList({ query: { limit: 1000 } })),
+    enabled: shouldSearchTv,
+    staleTime: 30_000,
+  });
 
   return useMemo(() => {
-    const movies: LibraryMovie[] = libraryMovies.data?.data ?? [];
-    const tvShows: LibraryTvShow[] = libraryTvShows.data?.data ?? [];
+    const movies = libraryMovies.data?.data ?? [];
+    const tvShows = libraryTvShows.data?.data ?? [];
 
     const movieTmdbIds = new Set(movies.map((m) => m.tmdbId));
     const tvTvdbIds = new Set(tvShows.map((s) => s.tvdbId));

--- a/packages/app-media/src/pages/search/useSearchAddActions.ts
+++ b/packages/app-media/src/pages/search/useSearchAddActions.ts
@@ -1,5 +1,12 @@
-import { usePillarMutation } from '@pops/pillar-sdk/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  libraryAddMovie,
+  libraryAddTvShow,
+  watchHistoryLog,
+  watchlistAdd,
+} from '../../media-api/index.js';
 import {
   makeKey,
   useAddMovieHandler,
@@ -10,34 +17,51 @@ import {
 } from './useSearchAddHandlers';
 import { useSearchAddState } from './useSearchAddState';
 
-interface AddMovieInput {
-  tmdbId: number;
-}
+function useSearchAddMutations() {
+  const queryClient = useQueryClient();
 
-interface AddMovieResponse {
-  data: { id: number; title: string };
-  created: boolean;
-  message?: string;
-}
+  const addMovieMutation = useMutation({
+    mutationFn: async (input: { tmdbId: number }) =>
+      unwrap(await libraryAddMovie({ body: { tmdbId: input.tmdbId } })),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'movies'] });
+    },
+  });
 
-interface AddTvShowInput {
-  tvdbId: number;
-}
+  const addTvShowMutation = useMutation({
+    mutationFn: async (input: { tvdbId: number }) =>
+      unwrap(await libraryAddTvShow({ body: { tvdbId: input.tvdbId } })),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'tvShows'] });
+    },
+  });
 
-interface AddTvShowResponse {
-  data: { show: { id: number; name: string } };
-  created: boolean;
-  message?: string;
-}
+  const watchlistAddMutation = useMutation({
+    mutationFn: async (input: { mediaType: 'movie'; mediaId: number }) =>
+      unwrap(await watchlistAdd({ body: { mediaType: input.mediaType, mediaId: input.mediaId } })),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+    },
+  });
 
-interface WatchlistAddInput {
-  mediaType: 'movie';
-  mediaId: number;
-}
+  const watchHistoryLogMutation = useMutation({
+    mutationFn: async (input: { mediaType: 'movie'; mediaId: number }) =>
+      unwrap(
+        await watchHistoryLog({
+          body: {
+            mediaType: input.mediaType,
+            mediaId: input.mediaId,
+            completed: 1,
+            source: 'manual',
+          },
+        })
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
+    },
+  });
 
-interface WatchHistoryLogInput {
-  mediaType: 'movie';
-  mediaId: number;
+  return { addMovieMutation, addTvShowMutation, watchlistAddMutation, watchHistoryLogMutation };
 }
 
 /**
@@ -47,30 +71,7 @@ interface WatchHistoryLogInput {
  */
 export function useSearchAddActions() {
   const state = useSearchAddState();
-  const addMovieMutation = usePillarMutation<AddMovieInput, AddMovieResponse>('media', [
-    'library',
-    'addMovie',
-  ]);
-  const addTvShowMutation = usePillarMutation<AddTvShowInput, AddTvShowResponse>('media', [
-    'library',
-    'addTvShow',
-  ]);
-  const watchlistAddMutation = usePillarMutation<WatchlistAddInput, unknown>('media', [
-    'watchlist',
-    'add',
-  ]);
-  const watchHistoryLogMutation = usePillarMutation<WatchHistoryLogInput, unknown>('media', [
-    'watchHistory',
-    'log',
-  ]);
-
-  const handlerArgs = {
-    state,
-    addMovieMutation,
-    addTvShowMutation,
-    watchlistAddMutation,
-    watchHistoryLogMutation,
-  };
+  const handlerArgs = { state, ...useSearchAddMutations() };
 
   return {
     addingIds: state.addingIds,

--- a/packages/app-media/src/pages/search/useSearchAddHandlers.ts
+++ b/packages/app-media/src/pages/search/useSearchAddHandlers.ts
@@ -1,9 +1,15 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import type { UsePillarMutationResult } from '@pops/pillar-sdk/react';
+import type { UseMutationResult } from '@tanstack/react-query';
 
 import type { SearchResultType } from '../../components/SearchResultCard';
+import type {
+  LibraryAddMovieResponse,
+  LibraryAddTvShowResponse,
+  WatchHistoryLogResponse,
+  WatchlistAddResponse,
+} from '../../media-api/index.js';
 import type { useSearchAddState } from './useSearchAddState';
 
 export const makeKey = (type: SearchResultType, id: number) => `${type}:${id}`;
@@ -12,20 +18,8 @@ interface AddMovieInput {
   tmdbId: number;
 }
 
-interface AddMovieResponse {
-  data: { id: number; title: string };
-  created: boolean;
-  message?: string;
-}
-
 interface AddTvShowInput {
   tvdbId: number;
-}
-
-interface AddTvShowResponse {
-  data: { show: { id: number; name: string } };
-  created: boolean;
-  message?: string;
 }
 
 interface WatchlistAddInput {
@@ -40,10 +34,10 @@ interface WatchHistoryLogInput {
 
 interface HandlerArgs {
   state: ReturnType<typeof useSearchAddState>;
-  addMovieMutation: UsePillarMutationResult<AddMovieInput, AddMovieResponse>;
-  addTvShowMutation: UsePillarMutationResult<AddTvShowInput, AddTvShowResponse>;
-  watchlistAddMutation: UsePillarMutationResult<WatchlistAddInput, unknown>;
-  watchHistoryLogMutation: UsePillarMutationResult<WatchHistoryLogInput, unknown>;
+  addMovieMutation: UseMutationResult<LibraryAddMovieResponse, Error, AddMovieInput>;
+  addTvShowMutation: UseMutationResult<LibraryAddTvShowResponse, Error, AddTvShowInput>;
+  watchlistAddMutation: UseMutationResult<WatchlistAddResponse, Error, WatchlistAddInput>;
+  watchHistoryLogMutation: UseMutationResult<WatchHistoryLogResponse, Error, WatchHistoryLogInput>;
 }
 
 export function useAddMovieHandler({ state, addMovieMutation }: HandlerArgs) {


### PR DESCRIPTION
Phase D tier-2. Rewires the search/history/rankings feature hooks (useLibraryLookups, useSearchAddActions/Mutations/Handlers, useHistoryPageModel, RankingsList) onto the Hey API SDK + react-query. 84 page tests pass; verified in isolation (fe-quality red-by-design), no regression. NOTE: the parent SearchPage.tsx (searchMovies/searchTvShows) + RankingsPage.tsx (comparisonsListDimensions) queries are outside these dirs and remain pillar-based — covered by the mop-up sweep.