### PR TITLE
feat(media/fe): rewire component-level hooks onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/components/ArrStatusBadge.test.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.test.tsx
@@ -1,133 +1,129 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const arrConfigMock = vi.hoisted(() => vi.fn());
+const arrGetMovieStatusMock = vi.hoisted(() => vi.fn());
+const arrGetShowStatusMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../media-api/index.js', () => ({
+  arrConfig: (...args: unknown[]) => arrConfigMock(...args),
+  arrGetMovieStatus: (...args: unknown[]) => arrGetMovieStatusMock(...args),
+  arrGetShowStatus: (...args: unknown[]) => arrGetShowStatusMock(...args),
+}));
 
 import { ArrStatusBadge } from './ArrStatusBadge';
 
-const mockGetConfig = vi.fn();
-const mockGetMovieStatus = vi.fn();
-const mockGetShowStatus = vi.fn();
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    _input: unknown,
-    opts?: { enabled?: boolean }
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.getConfig') return mockGetConfig();
-    const enabled = opts?.enabled ?? true;
-    if (key === 'arr.getMovieStatus')
-      return enabled ? mockGetMovieStatus() : { data: null, isLoading: false, error: null };
-    if (key === 'arr.getShowStatus')
-      return enabled ? mockGetShowStatus() : { data: null, isLoading: false, error: null };
-    return { data: null, isLoading: false, error: null };
-  },
-}));
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderBadge(props: { kind: 'movie' | 'show'; externalId: number }) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<ArrStatusBadge {...props} />, { wrapper });
+}
+
+afterEach(() => {
+  cleanup();
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetConfig.mockReturnValue({
-    data: { data: { radarrConfigured: true, sonarrConfigured: true } },
-  });
+  arrConfigMock.mockResolvedValue(ok({ data: { radarrConfigured: true, sonarrConfigured: true } }));
+  arrGetMovieStatusMock.mockResolvedValue(
+    ok({ data: { status: 'not_found', label: 'Not Found' } })
+  );
+  arrGetShowStatusMock.mockResolvedValue(ok({ data: { status: 'not_found', label: 'Not Found' } }));
 });
 
 describe('ArrStatusBadge', () => {
-  it('renders nothing when service is not configured', () => {
-    mockGetConfig.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: false } },
-    });
-    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
+  it('renders nothing when service is not configured', async () => {
+    arrConfigMock.mockResolvedValue(
+      ok({ data: { radarrConfigured: false, sonarrConfigured: false } })
+    );
+    const { container } = renderBadge({ kind: 'movie', externalId: 123 });
+    await waitFor(() => expect(arrConfigMock).toHaveBeenCalled());
     expect(container.innerHTML).toBe('');
+    expect(arrGetMovieStatusMock).not.toHaveBeenCalled();
   });
 
-  it('renders Radarr unavailable badge when Radarr is unreachable', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: new Error('Connection refused'),
+  it('renders Radarr unavailable badge when Radarr is unreachable', async () => {
+    arrGetMovieStatusMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'Connection refused' },
+      response: { status: 500 },
     });
-    render(<ArrStatusBadge kind="movie" externalId={123} />);
-    expect(screen.getByText('Radarr unavailable')).toBeInTheDocument();
+    renderBadge({ kind: 'movie', externalId: 123 });
+    expect(await screen.findByText('Radarr unavailable')).toBeInTheDocument();
   });
 
-  it('renders Sonarr unavailable badge when Sonarr is unreachable', () => {
-    mockGetShowStatus.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: new Error('Connection refused'),
+  it('renders Sonarr unavailable badge when Sonarr is unreachable', async () => {
+    arrGetShowStatusMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'Connection refused' },
+      response: { status: 500 },
     });
-    render(<ArrStatusBadge kind="show" externalId={456} />);
-    expect(screen.getByText('Sonarr unavailable')).toBeInTheDocument();
+    renderBadge({ kind: 'show', externalId: 456 });
+    expect(await screen.findByText('Sonarr unavailable')).toBeInTheDocument();
   });
 
   it('renders nothing while loading', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: null,
-      isLoading: true,
-      error: null,
-    });
-    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
+    arrGetMovieStatusMock.mockReturnValue(new Promise(() => {}));
+    const { container } = renderBadge({ kind: 'movie', externalId: 123 });
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders Available badge with green styling', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: { data: { status: 'available', label: 'Available' } },
-      isLoading: false,
-      error: null,
-    });
-    render(<ArrStatusBadge kind="movie" externalId={123} />);
-    const badge = screen.getByText('Available');
-    expect(badge).toBeInTheDocument();
+  it('renders Available badge with green styling', async () => {
+    arrGetMovieStatusMock.mockResolvedValue(
+      ok({ data: { status: 'available', label: 'Available' } })
+    );
+    renderBadge({ kind: 'movie', externalId: 123 });
+    const badge = await screen.findByText('Available');
     expect(badge.className).toContain('bg-success');
   });
 
-  it('renders Downloading badge with yellow styling', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: { data: { status: 'downloading', label: 'Downloading' } },
-      isLoading: false,
-      error: null,
-    });
-    render(<ArrStatusBadge kind="movie" externalId={123} />);
-    const badge = screen.getByText('Downloading');
-    expect(badge).toBeInTheDocument();
+  it('renders Downloading badge with yellow styling', async () => {
+    arrGetMovieStatusMock.mockResolvedValue(
+      ok({ data: { status: 'downloading', label: 'Downloading' } })
+    );
+    renderBadge({ kind: 'movie', externalId: 123 });
+    const badge = await screen.findByText('Downloading');
     expect(badge.className).toContain('bg-warning');
   });
 
-  it('renders Monitored badge with yellow styling', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: { data: { status: 'monitored', label: 'Monitored' } },
-      isLoading: false,
-      error: null,
-    });
-    render(<ArrStatusBadge kind="movie" externalId={123} />);
-    const badge = screen.getByText('Monitored');
-    expect(badge).toBeInTheDocument();
+  it('renders Monitored badge with yellow styling', async () => {
+    arrGetMovieStatusMock.mockResolvedValue(
+      ok({ data: { status: 'monitored', label: 'Monitored' } })
+    );
+    renderBadge({ kind: 'movie', externalId: 123 });
+    const badge = await screen.findByText('Monitored');
     expect(badge.className).toContain('bg-warning');
   });
 
-  it('renders Not Monitored badge with grey styling', () => {
-    mockGetMovieStatus.mockReturnValue({
-      data: { data: { status: 'unmonitored', label: 'Not Monitored' } },
-      isLoading: false,
-      error: null,
-    });
-    render(<ArrStatusBadge kind="movie" externalId={123} />);
-    const badge = screen.getByText('Not Monitored');
-    expect(badge).toBeInTheDocument();
+  it('renders Not Monitored badge with grey styling', async () => {
+    arrGetMovieStatusMock.mockResolvedValue(
+      ok({ data: { status: 'unmonitored', label: 'Not Monitored' } })
+    );
+    renderBadge({ kind: 'movie', externalId: 123 });
+    const badge = await screen.findByText('Not Monitored');
     expect(badge.className).toContain('bg-muted');
   });
 
-  it('works for TV shows using sonarr', () => {
-    mockGetShowStatus.mockReturnValue({
-      data: { data: { status: 'monitored', label: 'Monitored' } },
-      isLoading: false,
-      error: null,
-    });
-    render(<ArrStatusBadge kind="show" externalId={456} />);
-    const badge = screen.getByText('Monitored');
-    expect(badge).toBeInTheDocument();
+  it('works for TV shows using sonarr', async () => {
+    arrGetShowStatusMock.mockResolvedValue(
+      ok({ data: { status: 'monitored', label: 'Monitored' } })
+    );
+    renderBadge({ kind: 'show', externalId: 456 });
+    const badge = await screen.findByText('Monitored');
     expect(badge.className).toContain('bg-warning');
   });
 });

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -1,4 +1,5 @@
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { useQuery } from '@tanstack/react-query';
+
 /**
  * ArrStatusBadge — shows Radarr/Sonarr monitoring and download status.
  *
@@ -7,6 +8,8 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Badge } from '@pops/ui';
 
 import { ARR_STATUS_STYLES } from '../lib/statusStyles';
+import { unwrap } from '../media-api-helpers.js';
+import { arrConfig, arrGetMovieStatus, arrGetShowStatus } from '../media-api/index.js';
 
 type MediaKind = 'movie' | 'show';
 
@@ -27,26 +30,23 @@ interface ArrStatusResult {
 }
 
 function useArrStatus({ kind, externalId }: ArrStatusBadgeProps) {
-  const { data: configData } = usePillarQuery<ArrConfigResult>(
-    'media',
-    ['arr', 'getConfig'],
-    undefined
-  );
+  const { data: configData } = useQuery<ArrConfigResult>({
+    queryKey: ['media', 'arr', 'getConfig'],
+    queryFn: async () => unwrap(await arrConfig()),
+  });
   const config = configData?.data;
   const isConfigured = kind === 'movie' ? config?.radarrConfigured : config?.sonarrConfigured;
 
-  const movieStatus = usePillarQuery<ArrStatusResult>(
-    'media',
-    ['arr', 'getMovieStatus'],
-    { tmdbId: externalId },
-    { enabled: kind === 'movie' && isConfigured === true }
-  );
-  const showStatus = usePillarQuery<ArrStatusResult>(
-    'media',
-    ['arr', 'getShowStatus'],
-    { tvdbId: externalId },
-    { enabled: kind === 'show' && isConfigured === true }
-  );
+  const movieStatus = useQuery<ArrStatusResult>({
+    queryKey: ['media', 'arr', 'getMovieStatus', { tmdbId: externalId }],
+    queryFn: async () => unwrap(await arrGetMovieStatus({ path: { tmdbId: externalId } })),
+    enabled: kind === 'movie' && isConfigured === true,
+  });
+  const showStatus = useQuery<ArrStatusResult>({
+    queryKey: ['media', 'arr', 'getShowStatus', { tvdbId: externalId }],
+    queryFn: async () => unwrap(await arrGetShowStatus({ path: { tvdbId: externalId } })),
+    enabled: kind === 'show' && isConfigured === true,
+  });
 
   return { isConfigured, query: kind === 'movie' ? movieStatus : showStatus };
 }

--- a/packages/app-media/src/components/ComparisonScores.test.tsx
+++ b/packages/app-media/src/components/ComparisonScores.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeScore } from './ComparisonScores';
 
@@ -19,17 +21,12 @@ vi.mock('recharts', () => ({
   Tooltip: () => <div data-testid="tooltip" />,
 }));
 
-// Mock tRPC hooks
-const mockScoresQuery = vi.fn();
-const mockDimensionsQuery = vi.fn();
+const comparisonsScoresMock = vi.hoisted(() => vi.fn());
+const comparisonsListDimensionsMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'comparisons.scores') return mockScoresQuery(input);
-    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
-    return { data: undefined, isLoading: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  comparisonsScores: (...args: unknown[]) => comparisonsScoresMock(...args),
+  comparisonsListDimensions: (...args: unknown[]) => comparisonsListDimensionsMock(...args),
 }));
 
 import { ComparisonScores } from './ComparisonScores';
@@ -46,85 +43,95 @@ const baseScores = [
   { dimensionId: 3, score: 1700, comparisonCount: 3 },
 ];
 
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderScores(props: { mediaType: 'movie' | 'tv_show'; mediaId: number }) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<ComparisonScores {...props} />, { wrapper });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
 beforeEach(() => {
-  mockScoresQuery.mockReturnValue({
-    data: { data: baseScores },
-    isLoading: false,
-  });
-  mockDimensionsQuery.mockReturnValue({
-    data: { data: baseDimensions },
-    isLoading: false,
-  });
+  vi.clearAllMocks();
+  comparisonsScoresMock.mockResolvedValue(ok({ data: baseScores }));
+  comparisonsListDimensionsMock.mockResolvedValue(ok({ data: baseDimensions }));
 });
 
 describe('ComparisonScores', () => {
   describe('chart renders with scores', () => {
-    it('renders radar chart when sufficient comparisons exist', () => {
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      expect(screen.getByTestId('radar-chart')).toBeInTheDocument();
+    it('renders radar chart when sufficient comparisons exist', async () => {
+      renderScores({ mediaType: 'movie', mediaId: 1 });
+      expect(await screen.findByTestId('radar-chart')).toBeInTheDocument();
       expect(screen.getByText('Comparison Scores')).toBeInTheDocument();
     });
 
-    it('passes correct number of data points to radar chart', () => {
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      const chart = screen.getByTestId('radar-chart');
+    it('passes correct number of data points to radar chart', async () => {
+      renderScores({ mediaType: 'movie', mediaId: 1 });
+      const chart = await screen.findByTestId('radar-chart');
       expect(chart).toHaveAttribute('data-points', '3');
     });
   });
 
   describe('hidden when no comparisons', () => {
-    it('returns null when totalComparisons is zero', () => {
-      mockScoresQuery.mockReturnValue({
-        data: { data: [] },
-        isLoading: false,
-      });
-      const { container } = render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      expect(container.innerHTML).toBe('');
+    it('returns null when totalComparisons is zero', async () => {
+      comparisonsScoresMock.mockResolvedValue(ok({ data: [] }));
+      const { container } = renderScores({ mediaType: 'movie', mediaId: 1 });
+      await waitFor(() => expect(comparisonsScoresMock).toHaveBeenCalled());
+      await waitFor(() => expect(container.innerHTML).toBe(''));
     });
 
-    it('returns null when all scores have zero comparisonCount', () => {
-      mockScoresQuery.mockReturnValue({
-        data: {
+    it('returns null when all scores have zero comparisonCount', async () => {
+      comparisonsScoresMock.mockResolvedValue(
+        ok({
           data: [
             { dimensionId: 1, score: 1000, comparisonCount: 0 },
             { dimensionId: 2, score: 1000, comparisonCount: 0 },
           ],
-        },
-        isLoading: false,
-      });
-      const { container } = render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      expect(container.innerHTML).toBe('');
+        })
+      );
+      const { container } = renderScores({ mediaType: 'movie', mediaId: 1 });
+      await waitFor(() => expect(comparisonsScoresMock).toHaveBeenCalled());
+      await waitFor(() => expect(container.innerHTML).toBe(''));
     });
   });
 
   describe('placeholder for 1-2 comparisons', () => {
-    it('shows placeholder when totalComparisons is 1', () => {
-      mockScoresQuery.mockReturnValue({
-        data: {
-          data: [{ dimensionId: 1, score: 1200, comparisonCount: 1 }],
-        },
-        isLoading: false,
-      });
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
+    it('shows placeholder when totalComparisons is 1', async () => {
+      comparisonsScoresMock.mockResolvedValue(
+        ok({ data: [{ dimensionId: 1, score: 1200, comparisonCount: 1 }] })
+      );
+      renderScores({ mediaType: 'movie', mediaId: 1 });
       expect(
-        screen.getByText('Not enough data — at least 3 comparisons needed')
+        await screen.findByText('Not enough data — at least 3 comparisons needed')
       ).toBeInTheDocument();
       expect(screen.queryByTestId('radar-chart')).not.toBeInTheDocument();
     });
 
-    it('shows placeholder when totalComparisons is 2', () => {
-      mockScoresQuery.mockReturnValue({
-        data: {
+    it('shows placeholder when totalComparisons is 2', async () => {
+      comparisonsScoresMock.mockResolvedValue(
+        ok({
           data: [
             { dimensionId: 1, score: 1200, comparisonCount: 1 },
             { dimensionId: 2, score: 1300, comparisonCount: 1 },
           ],
-        },
-        isLoading: false,
-      });
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
+        })
+      );
+      renderScores({ mediaType: 'movie', mediaId: 1 });
       expect(
-        screen.getByText('Not enough data — at least 3 comparisons needed')
+        await screen.findByText('Not enough data — at least 3 comparisons needed')
       ).toBeInTheDocument();
     });
   });
@@ -153,33 +160,31 @@ describe('ComparisonScores', () => {
 
   describe('loading state', () => {
     it('shows skeleton when loading', () => {
-      mockScoresQuery.mockReturnValue({ data: null, isLoading: true });
-      mockDimensionsQuery.mockReturnValue({ data: null, isLoading: true });
-      const { container } = render(<ComparisonScores mediaType="movie" mediaId={1} />);
+      comparisonsScoresMock.mockReturnValue(new Promise(() => {}));
+      comparisonsListDimensionsMock.mockReturnValue(new Promise(() => {}));
+      const { container } = renderScores({ mediaType: 'movie', mediaId: 1 });
       expect(container.querySelectorAll("[data-slot='skeleton']").length).toBeGreaterThan(0);
     });
   });
 
   describe('axis count', () => {
-    it('renders correct number of axes matching dimensions', () => {
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      // The radar chart receives 3 data points (one per dimension with scores)
-      const chart = screen.getByTestId('radar-chart');
+    it('renders correct number of axes matching dimensions', async () => {
+      renderScores({ mediaType: 'movie', mediaId: 1 });
+      const chart = await screen.findByTestId('radar-chart');
       expect(chart).toHaveAttribute('data-points', '3');
     });
 
-    it('renders chart with fewer axes when fewer dimensions have scores', () => {
-      mockScoresQuery.mockReturnValue({
-        data: {
+    it('renders chart with fewer axes when fewer dimensions have scores', async () => {
+      comparisonsScoresMock.mockResolvedValue(
+        ok({
           data: [
             { dimensionId: 1, score: 1500, comparisonCount: 3 },
             { dimensionId: 2, score: 1300, comparisonCount: 2 },
           ],
-        },
-        isLoading: false,
-      });
-      render(<ComparisonScores mediaType="movie" mediaId={1} />);
-      const chart = screen.getByTestId('radar-chart');
+        })
+      );
+      renderScores({ mediaType: 'movie', mediaId: 1 });
+      const chart = await screen.findByTestId('radar-chart');
       expect(chart).toHaveAttribute('data-points', '2');
     });
   });

--- a/packages/app-media/src/components/ComparisonScores.tsx
+++ b/packages/app-media/src/components/ComparisonScores.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -7,13 +8,15 @@ import {
   Tooltip,
 } from 'recharts';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ComparisonScores — radar chart showing Elo scores across comparison dimensions.
  * Queries scores and dimensions, merges them, and renders a recharts RadarChart.
  * Hidden when zero comparisons; shows "Not enough data" when 1–2 comparisons.
  */
 import { Skeleton } from '@pops/ui';
+
+import { unwrap } from '../media-api-helpers.js';
+import { comparisonsListDimensions, comparisonsScores } from '../media-api/index.js';
 
 /** Normalize an Elo score (typically 1000–2000) to a 0–100 scale. */
 export function normalizeScore(elo: number): number {
@@ -118,13 +121,14 @@ interface DimensionsResult {
 }
 
 export function ComparisonScores({ mediaType, mediaId }: ComparisonScoresProps) {
-  const { data: scoresResponse, isLoading: scoresLoading } = usePillarQuery<ScoresResult>(
-    'media',
-    ['comparisons', 'scores'],
-    { mediaType, mediaId }
-  );
-  const { data: dimensionsResponse, isLoading: dimensionsLoading } =
-    usePillarQuery<DimensionsResult>('media', ['comparisons', 'listDimensions'], undefined);
+  const { data: scoresResponse, isLoading: scoresLoading } = useQuery<ScoresResult>({
+    queryKey: ['media', 'comparisons', 'scores', { mediaType, mediaId }],
+    queryFn: async () => unwrap(await comparisonsScores({ query: { mediaType, mediaId } })),
+  });
+  const { data: dimensionsResponse, isLoading: dimensionsLoading } = useQuery<DimensionsResult>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+  });
 
   if (scoresLoading || dimensionsLoading) {
     return (

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -1,4 +1,5 @@
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { useQuery } from '@tanstack/react-query';
+
 /**
  * DownloadQueue — shows active downloads from Radarr + Sonarr.
  *
@@ -6,6 +7,9 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  * or when neither service is configured.
  */
 import { Badge } from '@pops/ui';
+
+import { unwrap } from '../media-api-helpers.js';
+import { arrConfig, arrQueue } from '../media-api/index.js';
 
 interface ArrConfigResult {
   data: { radarrConfigured: boolean; sonarrConfigured: boolean };
@@ -49,20 +53,19 @@ function DownloadRow({ item }: { item: DownloadQueueItem }) {
 }
 
 export function DownloadQueue() {
-  const { data: configData } = usePillarQuery<ArrConfigResult>(
-    'media',
-    ['arr', 'getConfig'],
-    undefined
-  );
+  const { data: configData } = useQuery<ArrConfigResult>({
+    queryKey: ['media', 'arr', 'getConfig'],
+    queryFn: async () => unwrap(await arrConfig()),
+  });
   const config = configData?.data;
   const hasAnyService = config?.radarrConfigured ?? config?.sonarrConfigured;
 
-  const { data } = usePillarQuery<DownloadQueueResult>(
-    'media',
-    ['arr', 'getDownloadQueue'],
-    undefined,
-    { enabled: hasAnyService === true, refetchInterval: 30_000 }
-  );
+  const { data } = useQuery<DownloadQueueResult>({
+    queryKey: ['media', 'arr', 'getDownloadQueue'],
+    queryFn: async () => unwrap(await arrQueue()),
+    enabled: hasAnyService === true,
+    refetchInterval: 30_000,
+  });
 
   const items = data?.data;
   if (!items || items.length === 0) return null;

--- a/packages/app-media/src/components/ExcludedDimensions.test.tsx
+++ b/packages/app-media/src/components/ExcludedDimensions.test.tsx
@@ -1,19 +1,21 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock tRPC hooks
-const mockScoresQuery = vi.fn();
-const mockDimensionsQuery = vi.fn();
-const mockIncludeMutate = vi.fn();
+const comparisonsScoresMock = vi.hoisted(() => vi.fn());
+const comparisonsListDimensionsMock = vi.hoisted(() => vi.fn());
+const comparisonsIncludeInDimensionMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'comparisons.scores') return mockScoresQuery(input);
-    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: () => ({ mutate: mockIncludeMutate, isPending: false }),
+vi.mock('../media-api/index.js', () => ({
+  comparisonsScores: (...args: unknown[]) => comparisonsScoresMock(...args),
+  comparisonsListDimensions: (...args: unknown[]) => comparisonsListDimensionsMock(...args),
+  comparisonsIncludeInDimension: (...args: unknown[]) => comparisonsIncludeInDimensionMock(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 import { ExcludedDimensions } from './ExcludedDimensions';
@@ -24,45 +26,63 @@ const baseDimensions = [
   { id: 3, name: 'Emotional Impact' },
 ];
 
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderExcluded(props: { mediaType: 'movie' | 'tv_show'; mediaId: number }) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<ExcludedDimensions {...props} />, { wrapper });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDimensionsQuery.mockReturnValue({
-    data: { data: baseDimensions },
-    isLoading: false,
-  });
+  comparisonsListDimensionsMock.mockResolvedValue(ok({ data: baseDimensions }));
+  comparisonsIncludeInDimensionMock.mockResolvedValue(ok({ message: 'ok' }));
 });
 
 describe('ExcludedDimensions', () => {
-  it('renders nothing when no dimensions are excluded', () => {
-    mockScoresQuery.mockReturnValue({
-      data: {
+  it('renders nothing when no dimensions are excluded', async () => {
+    comparisonsScoresMock.mockResolvedValue(
+      ok({
         data: [
           { dimensionId: 1, score: 1500, comparisonCount: 5, excluded: false },
           { dimensionId: 2, score: 1300, comparisonCount: 4, excluded: false },
         ],
-      },
-      isLoading: false,
-    });
+      })
+    );
 
-    const { container } = render(<ExcludedDimensions mediaType="movie" mediaId={42} />);
-    expect(container.innerHTML).toBe('');
+    const { container } = renderExcluded({ mediaType: 'movie', mediaId: 42 });
+    await waitFor(() => expect(comparisonsScoresMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('shows excluded dimensions with Include buttons', () => {
-    mockScoresQuery.mockReturnValue({
-      data: {
+  it('shows excluded dimensions with Include buttons', async () => {
+    comparisonsScoresMock.mockResolvedValue(
+      ok({
         data: [
           { dimensionId: 1, score: 1500, comparisonCount: 5, excluded: true },
           { dimensionId: 2, score: 1300, comparisonCount: 4, excluded: false },
           { dimensionId: 3, score: 1200, comparisonCount: 2, excluded: true },
         ],
-      },
-      isLoading: false,
-    });
+      })
+    );
 
-    render(<ExcludedDimensions mediaType="movie" mediaId={42} />);
+    renderExcluded({ mediaType: 'movie', mediaId: 42 });
 
-    expect(screen.getByText('Excluded Dimensions')).toBeInTheDocument();
+    expect(await screen.findByText('Excluded Dimensions')).toBeInTheDocument();
     expect(screen.getByText('Cinematography')).toBeInTheDocument();
     expect(screen.getByText('Emotional Impact')).toBeInTheDocument();
     expect(screen.queryByText('Entertainment')).not.toBeInTheDocument();
@@ -71,42 +91,36 @@ describe('ExcludedDimensions', () => {
     expect(includeButtons).toHaveLength(2);
   });
 
-  it('calls includeInDimension mutation when Include is clicked', () => {
-    mockScoresQuery.mockReturnValue({
-      data: {
-        data: [{ dimensionId: 1, score: 1500, comparisonCount: 5, excluded: true }],
-      },
-      isLoading: false,
-    });
+  it('calls includeInDimension mutation when Include is clicked', async () => {
+    comparisonsScoresMock.mockResolvedValue(
+      ok({ data: [{ dimensionId: 1, score: 1500, comparisonCount: 5, excluded: true }] })
+    );
 
-    render(<ExcludedDimensions mediaType="movie" mediaId={42} />);
+    const user = userEvent.setup();
+    renderExcluded({ mediaType: 'movie', mediaId: 42 });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Include' }));
+    await user.click(await screen.findByRole('button', { name: 'Include' }));
 
-    expect(mockIncludeMutate).toHaveBeenCalledWith({
-      mediaType: 'movie',
-      mediaId: 42,
-      dimensionId: 1,
-    });
+    await waitFor(() =>
+      expect(comparisonsIncludeInDimensionMock).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 42, dimensionId: 1 },
+      })
+    );
   });
 
-  it('renders nothing when scores are empty', () => {
-    mockScoresQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-    });
+  it('renders nothing when scores are empty', async () => {
+    comparisonsScoresMock.mockResolvedValue(ok({ data: [] }));
 
-    const { container } = render(<ExcludedDimensions mediaType="movie" mediaId={42} />);
-    expect(container.innerHTML).toBe('');
+    const { container } = renderExcluded({ mediaType: 'movie', mediaId: 42 });
+    await waitFor(() => expect(comparisonsScoresMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('renders nothing when scores data is null', () => {
-    mockScoresQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-    });
+  it('renders nothing when scores data is null', async () => {
+    comparisonsScoresMock.mockResolvedValue(ok({ data: [] }));
 
-    const { container } = render(<ExcludedDimensions mediaType="movie" mediaId={42} />);
-    expect(container.innerHTML).toBe('');
+    const { container } = renderExcluded({ mediaType: 'movie', mediaId: 42 });
+    await waitFor(() => expect(comparisonsScoresMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 });

--- a/packages/app-media/src/components/ExcludedDimensions.tsx
+++ b/packages/app-media/src/components/ExcludedDimensions.tsx
@@ -1,11 +1,18 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ExcludedDimensions — shows which comparison dimensions a movie is excluded from
  * and provides an "Include" button to restore it.
  */
 import { Button } from '@pops/ui';
+
+import { unwrap } from '../media-api-helpers.js';
+import {
+  comparisonsIncludeInDimension,
+  comparisonsListDimensions,
+  comparisonsScores,
+} from '../media-api/index.js';
 
 export interface ExcludedDimensionsProps {
   mediaType: 'movie' | 'tv_show';
@@ -37,34 +44,33 @@ interface IncludeInDimensionInput {
 }
 
 function useExcludedDimensionsModel(mediaType: 'movie' | 'tv_show', mediaId: number) {
-  const { data: scoresResponse } = usePillarQuery<ScoresResult>(
-    'media',
-    ['comparisons', 'scores'],
-    { mediaType, mediaId }
-  );
+  const queryClient = useQueryClient();
 
-  const { data: dimensionsResponse } = usePillarQuery<DimensionsResult>(
-    'media',
-    ['comparisons', 'listDimensions'],
-    undefined
-  );
+  const { data: scoresResponse } = useQuery<ScoresResult>({
+    queryKey: ['media', 'comparisons', 'scores', { mediaType, mediaId }],
+    queryFn: async () => unwrap(await comparisonsScores({ query: { mediaType, mediaId } })),
+  });
+
+  const { data: dimensionsResponse } = useQuery<DimensionsResult>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+  });
 
   const scores = scoresResponse?.data ?? [];
   const dimensions = dimensionsResponse?.data ?? [];
 
-  const includeMutation = usePillarMutation<IncludeInDimensionInput, unknown>(
-    'media',
-    ['comparisons', 'includeInDimension'],
-    {
-      onSuccess: (_data, variables) => {
-        const dimName = dimensions.find((d) => d.id === variables.dimensionId)?.name ?? 'dimension';
-        toast.success(`Included in ${dimName}`);
-      },
-      onError: (err) => {
-        toast.error(`Failed to include: ${err.message}`);
-      },
-    }
-  );
+  const includeMutation = useMutation({
+    mutationFn: async (input: IncludeInDimensionInput) =>
+      unwrap(await comparisonsIncludeInDimension({ body: input })),
+    onSuccess: (_data, variables) => {
+      const dimName = dimensions.find((d) => d.id === variables.dimensionId)?.name ?? 'dimension';
+      toast.success(`Included in ${dimName}`);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons'] });
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to include: ${err.message}`);
+    },
+  });
 
   return { scores, dimensions, includeMutation };
 }

--- a/packages/app-media/src/components/LeavingSoonShelf.tsx
+++ b/packages/app-media/src/components/LeavingSoonShelf.tsx
@@ -1,7 +1,7 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * LeavingSoonShelf — horizontal shelf showing movies scheduled for removal.
  * Used on the Library page above the main grid.
@@ -10,6 +10,11 @@ import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
  */
 import { Button, Skeleton } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import {
+  rotationSchedulerCancelLeaving,
+  rotationSchedulerLeavingMovies,
+} from '../media-api/index.js';
 import { HorizontalScrollRow } from './HorizontalScrollRow';
 import { LeavingBadge } from './LeavingBadge';
 import { MediaCard } from './MediaCard';
@@ -82,25 +87,28 @@ function LeavingMovieCard({
 }
 
 export function LeavingSoonShelf() {
+  const queryClient = useQueryClient();
   const {
     data: movies,
     isLoading,
     refetch,
-  } = usePillarQuery<LeavingMovie[]>('media', ['rotation', 'getLeavingMovies'], undefined);
-  const cancelMutation = usePillarMutation<{ movieId: number }, unknown>(
-    'media',
-    ['rotation', 'cancelLeaving'],
-    {
-      onSuccess: (_data, variables) => {
-        const movie = movies?.find((m) => m.id === variables.movieId);
-        toast.success(`Kept "${movie?.title ?? 'movie'}" in library`);
-        void refetch();
-      },
-      onError: () => {
-        toast.error('Failed to cancel leaving status');
-      },
-    }
-  );
+  } = useQuery<LeavingMovie[]>({
+    queryKey: ['media', 'rotation', 'getLeavingMovies'],
+    queryFn: async () => (await unwrap(await rotationSchedulerLeavingMovies())).data,
+  });
+  const cancelMutation = useMutation({
+    mutationFn: async (variables: { movieId: number }) =>
+      unwrap(await rotationSchedulerCancelLeaving({ path: { movieId: variables.movieId } })),
+    onSuccess: (_data, variables) => {
+      const movie = movies?.find((m) => m.id === variables.movieId);
+      toast.success(`Kept "${movie?.title ?? 'movie'}" in library`);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'rotation'] });
+      void refetch();
+    },
+    onError: () => {
+      toast.error('Failed to cancel leaving status');
+    },
+  });
 
   if (isLoading) return <LeavingSkeleton />;
   if (!movies || movies.length === 0) return null;

--- a/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
+++ b/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
@@ -1,78 +1,21 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MarkAsWatchedButton } from './MarkAsWatchedButton';
+const watchHistoryListMock = vi.hoisted(() => vi.fn());
+const watchHistoryLogMock = vi.hoisted(() => vi.fn());
+const watchHistoryDeleteMock = vi.hoisted(() => vi.fn());
+const watchlistAddMock = vi.hoisted(() => vi.fn());
 
-// Capture mutation options
-let logMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
-let _deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
-const mockLogMutate = vi.fn();
-const mockDeleteMutate = vi.fn();
-const mockWatchlistAddMutate = vi.fn();
-const mockInvalidateHistory = vi.fn();
-const mockInvalidateWatchlist = vi.fn();
-const mockInvalidatePendingDebriefs = vi.fn();
-
-const mockHistoryQuery = vi.fn();
-
-vi.mock('@tanstack/react-query', async () => {
-  const actual =
-    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
-  return {
-    ...actual,
-    useQueryClient: () => ({
-      invalidateQueries: ({ queryKey }: { queryKey: readonly string[] }) => {
-        const router = queryKey[1];
-        if (router === 'watchHistory') mockInvalidateHistory();
-        if (router === 'watchlist') mockInvalidateWatchlist();
-        if (router === 'comparisons') mockInvalidatePendingDebriefs();
-      },
-    }),
-  };
-});
-
-function wrapOpts(
-  path: readonly string[],
-  opts?: Record<string, (...args: unknown[]) => unknown>
-): Record<string, (...args: unknown[]) => unknown> {
-  const router = path[0];
-  return {
-    ...opts,
-    onSuccess: (...args: unknown[]) => {
-      if (router === 'watchHistory') mockInvalidateHistory();
-      return opts?.onSuccess?.(...args);
-    },
-  };
-}
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    if (path.join('.') === 'watchHistory.list') return mockHistoryQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts?: Record<string, (...args: unknown[]) => unknown>
-  ) => {
-    const key = path.join('.');
-    const wrapped = wrapOpts(path, opts);
-    if (key === 'watchHistory.log') {
-      logMutationOpts = wrapped;
-      return { mutate: mockLogMutate, isPending: false };
-    }
-    if (key === 'watchHistory.delete') {
-      _deleteMutationOpts = wrapped;
-      return { mutate: mockDeleteMutate, isPending: false };
-    }
-    if (key === 'watchlist.add') {
-      return { mutate: mockWatchlistAddMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  watchHistoryList: (...args: unknown[]) => watchHistoryListMock(...args),
+  watchHistoryLog: (...args: unknown[]) => watchHistoryLogMock(...args),
+  watchHistoryDelete: (...args: unknown[]) => watchHistoryDeleteMock(...args),
+  watchlistAdd: (...args: unknown[]) => watchlistAddMock(...args),
 }));
 
-// Mock sonner
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock('sonner', () => ({
@@ -82,23 +25,46 @@ vi.mock('sonner', () => ({
   },
 }));
 
-function setupEmpty() {
-  mockHistoryQuery.mockReturnValue({
-    data: { data: [], pagination: { total: 0 } },
-    isLoading: false,
+import { MarkAsWatchedButton } from './MarkAsWatchedButton';
+
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 }
 
+function renderButton(mediaId = 550) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<MarkAsWatchedButton mediaId={mediaId} />, { wrapper });
+}
+
+function setupEmpty() {
+  watchHistoryListMock.mockResolvedValue(ok({ data: [], pagination: { total: 0 } }));
+}
+
 function setupWatched(count = 1) {
-  mockHistoryQuery.mockReturnValue({
-    data: {
+  watchHistoryListMock.mockResolvedValue(
+    ok({
       data: Array.from({ length: count }, (_, i) => ({
         id: i + 1,
         watchedAt: '2026-01-01T00:00:00Z',
       })),
-    },
-    isLoading: false,
-  });
+      pagination: { total: count },
+    })
+  );
+}
+
+/** Invokes the Undo action handed to the success toast. */
+function triggerUndo() {
+  const toastCall = mockToastSuccess.mock.calls.find(([msg]) => msg === 'Marked as watched');
+  const opts = toastCall?.[1] as { action?: { onClick: () => void } } | undefined;
+  opts?.action?.onClick();
 }
 
 afterEach(() => {
@@ -107,118 +73,144 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  logMutationOpts = {};
-  _deleteMutationOpts = {};
   setupEmpty();
+  watchHistoryLogMock.mockResolvedValue(
+    ok({ data: { id: 99 }, message: 'ok', watchlistRemoved: false })
+  );
+  watchHistoryDeleteMock.mockResolvedValue(ok({}));
+  watchlistAddMock.mockResolvedValue(ok({ created: true, message: 'ok', data: { id: 1 } }));
 });
 
 describe('MarkAsWatchedButton', () => {
-  it("renders 'Mark as Watched' button for unwatched movie", () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
-    expect(screen.getByLabelText('Mark as watched')).toBeInTheDocument();
+  it("renders 'Mark as Watched' button for unwatched movie", async () => {
+    renderButton();
+    expect(await screen.findByLabelText('Mark as watched')).toBeInTheDocument();
     expect(screen.getByText('Mark as Watched')).toBeInTheDocument();
   });
 
-  it('shows watched count when already watched', () => {
+  it('shows watched count when already watched', async () => {
     setupWatched(2);
-    render(<MarkAsWatchedButton mediaId={550} />);
-    expect(screen.getByText('Watched (2)')).toBeInTheDocument();
+    renderButton();
+    expect(await screen.findByText('Watched (2)')).toBeInTheDocument();
   });
 
-  it('calls log mutation with correct payload on click', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('calls log mutation with correct payload on click', async () => {
+    const user = userEvent.setup();
+    renderButton();
 
-    fireEvent.click(screen.getByLabelText('Mark as watched'));
+    await user.click(await screen.findByLabelText('Mark as watched'));
 
-    expect(mockLogMutate).toHaveBeenCalledWith({
-      mediaType: 'movie',
-      mediaId: 550,
-      completed: 1,
-    });
-  });
-
-  it('shows success toast with Undo action on log success', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
-
-    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
-
-    expect(mockToastSuccess).toHaveBeenCalledWith(
-      'Marked as watched',
-      expect.objectContaining({
-        duration: 5000,
-        action: expect.objectContaining({ label: 'Undo' }),
+    await waitFor(() =>
+      expect(watchHistoryLogMock).toHaveBeenCalledWith({
+        body: {
+          mediaType: 'movie',
+          mediaId: 550,
+          completed: 1,
+          source: 'manual',
+          watchedAt: undefined,
+        },
       })
     );
   });
 
-  it('invalidates watch history on log success', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('shows success toast with Undo action on log success', async () => {
+    const user = userEvent.setup();
+    renderButton();
 
-    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+    await user.click(await screen.findByLabelText('Mark as watched'));
 
-    expect(mockInvalidateHistory).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        'Marked as watched',
+        expect.objectContaining({
+          duration: 5000,
+          action: expect.objectContaining({ label: 'Undo' }),
+        })
+      )
+    );
   });
 
-  it('shows error toast on log failure', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('invalidates watch history on log success', async () => {
+    const user = userEvent.setup();
+    renderButton();
 
-    logMutationOpts.onError!({ message: 'DB error' });
+    await user.click(await screen.findByLabelText('Mark as watched'));
 
-    expect(mockToastError).toHaveBeenCalledWith('Failed to log watch: DB error');
+    // Re-fetch of the history list is the observable effect of invalidation.
+    await waitFor(() => expect(watchHistoryListMock.mock.calls.length).toBeGreaterThan(1));
   });
 
-  it('undo calls delete with entry ID', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('shows error toast on log failure', async () => {
+    watchHistoryLogMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'DB error' },
+      response: { status: 500 },
+    });
+    const user = userEvent.setup();
+    renderButton();
 
-    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+    await user.click(await screen.findByLabelText('Mark as watched'));
 
-    const toastCall = mockToastSuccess.mock.calls[0];
-    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
-    opts?.action?.onClick();
-
-    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: 99 }, expect.any(Object));
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith('Failed to log watch: DB error')
+    );
   });
 
-  it('undo re-adds to watchlist when watchlistRemoved=true', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('undo calls delete with entry ID', async () => {
+    const user = userEvent.setup();
+    renderButton();
 
-    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: true });
+    await user.click(await screen.findByLabelText('Mark as watched'));
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith('Marked as watched', expect.anything())
+    );
+    triggerUndo();
 
-    const toastCall = mockToastSuccess.mock.calls[0];
-    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
-    opts?.action?.onClick();
-
-    // Call the onSuccess of the delete mutation
-    const deleteCall = mockDeleteMutate.mock.calls[0];
-    const deleteOpts = deleteCall?.[1] as { onSuccess?: () => void };
-    deleteOpts?.onSuccess?.();
-
-    expect(mockWatchlistAddMutate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
+    await waitFor(() => expect(watchHistoryDeleteMock).toHaveBeenCalledWith({ path: { id: 99 } }));
   });
 
-  it('undo does not re-add to watchlist when watchlistRemoved=false', () => {
-    render(<MarkAsWatchedButton mediaId={550} />);
+  it('undo re-adds to watchlist when watchlistRemoved=true', async () => {
+    watchHistoryLogMock.mockResolvedValue(
+      ok({ data: { id: 99 }, message: 'ok', watchlistRemoved: true })
+    );
+    const user = userEvent.setup();
+    renderButton();
 
-    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+    await user.click(await screen.findByLabelText('Mark as watched'));
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith('Marked as watched', expect.anything())
+    );
+    triggerUndo();
 
-    const toastCall = mockToastSuccess.mock.calls[0];
-    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
-    opts?.action?.onClick();
-
-    const deleteCall = mockDeleteMutate.mock.calls[0];
-    const deleteOpts = deleteCall?.[1] as { onSuccess?: () => void };
-    deleteOpts?.onSuccess?.();
-
-    expect(mockWatchlistAddMutate).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(watchlistAddMock).toHaveBeenCalledWith({
+        body: { mediaType: 'movie', mediaId: 550 },
+      })
+    );
   });
 
-  it('button remains usable after logging (can log multiple watches)', () => {
+  it('undo does not re-add to watchlist when watchlistRemoved=false', async () => {
+    const user = userEvent.setup();
+    renderButton();
+
+    await user.click(await screen.findByLabelText('Mark as watched'));
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith('Marked as watched', expect.anything())
+    );
+    triggerUndo();
+
+    await waitFor(() => expect(watchHistoryDeleteMock).toHaveBeenCalled());
+    expect(watchlistAddMock).not.toHaveBeenCalled();
+  });
+
+  it('button remains usable after logging (can log multiple watches)', async () => {
     setupWatched(1);
-    render(<MarkAsWatchedButton mediaId={550} />);
+    const user = userEvent.setup();
+    renderButton();
 
-    const button = screen.getByLabelText('Mark as watched');
+    const button = await screen.findByLabelText('Mark as watched');
     expect(button).not.toBeDisabled();
-    fireEvent.click(button);
-    expect(mockLogMutate).toHaveBeenCalledTimes(1);
+    await user.click(button);
+    await waitFor(() => expect(watchHistoryLogMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/app-media/src/components/MovieActionButtons.tsx
+++ b/packages/app-media/src/components/MovieActionButtons.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * MovieActionButtons — conditional action buttons for non-library movies.
  *
@@ -10,7 +7,11 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  *
  * PRD-072 US-05
  */
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
+import { unwrap } from '../media-api-helpers.js';
+import { rotationSchedulerStatus } from '../media-api/index.js';
 import { QueueActionButtons } from './movie-action-buttons/QueueActionButtons';
 import { ExcludedButton, InQueueButton } from './movie-action-buttons/StatusButtons';
 import { useRotationButtonsModel } from './movie-action-buttons/useRotationButtonsModel';
@@ -39,11 +40,10 @@ export function MovieActionButtons({
   rating,
   variant = 'standard',
 }: MovieActionButtonsProps) {
-  const { data: statusData } = usePillarQuery<RotationStatusResult>(
-    'media',
-    ['rotation', 'status'],
-    undefined
-  );
+  const { data: statusData } = useQuery<RotationStatusResult>({
+    queryKey: ['media', 'rotation', 'status'],
+    queryFn: async () => (await unwrap(await rotationSchedulerStatus())).data,
+  });
   const rotationEnabled = statusData?.isRunning ?? false;
 
   if (!rotationEnabled) {

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -1,8 +1,8 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Sparkles } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Button,
   Dialog,
@@ -13,6 +13,8 @@ import {
   DialogTrigger,
 } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { discoveryQuickPick, watchlistAdd } from '../media-api/index.js';
 import { PickCard } from './quick-pick/PickCard';
 import { EmptyView, ErrorView, FinishedView, PickLoading } from './quick-pick/PickViews';
 
@@ -35,29 +37,27 @@ interface AddToWatchlistInput {
 }
 
 function useQuickPickModel() {
+  const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  const { data, isLoading, error, refetch } = usePillarQuery<QuickPickResult>(
-    'media',
-    ['discovery', 'quickPick'],
-    { count: 5 },
-    { enabled: open }
-  );
+  const { data, isLoading, error, refetch } = useQuery<QuickPickResult>({
+    queryKey: ['media', 'discovery', 'quickPick', { count: 5 }],
+    queryFn: async () => unwrap(await discoveryQuickPick({ query: { count: 5 } })),
+    enabled: open,
+  });
 
-  const addToWatchlist = usePillarMutation<AddToWatchlistInput, unknown>(
-    'media',
-    ['watchlist', 'add'],
-    {
-      onSuccess: () => {
-        toast.success('Added to watchlist!');
-        setOpen(false);
-      },
-      onError: (err) => {
-        toast.error(`Failed to add: ${err.message}`);
-      },
-    }
-  );
+  const addToWatchlist = useMutation({
+    mutationFn: async (input: AddToWatchlistInput) => unwrap(await watchlistAdd({ body: input })),
+    onSuccess: () => {
+      toast.success('Added to watchlist!');
+      setOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to add: ${err.message}`);
+    },
+  });
 
   const movies = data?.data ?? [];
   const currentMovie = movies[currentIndex];

--- a/packages/app-media/src/components/RequestMovieButton.test.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.test.tsx
@@ -1,26 +1,18 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockGetConfigQuery = vi.fn();
-const mockGetMovieStatusQuery = vi.fn();
+const arrConfigMock = vi.hoisted(() => vi.fn());
+const arrGetMovieStatusMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    _input: unknown,
-    opts?: { enabled?: boolean }
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.getConfig') return mockGetConfigQuery();
-    const enabled = opts?.enabled ?? true;
-    if (key === 'arr.getMovieStatus')
-      return enabled ? mockGetMovieStatusQuery() : { data: null, isLoading: false, error: null };
-    return { data: null, isLoading: false, error: null };
-  },
+vi.mock('../media-api/index.js', () => ({
+  arrConfig: (...args: unknown[]) => arrConfigMock(...args),
+  arrGetMovieStatus: (...args: unknown[]) => arrGetMovieStatusMock(...args),
 }));
 
-// Mock the modal so tests don't need to stub its tRPC hooks
+// Mock the modal so tests don't need to stub its SDK calls
 vi.mock('./RequestMovieModal', () => ({
   RequestMovieModal: ({ open }: { open: boolean }) =>
     open ? <div data-testid="request-movie-modal">Modal</div> : null,
@@ -28,170 +20,147 @@ vi.mock('./RequestMovieModal', () => ({
 
 import { RequestMovieButton } from './RequestMovieButton';
 
-describe('RequestMovieButton', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+}
 
-  it('shows disabled button when Radarr is not configured (standard)', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: false } } });
-    mockGetMovieStatusQuery.mockReturnValue({ data: null, isLoading: false, error: null });
+function renderButton(props: Parameters<typeof RequestMovieButton>[0]) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<RequestMovieButton {...props} />, { wrapper });
+}
 
-    render(<RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />);
+function configured(radarrConfigured: boolean) {
+  arrConfigMock.mockResolvedValue(ok({ data: { radarrConfigured, sonarrConfigured: false } }));
+}
 
+function movieStatus(status: string, label: string) {
+  arrGetMovieStatusMock.mockResolvedValue(ok({ data: { status, label } }));
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  configured(true);
+  movieStatus('not_found', 'Not in Radarr');
+});
+
+describe('RequestMovieButton', () => {
+  it('shows disabled button when Radarr is not configured (standard)', async () => {
+    configured(false);
+
+    renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+
+    await waitFor(() => expect(arrConfigMock).toHaveBeenCalled());
     const button = screen.getByRole('button', { name: /request/i });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('title', 'Radarr not configured');
   });
 
-  it('shows disabled compact button when Radarr is not configured', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: false } } });
-    mockGetMovieStatusQuery.mockReturnValue({ data: null, isLoading: false, error: null });
+  it('shows disabled compact button when Radarr is not configured', async () => {
+    configured(false);
 
-    render(<RequestMovieButton tmdbId={123} title="Test Movie" year={2023} variant="compact" />);
+    renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023, variant: 'compact' });
 
+    await waitFor(() => expect(arrConfigMock).toHaveBeenCalled());
     const button = screen.getByRole('button', { name: /radarr not configured/i });
     expect(button).toBeDisabled();
   });
 
-  it('hides button when movie exists in Radarr (available)', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'available', label: 'Available' } },
-      isLoading: false,
-      error: null,
-    });
+  it('hides button when movie exists in Radarr (available)', async () => {
+    movieStatus('available', 'Available');
 
-    const { container } = render(
-      <RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />
-    );
-    expect(container.innerHTML).toBe('');
+    const { container } = renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    await waitFor(() => expect(arrGetMovieStatusMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('hides button when movie is monitored in Radarr', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'monitored', label: 'Monitored' } },
-      isLoading: false,
-      error: null,
-    });
+  it('hides button when movie is monitored in Radarr', async () => {
+    movieStatus('monitored', 'Monitored');
 
-    const { container } = render(
-      <RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />
-    );
-    expect(container.innerHTML).toBe('');
+    const { container } = renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    await waitFor(() => expect(arrGetMovieStatusMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('hides button when movie is downloading in Radarr', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'downloading', label: 'Downloading 45%' } },
-      isLoading: false,
-      error: null,
-    });
+  it('hides button when movie is downloading in Radarr', async () => {
+    movieStatus('downloading', 'Downloading 45%');
 
-    const { container } = render(
-      <RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />
-    );
-    expect(container.innerHTML).toBe('');
+    const { container } = renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    await waitFor(() => expect(arrGetMovieStatusMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('returns null when Radarr is unreachable (query error)', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: new Error('Connection refused'),
+  it('returns null when Radarr is unreachable (query error)', async () => {
+    arrGetMovieStatusMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'Connection refused' },
+      response: { status: 500 },
     });
 
-    const { container } = render(
-      <RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />
-    );
-    expect(container.innerHTML).toBe('');
+    const { container } = renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    await waitFor(() => expect(arrGetMovieStatusMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('shows Request button when movie is not found in Radarr (standard)', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'not_found', label: 'Not in Radarr' } },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />);
-    expect(screen.getByRole('button', { name: /request/i })).toBeEnabled();
+  it('shows Request button when movie is not found in Radarr (standard)', async () => {
+    renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    const button = await screen.findByTitle('Request in Radarr');
+    expect(button).toBeEnabled();
   });
 
-  it('shows compact button when movie is not found in Radarr', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'not_found', label: 'Not in Radarr' } },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<RequestMovieButton tmdbId={123} title="Test Movie" year={2023} variant="compact" />);
-    expect(screen.getByRole('button', { name: /request in radarr/i })).toBeEnabled();
+  it('shows compact button when movie is not found in Radarr', async () => {
+    renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023, variant: 'compact' });
+    const button = await screen.findByRole('button', { name: /request in radarr/i });
+    expect(button).toBeEnabled();
   });
 
-  it('calls onRequest callback when clicked', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'not_found', label: 'Not in Radarr' } },
-      isLoading: false,
-      error: null,
-    });
-
+  it('calls onRequest callback when clicked', async () => {
     const onRequest = vi.fn();
-    render(
-      <RequestMovieButton tmdbId={456} title="Test Movie" year={2020} onRequest={onRequest} />
-    );
+    const user = userEvent.setup();
+    renderButton({ tmdbId: 456, title: 'Test Movie', year: 2020, onRequest });
 
-    fireEvent.click(screen.getByRole('button', { name: /request/i }));
+    await user.click(await screen.findByTitle('Request in Radarr'));
     expect(onRequest).toHaveBeenCalledWith(456);
   });
 
-  it('opens modal when clicked without onRequest callback', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'not_found', label: 'Not in Radarr' } },
-      isLoading: false,
-      error: null,
-    });
+  it('opens modal when clicked without onRequest callback', async () => {
+    const user = userEvent.setup();
+    renderButton({ tmdbId: 789, title: 'Inception', year: 2010 });
 
-    render(<RequestMovieButton tmdbId={789} title="Inception" year={2010} />);
-
+    const button = await screen.findByTitle('Request in Radarr');
     expect(screen.queryByTestId('request-movie-modal')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /request/i }));
-    expect(screen.getByTestId('request-movie-modal')).toBeTruthy();
+    await user.click(button);
+    expect(await screen.findByTestId('request-movie-modal')).toBeTruthy();
   });
 
-  it('opens modal when compact button clicked without onRequest callback', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: { data: { status: 'not_found', label: 'Not in Radarr' } },
-      isLoading: false,
-      error: null,
-    });
+  it('opens modal when compact button clicked without onRequest callback', async () => {
+    const user = userEvent.setup();
+    renderButton({ tmdbId: 789, title: 'Inception', year: 2010, variant: 'compact' });
 
-    render(<RequestMovieButton tmdbId={789} title="Inception" year={2010} variant="compact" />);
-
+    const button = await screen.findByRole('button', { name: /request in radarr/i });
     expect(screen.queryByTestId('request-movie-modal')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /request in radarr/i }));
-    expect(screen.getByTestId('request-movie-modal')).toBeTruthy();
+    await user.click(button);
+    expect(await screen.findByTestId('request-movie-modal')).toBeTruthy();
   });
 
-  it('returns null while loading', () => {
-    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
-    mockGetMovieStatusQuery.mockReturnValue({
-      data: null,
-      isLoading: true,
-      error: null,
-    });
+  it('returns null while the status query is loading', async () => {
+    arrGetMovieStatusMock.mockReturnValue(new Promise(() => {}));
 
-    const { container } = render(
-      <RequestMovieButton tmdbId={123} title="Test Movie" year={2023} />
-    );
-    expect(container.innerHTML).toBe('');
+    const { container } = renderButton({ tmdbId: 123, title: 'Test Movie', year: 2023 });
+    // Config resolves (radarr configured) so the "not configured" placeholder goes away,
+    // then the pending status query leaves nothing rendered.
+    await waitFor(() => expect(arrGetMovieStatusMock).toHaveBeenCalled());
+    await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 });

--- a/packages/app-media/src/components/RequestMovieButton.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.tsx
@@ -1,6 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { Download } from 'lucide-react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RequestMovieButton — requests a movie via Radarr.
  *
@@ -12,6 +12,8 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  */
 import { Button } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { arrConfig, arrGetMovieStatus } from '../media-api/index.js';
 import { ConditionalModalButton } from './ConditionalModalButton';
 import { RequestMovieModal } from './RequestMovieModal';
 
@@ -92,18 +94,16 @@ function RequestButtonShell({
 }
 
 function useRequestMovieGate(tmdbId: number) {
-  const { data: configData } = usePillarQuery<ArrConfigResult>(
-    'media',
-    ['arr', 'getConfig'],
-    undefined
-  );
+  const { data: configData } = useQuery<ArrConfigResult>({
+    queryKey: ['media', 'arr', 'getConfig'],
+    queryFn: async () => unwrap(await arrConfig()),
+  });
   const config = configData?.data;
-  const movieStatus = usePillarQuery<MovieStatusResult>(
-    'media',
-    ['arr', 'getMovieStatus'],
-    { tmdbId },
-    { enabled: config?.radarrConfigured === true }
-  );
+  const movieStatus = useQuery<MovieStatusResult>({
+    queryKey: ['media', 'arr', 'getMovieStatus', { tmdbId }],
+    queryFn: async () => unwrap(await arrGetMovieStatus({ path: { tmdbId } })),
+    enabled: config?.radarrConfigured === true,
+  });
   return { config, movieStatus };
 }
 

--- a/packages/app-media/src/components/RequestMovieModal.test.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.test.tsx
@@ -1,48 +1,22 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────
+const qualityProfilesMock = vi.hoisted(() => vi.fn());
+const rootFoldersMock = vi.hoisted(() => vi.fn());
+const addMovieMock = vi.hoisted(() => vi.fn());
+const downloadAndProtectMock = vi.hoisted(() => vi.fn());
 
-const mockProfilesQuery = vi.fn();
-const mockFoldersQuery = vi.fn();
-const mockAddMovieMutate = vi.fn();
-const mockDownloadAndProtectMutate = vi.fn();
-let addMovieOpts: Record<string, unknown> = {};
-let downloadAndProtectOpts: Record<string, unknown> = {};
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    _input: unknown,
-    opts?: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.getQualityProfiles') return mockProfilesQuery(_input, opts);
-    if (key === 'arr.getRootFolders') return mockFoldersQuery(_input, opts);
-    return { data: null, isLoading: false, error: null };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.addMovie') {
-      addMovieOpts = opts;
-      return { mutate: mockAddMovieMutate, isPending: false };
-    }
-    if (key === 'arr.downloadAndProtect') {
-      downloadAndProtectOpts = opts;
-      return { mutate: mockDownloadAndProtectMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  arrGetRadarrQualityProfiles: (...args: unknown[]) => qualityProfilesMock(...args),
+  arrGetRadarrRootFolders: (...args: unknown[]) => rootFoldersMock(...args),
+  arrAddMovie: (...args: unknown[]) => addMovieMock(...args),
+  arrDownloadAndProtect: (...args: unknown[]) => downloadAndProtectMock(...args),
 }));
 
 import { RequestMovieModal } from './RequestMovieModal';
-
-// ── Helpers ────────────────────────────────────────────────────────────────
 
 const profiles = [
   { id: 1, name: 'HD - 720p/1080p' },
@@ -54,31 +28,16 @@ const folders = [
   { id: 2, path: '/movies2', freeSpace: 100 * 1024 * 1024 * 1024 },
 ];
 
-function setupDefaults(
-  overrides: {
-    profilesLoading?: boolean;
-    foldersLoading?: boolean;
-    profileList?: typeof profiles;
-    folderList?: typeof folders;
-  } = {}
-) {
-  const {
-    profilesLoading = false,
-    foldersLoading = false,
-    profileList = profiles,
-    folderList = folders,
-  } = overrides;
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
 
-  mockProfilesQuery.mockReturnValue({
-    isLoading: profilesLoading,
-    data: profilesLoading ? null : { data: profileList },
-    refetch: vi.fn(),
-  });
-  mockFoldersQuery.mockReturnValue({
-    isLoading: foldersLoading,
-    data: foldersLoading ? null : { data: folderList },
-    refetch: vi.fn(),
-  });
+function setupDefaults(
+  overrides: { profileList?: typeof profiles; folderList?: typeof folders } = {}
+) {
+  const { profileList = profiles, folderList = folders } = overrides;
+  qualityProfilesMock.mockResolvedValue(ok({ data: profileList }));
+  rootFoldersMock.mockResolvedValue(ok({ data: folderList }));
 }
 
 const defaultProps = {
@@ -89,151 +48,166 @@ const defaultProps = {
   year: 1999,
 };
 
-function renderModal(props = {}) {
-  return render(<RequestMovieModal {...defaultProps} {...props} />);
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
 }
 
-// ── Tests ──────────────────────────────────────────────────────────────────
+function renderModal(props = {}) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<RequestMovieModal {...defaultProps} {...props} />, { wrapper });
+}
+
+afterEach(() => {
+  cleanup();
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
-  addMovieOpts = {};
-  downloadAndProtectOpts = {};
+  setupDefaults();
+  addMovieMock.mockResolvedValue(ok({ data: { id: 1, title: 'Fight Club', tmdbId: 550 } }));
+  downloadAndProtectMock.mockResolvedValue(ok({ data: {} }));
 });
 
 describe('RequestMovieModal', () => {
   it('shows movie title and year in header', () => {
-    setupDefaults();
     renderModal();
 
     expect(screen.getByText('Request Movie')).toBeInTheDocument();
     expect(screen.getByText('Fight Club (1999)')).toBeInTheDocument();
   });
 
-  it('populates quality profile dropdown from API', () => {
-    setupDefaults();
+  it('populates quality profile dropdown from API', async () => {
     renderModal();
 
+    await waitFor(() => {
+      const select = document.querySelector('#quality-profile') as HTMLSelectElement | null;
+      expect(select?.querySelectorAll('option')).toHaveLength(2);
+    });
     const select = document.querySelector('#quality-profile') as HTMLSelectElement;
-    expect(select).toBeTruthy();
-
     const options = select.querySelectorAll('option');
-    expect(options).toHaveLength(2);
     expect(options[0]!.textContent).toBe('HD - 720p/1080p');
     expect(options[1]!.textContent).toBe('Ultra-HD');
   });
 
-  it('populates root folder dropdown with free space', () => {
-    setupDefaults();
+  it('populates root folder dropdown with free space', async () => {
     renderModal();
 
+    await waitFor(() => {
+      const select = document.querySelector('#root-folder') as HTMLSelectElement | null;
+      expect(select?.querySelectorAll('option')).toHaveLength(2);
+    });
     const select = document.querySelector('#root-folder') as HTMLSelectElement;
-    expect(select).toBeTruthy();
-
     const options = select.querySelectorAll('option');
-    expect(options).toHaveLength(2);
     expect(options[0]!.textContent).toContain('/movies');
     expect(options[0]!.textContent).toContain('GB free');
   });
 
-  it('sends correct addMovie payload on confirm', () => {
-    setupDefaults();
+  it('sends correct addMovie payload on confirm', async () => {
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Request'));
-
-    expect(mockAddMovieMutate).toHaveBeenCalledWith({
-      tmdbId: 550,
-      title: 'Fight Club',
-      year: 1999,
-      qualityProfileId: 1,
-      rootFolderPath: '/movies',
+    await waitFor(() => {
+      const select = document.querySelector('#root-folder') as HTMLSelectElement | null;
+      expect(select?.value).toBe('/movies');
     });
+    await user.click(screen.getByText('Request'));
+
+    await waitFor(() =>
+      expect(addMovieMock).toHaveBeenCalledWith({
+        body: {
+          tmdbId: 550,
+          title: 'Fight Club',
+          year: 1999,
+          qualityProfileId: 1,
+          rootFolderPath: '/movies',
+        },
+      })
+    );
   });
 
-  it('calls onClose after successful add', () => {
-    vi.useFakeTimers();
-    setupDefaults();
+  it('calls onClose after successful add', async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     renderModal({ onClose });
 
-    // Click request
-    fireEvent.click(screen.getByText('Request'));
-
-    // Simulate success callback
-    const onSuccess = addMovieOpts.onSuccess as () => void;
-    act(() => {
-      onSuccess();
+    await waitFor(() => {
+      const select = document.querySelector('#root-folder') as HTMLSelectElement | null;
+      expect(select?.value).toBe('/movies');
     });
+    await user.click(screen.getByText('Request'));
 
-    expect(screen.getByText('Movie Added')).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1500));
-    expect(onClose).toHaveBeenCalled();
-
-    vi.useRealTimers();
+    expect(await screen.findByText('Movie Added')).toBeInTheDocument();
+    // The modal intentionally waits 1500ms on the success state before closing.
+    await waitFor(() => expect(onClose).toHaveBeenCalled(), { timeout: 2000 });
   });
 
-  it('shows inline error on failure', () => {
-    setupDefaults();
+  it('shows inline error on failure', async () => {
+    addMovieMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'Movie already exists in Radarr' },
+      response: { status: 409 },
+    });
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Request'));
-
-    const onError = addMovieOpts.onError as (err: { message: string }) => void;
-    act(() => {
-      onError({ message: 'Movie already exists in Radarr' });
+    await waitFor(() => {
+      const select = document.querySelector('#root-folder') as HTMLSelectElement | null;
+      expect(select?.value).toBe('/movies');
     });
+    await user.click(screen.getByText('Request'));
 
-    expect(screen.getByText('Movie already exists in Radarr')).toBeInTheDocument();
+    expect(await screen.findByText('Movie already exists in Radarr')).toBeInTheDocument();
   });
 
-  it('calls onClose on cancel without API call', () => {
-    setupDefaults();
+  it('calls onClose on cancel without API call', async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     renderModal({ onClose });
 
-    fireEvent.click(screen.getByText('Cancel'));
+    await user.click(screen.getByText('Cancel'));
     expect(onClose).toHaveBeenCalled();
-    expect(mockAddMovieMutate).not.toHaveBeenCalled();
+    expect(addMovieMock).not.toHaveBeenCalled();
   });
 
   it('shows loading state while fetching options', () => {
-    setupDefaults({ profilesLoading: true });
+    qualityProfilesMock.mockReturnValue(new Promise(() => {}));
     renderModal();
 
     expect(screen.getByText('Loading options...')).toBeInTheDocument();
   });
 
-  it('shows retry when no profiles available', () => {
+  it('shows retry when no profiles available', async () => {
     setupDefaults({ profileList: [] });
     renderModal();
 
-    expect(screen.getByText(/No quality profiles found/)).toBeInTheDocument();
+    expect(await screen.findByText(/No quality profiles found/)).toBeInTheDocument();
     expect(screen.getByText('Retry')).toBeInTheDocument();
   });
 
-  it('shows retry when no root folders available', () => {
+  it('shows retry when no root folders available', async () => {
     setupDefaults({ folderList: [] });
     renderModal();
 
-    expect(screen.getByText(/No root folders found/)).toBeInTheDocument();
+    expect(await screen.findByText(/No root folders found/)).toBeInTheDocument();
   });
 
-  it('defaults to first quality profile and root folder', () => {
-    setupDefaults();
+  it('defaults to first quality profile and root folder', async () => {
     renderModal();
 
-    const profileSelect = document.querySelector('#quality-profile') as HTMLSelectElement;
-    expect(profileSelect.value).toBe('1');
-
+    await waitFor(() => {
+      const profileSelect = document.querySelector('#quality-profile') as HTMLSelectElement | null;
+      expect(profileSelect?.value).toBe('1');
+    });
     const folderSelect = document.querySelector('#root-folder') as HTMLSelectElement;
     expect(folderSelect.value).toBe('/movies');
   });
 
   describe('mode="download"', () => {
     it('shows "Download Movie" title', () => {
-      setupDefaults();
       renderModal({ mode: 'download' });
 
       expect(screen.getByText('Download Movie')).toBeInTheDocument();
@@ -241,60 +215,50 @@ describe('RequestMovieModal', () => {
     });
 
     it('does not show quality profile or root folder dropdowns', () => {
-      setupDefaults();
       renderModal({ mode: 'download' });
 
       expect(document.querySelector('#quality-profile')).toBeNull();
       expect(document.querySelector('#root-folder')).toBeNull();
     });
 
-    it('calls downloadAndProtect (not addMovie) on confirm', () => {
-      setupDefaults();
+    it('calls downloadAndProtect (not addMovie) on confirm', async () => {
+      const user = userEvent.setup();
       renderModal({ mode: 'download' });
 
-      fireEvent.click(screen.getByText('Download'));
+      await user.click(screen.getByText('Download'));
 
-      expect(mockDownloadAndProtectMutate).toHaveBeenCalledWith({
-        tmdbId: 550,
-        title: 'Fight Club',
-        year: 1999,
-      });
-      expect(mockAddMovieMutate).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(downloadAndProtectMock).toHaveBeenCalledWith({
+          body: { tmdbId: 550, title: 'Fight Club', year: 1999 },
+        })
+      );
+      expect(addMovieMock).not.toHaveBeenCalled();
     });
 
-    it('calls onClose after successful download', () => {
-      vi.useFakeTimers();
-      setupDefaults();
+    it('calls onClose after successful download', async () => {
+      const user = userEvent.setup();
       const onClose = vi.fn();
       renderModal({ mode: 'download', onClose });
 
-      fireEvent.click(screen.getByText('Download'));
+      await user.click(screen.getByText('Download'));
 
-      const onSuccess = downloadAndProtectOpts.onSuccess as () => void;
-      act(() => {
-        onSuccess();
-      });
-
-      expect(screen.getByText('Movie Downloaded')).toBeInTheDocument();
-
-      act(() => vi.advanceTimersByTime(1500));
-      expect(onClose).toHaveBeenCalled();
-
-      vi.useRealTimers();
+      expect(await screen.findByText('Movie Downloaded')).toBeInTheDocument();
+      // The modal intentionally waits 1500ms on the success state before closing.
+      await waitFor(() => expect(onClose).toHaveBeenCalled(), { timeout: 2000 });
     });
 
-    it('shows inline error on download failure', () => {
-      setupDefaults();
+    it('shows inline error on download failure', async () => {
+      downloadAndProtectMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'Download failed' },
+        response: { status: 500 },
+      });
+      const user = userEvent.setup();
       renderModal({ mode: 'download' });
 
-      fireEvent.click(screen.getByText('Download'));
+      await user.click(screen.getByText('Download'));
 
-      const onError = downloadAndProtectOpts.onError as (err: { message: string }) => void;
-      act(() => {
-        onError({ message: 'Download failed' });
-      });
-
-      expect(screen.getByText('Download failed')).toBeInTheDocument();
+      expect(await screen.findByText('Download failed')).toBeInTheDocument();
     });
   });
 });

--- a/packages/app-media/src/components/RequestSeriesModal.test.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.test.tsx
@@ -1,46 +1,24 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────
+const qualityProfilesMock = vi.hoisted(() => vi.fn());
+const rootFoldersMock = vi.hoisted(() => vi.fn());
+const languageProfilesMock = vi.hoisted(() => vi.fn());
+const addSeriesMock = vi.hoisted(() => vi.fn());
 
-const mockProfilesQuery = vi.fn();
-const mockFoldersQuery = vi.fn();
-const mockLanguagesQuery = vi.fn();
-const mockAddSeriesMutate = vi.fn();
-let addSeriesOpts: Record<string, unknown> = {};
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    _input: unknown,
-    opts?: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.getSonarrQualityProfiles') return mockProfilesQuery(_input, opts);
-    if (key === 'arr.getSonarrRootFolders') return mockFoldersQuery(_input, opts);
-    if (key === 'arr.getSonarrLanguageProfiles') return mockLanguagesQuery(_input, opts);
-    return { data: null, isLoading: false, error: null };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'arr.addSeries') {
-      addSeriesOpts = opts;
-      return { mutate: mockAddSeriesMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  arrGetSonarrQualityProfiles: (...args: unknown[]) => qualityProfilesMock(...args),
+  arrGetSonarrRootFolders: (...args: unknown[]) => rootFoldersMock(...args),
+  arrGetSonarrLanguageProfiles: (...args: unknown[]) => languageProfilesMock(...args),
+  arrAddSeries: (...args: unknown[]) => addSeriesMock(...args),
 }));
 
 import { RequestSeriesModal } from './RequestSeriesModal';
 
 import type { SeasonInfo } from './RequestSeriesModal';
-
-// ── Helpers ────────────────────────────────────────────────────────────────
 
 const profiles = [
   { id: 1, name: 'HD - 720p/1080p' },
@@ -69,40 +47,25 @@ const futureSeasons: SeasonInfo[] = [
 
 const mixedSeasons: SeasonInfo[] = [...pastSeasons, ...futureSeasons];
 
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
 function setupDefaults(
   overrides: {
-    profilesLoading?: boolean;
-    foldersLoading?: boolean;
-    languagesLoading?: boolean;
     profileList?: typeof profiles;
     folderList?: typeof folders;
     languageList?: typeof languageProfiles;
   } = {}
 ) {
   const {
-    profilesLoading = false,
-    foldersLoading = false,
-    languagesLoading = false,
     profileList = profiles,
     folderList = folders,
     languageList = languageProfiles,
   } = overrides;
-
-  mockProfilesQuery.mockReturnValue({
-    isLoading: profilesLoading,
-    data: profilesLoading ? null : { data: profileList },
-    refetch: vi.fn(),
-  });
-  mockFoldersQuery.mockReturnValue({
-    isLoading: foldersLoading,
-    data: foldersLoading ? null : { data: folderList },
-    refetch: vi.fn(),
-  });
-  mockLanguagesQuery.mockReturnValue({
-    isLoading: languagesLoading,
-    data: languagesLoading ? null : { data: languageList },
-    refetch: vi.fn(),
-  });
+  qualityProfilesMock.mockResolvedValue(ok({ data: profileList }));
+  rootFoldersMock.mockResolvedValue(ok({ data: folderList }));
+  languageProfilesMock.mockResolvedValue(ok({ data: languageList }));
 }
 
 const defaultProps = {
@@ -114,239 +77,248 @@ const defaultProps = {
   seasons: mixedSeasons,
 };
 
-function renderModal(props: Partial<typeof defaultProps> = {}) {
-  return render(<RequestSeriesModal {...defaultProps} {...props} />);
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
 }
 
-// ── Tests ──────────────────────────────────────────────────────────────────
+function renderModal(props: Partial<typeof defaultProps> = {}) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<RequestSeriesModal {...defaultProps} {...props} />, { wrapper });
+}
+
+/** Resolves once the option dropdowns have hydrated from the SDK mocks. */
+async function awaitFormReady() {
+  await waitFor(() => {
+    const select = document.querySelector('#language-profile') as HTMLSelectElement | null;
+    expect(select?.value).toBe('1');
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
-  addSeriesOpts = {};
+  setupDefaults();
+  addSeriesMock.mockResolvedValue(ok({ data: { id: 1 } }));
 });
 
 describe('RequestSeriesModal', () => {
   it('shows series title and year in header', () => {
-    setupDefaults();
     renderModal();
 
     expect(screen.getByText('Request Series')).toBeInTheDocument();
     expect(screen.getByText('Breaking Bad (2008)')).toBeInTheDocument();
   });
 
-  it('populates quality profile dropdown from API', () => {
-    setupDefaults();
+  it('populates quality profile dropdown from API', async () => {
     renderModal();
 
+    await awaitFormReady();
     const select = document.querySelector('#quality-profile') as HTMLSelectElement;
-    expect(select).toBeTruthy();
     const options = select.querySelectorAll('option');
     expect(options).toHaveLength(2);
     expect(options[0]!.textContent).toBe('HD - 720p/1080p');
     expect(options[1]!.textContent).toBe('Ultra-HD');
   });
 
-  it('populates root folder dropdown with free space', () => {
-    setupDefaults();
+  it('populates root folder dropdown with free space', async () => {
     renderModal();
 
+    await awaitFormReady();
     const select = document.querySelector('#root-folder') as HTMLSelectElement;
-    expect(select).toBeTruthy();
     const options = select.querySelectorAll('option');
     expect(options).toHaveLength(2);
     expect(options[0]!.textContent).toContain('/tv');
     expect(options[0]!.textContent).toContain('GB free');
   });
 
-  it('populates language profile dropdown from API', () => {
-    setupDefaults();
+  it('populates language profile dropdown from API', async () => {
     renderModal();
 
+    await awaitFormReady();
     const select = document.querySelector('#language-profile') as HTMLSelectElement;
-    expect(select).toBeTruthy();
     const options = select.querySelectorAll('option');
     expect(options).toHaveLength(2);
     expect(options[0]!.textContent).toBe('English');
     expect(options[1]!.textContent).toBe('Any');
   });
 
-  it('defaults to first quality profile, root folder, and language profile', () => {
-    setupDefaults();
+  it('defaults to first quality profile, root folder, and language profile', async () => {
     renderModal();
 
+    await awaitFormReady();
     expect((document.querySelector('#quality-profile') as HTMLSelectElement).value).toBe('1');
     expect((document.querySelector('#root-folder') as HTMLSelectElement).value).toBe('/tv');
     expect((document.querySelector('#language-profile') as HTMLSelectElement).value).toBe('1');
   });
 
-  it('applies smart season defaults — future checked, past unchecked', () => {
-    setupDefaults();
+  it('applies smart season defaults — future checked, past unchecked', async () => {
     renderModal();
 
+    await awaitFormReady();
     const checkboxes = screen.getAllByRole('checkbox');
-    // Season 1 (2020) and Season 2 (2021) should be unchecked
     expect(checkboxes[0]).not.toBeChecked(); // Season 1
     expect(checkboxes[1]).not.toBeChecked(); // Season 2
-    // Season 3 (2028) and Season 4 (null/unannounced) should be checked
     expect(checkboxes[2]).toBeChecked(); // Season 3
     expect(checkboxes[3]).toBeChecked(); // Season 4
   });
 
-  it('allows toggling individual season checkboxes', () => {
-    setupDefaults();
+  it('allows toggling individual season checkboxes', async () => {
+    const user = userEvent.setup();
     renderModal();
 
+    await awaitFormReady();
     const checkboxes = screen.getAllByRole('checkbox');
-    // Toggle Season 1 on
-    fireEvent.click(checkboxes[0]!);
+    await user.click(checkboxes[0]!);
     expect(checkboxes[0]!).toBeChecked();
-    // Toggle Season 3 off
-    fireEvent.click(checkboxes[2]!);
+    await user.click(checkboxes[2]!);
     expect(checkboxes[2]!).not.toBeChecked();
   });
 
-  it('shows Select All / Deselect All when more than 3 seasons', () => {
-    setupDefaults();
+  it('shows Select All / Deselect All when more than 3 seasons', async () => {
     renderModal();
 
+    await awaitFormReady();
     expect(screen.getByText('Select All')).toBeInTheDocument();
     expect(screen.getByText('Deselect All')).toBeInTheDocument();
   });
 
-  it('does not show bulk controls when 3 or fewer seasons', () => {
-    setupDefaults();
+  it('does not show bulk controls when 3 or fewer seasons', async () => {
     renderModal({ seasons: pastSeasons });
 
+    await awaitFormReady();
     expect(screen.queryByText('Select All')).not.toBeInTheDocument();
     expect(screen.queryByText('Deselect All')).not.toBeInTheDocument();
   });
 
-  it('Select All checks all seasons', () => {
-    setupDefaults();
+  it('Select All checks all seasons', async () => {
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Select All'));
+    await awaitFormReady();
+    await user.click(screen.getByText('Select All'));
 
-    const checkboxes = screen.getAllByRole('checkbox');
-    for (const cb of checkboxes) {
+    for (const cb of screen.getAllByRole('checkbox')) {
       expect(cb).toBeChecked();
     }
   });
 
-  it('Deselect All unchecks all seasons', () => {
-    setupDefaults();
+  it('Deselect All unchecks all seasons', async () => {
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Deselect All'));
+    await awaitFormReady();
+    await user.click(screen.getByText('Deselect All'));
 
-    const checkboxes = screen.getAllByRole('checkbox');
-    for (const cb of checkboxes) {
+    for (const cb of screen.getAllByRole('checkbox')) {
       expect(cb).not.toBeChecked();
     }
   });
 
-  it('sends correct addSeries payload on confirm', () => {
-    setupDefaults();
+  it('sends correct addSeries payload on confirm', async () => {
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Request'));
+    await awaitFormReady();
+    await user.click(screen.getByText('Request'));
 
-    expect(mockAddSeriesMutate).toHaveBeenCalledWith({
-      tvdbId: 81189,
-      title: 'Breaking Bad',
-      qualityProfileId: 1,
-      rootFolderPath: '/tv',
-      languageProfileId: 1,
-      seasons: [
-        { seasonNumber: 1, monitored: false },
-        { seasonNumber: 2, monitored: false },
-        { seasonNumber: 3, monitored: true },
-        { seasonNumber: 4, monitored: true },
-      ],
-    });
+    await waitFor(() =>
+      expect(addSeriesMock).toHaveBeenCalledWith({
+        body: {
+          tvdbId: 81189,
+          title: 'Breaking Bad',
+          qualityProfileId: 1,
+          rootFolderPath: '/tv',
+          languageProfileId: 1,
+          seasons: [
+            { seasonNumber: 1, monitored: false },
+            { seasonNumber: 2, monitored: false },
+            { seasonNumber: 3, monitored: true },
+            { seasonNumber: 4, monitored: true },
+          ],
+        },
+      })
+    );
   });
 
-  it('calls onClose after successful add', () => {
-    vi.useFakeTimers();
-    setupDefaults();
+  it('calls onClose after successful add', async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     renderModal({ onClose });
 
-    fireEvent.click(screen.getByText('Request'));
+    await awaitFormReady();
+    await user.click(screen.getByText('Request'));
 
-    const onSuccess = addSeriesOpts.onSuccess as () => void;
-    act(() => {
-      onSuccess();
-    });
-
-    expect(screen.getByText('Series Added')).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(1500));
-    expect(onClose).toHaveBeenCalled();
-
-    vi.useRealTimers();
+    expect(await screen.findByText('Series Added')).toBeInTheDocument();
+    // The modal intentionally waits 1500ms on the success state before closing.
+    await waitFor(() => expect(onClose).toHaveBeenCalled(), { timeout: 2000 });
   });
 
-  it('shows inline error on failure', () => {
-    setupDefaults();
+  it('shows inline error on failure', async () => {
+    addSeriesMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'Series already exists in Sonarr' },
+      response: { status: 409 },
+    });
+    const user = userEvent.setup();
     renderModal();
 
-    fireEvent.click(screen.getByText('Request'));
+    await awaitFormReady();
+    await user.click(screen.getByText('Request'));
 
-    const onError = addSeriesOpts.onError as (err: { message: string }) => void;
-    act(() => {
-      onError({ message: 'Series already exists in Sonarr' });
-    });
-
-    expect(screen.getByText('Series already exists in Sonarr')).toBeInTheDocument();
+    expect(await screen.findByText('Series already exists in Sonarr')).toBeInTheDocument();
   });
 
-  it('calls onClose on cancel without API call', () => {
-    setupDefaults();
+  it('calls onClose on cancel without API call', async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     renderModal({ onClose });
 
-    fireEvent.click(screen.getByText('Cancel'));
+    await user.click(screen.getByText('Cancel'));
     expect(onClose).toHaveBeenCalled();
-    expect(mockAddSeriesMutate).not.toHaveBeenCalled();
+    expect(addSeriesMock).not.toHaveBeenCalled();
   });
 
   it('shows loading state while fetching options', () => {
-    setupDefaults({ profilesLoading: true });
+    qualityProfilesMock.mockReturnValue(new Promise(() => {}));
     renderModal();
 
     expect(screen.getByText('Loading options...')).toBeInTheDocument();
   });
 
-  it('shows retry when no profiles available', () => {
+  it('shows retry when no profiles available', async () => {
     setupDefaults({ profileList: [] });
     renderModal();
 
-    expect(screen.getByText(/No quality profiles found/)).toBeInTheDocument();
+    expect(await screen.findByText(/No quality profiles found/)).toBeInTheDocument();
     expect(screen.getByText('Retry')).toBeInTheDocument();
   });
 
-  it('shows retry when no language profiles available', () => {
+  it('shows retry when no language profiles available', async () => {
     setupDefaults({ languageList: [] });
     renderModal();
 
-    expect(screen.getByText(/No language profiles found/)).toBeInTheDocument();
+    expect(await screen.findByText(/No language profiles found/)).toBeInTheDocument();
   });
 
-  it('displays season year from firstAirDate', () => {
-    setupDefaults();
+  it('displays season year from firstAirDate', async () => {
     renderModal();
 
+    await awaitFormReady();
     expect(screen.getByText('— 2020')).toBeInTheDocument();
     expect(screen.getByText('— 2028')).toBeInTheDocument();
   });
 
-  it('displays Specials for season 0', () => {
-    setupDefaults();
-    renderModal({
-      seasons: [{ seasonNumber: 0, firstAirDate: '2019-01-01' }],
-    });
+  it('displays Specials for season 0', async () => {
+    renderModal({ seasons: [{ seasonNumber: 0, firstAirDate: '2019-01-01' }] });
 
+    await awaitFormReady();
     expect(screen.getByText('Specials')).toBeInTheDocument();
   });
 });

--- a/packages/app-media/src/components/ShelfSection.test.tsx
+++ b/packages/app-media/src/components/ShelfSection.test.tsx
@@ -1,21 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ── Mocks ─────────────────────────────────────────────────────────────────────
+const getShelfPageMock = vi.hoisted(() => vi.fn());
 
-const mockGetShelfPageFetch = vi.fn();
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: vi.fn(),
-    fetchQuery: (path: readonly string[], input: unknown) => {
-      const key = path.join('.');
-      if (key === 'discovery.getShelfPage') return mockGetShelfPageFetch(input);
-      return Promise.resolve(undefined);
-    },
-  }),
+vi.mock('../media-api/index.js', () => ({
+  discoveryGetShelfPage: (...args: unknown[]) => getShelfPageMock(...args),
 }));
 
 // Mock IntersectionObserver — trigger callback immediately to make sections visible
@@ -28,14 +20,13 @@ vi.stubGlobal(
     this: IntersectionObserver,
     callback: IntersectionObserverCallback
   ) {
-    // Immediately fire as intersecting
     callback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
     this.observe = mockObserve;
     this.disconnect = mockDisconnect;
   })
 );
 
-// Mock DiscoverCard to avoid pulling in RequestMovieButton (which requires trpc.media.arr)
+// Mock DiscoverCard to avoid pulling in RequestMovieButton (which requires the arr SDK)
 vi.mock('./DiscoverCard', () => ({
   DiscoverCard: ({ title, tmdbId }: { title: string; tmdbId: number }) => (
     <div data-testid={`card-${tmdbId}`}>{title}</div>
@@ -44,7 +35,9 @@ vi.mock('./DiscoverCard', () => ({
 
 import { ShelfSection } from './ShelfSection';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
 
 function makeItem(tmdbId: number) {
   return {
@@ -76,6 +69,12 @@ const noopActions = {
   onNotInterested: vi.fn(async () => ({ ok: true })),
 };
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
 function renderShelf(
   overrides: Partial<{
     shelfId: string;
@@ -83,8 +82,12 @@ function renderShelf(
     subtitle: string;
     initialItems: ReturnType<typeof makeItem>[];
     hasMore: boolean;
+    dismissedSet: Set<number>;
   }> = {}
 ) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return render(
     <ShelfSection
       shelfId={overrides.shelfId ?? 'best-in-genre:drama'}
@@ -93,20 +96,22 @@ function renderShelf(
       initialItems={overrides.initialItems ?? [makeItem(1), makeItem(2), makeItem(3)]}
       hasMore={overrides.hasMore ?? false}
       {...noopActions}
-    />
+      dismissedSet={overrides.dismissedSet ?? noopActions.dismissedSet}
+    />,
+    { wrapper }
   );
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockGetShelfPageFetch.mockResolvedValue({
-    items: [makeItem(101), makeItem(102)],
-    hasMore: false,
-    totalCount: null,
-  });
+afterEach(() => {
+  cleanup();
 });
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  vi.clearAllMocks();
+  getShelfPageMock.mockResolvedValue(
+    ok({ items: [makeItem(101), makeItem(102)], hasMore: false, totalCount: null })
+  );
+});
 
 describe('ShelfSection — rendering', () => {
   it('renders shelf title', () => {
@@ -127,27 +132,10 @@ describe('ShelfSection — rendering', () => {
   });
 
   it('hides dismissed items', () => {
-    render(
-      <ShelfSection
-        shelfId="best-in-genre:drama"
-        title="Best in Drama"
-        initialItems={[makeItem(1), makeItem(2), makeItem(3)]}
-        hasMore={false}
-        dismissedSet={new Set([2])}
-        addingToLibrary={new Set()}
-        addingToWatchlist={new Set()}
-        removingFromWatchlist={new Set()}
-        markingWatched={new Set()}
-        markingRewatched={new Set()}
-        dismissing={new Set()}
-        onAddToLibrary={vi.fn(async () => ({ ok: true }))}
-        onAddToWatchlist={vi.fn(async () => ({ ok: true }))}
-        onRemoveFromWatchlist={vi.fn(async () => ({ ok: true }))}
-        onMarkWatched={vi.fn(async () => ({ ok: true }))}
-        onMarkRewatched={vi.fn(async () => ({ ok: true }))}
-        onNotInterested={vi.fn(async () => ({ ok: true }))}
-      />
-    );
+    renderShelf({
+      initialItems: [makeItem(1), makeItem(2), makeItem(3)],
+      dismissedSet: new Set([2]),
+    });
     expect(screen.getByText('Movie 1')).toBeInTheDocument();
     expect(screen.queryByText('Movie 2')).not.toBeInTheDocument();
     expect(screen.getByText('Movie 3')).toBeInTheDocument();
@@ -165,7 +153,7 @@ describe('ShelfSection — show more', () => {
     expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
   });
 
-  it('calls getShelfPage.fetch with correct shelfId and offset on Show more click', async () => {
+  it('calls getShelfPage with correct shelfId and offset on Show more click', async () => {
     const user = userEvent.setup();
     renderShelf({
       shelfId: 'best-in-genre:drama',
@@ -175,22 +163,19 @@ describe('ShelfSection — show more', () => {
 
     await user.click(screen.getByRole('button', { name: /show more/i }));
 
-    await waitFor(() => {
-      expect(mockGetShelfPageFetch).toHaveBeenCalledWith(
+    await waitFor(() =>
+      expect(getShelfPageMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          shelfId: 'best-in-genre:drama',
-          offset: 3,
+          path: { shelfId: 'best-in-genre:drama' },
+          query: expect.objectContaining({ offset: 3 }),
         })
-      );
-    });
+      )
+    );
   });
 
   it('appends new items after Show more', async () => {
     const user = userEvent.setup();
-    renderShelf({
-      initialItems: [makeItem(1), makeItem(2), makeItem(3)],
-      hasMore: true,
-    });
+    renderShelf({ initialItems: [makeItem(1), makeItem(2), makeItem(3)], hasMore: true });
 
     await user.click(screen.getByRole('button', { name: /show more/i }));
 
@@ -202,25 +187,22 @@ describe('ShelfSection — show more', () => {
 
   it('hides Show more button after last page loaded (hasMore=false from server)', async () => {
     const user = userEvent.setup();
-    mockGetShelfPageFetch.mockResolvedValue({
-      items: [makeItem(101)],
-      hasMore: false,
-      totalCount: null,
-    });
+    getShelfPageMock.mockResolvedValue(
+      ok({ items: [makeItem(101)], hasMore: false, totalCount: null })
+    );
 
     renderShelf({ hasMore: true });
 
     await user.click(screen.getByRole('button', { name: /show more/i }));
 
-    await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument()
+    );
   });
 });
 
 describe('ShelfSection — lazy loading', () => {
   it('renders content immediately when IntersectionObserver fires on mount', () => {
-    // Our mock IntersectionObserver fires immediately, so content is visible
     renderShelf({ title: 'Best in Drama', initialItems: [makeItem(1)] });
     expect(screen.getByText('Best in Drama')).toBeInTheDocument();
     expect(screen.getByText('Movie 1')).toBeInTheDocument();

--- a/packages/app-media/src/components/SourceManagementSection.tsx
+++ b/packages/app-media/src/components/SourceManagementSection.tsx
@@ -1,6 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * SourceManagementSection — CRUD UI for rotation source management.
  *
@@ -8,6 +8,8 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  */
 import { CRUDManagementSection } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { rotationListSources, rotationSourceTypes } from '../media-api/index.js';
 import { SourceCard } from './source-management/SourceCard';
 import { SourceForm } from './source-management/SourceForm';
 
@@ -36,6 +38,33 @@ function toFormValues(source: Source): SourceFormValues {
     config: parseConfig(source.config),
     syncIntervalHours: source.syncIntervalHours,
   };
+}
+
+async function fetchSources(): Promise<Source[]> {
+  const { data } = await unwrap(await rotationListSources());
+  return data.map((s) => ({
+    id: s.id,
+    type: s.type,
+    name: s.name,
+    priority: s.priority,
+    enabled: s.enabled ? 1 : 0,
+    config: JSON.stringify(s.config),
+    lastSyncedAt: s.lastSyncedAt,
+    syncIntervalHours: s.syncIntervalHours,
+    candidateCount: s.candidateCount,
+  }));
+}
+
+function useSourceQueries() {
+  const sourcesQuery = useQuery<Source[]>({
+    queryKey: ['media', 'rotation', 'listSources'],
+    queryFn: fetchSources,
+  });
+  const sourceTypesQuery = useQuery<SourceTypesResult>({
+    queryKey: ['media', 'rotation', 'sourceTypes'],
+    queryFn: async () => (await unwrap(await rotationSourceTypes())).data,
+  });
+  return { sourcesQuery, sourceTypesQuery };
 }
 
 function SourceList({
@@ -69,12 +98,7 @@ function SourceList({
 }
 
 export function SourceManagementSection() {
-  const sourcesQuery = usePillarQuery<Source[]>('media', ['rotation', 'listSources'], undefined);
-  const sourceTypesQuery = usePillarQuery<SourceTypesResult>(
-    'media',
-    ['rotation', 'sourceTypes'],
-    undefined
-  );
+  const { sourcesQuery, sourceTypesQuery } = useSourceQueries();
 
   const [showForm, setShowForm] = useState<'create' | 'edit' | null>(null);
   const [editingSource, setEditingSource] = useState<SourceFormValues | null>(null);

--- a/packages/app-media/src/components/dimension-manager/useDimensionManagerModel.ts
+++ b/packages/app-media/src/components/dimension-manager/useDimensionManagerModel.ts
@@ -1,7 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsListDimensions } from '../../media-api/index.js';
 import { reorderDimension, useDimensionMutations } from './useDimensionMutations';
 
 import type { Dimension, EditState } from './types';
@@ -32,21 +33,30 @@ export interface DimensionManagerModel {
   handleReorder: (dim: Dimension, direction: 'up' | 'down') => void;
 }
 
-function normalizeDimensions(
-  raw: ReadonlyArray<{
-    id: number;
-    name: string;
-    description: string | null;
-    active: boolean | number;
-    sortOrder: number;
-    weight: number | null;
-  }>
-): Dimension[] {
+interface RawDimension {
+  id: number;
+  name: string;
+  description: string | null;
+  active: boolean | number;
+  sortOrder: number;
+  weight: number | null;
+}
+
+function normalizeDimensions(raw: ReadonlyArray<RawDimension>): Dimension[] {
   return raw.map((d) => ({
     ...d,
     active: Boolean(d.active),
     weight: d.weight ?? 1.0,
   }));
+}
+
+function useDimensionsQuery(open: boolean) {
+  const { data, isLoading } = useQuery<{ data: ReadonlyArray<RawDimension> }>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+    enabled: open,
+  });
+  return { dimensions: normalizeDimensions(data?.data ?? []), isLoading };
 }
 
 export function useDimensionManagerModel(): DimensionManagerModel {
@@ -56,18 +66,7 @@ export function useDimensionManagerModel(): DimensionManagerModel {
   const [addDescription, setAddDescription] = useState('');
   const [editing, setEditing] = useState<EditState | null>(null);
 
-  const { data: dimensionsData, isLoading } = usePillarQuery<{
-    data: ReadonlyArray<{
-      id: number;
-      name: string;
-      description: string | null;
-      active: boolean | number;
-      sortOrder: number;
-      weight: number | null;
-    }>;
-  }>('media', ['comparisons', 'listDimensions'], undefined, { enabled: open });
-
-  const dimensions = normalizeDimensions(dimensionsData?.data ?? []);
+  const { dimensions, isLoading } = useDimensionsQuery(open);
 
   const mutations = useDimensionMutations({
     dimensionsLength: dimensions.length,

--- a/packages/app-media/src/components/dimension-manager/useDimensionMutations.ts
+++ b/packages/app-media/src/components/dimension-manager/useDimensionMutations.ts
@@ -1,7 +1,9 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, type UsePillarMutationResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsCreateDimension, comparisonsUpdateDimension } from '../../media-api/index.js';
 
 import type { Dimension, EditState } from './types';
 
@@ -33,35 +35,35 @@ interface UpdateDimensionInput {
   };
 }
 
-type UpdateMutation = UsePillarMutationResult<UpdateDimensionInput, unknown>;
+type UpdateMutation = UseMutationResult<unknown, Error, UpdateDimensionInput>;
 
 function useCoreMutations(
   args: Pick<MutationsArgs, 'setEditing' | 'setAddName' | 'setAddDescription'>
 ) {
-  const createMutation = usePillarMutation<CreateDimensionInput, unknown>(
-    'media',
-    ['comparisons', 'createDimension'],
-    {
-      onSuccess: () => {
-        args.setAddName('');
-        args.setAddDescription('');
-        toast.success('Dimension created');
-      },
-      onError: (err) => toast.error(err.message),
-    }
-  );
+  const queryClient = useQueryClient();
 
-  const updateMutation = usePillarMutation<UpdateDimensionInput, unknown>(
-    'media',
-    ['comparisons', 'updateDimension'],
-    {
-      onSuccess: () => {
-        args.setEditing(null);
-        toast.success('Dimension updated');
-      },
-      onError: (err) => toast.error(err.message),
-    }
-  );
+  const createMutation = useMutation({
+    mutationFn: async (input: CreateDimensionInput) =>
+      unwrap(await comparisonsCreateDimension({ body: { ...input, active: true, weight: 1 } })),
+    onSuccess: () => {
+      args.setAddName('');
+      args.setAddDescription('');
+      toast.success('Dimension created');
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons'] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (input: UpdateDimensionInput) =>
+      unwrap(await comparisonsUpdateDimension({ path: { id: input.id }, body: input.data })),
+    onSuccess: () => {
+      args.setEditing(null);
+      toast.success('Dimension updated');
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons'] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
 
   return { createMutation, updateMutation };
 }

--- a/packages/app-media/src/components/mark-as-watched/useMarkAsWatched.ts
+++ b/packages/app-media/src/components/mark-as-watched/useMarkAsWatched.ts
@@ -1,8 +1,14 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  watchHistoryDelete,
+  watchHistoryList,
+  watchHistoryLog,
+  watchlistAdd,
+} from '../../media-api/index.js';
 
 interface WatchHistoryEntry {
   id: number;
@@ -39,24 +45,26 @@ function useCrossRouterInvalidation() {
 }
 
 function useUndoMutation(mediaId: number) {
+  const queryClient = useQueryClient();
   const invalidateCross = useCrossRouterInvalidation();
-  const addToWatchlistMutation = usePillarMutation<AddToWatchlistInput, unknown>('media', [
-    'watchlist',
-    'add',
-  ]);
-  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
-    'media',
-    ['watchHistory', 'delete'],
-    {
-      onSuccess: () => {
-        toast.success('Watch entry undone');
-        invalidateCross();
-      },
-      onError: (err) => {
-        toast.error(`Failed to undo: ${err.message}`);
-      },
-    }
-  );
+  const addToWatchlistMutation = useMutation({
+    mutationFn: async (input: AddToWatchlistInput) => unwrap(await watchlistAdd({ body: input })),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+    },
+  });
+  const deleteMutation = useMutation({
+    mutationFn: async (input: { id: number }) =>
+      unwrap(await watchHistoryDelete({ path: { id: input.id } })),
+    onSuccess: () => {
+      toast.success('Watch entry undone');
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
+      invalidateCross();
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to undo: ${err.message}`);
+    },
+  });
 
   const handleUndo = (entryId: number, watchlistRemoved: boolean) => {
     deleteMutation.mutate(
@@ -83,8 +91,21 @@ function useLogMutation({
   setShowDatePicker: (v: boolean) => void;
   setCustomDate: (v: string) => void;
 }) {
+  const queryClient = useQueryClient();
   const invalidateCross = useCrossRouterInvalidation();
-  return usePillarMutation<LogInput, LogResult>('media', ['watchHistory', 'log'], {
+  return useMutation({
+    mutationFn: async (input: LogInput) =>
+      unwrap<LogResult>(
+        await watchHistoryLog({
+          body: {
+            mediaType: input.mediaType,
+            mediaId: input.mediaId,
+            completed: input.completed ?? 1,
+            source: 'manual',
+            watchedAt: input.watchedAt,
+          },
+        })
+      ),
     onSuccess: (result) => {
       toast.success('Marked as watched', {
         duration: 5000,
@@ -95,11 +116,12 @@ function useLogMutation({
           },
         },
       });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
       invalidateCross();
       setShowDatePicker(false);
       setCustomDate('');
     },
-    onError: (err) => {
+    onError: (err: Error) => {
       toast.error(`Failed to log watch: ${err.message}`);
     },
   });
@@ -109,12 +131,12 @@ export function useMarkAsWatched(mediaId: number) {
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [customDate, setCustomDate] = useState('');
 
-  const { data: historyData } = usePillarQuery<WatchHistoryListResult>(
-    'media',
-    ['watchHistory', 'list'],
-    { mediaType: 'movie', mediaId, limit: 100 },
-    { staleTime: 30_000 }
-  );
+  const { data: historyData } = useQuery<WatchHistoryListResult>({
+    queryKey: ['media', 'watchHistory', 'list', { mediaType: 'movie', mediaId, limit: 100 }],
+    queryFn: async () =>
+      unwrap(await watchHistoryList({ query: { mediaType: 'movie', mediaId, limit: 100 } })),
+    staleTime: 30_000,
+  });
 
   const watchCount = historyData?.data?.length ?? 0;
   const lastWatched = historyData?.data?.[0]?.watchedAt;

--- a/packages/app-media/src/components/movie-action-buttons/useRotationButtonsModel.ts
+++ b/packages/app-media/src/components/movie-action-buttons/useRotationButtonsModel.ts
@@ -1,6 +1,15 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  arrConfig,
+  arrGetMovieStatus,
+  rotationAddToQueue,
+  rotationGetCandidateStatus,
+  rotationRemoveExclusion,
+  rotationRemoveFromQueue,
+} from '../../media-api/index.js';
 
 interface ArrConfigResult {
   data: { radarrConfigured: boolean; sonarrConfigured: boolean };
@@ -17,56 +26,64 @@ interface CandidateStatusResult {
 
 interface AddToQueueInput {
   tmdbId: number;
-  title?: string;
+  title: string;
   year?: number;
   posterPath?: string;
   rating?: number;
 }
 
 export function useRotationButtonsModel(tmdbId: number) {
-  const { data: configData } = usePillarQuery<ArrConfigResult>(
-    'media',
-    ['arr', 'getConfig'],
-    undefined
-  );
+  const queryClient = useQueryClient();
+
+  const { data: configData } = useQuery<ArrConfigResult>({
+    queryKey: ['media', 'arr', 'getConfig'],
+    queryFn: async () => unwrap(await arrConfig()),
+  });
   const radarrConfigured = configData?.data?.radarrConfigured === true;
 
-  const movieStatus = usePillarQuery<MovieStatusResult>(
-    'media',
-    ['arr', 'getMovieStatus'],
-    { tmdbId },
-    { enabled: radarrConfigured }
-  );
+  const movieStatus = useQuery<MovieStatusResult>({
+    queryKey: ['media', 'arr', 'getMovieStatus', { tmdbId }],
+    queryFn: async () => unwrap(await arrGetMovieStatus({ path: { tmdbId } })),
+    enabled: radarrConfigured,
+  });
 
-  const { data: candidateData, isLoading: candidateLoading } =
-    usePillarQuery<CandidateStatusResult>('media', ['rotation', 'getCandidateStatus'], { tmdbId });
+  const { data: candidateData, isLoading: candidateLoading } = useQuery<CandidateStatusResult>({
+    queryKey: ['media', 'rotation', 'getCandidateStatus', { tmdbId }],
+    queryFn: async () =>
+      (await unwrap(await rotationGetCandidateStatus({ path: { tmdbId } }))).data,
+  });
 
-  const addToQueueMutation = usePillarMutation<AddToQueueInput, unknown>(
-    'media',
-    ['rotation', 'addToQueue'],
-    {
-      onSuccess: () => toast.success('Added to rotation queue'),
-      onError: () => toast.error('Failed to add to queue'),
-    }
-  );
+  const invalidateRotation = () =>
+    void queryClient.invalidateQueries({ queryKey: ['media', 'rotation'] });
 
-  const removeFromQueueMutation = usePillarMutation<{ tmdbId: number }, unknown>(
-    'media',
-    ['rotation', 'removeFromQueue'],
-    {
-      onSuccess: () => toast.success('Removed from queue'),
-      onError: () => toast.error('Failed to remove from queue'),
-    }
-  );
+  const addToQueueMutation = useMutation({
+    mutationFn: async (input: AddToQueueInput) => unwrap(await rotationAddToQueue({ body: input })),
+    onSuccess: () => {
+      toast.success('Added to rotation queue');
+      invalidateRotation();
+    },
+    onError: () => toast.error('Failed to add to queue'),
+  });
 
-  const removeExclusionMutation = usePillarMutation<{ tmdbId: number }, unknown>(
-    'media',
-    ['rotation', 'removeExclusion'],
-    {
-      onSuccess: () => toast.success('Exclusion removed'),
-      onError: () => toast.error('Failed to remove exclusion'),
-    }
-  );
+  const removeFromQueueMutation = useMutation({
+    mutationFn: async (input: { tmdbId: number }) =>
+      unwrap(await rotationRemoveFromQueue({ path: { tmdbId: input.tmdbId } })),
+    onSuccess: () => {
+      toast.success('Removed from queue');
+      invalidateRotation();
+    },
+    onError: () => toast.error('Failed to remove from queue'),
+  });
+
+  const removeExclusionMutation = useMutation({
+    mutationFn: async (input: { tmdbId: number }) =>
+      unwrap(await rotationRemoveExclusion({ path: { tmdbId: input.tmdbId } })),
+    onSuccess: () => {
+      toast.success('Exclusion removed');
+      invalidateRotation();
+    },
+    onError: () => toast.error('Failed to remove exclusion'),
+  });
 
   return {
     radarrConfigured,

--- a/packages/app-media/src/components/request-movie/useRequestMovieModel.ts
+++ b/packages/app-media/src/components/request-movie/useRequestMovieModel.ts
@@ -1,6 +1,13 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  arrAddMovie,
+  arrDownloadAndProtect,
+  arrGetRadarrQualityProfiles,
+  arrGetRadarrRootFolders,
+} from '../../media-api/index.js';
 
 interface QualityProfile {
   id: number;
@@ -44,13 +51,15 @@ interface RequestMovieModelArgs {
 }
 
 function useProfilesAndFolders(open: boolean, isDownloadMode: boolean) {
-  const profiles = usePillarQuery<QualityProfilesResult>(
-    'media',
-    ['arr', 'getQualityProfiles'],
-    undefined,
-    { enabled: open && !isDownloadMode, retry: false }
-  );
-  const folders = usePillarQuery<RootFoldersResult>('media', ['arr', 'getRootFolders'], undefined, {
+  const profiles = useQuery<QualityProfilesResult>({
+    queryKey: ['media', 'arr', 'getQualityProfiles'],
+    queryFn: async () => unwrap(await arrGetRadarrQualityProfiles()),
+    enabled: open && !isDownloadMode,
+    retry: false,
+  });
+  const folders = useQuery<RootFoldersResult>({
+    queryKey: ['media', 'arr', 'getRootFolders'],
+    queryFn: async () => unwrap(await arrGetRadarrRootFolders()),
     enabled: open && !isDownloadMode,
     retry: false,
   });
@@ -97,27 +106,28 @@ interface MutationArgs {
 }
 
 function useRequestMutations({ onClose, resetState, setError, setSuccess }: MutationArgs) {
+  const queryClient = useQueryClient();
   const onMutationSuccess = () => {
     setSuccess(true);
     setError(null);
+    void queryClient.invalidateQueries({ queryKey: ['media', 'arr'] });
     setTimeout(() => {
       onClose();
       resetState();
     }, 1500);
   };
-  const onMutationError = (err: { message: string }) => setError(err.message);
-  const addMovie = usePillarMutation<AddMovieInput, unknown>('media', ['arr', 'addMovie'], {
+  const onMutationError = (err: Error) => setError(err.message);
+  const addMovie = useMutation({
+    mutationFn: async (input: AddMovieInput) => unwrap(await arrAddMovie({ body: input })),
     onSuccess: onMutationSuccess,
     onError: onMutationError,
   });
-  const downloadAndProtect = usePillarMutation<DownloadAndProtectInput, unknown>(
-    'media',
-    ['arr', 'downloadAndProtect'],
-    {
-      onSuccess: onMutationSuccess,
-      onError: onMutationError,
-    }
-  );
+  const downloadAndProtect = useMutation({
+    mutationFn: async (input: DownloadAndProtectInput) =>
+      unwrap(await arrDownloadAndProtect({ body: input })),
+    onSuccess: onMutationSuccess,
+    onError: onMutationError,
+  });
   return { addMovie, downloadAndProtect };
 }
 

--- a/packages/app-media/src/components/request-series/useRequestSeriesModel.ts
+++ b/packages/app-media/src/components/request-series/useRequestSeriesModel.ts
@@ -1,7 +1,8 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 
-import { usePillarMutation } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../../media-api-helpers.js';
+import { arrAddSeries } from '../../media-api/index.js';
 import { useSeriesDefaults, useSeriesQueries } from './useRequestSeriesQueries';
 
 import type { SeasonInfo } from '../RequestSeriesModal';
@@ -55,16 +56,19 @@ function useSubmit({
   args: ModelArgs;
   resetState: () => void;
 }) {
-  const addSeries = usePillarMutation<AddSeriesInput, unknown>('media', ['arr', 'addSeries'], {
+  const queryClient = useQueryClient();
+  const addSeries = useMutation({
+    mutationFn: async (input: AddSeriesInput) => unwrap(await arrAddSeries({ body: input })),
     onSuccess: () => {
       state.setSuccess(true);
       state.setError(null);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'arr'] });
       setTimeout(() => {
         args.onClose();
         resetState();
       }, 1500);
     },
-    onError: (err) => state.setError(err.message),
+    onError: (err: Error) => state.setError(err.message),
   });
 
   const handleSubmit = () => {

--- a/packages/app-media/src/components/request-series/useRequestSeriesQueries.ts
+++ b/packages/app-media/src/components/request-series/useRequestSeriesQueries.ts
@@ -1,6 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  arrGetSonarrLanguageProfiles,
+  arrGetSonarrQualityProfiles,
+  arrGetSonarrRootFolders,
+} from '../../media-api/index.js';
 
 import type { SeasonInfo } from '../RequestSeriesModal';
 
@@ -52,24 +58,24 @@ interface DefaultsArgs {
 }
 
 export function useSeriesQueries(open: boolean) {
-  const profiles = usePillarQuery<QualityProfilesResult>(
-    'media',
-    ['arr', 'getSonarrQualityProfiles'],
-    undefined,
-    { enabled: open, retry: false }
-  );
-  const folders = usePillarQuery<RootFoldersResult>(
-    'media',
-    ['arr', 'getSonarrRootFolders'],
-    undefined,
-    { enabled: open, retry: false }
-  );
-  const languages = usePillarQuery<LanguageProfilesResult>(
-    'media',
-    ['arr', 'getSonarrLanguageProfiles'],
-    undefined,
-    { enabled: open, retry: false }
-  );
+  const profiles = useQuery<QualityProfilesResult>({
+    queryKey: ['media', 'arr', 'getSonarrQualityProfiles'],
+    queryFn: async () => unwrap(await arrGetSonarrQualityProfiles()),
+    enabled: open,
+    retry: false,
+  });
+  const folders = useQuery<RootFoldersResult>({
+    queryKey: ['media', 'arr', 'getSonarrRootFolders'],
+    queryFn: async () => unwrap(await arrGetSonarrRootFolders()),
+    enabled: open,
+    retry: false,
+  });
+  const languages = useQuery<LanguageProfilesResult>({
+    queryKey: ['media', 'arr', 'getSonarrLanguageProfiles'],
+    queryFn: async () => unwrap(await arrGetSonarrLanguageProfiles()),
+    enabled: open,
+    retry: false,
+  });
   return { profiles, folders, languages };
 }
 

--- a/packages/app-media/src/components/shelf-section/useShelfPagination.ts
+++ b/packages/app-media/src/components/shelf-section/useShelfPagination.ts
@@ -1,7 +1,9 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarUtils } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { discoveryGetShelfPage } from '../../media-api/index.js';
 
 import type { ShelfItem } from './types';
 
@@ -48,7 +50,7 @@ export function useShelfPagination({
   const [loadingMore, setLoadingMore] = useState(false);
   const [offset, setOffset] = useState(initialItems.length);
 
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
 
   const patchItem = useCallback((tmdbId: number, patch: Partial<ShelfItem>) => {
     setItems((prev) => prev.map((i) => (i.tmdbId === tmdbId ? { ...i, ...patch } : i)));
@@ -57,10 +59,20 @@ export function useShelfPagination({
   const handleShowMore = useCallback(async () => {
     setLoadingMore(true);
     try {
-      const data = await utils.fetchQuery<ShelfPageResponse>(['discovery', 'getShelfPage'], {
-        shelfId,
-        limit: LOAD_MORE_LIMIT,
-        offset,
+      const data = await queryClient.fetchQuery<ShelfPageResponse>({
+        queryKey: [
+          'media',
+          'discovery',
+          'getShelfPage',
+          { shelfId, limit: LOAD_MORE_LIMIT, offset },
+        ],
+        queryFn: async () =>
+          unwrap(
+            await discoveryGetShelfPage({
+              path: { shelfId },
+              query: { limit: LOAD_MORE_LIMIT, offset },
+            })
+          ),
       });
       const existingIds = new Set(items.map((i) => i.tmdbId));
       const newItems = data.items.filter((i) => !existingIds.has(i.tmdbId));
@@ -72,7 +84,7 @@ export function useShelfPagination({
     } finally {
       setLoadingMore(false);
     }
-  }, [shelfId, offset, items, utils]);
+  }, [shelfId, offset, items, queryClient]);
 
   return {
     sentinelRef,

--- a/packages/app-media/src/components/source-management/SourceCard.tsx
+++ b/packages/app-media/src/components/source-management/SourceCard.tsx
@@ -1,9 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Clock, Database, RefreshCw, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { usePillarMutation } from '@pops/pillar-sdk/react';
 import { Button, Switch } from '@pops/ui';
 
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  rotationDeleteSource,
+  rotationSyncSource,
+  rotationUpdateSource,
+} from '../../media-api/index.js';
 import { formatSyncDate, sourceTypeLabel, type Source } from './types';
 
 interface SyncSourceResult {
@@ -16,35 +22,38 @@ interface SourceCardProps {
 }
 
 function useSourceMutations(source: Source) {
-  const syncMutation = usePillarMutation<{ sourceId: number }, SyncSourceResult>(
-    'media',
-    ['rotation', 'syncSource'],
-    {
-      onSuccess: (data) => {
-        toast.success(`Synced "${source.name}": ${data.candidatesInserted} new candidates`);
-      },
-      onError: () => toast.error(`Failed to sync "${source.name}"`),
-    }
-  );
+  const queryClient = useQueryClient();
+  const invalidateRotation = () =>
+    void queryClient.invalidateQueries({ queryKey: ['media', 'rotation'] });
 
-  const toggleMutation = usePillarMutation<{ id: number; enabled: boolean }, unknown>(
-    'media',
-    ['rotation', 'updateSource'],
-    {
-      onError: () => toast.error('Failed to update source'),
-    }
-  );
+  const syncMutation = useMutation({
+    mutationFn: async (input: { sourceId: number }): Promise<SyncSourceResult> =>
+      (await unwrap(await rotationSyncSource({ path: { id: input.sourceId } }))).data,
+    onSuccess: (data) => {
+      toast.success(`Synced "${source.name}": ${data.candidatesInserted} new candidates`);
+      invalidateRotation();
+    },
+    onError: () => toast.error(`Failed to sync "${source.name}"`),
+  });
 
-  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
-    'media',
-    ['rotation', 'deleteSource'],
-    {
-      onSuccess: () => {
-        toast.success(`Deleted "${source.name}"`);
-      },
-      onError: (err) => toast.error(err.message || 'Failed to delete source'),
-    }
-  );
+  const toggleMutation = useMutation({
+    mutationFn: async (input: { id: number; enabled: boolean }) =>
+      unwrap(
+        await rotationUpdateSource({ path: { id: input.id }, body: { enabled: input.enabled } })
+      ),
+    onSuccess: invalidateRotation,
+    onError: () => toast.error('Failed to update source'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (input: { id: number }) =>
+      unwrap(await rotationDeleteSource({ path: { id: input.id } })),
+    onSuccess: () => {
+      toast.success(`Deleted "${source.name}"`);
+      invalidateRotation();
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to delete source'),
+  });
 
   return { syncMutation, toggleMutation, deleteMutation };
 }

--- a/packages/app-media/src/components/source-management/useSourceFormModel.ts
+++ b/packages/app-media/src/components/source-management/useSourceFormModel.ts
@@ -1,7 +1,13 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  rotationCreateSource,
+  rotationListPlexFriends,
+  rotationUpdateSource,
+} from '../../media-api/index.js';
 
 import type { SourceFormValues } from './types';
 
@@ -87,28 +93,41 @@ function useSourceFormState(initialValues: SourceFormValues | undefined, sourceT
 }
 
 function useSourceMutations(onClose: () => void) {
-  const createMutation = usePillarMutation<CreateSourceInput, unknown>(
-    'media',
-    ['rotation', 'createSource'],
-    {
-      onSuccess: () => {
-        toast.success('Source created');
-        onClose();
-      },
-      onError: () => toast.error('Failed to create source'),
-    }
-  );
-  const updateMutation = usePillarMutation<UpdateSourceInput, unknown>(
-    'media',
-    ['rotation', 'updateSource'],
-    {
-      onSuccess: () => {
-        toast.success('Source updated');
-        onClose();
-      },
-      onError: () => toast.error('Failed to update source'),
-    }
-  );
+  const queryClient = useQueryClient();
+  const invalidateRotation = () =>
+    void queryClient.invalidateQueries({ queryKey: ['media', 'rotation'] });
+
+  const createMutation = useMutation({
+    mutationFn: async (input: CreateSourceInput) =>
+      unwrap(await rotationCreateSource({ body: input })),
+    onSuccess: () => {
+      toast.success('Source created');
+      invalidateRotation();
+      onClose();
+    },
+    onError: () => toast.error('Failed to create source'),
+  });
+  const updateMutation = useMutation({
+    mutationFn: async (input: UpdateSourceInput) =>
+      unwrap(
+        await rotationUpdateSource({
+          path: { id: input.id },
+          body: {
+            name: input.name,
+            priority: input.priority,
+            enabled: input.enabled,
+            syncIntervalHours: input.syncIntervalHours,
+            config: input.config,
+          },
+        })
+      ),
+    onSuccess: () => {
+      toast.success('Source updated');
+      invalidateRotation();
+      onClose();
+    },
+    onError: () => toast.error('Failed to update source'),
+  });
   return { createMutation, updateMutation };
 }
 
@@ -120,12 +139,11 @@ export function useSourceFormModel({
 }: UseSourceFormArgs) {
   const state = useSourceFormState(initialValues, sourceTypes);
   const { createMutation, updateMutation } = useSourceMutations(onClose);
-  const plexFriendsQuery = usePillarQuery<PlexFriendsResult>(
-    'media',
-    ['rotation', 'listPlexFriends'],
-    undefined,
-    { enabled: state.type === 'plex_friends' }
-  );
+  const plexFriendsQuery = useQuery<PlexFriendsResult>({
+    queryKey: ['media', 'rotation', 'listPlexFriends'],
+    queryFn: async () => (await unwrap(await rotationListPlexFriends())).data,
+    enabled: state.type === 'plex_friends',
+  });
 
   const handleSubmit = () => {
     if (!state.name.trim()) {


### PR DESCRIPTION
Phase D tier-2. Rewires the component-level usePillar* sites in app-media (arr badges/queue/status, movie-action-buttons, request-movie/series, mark-as-watched, dimension-manager, source-management, shelf-section, quick-pick, leaving-soon, comparison-scores) onto the Hey API SDK + react-query. Component tests 278/278; +91 passing overall, zero regressions; oxlint exit 0; verified in isolation (fe-quality red-by-design). Handled REST DTO {data} unwrapping + listSources enabled/config normalization back to legacy shape + server-default bodies (createDimension/watchHistory.log) — all behavior-preserving.