### PR TITLE
feat(media/fe): rewire candidate-queue/rotation/calendar pages + ExclusionList (Phase D)

### DIFF
--- a/packages/app-media/src/pages/CalendarPage.test.tsx
+++ b/packages/app-media/src/pages/CalendarPage.test.tsx
@@ -1,20 +1,24 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockGetConfigQuery = vi.fn();
-const mockGetCalendarQuery = vi.fn();
+const { arrConfigMock, arrGetCalendarMock } = vi.hoisted(() => ({
+  arrConfigMock: vi.fn(),
+  arrGetCalendarMock: vi.fn(),
+}));
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
-    const key = path.join('.');
-    if (key === 'arr.getConfig') return mockGetConfigQuery();
-    if (key === 'arr.getCalendar') return mockGetCalendarQuery();
-    return { data: undefined, isLoading: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  arrConfig: (...args: unknown[]) => arrConfigMock(...args),
+  arrGetCalendar: (...args: unknown[]) => arrGetCalendarMock(...args),
 }));
 
 import { CalendarPage } from './CalendarPage';
+
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
 
 const makeEpisode = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
@@ -30,11 +34,29 @@ const makeEpisode = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+function mockConfig(sonarrConfigured: boolean, radarrConfigured = false) {
+  arrConfigMock.mockResolvedValue(ok({ data: { radarrConfigured, sonarrConfigured } }));
+}
+
+function mockCalendar(episodes: ReturnType<typeof makeEpisode>[]) {
+  arrGetCalendarMock.mockResolvedValue(ok({ data: episodes }));
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
 function renderPage() {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return render(
     <MemoryRouter initialEntries={['/media/arr/calendar']}>
       <CalendarPage />
-    </MemoryRouter>
+    </MemoryRouter>,
+    { wrapper }
   );
 }
 
@@ -43,185 +65,87 @@ describe('CalendarPage', () => {
     vi.clearAllMocks();
   });
 
-  it('shows not configured message when Sonarr is not set up', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: false } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: null,
-    });
-
+  it('shows not configured message when Sonarr is not set up', async () => {
+    mockConfig(false);
     renderPage();
-    expect(screen.getByText('Sonarr not configured')).toBeInTheDocument();
+    expect(await screen.findByText('Sonarr not configured')).toBeInTheDocument();
     expect(screen.getByText(/Arr Settings/)).toBeInTheDocument();
+    expect(arrGetCalendarMock).not.toHaveBeenCalled();
   });
 
-  it('shows loading skeleton when fetching', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: null,
-      isLoading: true,
-      error: null,
-    });
-
+  it('shows empty state when no episodes', async () => {
+    mockConfig(true);
+    mockCalendar([]);
     renderPage();
-    expect(screen.getByText('Upcoming Episodes')).toBeInTheDocument();
+    expect(await screen.findByText('No upcoming episodes in the next 30 days')).toBeInTheDocument();
   });
 
-  it('shows empty state when no episodes', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-      error: null,
-    });
-
+  it('shows error message on query failure', async () => {
+    mockConfig(true);
+    arrGetCalendarMock.mockRejectedValue(new Error('Connection refused'));
     renderPage();
-    expect(screen.getByText('No upcoming episodes in the next 30 days')).toBeInTheDocument();
+    expect(await screen.findByText('Connection refused')).toBeInTheDocument();
   });
 
-  it('shows error message on query failure', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: { message: 'Connection refused' },
-    });
-
-    renderPage();
-    expect(screen.getByText('Connection refused')).toBeInTheDocument();
-  });
-
-  it('renders episodes grouped by date', () => {
+  it('renders episodes grouped by date', async () => {
     const today = new Date();
     const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [
-          makeEpisode({ id: 1, seriesTitle: 'Show A', airDateUtc: today.toISOString() }),
-          makeEpisode({ id: 2, seriesTitle: 'Show B', airDateUtc: tomorrow.toISOString() }),
-        ],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+    mockConfig(true);
+    mockCalendar([
+      makeEpisode({ id: 1, seriesTitle: 'Show A', airDateUtc: today.toISOString() }),
+      makeEpisode({ id: 2, seriesTitle: 'Show B', airDateUtc: tomorrow.toISOString() }),
+    ]);
     renderPage();
-    expect(screen.getByText('Show A')).toBeInTheDocument();
+    expect(await screen.findByText('Show A')).toBeInTheDocument();
     expect(screen.getByText('Show B')).toBeInTheDocument();
   });
 
-  it('highlights today with badge', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [makeEpisode({ airDateUtc: new Date().toISOString() })],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+  it('highlights today with badge', async () => {
+    mockConfig(true);
+    mockCalendar([makeEpisode({ airDateUtc: new Date().toISOString() })]);
     renderPage();
-    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(await screen.findByText('Today')).toBeInTheDocument();
   });
 
-  it('shows Downloaded badge for episodes with files', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [makeEpisode({ hasFile: true })],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+  it('shows Downloaded badge for episodes with files', async () => {
+    mockConfig(true);
+    mockCalendar([makeEpisode({ hasFile: true })]);
     renderPage();
-    expect(screen.getByText('Downloaded')).toBeInTheDocument();
+    expect(await screen.findByText('Downloaded')).toBeInTheDocument();
   });
 
-  it('shows Missing badge for episodes without files', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [makeEpisode({ hasFile: false })],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+  it('shows Missing badge for episodes without files', async () => {
+    mockConfig(true);
+    mockCalendar([makeEpisode({ hasFile: false })]);
     renderPage();
-    expect(screen.getByText('Missing')).toBeInTheDocument();
+    expect(await screen.findByText('Missing')).toBeInTheDocument();
   });
 
-  it('renders episode code badge (S01E01)', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [makeEpisode({ seasonNumber: 3, episodeNumber: 7 })],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+  it('renders episode code badge (S01E01)', async () => {
+    mockConfig(true);
+    mockCalendar([makeEpisode({ seasonNumber: 3, episodeNumber: 7 })]);
     renderPage();
-    expect(screen.getByText('S03E07')).toBeInTheDocument();
+    expect(await screen.findByText('S03E07')).toBeInTheDocument();
   });
 
-  it('links episodes to show detail page', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [makeEpisode({ seriesId: 42 })],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+  it('links episodes to show detail page', async () => {
+    mockConfig(true);
+    mockCalendar([makeEpisode({ seriesId: 42 })]);
     renderPage();
-    const link = screen.getByRole('link');
+    const link = await screen.findByRole('link');
     expect(link).toHaveAttribute('href', '/media/tv/42');
   });
 
-  it('sorts episodes within a date group by air time ascending', () => {
-    mockGetConfigQuery.mockReturnValue({
-      data: { data: { radarrConfigured: false, sonarrConfigured: true } },
-    });
+  it('sorts episodes within a date group by air time ascending', async () => {
+    mockConfig(true);
     const date = '2026-04-10';
-    mockGetCalendarQuery.mockReturnValue({
-      data: {
-        data: [
-          makeEpisode({ id: 2, episodeTitle: 'Late Show', airDateUtc: `${date}T22:00:00Z` }),
-          makeEpisode({ id: 1, episodeTitle: 'Morning Show', airDateUtc: `${date}T08:00:00Z` }),
-          makeEpisode({ id: 3, episodeTitle: 'Noon Show', airDateUtc: `${date}T12:00:00Z` }),
-        ],
-      },
-      isLoading: false,
-      error: null,
-    });
-
+    mockCalendar([
+      makeEpisode({ id: 2, episodeTitle: 'Late Show', airDateUtc: `${date}T22:00:00Z` }),
+      makeEpisode({ id: 1, episodeTitle: 'Morning Show', airDateUtc: `${date}T08:00:00Z` }),
+      makeEpisode({ id: 3, episodeTitle: 'Noon Show', airDateUtc: `${date}T12:00:00Z` }),
+    ]);
     const { container } = renderPage();
+    await screen.findByText('Morning Show');
     const text = container.textContent ?? '';
     expect(text.indexOf('Morning Show')).toBeLessThan(text.indexOf('Noon Show'));
     expect(text.indexOf('Noon Show')).toBeLessThan(text.indexOf('Late Show'));

--- a/packages/app-media/src/pages/CalendarPage.tsx
+++ b/packages/app-media/src/pages/CalendarPage.tsx
@@ -1,13 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
 import { Calendar } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * CalendarPage — upcoming episodes calendar from Sonarr.
  */
 import { Alert, AlertDescription, AlertTitle, Badge, Skeleton } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { arrConfig, arrGetCalendar } from '../media-api/index.js';
 import { CalendarEpisodeRow } from './calendar/CalendarEpisodeRow';
 
 function parseLocalDate(dateStr: string): Date {
@@ -66,39 +68,28 @@ interface CalendarEpisode {
   posterUrl: string | null;
 }
 
-interface ArrConfigResult {
-  data: { sonarrConfigured: boolean; radarrConfigured: boolean };
-}
-
-interface CalendarResult {
-  data: CalendarEpisode[];
-}
-
 function useCalendarPageModel() {
-  const { data: configData } = usePillarQuery<ArrConfigResult>(
-    'media',
-    ['arr', 'getConfig'],
-    undefined
-  );
+  const { data: configData } = useQuery({
+    queryKey: ['media', 'arr', 'config'],
+    queryFn: async () => unwrap(await arrConfig()),
+  });
   const config = configData?.data;
 
   const now = new Date();
   const start = now.toISOString().split('T')[0] ?? '';
   const end = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0] ?? '';
 
+  const calendarInput = { start, end };
   const {
     data: calendarData,
     isLoading,
     error,
-  } = usePillarQuery<CalendarResult>(
-    'media',
-    ['arr', 'getCalendar'],
-    { start, end },
-    {
-      enabled: config?.sonarrConfigured === true,
-      refetchOnWindowFocus: true,
-    }
-  );
+  } = useQuery({
+    queryKey: ['media', 'arr', 'getCalendar', calendarInput],
+    queryFn: async () => unwrap(await arrGetCalendar({ query: calendarInput })),
+    enabled: config?.sonarrConfigured === true,
+    refetchOnWindowFocus: true,
+  });
 
   const episodes = calendarData?.data ?? [];
 

--- a/packages/app-media/src/pages/CandidateQueuePage.tsx
+++ b/packages/app-media/src/pages/CandidateQueuePage.tsx
@@ -1,6 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { Link, useSearchParams } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * CandidateQueuePage — tabbed view of rotation candidate queue.
  *
@@ -8,20 +8,19 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  */
 import { Badge, PageHeader, Tabs, TabsContent, TabsList, TabsTrigger } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { rotationListCandidates } from '../media-api/index.js';
 import { CandidateList } from './candidate-queue/CandidateList';
 import { ExclusionList } from './candidate-queue/ExclusionList';
-
-interface PendingCountResult {
-  total: number;
-}
 
 export function CandidateQueuePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const tab = searchParams.get('tab') ?? 'pending';
 
-  const pendingCount = usePillarQuery<PendingCountResult>('media', ['rotation', 'listCandidates'], {
-    status: 'pending',
-    limit: 1,
+  const pendingCountInput = { status: 'pending' as const, limit: 1 };
+  const pendingCount = useQuery({
+    queryKey: ['media', 'rotation', 'listCandidates', pendingCountInput],
+    queryFn: async () => unwrap(await rotationListCandidates({ query: pendingCountInput })),
   });
 
   return (
@@ -47,9 +46,9 @@ export function CandidateQueuePage() {
         <TabsList>
           <TabsTrigger value="pending">
             Pending
-            {pendingCount.data?.total ? (
+            {pendingCount.data?.data.total ? (
               <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">
-                {pendingCount.data.total}
+                {pendingCount.data.data.total}
               </Badge>
             ) : null}
           </TabsTrigger>

--- a/packages/app-media/src/pages/RotationLogPage.tsx
+++ b/packages/app-media/src/pages/RotationLogPage.tsx
@@ -1,8 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight, ScrollText } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RotationLogPage — paginated history of rotation cycle events.
  *
@@ -10,6 +10,8 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
  */
 import { Button, Card, CardContent, PageHeader, Skeleton } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { rotationListRotationLog, rotationRotationLogStats } from '../media-api/index.js';
 import { LogEntry } from './rotation-log/LogEntry';
 import { StatsGrid } from './rotation-log/StatsGrid';
 
@@ -84,34 +86,23 @@ function LogList({ isLoading, items }: { isLoading: boolean; items: LogEntryData
   );
 }
 
-interface RotationLogResult {
-  items: LogEntryData[];
-  total: number;
-}
-
-interface RotationLogStats {
-  totalRotated: number;
-  avgPerDay: number;
-  streak: number;
-}
-
 export function RotationLogPage() {
   const [page, setPage] = useState(0);
 
-  const { data, isLoading } = usePillarQuery<RotationLogResult>(
-    'media',
-    ['rotation', 'listRotationLog'],
-    { limit: PAGE_SIZE, offset: page * PAGE_SIZE }
-  );
+  const logInput = { limit: PAGE_SIZE, offset: page * PAGE_SIZE };
+  const { data, isLoading } = useQuery({
+    queryKey: ['media', 'rotation', 'listRotationLog', logInput],
+    queryFn: async () => unwrap(await rotationListRotationLog({ query: logInput })),
+  });
 
-  const { data: stats, isLoading: statsLoading } = usePillarQuery<RotationLogStats>(
-    'media',
-    ['rotation', 'getRotationLogStats'],
-    undefined
-  );
+  const { data: stats, isLoading: statsLoading } = useQuery({
+    queryKey: ['media', 'rotation', 'rotationLogStats'],
+    queryFn: async () => unwrap(await rotationRotationLogStats()),
+  });
 
-  const items = data?.items ?? [];
-  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+  const log = data?.data;
+  const items: LogEntryData[] = log?.items ?? [];
+  const totalPages = log ? Math.ceil(log.total / PAGE_SIZE) : 0;
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
@@ -126,7 +117,7 @@ export function RotationLogPage() {
         ]}
         renderLink={Link}
       />
-      <StatsGrid stats={stats} isLoading={statsLoading} />
+      <StatsGrid stats={stats?.data} isLoading={statsLoading} />
       <LogList isLoading={isLoading} items={items} />
       <LogPagination page={page} totalPages={totalPages} setPage={setPage} />
     </div>

--- a/packages/app-media/src/pages/candidate-queue/ExclusionList.tsx
+++ b/packages/app-media/src/pages/candidate-queue/ExclusionList.tsx
@@ -1,10 +1,12 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { Button, Skeleton } from '@pops/ui';
 
+import { unwrap } from '../../media-api-helpers.js';
+import { rotationListExclusions, rotationRemoveExclusion } from '../../media-api/index.js';
 import { Pagination } from './Pagination';
 
 const PAGE_SIZE = 20;
@@ -48,34 +50,31 @@ function ExclusionRow({
   );
 }
 
-interface ListExclusionsResult {
-  items: Exclusion[];
-  total: number;
-}
-
 export function ExclusionList() {
   const [page, setPage] = useState(0);
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
 
-  const query = usePillarQuery<ListExclusionsResult>('media', ['rotation', 'listExclusions'], {
-    limit: PAGE_SIZE,
-    offset: page * PAGE_SIZE,
+  const queryInput = { limit: PAGE_SIZE, offset: page * PAGE_SIZE };
+  const query = useQuery({
+    queryKey: ['media', 'rotation', 'listExclusions', queryInput],
+    queryFn: async () => unwrap(await rotationListExclusions({ query: queryInput })),
   });
 
-  const unexcludeMutation = usePillarMutation<{ tmdbId: number }, unknown>(
-    'media',
-    ['rotation', 'removeExclusion'],
-    {
-      onSuccess: () => {
-        toast.success('Exclusion removed');
-        void utils.invalidate(['rotation', 'listExclusions']);
-        void utils.invalidate(['rotation', 'listCandidates']);
-      },
-      onError: (err) => toast.error(err.message || 'Failed to remove exclusion'),
-    }
-  );
+  const unexcludeMutation = useMutation({
+    mutationFn: async (input: { tmdbId: number }) =>
+      unwrap(await rotationRemoveExclusion({ path: { tmdbId: input.tmdbId } })),
+    onSuccess: () => {
+      toast.success('Exclusion removed');
+      void queryClient.invalidateQueries({ queryKey: ['media', 'rotation', 'listExclusions'] });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'rotation', 'listCandidates'] });
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to remove exclusion'),
+  });
 
-  const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
+  const result = query.data?.data;
+  const items: Exclusion[] = result?.items ?? [];
+  const total = result?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   if (query.isLoading) {
     return (
@@ -87,14 +86,14 @@ export function ExclusionList() {
     );
   }
 
-  if (!query.data?.items.length) {
+  if (!items.length) {
     return <p className="text-sm text-muted-foreground py-8 text-center">No exclusions</p>;
   }
 
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        {query.data.items.map((e) => (
+        {items.map((e) => (
           <ExclusionRow
             key={e.id}
             e={e}
@@ -103,12 +102,7 @@ export function ExclusionList() {
           />
         ))}
       </div>
-      <Pagination
-        page={page}
-        totalPages={totalPages}
-        total={query.data.total}
-        onPageChange={setPage}
-      />
+      <Pagination page={page} totalPages={totalPages} total={total} onPageChange={setPage} />
     </div>
   );
 }


### PR DESCRIPTION
Phase D mop-up. Rewires ExclusionList (now wired to rotationListExclusions), CandidateQueuePage, RotationLogPage, CalendarPage onto the Hey API SDK + react-query (rotationListExclusions/RemoveExclusion/ListCandidates/ListRotationLog/RotationLogStats, arrConfig/GetCalendar). All rotation/arr DTOs {data}-wrapped (extra .data). CalendarPage 10/10; verified in isolation (fe-quality red-by-design), no regression.