### PR TITLE
feat(media/fe): rewire movie-detail + tv-show-detail onto the Hey API REST client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -1,24 +1,22 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { PillarCallError } from '@pops/pillar-sdk/client';
-
-const mockMovieQuery = vi.fn();
-const mockWatchHistoryQuery = vi.fn();
-const mockGetStalenessQuery = vi.fn();
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'movies.get') return mockMovieQuery(input);
-    if (key === 'watchHistory.list') return mockWatchHistoryQuery(input);
-    if (key === 'comparisons.getStaleness') return mockGetStalenessQuery(input);
-    return { data: undefined, isLoading: false };
-  },
+const { moviesGetMock, watchHistoryListMock, comparisonsGetStalenessMock } = vi.hoisted(() => ({
+  moviesGetMock: vi.fn(),
+  watchHistoryListMock: vi.fn(),
+  comparisonsGetStalenessMock: vi.fn(),
 }));
 
-// Mock sub-components that need their own tRPC context
+vi.mock('../media-api/index.js', () => ({
+  moviesGet: (...args: unknown[]) => moviesGetMock(...args),
+  watchHistoryList: (...args: unknown[]) => watchHistoryListMock(...args),
+  comparisonsGetStaleness: (...args: unknown[]) => comparisonsGetStalenessMock(...args),
+}));
+
+// Mock sub-components that need their own data context.
 vi.mock('../components/WatchlistToggle', () => ({
   WatchlistToggle: () => <button>Watchlist</button>,
 }));
@@ -48,13 +46,27 @@ vi.mock('../components/LeavingBadge', () => ({
 
 import { MovieDetailPage } from './MovieDetailPage';
 
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
 function renderAtRoute(path: string) {
+  const queryClient = makeQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/media/movies/:id" element={<MovieDetailPage />} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
+    { wrapper }
   );
 }
 
@@ -86,94 +98,82 @@ const baseMovie = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
+function mockMovie(overrides: Record<string, unknown> = {}) {
+  moviesGetMock.mockResolvedValue(ok({ data: { ...baseMovie, ...overrides } }));
+}
+
 beforeEach(() => {
-  mockMovieQuery.mockReturnValue({
-    data: { data: baseMovie },
-    isLoading: false,
-    error: null,
-  });
-  mockWatchHistoryQuery.mockReturnValue({
-    data: { data: [] },
-  });
-  mockGetStalenessQuery.mockReturnValue({
-    data: { data: { staleness: 1.0 } },
-  });
+  vi.clearAllMocks();
+  mockMovie();
+  watchHistoryListMock.mockResolvedValue(ok({ data: [] }));
+  comparisonsGetStalenessMock.mockResolvedValue(ok({ data: { staleness: 1.0 } }));
 });
 
 describe('MovieDetailPage', () => {
   describe('hero with backdrop', () => {
-    it('renders backdrop image when backdropUrl is present', () => {
+    it('renders backdrop image when backdropUrl is present', async () => {
       const { container } = renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       const backdrop = container.querySelector('img[src="/media/images/movie/278/backdrop.jpg"]');
       expect(backdrop).toBeInTheDocument();
     });
 
-    it('renders poster image', () => {
+    it('renders poster image', async () => {
       renderAtRoute('/media/movies/1');
-      expect(screen.getByAltText('The Shawshank Redemption poster')).toBeInTheDocument();
+      expect(await screen.findByAltText('The Shawshank Redemption poster')).toBeInTheDocument();
     });
 
-    it('renders title in h1', () => {
+    it('renders title in h1', async () => {
       renderAtRoute('/media/movies/1');
-      const heading = screen.getByRole('heading', { level: 1 });
+      const heading = await screen.findByRole('heading', { level: 1 });
       expect(heading).toHaveTextContent('The Shawshank Redemption');
     });
 
-    it('renders tagline', () => {
+    it('renders tagline', async () => {
       renderAtRoute('/media/movies/1');
       expect(
-        screen.getByText('Fear can hold you prisoner. Hope can set you free.')
+        await screen.findByText('Fear can hold you prisoner. Hope can set you free.')
       ).toBeInTheDocument();
     });
 
-    it('renders year and runtime in hero subtitle', () => {
+    it('renders year and runtime in hero subtitle', async () => {
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('1994')).toBeInTheDocument();
+      expect(await screen.findByText('1994')).toBeInTheDocument();
       // Runtime appears in both hero and metadata grid
       expect(screen.getAllByText('2h 22m')).toHaveLength(2);
     });
   });
 
   describe('fallback gradient without backdrop', () => {
-    it('does not render backdrop img when backdropUrl is null', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, backdropUrl: null, backdropPath: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('does not render backdrop img when backdropUrl is null', async () => {
+      mockMovie({ backdropUrl: null, backdropPath: null });
       renderAtRoute('/media/movies/1');
-      // Only poster img should exist, no backdrop
+      await screen.findByRole('heading', { level: 1 });
       const imgs = screen.getAllByRole('img');
       expect(imgs).toHaveLength(1); // just the poster
       expect(imgs[0]).toHaveAttribute('alt', 'The Shawshank Redemption poster');
     });
 
-    it('still renders the gradient overlay div', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, backdropUrl: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('still renders the gradient overlay div', async () => {
+      mockMovie({ backdropUrl: null });
       const { container } = renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       const gradient = container.querySelector('.bg-gradient-to-t');
       expect(gradient).toBeInTheDocument();
     });
   });
 
   describe('poster fallback chain', () => {
-    it('renders poster when posterUrl is present', () => {
+    it('renders poster when posterUrl is present', async () => {
       renderAtRoute('/media/movies/1');
-      const poster = screen.getByAltText('The Shawshank Redemption poster');
+      const poster = await screen.findByAltText('The Shawshank Redemption poster');
       expect(poster).toHaveAttribute('src', '/media/images/movie/278/poster.jpg');
     });
 
-    it('renders a placeholder div when posterUrl is null (no img element)', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, posterUrl: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('renders a placeholder div when posterUrl is null (no img element)', async () => {
+      mockMovie({ posterUrl: null });
       const { container } = renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       // Component renders a <div> placeholder instead of <img> when posterUrl is null
       expect(screen.queryByAltText('The Shawshank Redemption poster')).not.toBeInTheDocument();
       const placeholder = container.querySelector('div.rounded-lg.bg-muted.shadow-lg');
@@ -182,118 +182,101 @@ describe('MovieDetailPage', () => {
   });
 
   describe('runtime formatting', () => {
-    it('formats runtime as Xh Ym', () => {
+    it('formats runtime as Xh Ym', async () => {
       renderAtRoute('/media/movies/1');
       // Runtime appears in both hero subtitle and metadata grid
-      expect(screen.getAllByText('2h 22m').length).toBeGreaterThanOrEqual(1);
+      expect((await screen.findAllByText('2h 22m')).length).toBeGreaterThanOrEqual(1);
     });
 
-    it('hides runtime when null', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, runtime: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('hides runtime when null', async () => {
+      mockMovie({ runtime: null });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByText(/\d+h \d+m/)).not.toBeInTheDocument();
     });
   });
 
   describe('hidden fields when null/zero', () => {
-    it('hides budget when zero', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, budget: 0 } },
-        isLoading: false,
-        error: null,
-      });
+    it('hides budget when zero', async () => {
+      mockMovie({ budget: 0 });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByText('Budget')).not.toBeInTheDocument();
     });
 
-    it('hides revenue when null', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, revenue: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('hides revenue when null', async () => {
+      mockMovie({ revenue: null });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByText('Revenue')).not.toBeInTheDocument();
     });
 
-    it('hides tagline when null', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, tagline: null } },
-        isLoading: false,
-        error: null,
-      });
+    it('hides tagline when null', async () => {
+      mockMovie({ tagline: null });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByText('Fear can hold you prisoner')).not.toBeInTheDocument();
     });
   });
 
   describe('language display', () => {
-    it('shows full language name instead of ISO code', () => {
+    it('shows full language name instead of ISO code', async () => {
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(await screen.findByText('English')).toBeInTheDocument();
       expect(screen.queryByText('EN')).not.toBeInTheDocument();
     });
 
-    it('shows Japanese for ja', () => {
-      mockMovieQuery.mockReturnValue({
-        data: { data: { ...baseMovie, originalLanguage: 'ja' } },
-        isLoading: false,
-        error: null,
-      });
+    it('shows Japanese for ja', async () => {
+      mockMovie({ originalLanguage: 'ja' });
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('Japanese')).toBeInTheDocument();
+      expect(await screen.findByText('Japanese')).toBeInTheDocument();
     });
   });
 
   describe('404 handling', () => {
-    it('shows not found message for NOT_FOUND error', () => {
-      mockMovieQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
+    it('shows not found message for 404 error', async () => {
+      moviesGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'not found' },
+        response: new Response(null, { status: 404 }),
       });
       renderAtRoute('/media/movies/999');
-      expect(screen.getByText('Movie not found')).toBeInTheDocument();
+      expect(await screen.findByText('Movie not found')).toBeInTheDocument();
       expect(screen.getByText("This movie doesn't exist in your library.")).toBeInTheDocument();
     });
 
-    it('shows generic error for other errors', () => {
-      const err = new PillarCallError('media', { kind: 'unavailable', pillar: 'media' });
-      mockMovieQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: err,
+    it('shows generic error for other errors', async () => {
+      moviesGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'pillar unavailable' },
+        response: new Response(null, { status: 500 }),
       });
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('Error')).toBeInTheDocument();
-      expect(screen.getByText(err.message)).toBeInTheDocument();
+      expect(await screen.findByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('pillar unavailable')).toBeInTheDocument();
     });
 
-    it('shows back to library link on error', () => {
-      mockMovieQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
+    it('shows back to library link on error', async () => {
+      moviesGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'not found' },
+        response: new Response(null, { status: 404 }),
       });
       renderAtRoute('/media/movies/999');
-      expect(screen.getByText('Back to library')).toHaveAttribute('href', '/media');
+      expect(await screen.findByText('Back to library')).toHaveAttribute('href', '/media');
     });
   });
 
   describe('watch history', () => {
-    it("shows 'Not watched yet' when no watch history", () => {
-      mockWatchHistoryQuery.mockReturnValue({ data: { data: [] } });
+    it("shows 'Not watched yet' when no watch history", async () => {
+      watchHistoryListMock.mockResolvedValue(ok({ data: [] }));
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('Not watched yet')).toBeInTheDocument();
+      expect(await screen.findByText('Not watched yet')).toBeInTheDocument();
     });
 
-    it('shows watch dates chronologically', () => {
-      mockWatchHistoryQuery.mockReturnValue({
-        data: {
+    it('shows watch dates chronologically', async () => {
+      watchHistoryListMock.mockResolvedValue(
+        ok({
           data: [
             {
               id: 2,
@@ -310,9 +293,10 @@ describe('MovieDetailPage', () => {
               completed: 1,
             },
           ],
-        },
-      });
+        })
+      );
       const { container } = renderAtRoute('/media/movies/1');
+      await screen.findByText('Watch History');
       // Get list items from the watch history ul specifically
       const watchHistoryList = container.querySelector('ul');
       expect(watchHistoryList).toBeInTheDocument();
@@ -323,70 +307,53 @@ describe('MovieDetailPage', () => {
       expect(items[1]!.textContent).toContain('March');
     });
 
-    it('renders Watch History heading', () => {
+    it('renders Watch History heading', async () => {
       renderAtRoute('/media/movies/1');
-      expect(screen.getByText('Watch History')).toBeInTheDocument();
+      expect(await screen.findByText('Watch History')).toBeInTheDocument();
     });
   });
 
   describe('loading state', () => {
-    it('shows skeleton when loading', () => {
-      mockMovieQuery.mockReturnValue({
-        data: null,
-        isLoading: true,
-        error: null,
-      });
+    it('shows skeleton when loading', async () => {
+      let resolveMovie: ((value: unknown) => void) | undefined;
+      moviesGetMock.mockReturnValue(
+        new Promise((resolve) => {
+          resolveMovie = resolve;
+        })
+      );
       const { container } = renderAtRoute('/media/movies/1');
-      // Skeleton renders multiple placeholder elements
+      // Skeleton renders multiple placeholder elements while the query is pending.
       expect(
         container.querySelectorAll("[class*='animate-pulse'], [data-slot='skeleton']").length
       ).toBeGreaterThan(0);
+      resolveMovie?.(ok({ data: baseMovie }));
     });
   });
 
   describe('leaving badge in hero row', () => {
-    it('renders LeavingBadge when rotationStatus is leaving and rotationExpiresAt is set', () => {
-      mockMovieQuery.mockReturnValue({
-        data: {
-          data: {
-            ...baseMovie,
-            rotationStatus: 'leaving',
-            rotationExpiresAt: '2026-05-01T00:00:00Z',
-          },
-        },
-        isLoading: false,
-        error: null,
-      });
+    it('renders LeavingBadge when rotationStatus is leaving and rotationExpiresAt is set', async () => {
+      mockMovie({ rotationStatus: 'leaving', rotationExpiresAt: '2026-05-01T00:00:00Z' });
       renderAtRoute('/media/movies/1');
-      expect(screen.getByTestId('leaving-badge')).toBeInTheDocument();
+      expect(await screen.findByTestId('leaving-badge')).toBeInTheDocument();
     });
 
-    it('does not render LeavingBadge when rotationStatus is not leaving', () => {
-      mockMovieQuery.mockReturnValue({
-        data: {
-          data: { ...baseMovie, rotationStatus: 'protected', rotationExpiresAt: null },
-        },
-        isLoading: false,
-        error: null,
-      });
+    it('does not render LeavingBadge when rotationStatus is not leaving', async () => {
+      mockMovie({ rotationStatus: 'protected', rotationExpiresAt: null });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
 
-    it('does not render LeavingBadge when rotationStatus is leaving but rotationExpiresAt is null', () => {
-      mockMovieQuery.mockReturnValue({
-        data: {
-          data: { ...baseMovie, rotationStatus: 'leaving', rotationExpiresAt: null },
-        },
-        isLoading: false,
-        error: null,
-      });
+    it('does not render LeavingBadge when rotationStatus is leaving but rotationExpiresAt is null', async () => {
+      mockMovie({ rotationStatus: 'leaving', rotationExpiresAt: null });
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
 
-    it('does not render LeavingBadge when rotationStatus is absent', () => {
+    it('does not render LeavingBadge when rotationStatus is absent', async () => {
       renderAtRoute('/media/movies/1');
+      await screen.findByRole('heading', { level: 1 });
       expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
   });

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -1,8 +1,8 @@
 import { Link, useParams } from 'react-router';
 
-import { isNotFound } from '@pops/pillar-sdk/client';
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
+import { isNotFoundError } from '../media-api-helpers.js';
 import { MovieDetailContent } from './movie-detail/MovieDetailContent';
 import { MovieDetailSkeleton } from './movie-detail/MovieDetailSkeleton';
 import { MovieHero } from './movie-detail/MovieHero';
@@ -20,7 +20,7 @@ function InvalidIdView() {
 }
 
 function ErrorView({ error }: { error: unknown }) {
-  const is404 = isNotFound(error);
+  const is404 = isNotFoundError(error);
   const message = error instanceof Error ? error.message : String(error);
   return (
     <div className="p-6">

--- a/packages/app-media/src/pages/TvShowDetailPage.test.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.test.tsx
@@ -1,71 +1,34 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { TvShowDetailPage } from './TvShowDetailPage';
+import { MediaApiError } from '../media-api-helpers.js';
 
 const {
-  mockShowQuery,
-  mockSeasonsQuery,
-  mockProgressQuery,
-  mockBatchLogMutation,
-  mockCheckSeriesQuery,
-  mockSeasonMonitorMutation,
-  mockInvalidate,
-  mockSetData,
+  tvShowsGetMock,
+  tvShowsListSeasonsMock,
+  watchHistoryProgressMock,
+  arrCheckSeriesMock,
+  watchHistoryBatchLogMock,
+  arrUpdateSeasonMonitoringMock,
 } = vi.hoisted(() => ({
-  mockShowQuery: vi.fn(),
-  mockSeasonsQuery: vi.fn(),
-  mockProgressQuery: vi.fn(),
-  mockBatchLogMutation: vi.fn(),
-  mockCheckSeriesQuery: vi.fn(),
-  mockSeasonMonitorMutation: vi.fn(),
-  mockInvalidate: vi.fn(),
-  mockSetData: vi.fn(),
+  tvShowsGetMock: vi.fn(),
+  tvShowsListSeasonsMock: vi.fn(),
+  watchHistoryProgressMock: vi.fn(),
+  arrCheckSeriesMock: vi.fn(),
+  watchHistoryBatchLogMock: vi.fn(),
+  arrUpdateSeasonMonitoringMock: vi.fn(),
 }));
 
-let batchLogOpts: Record<string, unknown> = {};
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'tvShows.get') return mockShowQuery(input);
-    if (key === 'tvShows.listSeasons') return mockSeasonsQuery(input);
-    if (key === 'watchHistory.progress') return mockProgressQuery(input);
-    if (key === 'arr.checkSeries') return mockCheckSeriesQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'watchHistory.batchLog') {
-      batchLogOpts = opts;
-      mockBatchLogMutation.mockImplementation(() => {
-        if (typeof opts.onMutate === 'function') (opts.onMutate as () => void)();
-        if (typeof opts.onSuccess === 'function')
-          (opts.onSuccess as (r: { data: { logged: number } }) => void)({ data: { logged: 16 } });
-        if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
-      });
-      return { mutate: mockBatchLogMutation, isPending: false };
-    }
-    if (key === 'arr.updateSeasonMonitoring') {
-      mockSeasonMonitorMutation.mockImplementation((variables: { seasonNumber: number }) => {
-        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-        if (typeof opts.onSettled === 'function')
-          (opts.onSettled as (d: unknown, e: unknown, v: { seasonNumber: number }) => void)(
-            undefined,
-            undefined,
-            variables
-          );
-      });
-      return { mutate: mockSeasonMonitorMutation, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({ setData: mockSetData, invalidate: mockInvalidate }),
+vi.mock('../media-api/index.js', () => ({
+  tvShowsGet: (...args: unknown[]) => tvShowsGetMock(...args),
+  tvShowsListSeasons: (...args: unknown[]) => tvShowsListSeasonsMock(...args),
+  watchHistoryProgress: (...args: unknown[]) => watchHistoryProgressMock(...args),
+  arrCheckSeries: (...args: unknown[]) => arrCheckSeriesMock(...args),
+  watchHistoryBatchLog: (...args: unknown[]) => watchHistoryBatchLogMock(...args),
+  arrUpdateSeasonMonitoring: (...args: unknown[]) => arrUpdateSeasonMonitoringMock(...args),
 }));
 
 vi.mock('../components/ArrStatusBadge', () => ({
@@ -75,6 +38,12 @@ vi.mock('../components/ArrStatusBadge', () => ({
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
+
+import { TvShowDetailPage } from './TvShowDetailPage';
+
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
 
 const SHOW = {
   id: 1,
@@ -116,476 +85,6 @@ const PROGRESS = {
   },
 };
 
-function renderPage(showId = '1') {
-  return render(
-    <MemoryRouter initialEntries={[`/media/tv/${showId}`]}>
-      <Routes>
-        <Route path="/media/tv/:id" element={<TvShowDetailPage />} />
-      </Routes>
-    </MemoryRouter>
-  );
-}
-
-function setupQueries(
-  showOverrides: Record<string, unknown> = {},
-  seasons = SEASONS,
-  progress = PROGRESS
-) {
-  mockShowQuery.mockReturnValue({
-    data: { data: { ...SHOW, ...showOverrides } },
-    isLoading: false,
-    error: null,
-  });
-  mockSeasonsQuery.mockReturnValue({
-    data: { data: seasons },
-    isLoading: false,
-  });
-  mockProgressQuery.mockReturnValue({
-    data: { data: progress },
-    isLoading: false,
-  });
-}
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  batchLogOpts = {};
-  mockSeasonsQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockProgressQuery.mockReturnValue({ data: null, isLoading: false });
-  mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: false });
-});
-
-describe('TvShowDetailPage — season list', () => {
-  describe('rendering', () => {
-    it('renders season cards with correct data', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByRole('heading', { name: 'Seasons' })).toBeInTheDocument();
-      expect(screen.getByText('Season 1')).toBeInTheDocument();
-      expect(screen.getByText('Season 2')).toBeInTheDocument();
-      expect(screen.getByText('Season 3')).toBeInTheDocument();
-      expect(screen.getByText('Specials')).toBeInTheDocument();
-    });
-
-    it('renders episode counts', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('7 episodes')).toBeInTheDocument();
-      expect(screen.getAllByText('13 episodes')).toHaveLength(2);
-      expect(screen.getByText('3 episodes')).toBeInTheDocument();
-    });
-
-    it('shows empty state when no seasons', () => {
-      setupQueries({}, [], {
-        ...PROGRESS,
-        overall: { watched: 0, total: 0, percentage: 0 },
-        seasons: [],
-      });
-      renderPage();
-      expect(screen.getByRole('heading', { name: 'Seasons' })).toBeInTheDocument();
-      expect(screen.getByText('No seasons available')).toBeInTheDocument();
-    });
-  });
-
-  describe('sort order', () => {
-    it('puts specials (season 0) last', () => {
-      setupQueries();
-      const { container } = renderPage();
-      const links = container.querySelectorAll('a[href*="/season/"]');
-      expect(links).toHaveLength(4);
-      expect(links[0]!.getAttribute('href')).toBe('/media/tv/1/season/1');
-      expect(links[1]!.getAttribute('href')).toBe('/media/tv/1/season/2');
-      expect(links[2]!.getAttribute('href')).toBe('/media/tv/1/season/3');
-      expect(links[3]!.getAttribute('href')).toBe('/media/tv/1/season/0');
-    });
-  });
-
-  describe('navigation', () => {
-    it('links to correct season detail page', () => {
-      setupQueries();
-      const { container } = renderPage();
-      const seasonLink = container.querySelector('a[href="/media/tv/1/season/2"]');
-      expect(seasonLink).toBeInTheDocument();
-    });
-  });
-
-  describe('progress bars', () => {
-    it('renders progress bar for season with progress', () => {
-      setupQueries();
-      const { container } = renderPage();
-      const progressBars = container.querySelectorAll('[role="progressbar"]');
-      expect(progressBars.length).toBeGreaterThan(0);
-    });
-
-    it('renders green bar for completed season (100%)', () => {
-      setupQueries({}, [{ id: 11, seasonNumber: 1, name: 'Season 1', episodeCount: 7 }], {
-        ...PROGRESS,
-        seasons: [{ seasonId: 11, seasonNumber: 1, watched: 7, total: 7, percentage: 100 }],
-      });
-      const { container } = renderPage();
-      const bar = container.querySelector('[aria-valuenow="100"]');
-      expect(bar).toBeInTheDocument();
-      expect(bar?.className).toContain('bg-success');
-    });
-
-    it('renders accent bar for in-progress season (50%)', () => {
-      setupQueries({}, [{ id: 12, seasonNumber: 2, name: 'Season 2', episodeCount: 10 }], {
-        ...PROGRESS,
-        seasons: [{ seasonId: 12, seasonNumber: 2, watched: 5, total: 10, percentage: 50 }],
-      });
-      const { container } = renderPage();
-      const bar = container.querySelector('[aria-valuenow="50"]');
-      expect(bar).toBeInTheDocument();
-      expect(bar?.className).toContain('bg-primary');
-    });
-
-    it('does not render progress bar for 0% season', () => {
-      setupQueries({}, [{ id: 10, seasonNumber: 1, name: 'Season 1', episodeCount: 5 }], {
-        ...PROGRESS,
-        overall: { watched: 0, total: 5, percentage: 0 },
-        seasons: [{ seasonId: 10, seasonNumber: 1, watched: 0, total: 5, percentage: 0 }],
-      });
-      const { container } = renderPage();
-      const seasonLinks = container.querySelectorAll('a[href*="/season/"]');
-      expect(seasonLinks).toHaveLength(1);
-      const bar = seasonLinks[0]!.querySelector('[role="progressbar"]');
-      expect(bar).toBeInTheDocument();
-    });
-  });
-
-  describe('404 handling', () => {
-    it('shows error for invalid show ID', () => {
-      mockShowQuery.mockReturnValue({ data: null, isLoading: false, error: null });
-      renderPage('abc');
-      expect(screen.getByText('Invalid show ID')).toBeInTheDocument();
-    });
-
-    it('shows not found for missing show', () => {
-      mockShowQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: { data: { code: 'NOT_FOUND' }, message: 'Not found' },
-      });
-      renderPage('999');
-      expect(screen.getByText('Show not found')).toBeInTheDocument();
-    });
-  });
-});
-
-describe('TvShowDetailPage — hero and metadata', () => {
-  describe('hero with backdrop', () => {
-    it('renders backdrop image when backdropUrl is present', () => {
-      setupQueries();
-      const { container } = renderPage();
-      const backdrop = container.querySelector('img[src="/media/images/tv/81189/backdrop.jpg"]');
-      expect(backdrop).toBeInTheDocument();
-    });
-
-    it('does not render backdrop image when backdropUrl is null (fallback gradient)', () => {
-      setupQueries({ backdropUrl: null });
-      const { container } = renderPage();
-      const images = container.querySelectorAll('img');
-      expect(images).toHaveLength(1);
-      expect(images[0]!.getAttribute('alt')).toBe('Breaking Bad poster');
-      const hero = container.querySelector('.bg-muted');
-      expect(hero).toBeInTheDocument();
-      const gradient = container.querySelector('.bg-gradient-to-t');
-      expect(gradient).toBeInTheDocument();
-    });
-
-    it('renders poster image', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByAltText('Breaking Bad poster')).toBeInTheDocument();
-    });
-
-    it('renders a placeholder div when posterUrl is null (no img element)', () => {
-      setupQueries({ posterUrl: null });
-      const { container } = renderPage();
-      expect(container.querySelector('img[alt="Breaking Bad poster"]')).not.toBeInTheDocument();
-      const placeholder = container.querySelector('div.rounded-lg.bg-muted.shadow-lg');
-      expect(placeholder).toBeInTheDocument();
-    });
-
-    it('renders title in h1', () => {
-      setupQueries();
-      renderPage();
-      const heading = screen.getByRole('heading', { level: 1 });
-      expect(heading).toHaveTextContent('Breaking Bad');
-    });
-  });
-
-  describe('status badge', () => {
-    it('renders status text for ended show', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('renders status text for returning series', () => {
-      setupQueries({ status: 'Returning Series' });
-      renderPage();
-      expect(screen.getAllByText('Returning Series').length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('renders separator dot between year range and status', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('·')).toBeInTheDocument();
-    });
-
-    it('does not render separator when no year range', () => {
-      setupQueries({ firstAirDate: null, lastAirDate: null });
-      renderPage();
-      expect(screen.queryByText('·')).not.toBeInTheDocument();
-      expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('does not render status when status is null', () => {
-      setupQueries({ status: null });
-      renderPage();
-      expect(screen.queryByText('·')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('year range formatting', () => {
-    it('shows start–end for ended show spanning multiple years', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('2008–2013')).toBeInTheDocument();
-    });
-
-    it('shows year–Present for returning series', () => {
-      setupQueries({
-        status: 'Returning Series',
-        firstAirDate: '2022-02-18',
-        lastAirDate: '2024-01-12',
-      });
-      renderPage();
-      expect(screen.getByText('2022–Present')).toBeInTheDocument();
-    });
-
-    it('shows single year when start and end are in same year', () => {
-      setupQueries({
-        firstAirDate: '2020-06-01',
-        lastAirDate: '2020-12-15',
-        status: 'Ended',
-      });
-      renderPage();
-      expect(screen.getByText('2020')).toBeInTheDocument();
-    });
-  });
-
-  describe('networks display', () => {
-    it('renders networks in metadata grid', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('Networks')).toBeInTheDocument();
-      expect(screen.getByText('AMC')).toBeInTheDocument();
-    });
-
-    it('renders multiple networks as comma-separated list', () => {
-      setupQueries({ networks: ['HBO', 'Max'] });
-      renderPage();
-      expect(screen.getByText('HBO, Max')).toBeInTheDocument();
-    });
-
-    it('does not render networks when empty', () => {
-      setupQueries({ networks: [] });
-      renderPage();
-      expect(screen.queryByText('Networks')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('genres', () => {
-    it('renders genre badges', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('Drama')).toBeInTheDocument();
-      expect(screen.getByText('Crime')).toBeInTheDocument();
-    });
-  });
-
-  describe('overview', () => {
-    it('renders overview text', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByText('A chemistry teacher turned meth cook.')).toBeInTheDocument();
-    });
-  });
-});
-
-describe('TvShowDetailPage — overall progress bar', () => {
-  it('renders overall progress bar with label', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 20, total: 36, percentage: 56 },
-    });
-    renderPage();
-    expect(screen.getByText('20/36')).toBeInTheDocument();
-  });
-
-  it('renders green bar at 100%', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 36, total: 36, percentage: 100 },
-      seasons: PROGRESS.seasons.map((s) => ({ ...s, watched: s.total, percentage: 100 })),
-    });
-    const { container } = renderPage();
-    const bars = container.querySelectorAll('[aria-valuenow="100"]');
-    const greenBar = Array.from(bars).find((b) => b.className.includes('bg-success'));
-    expect(greenBar).toBeTruthy();
-  });
-
-  it('renders primary bar at 50%', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 18, total: 36, percentage: 50 },
-    });
-    const { container } = renderPage();
-    const bar = container.querySelector('[aria-valuenow="50"]');
-    expect(bar).toBeInTheDocument();
-    expect(bar?.className).toContain('bg-primary');
-  });
-
-  it('does not render progress bar when total is 0', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 0, total: 0, percentage: 0 },
-    });
-    renderPage();
-    expect(screen.queryByText(/\/0/)).not.toBeInTheDocument();
-  });
-});
-
-describe('TvShowDetailPage — next episode indicator', () => {
-  it('renders next episode link with correct text', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      nextEpisode: { seasonNumber: 2, episodeNumber: 9, episodeName: '4 Days Out' },
-    });
-    renderPage();
-    expect(screen.getByText(/Continue watching: S02E09 — 4 Days Out/)).toBeInTheDocument();
-  });
-
-  it('renders next episode without name', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      nextEpisode: { seasonNumber: 3, episodeNumber: 1, episodeName: null },
-    });
-    renderPage();
-    expect(screen.getByText('Continue watching: S03E01')).toBeInTheDocument();
-  });
-
-  it('does not render next episode when all watched', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 36, total: 36, percentage: 100 },
-      nextEpisode: null,
-    });
-    renderPage();
-    expect(screen.queryByText(/Continue watching/)).not.toBeInTheDocument();
-  });
-
-  it('links to correct season page', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      nextEpisode: { seasonNumber: 2, episodeNumber: 9, episodeName: '4 Days Out' },
-    });
-    const { container } = renderPage();
-    const link = container.querySelector('a[href="/media/tv/1/season/2"]');
-    expect(link?.textContent).toContain('Continue watching');
-  });
-});
-
-describe('TvShowDetailPage — batch mark all watched', () => {
-  it('shows Mark All Watched button when not all watched', () => {
-    setupQueries();
-    renderPage();
-    expect(screen.getByRole('button', { name: 'Mark All Watched' })).toBeInTheDocument();
-  });
-
-  it('shows All Watched checkmark when fully watched', () => {
-    setupQueries({}, SEASONS, {
-      ...PROGRESS,
-      overall: { watched: 36, total: 36, percentage: 100 },
-      seasons: PROGRESS.seasons.map((s) => ({ ...s, watched: s.total, percentage: 100 })),
-    });
-    renderPage();
-    expect(screen.getByText('All Watched')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Mark All Watched' })).not.toBeInTheDocument();
-  });
-
-  it('calls batchLog mutation with correct args on click', () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    expect(mockBatchLogMutation).toHaveBeenCalledWith({
-      mediaType: 'show',
-      mediaId: 1,
-    });
-  });
-
-  it('writes optimistic progress via setData on batch mark', async () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalledWith(
-        ['watchHistory', 'progress'],
-        { tvShowId: 1 },
-        expect.any(Function)
-      );
-    });
-  });
-
-  it('invalidates watch history after batch mark settles', async () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    await waitFor(() => {
-      expect(mockInvalidate).toHaveBeenCalledWith(['watchHistory']);
-    });
-  });
-
-  it('invalidates listSeasons after batch mark settles', async () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    await waitFor(() => {
-      expect(mockInvalidate).toHaveBeenCalledWith(['tvShows', 'listSeasons']);
-    });
-  });
-
-  it('reverts progress data on error', async () => {
-    setupQueries();
-    renderPage();
-    mockBatchLogMutation.mockImplementation(() => {
-      const previousEnvelope = { data: PROGRESS };
-      mockSetData.mockReturnValueOnce(previousEnvelope);
-      const context =
-        typeof batchLogOpts.onMutate === 'function'
-          ? (batchLogOpts.onMutate as () => { previous: typeof previousEnvelope })()
-          : undefined;
-      if (typeof batchLogOpts.onError === 'function')
-        (
-          batchLogOpts.onError as (
-            err: { message: string },
-            vars: unknown,
-            ctx: typeof context
-          ) => void
-        )({ message: 'Network error' }, { mediaType: 'show', mediaId: 1 }, context);
-      if (typeof batchLogOpts.onSettled === 'function') (batchLogOpts.onSettled as () => void)();
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalledTimes(2);
-    });
-    const rollbackCall = mockSetData.mock.calls[1]!;
-    expect(rollbackCall[0]).toEqual(['watchHistory', 'progress']);
-    expect(rollbackCall[1]).toEqual({ tvShowId: 1 });
-  });
-});
-
 const SONARR_SERIES = {
   exists: true,
   sonarrId: 99,
@@ -597,59 +96,554 @@ const SONARR_SERIES = {
   ],
 };
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderPage(showId = '1', queryClient = makeQueryClient()) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  const view = render(
+    <MemoryRouter initialEntries={[`/media/tv/${showId}`]}>
+      <Routes>
+        <Route path="/media/tv/:id" element={<TvShowDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper }
+  );
+  return { ...view, queryClient };
+}
+
+function setupQueries(
+  showOverrides: Record<string, unknown> = {},
+  seasons: Array<Record<string, unknown>> = SEASONS,
+  progress: Record<string, unknown> | null = PROGRESS
+) {
+  tvShowsGetMock.mockResolvedValue(ok({ data: { ...SHOW, ...showOverrides } }));
+  tvShowsListSeasonsMock.mockResolvedValue(ok({ data: seasons, total: seasons.length }));
+  watchHistoryProgressMock.mockResolvedValue(ok({ data: progress }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tvShowsListSeasonsMock.mockResolvedValue(ok({ data: [], total: 0 }));
+  watchHistoryProgressMock.mockResolvedValue(ok({ data: null }));
+  arrCheckSeriesMock.mockResolvedValue(
+    ok({ data: { exists: false, sonarrId: null, seasons: [] } })
+  );
+  watchHistoryBatchLogMock.mockResolvedValue(
+    ok({ data: { logged: 16, skipped: 0 }, message: 'ok' })
+  );
+  arrUpdateSeasonMonitoringMock.mockResolvedValue(ok({ message: 'ok' }));
+});
+
+describe('TvShowDetailPage — season list', () => {
+  describe('rendering', () => {
+    it('renders season cards with correct data', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByRole('heading', { name: 'Seasons' })).toBeInTheDocument();
+      expect(screen.getByText('Season 1')).toBeInTheDocument();
+      expect(screen.getByText('Season 2')).toBeInTheDocument();
+      expect(screen.getByText('Season 3')).toBeInTheDocument();
+      expect(screen.getByText('Specials')).toBeInTheDocument();
+    });
+
+    it('renders episode counts', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('7 episodes')).toBeInTheDocument();
+      expect(screen.getAllByText('13 episodes')).toHaveLength(2);
+      expect(screen.getByText('3 episodes')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no seasons', async () => {
+      setupQueries({}, [], {
+        ...PROGRESS,
+        overall: { watched: 0, total: 0, percentage: 0 },
+        seasons: [],
+      });
+      renderPage();
+      expect(await screen.findByRole('heading', { name: 'Seasons' })).toBeInTheDocument();
+      expect(screen.getByText('No seasons available')).toBeInTheDocument();
+    });
+  });
+
+  describe('sort order', () => {
+    it('puts specials (season 0) last', async () => {
+      setupQueries();
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const links = container.querySelectorAll('a[href*="/season/"]');
+      expect(links).toHaveLength(4);
+      expect(links[0]!.getAttribute('href')).toBe('/media/tv/1/season/1');
+      expect(links[1]!.getAttribute('href')).toBe('/media/tv/1/season/2');
+      expect(links[2]!.getAttribute('href')).toBe('/media/tv/1/season/3');
+      expect(links[3]!.getAttribute('href')).toBe('/media/tv/1/season/0');
+    });
+  });
+
+  describe('navigation', () => {
+    it('links to correct season detail page', async () => {
+      setupQueries();
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const seasonLink = container.querySelector('a[href="/media/tv/1/season/2"]');
+      expect(seasonLink).toBeInTheDocument();
+    });
+  });
+
+  describe('progress bars', () => {
+    it('renders progress bar for season with progress', async () => {
+      setupQueries();
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const progressBars = container.querySelectorAll('[role="progressbar"]');
+      expect(progressBars.length).toBeGreaterThan(0);
+    });
+
+    it('renders green bar for completed season (100%)', async () => {
+      setupQueries({}, [{ id: 11, seasonNumber: 1, name: 'Season 1', episodeCount: 7 }], {
+        ...PROGRESS,
+        seasons: [{ seasonId: 11, seasonNumber: 1, watched: 7, total: 7, percentage: 100 }],
+      });
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const bar = container.querySelector('[aria-valuenow="100"]');
+      expect(bar).toBeInTheDocument();
+      expect(bar?.className).toContain('bg-success');
+    });
+
+    it('renders accent bar for in-progress season (50%)', async () => {
+      setupQueries({}, [{ id: 12, seasonNumber: 2, name: 'Season 2', episodeCount: 10 }], {
+        ...PROGRESS,
+        seasons: [{ seasonId: 12, seasonNumber: 2, watched: 5, total: 10, percentage: 50 }],
+      });
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const bar = container.querySelector('[aria-valuenow="50"]');
+      expect(bar).toBeInTheDocument();
+      expect(bar?.className).toContain('bg-primary');
+    });
+
+    it('does not render progress bar for 0% season', async () => {
+      setupQueries({}, [{ id: 10, seasonNumber: 1, name: 'Season 1', episodeCount: 5 }], {
+        ...PROGRESS,
+        overall: { watched: 0, total: 5, percentage: 0 },
+        seasons: [{ seasonId: 10, seasonNumber: 1, watched: 0, total: 5, percentage: 0 }],
+      });
+      const { container } = renderPage();
+      await screen.findByRole('heading', { name: 'Seasons' });
+      const seasonLinks = container.querySelectorAll('a[href*="/season/"]');
+      expect(seasonLinks).toHaveLength(1);
+      const bar = seasonLinks[0]!.querySelector('[role="progressbar"]');
+      expect(bar).toBeInTheDocument();
+    });
+  });
+
+  describe('404 handling', () => {
+    it('shows error for invalid show ID', () => {
+      renderPage('abc');
+      expect(screen.getByText('Invalid show ID')).toBeInTheDocument();
+    });
+
+    it('shows not found for missing show', async () => {
+      tvShowsGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'Not found' },
+        response: new Response(null, { status: 404 }),
+      });
+      renderPage('999');
+      expect(await screen.findByText('Show not found')).toBeInTheDocument();
+    });
+
+    it('shows generic error for non-404 failures', async () => {
+      tvShowsGetMock.mockResolvedValue({
+        data: undefined,
+        error: { message: 'pillar unavailable' },
+        response: new Response(null, { status: 500 }),
+      });
+      renderPage('1');
+      expect(await screen.findByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('pillar unavailable')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('TvShowDetailPage — hero and metadata', () => {
+  describe('hero with backdrop', () => {
+    it('renders backdrop image when backdropUrl is present', async () => {
+      setupQueries();
+      const { container } = renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      const backdrop = container.querySelector('img[src="/media/images/tv/81189/backdrop.jpg"]');
+      expect(backdrop).toBeInTheDocument();
+    });
+
+    it('does not render backdrop image when backdropUrl is null (fallback gradient)', async () => {
+      setupQueries({ backdropUrl: null });
+      const { container } = renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      const images = container.querySelectorAll('img');
+      expect(images).toHaveLength(1);
+      expect(images[0]!.getAttribute('alt')).toBe('Breaking Bad poster');
+      const hero = container.querySelector('.bg-muted');
+      expect(hero).toBeInTheDocument();
+      const gradient = container.querySelector('.bg-gradient-to-t');
+      expect(gradient).toBeInTheDocument();
+    });
+
+    it('renders poster image', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByAltText('Breaking Bad poster')).toBeInTheDocument();
+    });
+
+    it('renders a placeholder div when posterUrl is null (no img element)', async () => {
+      setupQueries({ posterUrl: null });
+      const { container } = renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      expect(container.querySelector('img[alt="Breaking Bad poster"]')).not.toBeInTheDocument();
+      const placeholder = container.querySelector('div.rounded-lg.bg-muted.shadow-lg');
+      expect(placeholder).toBeInTheDocument();
+    });
+
+    it('renders title in h1', async () => {
+      setupQueries();
+      renderPage();
+      const heading = await screen.findByRole('heading', { level: 1 });
+      expect(heading).toHaveTextContent('Breaking Bad');
+    });
+  });
+
+  describe('status badge', () => {
+    it('renders status text for ended show', async () => {
+      setupQueries();
+      renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders status text for returning series', async () => {
+      setupQueries({ status: 'Returning Series' });
+      renderPage();
+      expect((await screen.findAllByText('Returning Series')).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders separator dot between year range and status', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('·')).toBeInTheDocument();
+    });
+
+    it('does not render separator when no year range', async () => {
+      setupQueries({ firstAirDate: null, lastAirDate: null });
+      renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      expect(screen.queryByText('·')).not.toBeInTheDocument();
+      expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not render status when status is null', async () => {
+      setupQueries({ status: null });
+      renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      expect(screen.queryByText('·')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('year range formatting', () => {
+    it('shows start–end for ended show spanning multiple years', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('2008–2013')).toBeInTheDocument();
+    });
+
+    it('shows year–Present for returning series', async () => {
+      setupQueries({
+        status: 'Returning Series',
+        firstAirDate: '2022-02-18',
+        lastAirDate: '2024-01-12',
+      });
+      renderPage();
+      expect(await screen.findByText('2022–Present')).toBeInTheDocument();
+    });
+
+    it('shows single year when start and end are in same year', async () => {
+      setupQueries({
+        firstAirDate: '2020-06-01',
+        lastAirDate: '2020-12-15',
+        status: 'Ended',
+      });
+      renderPage();
+      expect(await screen.findByText('2020')).toBeInTheDocument();
+    });
+  });
+
+  describe('networks display', () => {
+    it('renders networks in metadata grid', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('Networks')).toBeInTheDocument();
+      expect(screen.getByText('AMC')).toBeInTheDocument();
+    });
+
+    it('renders multiple networks as comma-separated list', async () => {
+      setupQueries({ networks: ['HBO', 'Max'] });
+      renderPage();
+      expect(await screen.findByText('HBO, Max')).toBeInTheDocument();
+    });
+
+    it('does not render networks when empty', async () => {
+      setupQueries({ networks: [] });
+      renderPage();
+      await screen.findByRole('heading', { level: 1 });
+      expect(screen.queryByText('Networks')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('genres', () => {
+    it('renders genre badges', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('Drama')).toBeInTheDocument();
+      expect(screen.getByText('Crime')).toBeInTheDocument();
+    });
+  });
+
+  describe('overview', () => {
+    it('renders overview text', async () => {
+      setupQueries();
+      renderPage();
+      expect(await screen.findByText('A chemistry teacher turned meth cook.')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('TvShowDetailPage — overall progress bar', () => {
+  it('renders overall progress bar with label', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 20, total: 36, percentage: 56 },
+    });
+    renderPage();
+    expect(await screen.findByText('20/36')).toBeInTheDocument();
+  });
+
+  it('renders green bar at 100%', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 36, total: 36, percentage: 100 },
+      seasons: PROGRESS.seasons.map((s) => ({ ...s, watched: s.total, percentage: 100 })),
+    });
+    const { container } = renderPage();
+    await screen.findByRole('heading', { level: 1 });
+    const bars = container.querySelectorAll('[aria-valuenow="100"]');
+    const greenBar = Array.from(bars).find((b) => b.className.includes('bg-success'));
+    expect(greenBar).toBeTruthy();
+  });
+
+  it('renders primary bar at 50%', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 18, total: 36, percentage: 50 },
+    });
+    const { container } = renderPage();
+    await screen.findByRole('heading', { level: 1 });
+    const bar = container.querySelector('[aria-valuenow="50"]');
+    expect(bar).toBeInTheDocument();
+    expect(bar?.className).toContain('bg-primary');
+  });
+
+  it('does not render progress bar when total is 0', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 0, total: 0, percentage: 0 },
+    });
+    renderPage();
+    await screen.findByRole('heading', { level: 1 });
+    expect(screen.queryByText(/\/0/)).not.toBeInTheDocument();
+  });
+});
+
+describe('TvShowDetailPage — next episode indicator', () => {
+  it('renders next episode link with correct text', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      nextEpisode: { seasonNumber: 2, episodeNumber: 9, episodeName: '4 Days Out' },
+    });
+    renderPage();
+    expect(await screen.findByText(/Continue watching: S02E09 — 4 Days Out/)).toBeInTheDocument();
+  });
+
+  it('renders next episode without name', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      nextEpisode: { seasonNumber: 3, episodeNumber: 1, episodeName: null },
+    });
+    renderPage();
+    expect(await screen.findByText('Continue watching: S03E01')).toBeInTheDocument();
+  });
+
+  it('does not render next episode when all watched', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 36, total: 36, percentage: 100 },
+      nextEpisode: null,
+    });
+    renderPage();
+    await screen.findByRole('heading', { level: 1 });
+    expect(screen.queryByText(/Continue watching/)).not.toBeInTheDocument();
+  });
+
+  it('links to correct season page', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      nextEpisode: { seasonNumber: 2, episodeNumber: 9, episodeName: '4 Days Out' },
+    });
+    const { container } = renderPage();
+    await screen.findByText(/Continue watching/);
+    const link = container.querySelector('a[href="/media/tv/1/season/2"]');
+    expect(link?.textContent).toContain('Continue watching');
+  });
+});
+
+describe('TvShowDetailPage — batch mark all watched', () => {
+  it('shows Mark All Watched button when not all watched', async () => {
+    setupQueries();
+    renderPage();
+    expect(await screen.findByRole('button', { name: 'Mark All Watched' })).toBeInTheDocument();
+  });
+
+  it('shows All Watched checkmark when fully watched', async () => {
+    setupQueries({}, SEASONS, {
+      ...PROGRESS,
+      overall: { watched: 36, total: 36, percentage: 100 },
+      seasons: PROGRESS.seasons.map((s) => ({ ...s, watched: s.total, percentage: 100 })),
+    });
+    renderPage();
+    expect(await screen.findByText('All Watched')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Mark All Watched' })).not.toBeInTheDocument();
+  });
+
+  it('calls batchLog SDK with correct body on click', async () => {
+    setupQueries();
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark All Watched' }));
+    await waitFor(() => {
+      expect(watchHistoryBatchLogMock).toHaveBeenCalledWith({
+        body: { mediaType: 'show', mediaId: 1, completed: 1 },
+      });
+    });
+  });
+
+  it('writes optimistic progress to the cache on batch mark', async () => {
+    setupQueries();
+    const { queryClient } = renderPage();
+    await screen.findByText('20/36');
+    const setSpy = vi.spyOn(queryClient, 'setQueryData');
+    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
+    await waitFor(() => {
+      const progressWrite = setSpy.mock.calls.find(
+        (call) =>
+          Array.isArray(call[0]) && call[0][1] === 'watchHistory' && call[0][2] === 'progress'
+      );
+      expect(progressWrite).toBeTruthy();
+      const written = progressWrite![1] as { data: { overall: { percentage: number } } };
+      expect(written.data.overall.percentage).toBe(100);
+    });
+  });
+
+  it('invalidates watch history and listSeasons after batch mark settles', async () => {
+    setupQueries();
+    const { queryClient } = renderPage();
+    await screen.findByText('20/36');
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'watchHistory'],
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['media', 'tvShows', 'listSeasons'],
+      });
+    });
+  });
+
+  it('reverts optimistic progress on error', async () => {
+    setupQueries();
+    watchHistoryBatchLogMock.mockRejectedValue(new MediaApiError('Network error', 500));
+    const { queryClient } = renderPage();
+    await screen.findByText('20/36');
+    const key = ['media', 'watchHistory', 'progress', { tvShowId: 1 }];
+    const before = queryClient.getQueryData(key);
+    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
+    await waitFor(() => {
+      expect(watchHistoryBatchLogMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(queryClient.getQueryData(key)).toEqual(before);
+    });
+  });
+});
+
 function setupWithSonarr(sonarr = SONARR_SERIES) {
   setupQueries();
-  mockCheckSeriesQuery.mockReturnValue({ data: { data: sonarr }, isLoading: false });
+  arrCheckSeriesMock.mockResolvedValue(ok({ data: sonarr }));
 }
 
 describe('TvShowDetailPage — season monitoring toggles', () => {
-  it('shows monitoring toggle per season when series exists in Sonarr', () => {
+  it('shows monitoring toggle per season when series exists in Sonarr', async () => {
     setupWithSonarr();
     renderPage();
-    expect(screen.getByRole('switch', { name: 'Monitor Season 1' })).toBeInTheDocument();
+    expect(await screen.findByRole('switch', { name: 'Monitor Season 1' })).toBeInTheDocument();
     expect(screen.getByRole('switch', { name: 'Monitor Season 2' })).toBeInTheDocument();
   });
 
-  it('reflects monitored state from Sonarr seasons data', () => {
+  it('reflects monitored state from Sonarr seasons data', async () => {
     setupWithSonarr();
     renderPage();
-    expect(screen.getByRole('switch', { name: 'Monitor Season 1' })).toBeChecked();
+    expect(await screen.findByRole('switch', { name: 'Monitor Season 1' })).toBeChecked();
     expect(screen.getByRole('switch', { name: 'Monitor Season 2' })).not.toBeChecked();
   });
 
-  it('hides monitoring toggles when series is not in Sonarr', () => {
+  it('hides monitoring toggles when series is not in Sonarr', async () => {
     setupQueries();
-    mockCheckSeriesQuery.mockReturnValue({
-      data: { data: { exists: false, sonarrId: null, seasons: [] } },
-      isLoading: false,
-    });
+    arrCheckSeriesMock.mockResolvedValue(
+      ok({ data: { exists: false, sonarrId: null, seasons: [] } })
+    );
     renderPage();
+    await screen.findByRole('heading', { name: 'Seasons' });
     expect(screen.queryByRole('switch', { name: /Monitor Season/ })).not.toBeInTheDocument();
   });
 
-  it('hides monitoring toggles when Sonarr data is not loaded', () => {
+  it('hides monitoring toggles when Sonarr data is not loaded', async () => {
     setupQueries();
-    mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: true });
+    arrCheckSeriesMock.mockResolvedValue(ok({ data: undefined }));
     renderPage();
+    await screen.findByRole('heading', { name: 'Seasons' });
     expect(screen.queryByRole('switch', { name: /Monitor Season/ })).not.toBeInTheDocument();
   });
 
-  it('calls updateSeasonMonitoring when toggle is clicked', () => {
+  it('calls updateSeasonMonitoring SDK when toggle is clicked', async () => {
     setupWithSonarr();
     renderPage();
-    const toggle = screen.getByRole('switch', { name: 'Monitor Season 1' });
+    const toggle = await screen.findByRole('switch', { name: 'Monitor Season 1' });
     fireEvent.click(toggle);
-    expect(mockSeasonMonitorMutation).toHaveBeenCalledWith({
-      sonarrId: 99,
-      seasonNumber: 1,
-      monitored: false,
+    await waitFor(() => {
+      expect(arrUpdateSeasonMonitoringMock).toHaveBeenCalledWith({
+        path: { sonarrId: 99, seasonNumber: 1 },
+        body: { monitored: false },
+      });
     });
   });
 
-  it('optimistically updates toggle state on click', () => {
+  it('optimistically updates toggle state on click', async () => {
     setupWithSonarr();
     renderPage();
-    const toggle = screen.getByRole('switch', { name: 'Monitor Season 2' });
+    const toggle = await screen.findByRole('switch', { name: 'Monitor Season 2' });
     fireEvent.click(toggle);
     expect(toggle).toBeChecked();
   });

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router';
 
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
+import { isNotFoundError } from '../media-api-helpers.js';
 import { TvShowDetailContent } from './tv-show-detail/TvShowDetailContent';
 import { TvShowDetailSkeleton } from './tv-show-detail/TvShowDetailSkeleton';
 import { TvShowHero } from './tv-show-detail/TvShowHero';
@@ -18,8 +19,8 @@ function InvalidIdView() {
   );
 }
 
-function ErrorView({ error }: { error: { data?: { code?: string } | null; message: string } }) {
-  const is404 = error.data?.code === 'NOT_FOUND';
+function ErrorView({ error }: { error: Error }) {
+  const is404 = isNotFoundError(error);
   return (
     <div className="p-6">
       <Alert variant="destructive">

--- a/packages/app-media/src/pages/movie-detail/useMovieDetailModel.ts
+++ b/packages/app-media/src/pages/movie-detail/useMovieDetailModel.ts
@@ -1,7 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { useSetPageContext } from '@pops/navigation';
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsGetStaleness, moviesGet, watchHistoryList } from '../../media-api/index.js';
 
 interface Movie {
   id: number;
@@ -33,7 +36,7 @@ interface MovieGetResponse {
 interface WatchHistoryListResponse {
   data: Array<{
     id: number;
-    mediaType: 'movie' | 'tv_show';
+    mediaType: string;
     mediaId: number;
     watchedAt: string;
     completed: number;
@@ -46,24 +49,24 @@ interface StalenessResponse {
 
 function useMovieQueries(movieId: number) {
   const enabled = !Number.isNaN(movieId);
-  const { data, isLoading, error } = usePillarQuery<MovieGetResponse>(
-    'media',
-    ['movies', 'get'],
-    { id: movieId },
-    { enabled }
-  );
-  const { data: watchHistoryData } = usePillarQuery<WatchHistoryListResponse>(
-    'media',
-    ['watchHistory', 'list'],
-    { mediaType: 'movie', mediaId: movieId },
-    { enabled }
-  );
-  const { data: stalenessData } = usePillarQuery<StalenessResponse>(
-    'media',
-    ['comparisons', 'getStaleness'],
-    { mediaType: 'movie', mediaId: movieId },
-    { enabled }
-  );
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['media', 'movies', 'get', { id: movieId }],
+    queryFn: async (): Promise<MovieGetResponse> =>
+      unwrap(await moviesGet({ path: { id: movieId } })),
+    enabled,
+  });
+  const { data: watchHistoryData } = useQuery({
+    queryKey: ['media', 'watchHistory', 'list', { mediaType: 'movie', mediaId: movieId }],
+    queryFn: async (): Promise<WatchHistoryListResponse> =>
+      unwrap(await watchHistoryList({ query: { mediaType: 'movie', mediaId: movieId } })),
+    enabled,
+  });
+  const { data: stalenessData } = useQuery({
+    queryKey: ['media', 'comparisons', 'getStaleness', { mediaType: 'movie', mediaId: movieId }],
+    queryFn: async (): Promise<StalenessResponse> =>
+      unwrap(await comparisonsGetStaleness({ query: { mediaType: 'movie', mediaId: movieId } })),
+    enabled,
+  });
   return { data, isLoading, error, watchHistoryData, stalenessData };
 }
 

--- a/packages/app-media/src/pages/tv-show-detail/types.ts
+++ b/packages/app-media/src/pages/tv-show-detail/types.ts
@@ -20,3 +20,5 @@ export interface SonarrSeriesData {
   sonarrId?: number | null;
   seasons?: { seasonNumber: number; monitored: boolean }[];
 }
+
+export type ProgressEnvelope = { data: ProgressData | null };

--- a/packages/app-media/src/pages/tv-show-detail/useTvShowDetailModel.ts
+++ b/packages/app-media/src/pages/tv-show-detail/useTvShowDetailModel.ts
@@ -1,12 +1,18 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { useSetPageContext } from '@pops/navigation';
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
-import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  arrCheckSeries,
+  tvShowsGet,
+  tvShowsListSeasons,
+  watchHistoryProgress,
+} from '../../media-api/index.js';
+import { useBatchLogMutation, useMonitoringMutation } from './useTvShowMutations';
 
-import type { ProgressData, SeasonRow, SonarrSeriesData } from './types';
+import type { ProgressEnvelope, SeasonRow, SonarrSeriesData } from './types';
 
 type ShowDetail = {
   id: number;
@@ -28,129 +34,35 @@ type ShowDetail = {
 type ShowEnvelope = { data: ShowDetail | null };
 
 type SeasonsEnvelope = { data: SeasonRow[] };
-type ProgressEnvelope = { data: ProgressData | null };
 type SonarrEnvelope = { data: SonarrSeriesData | null };
-
-type ProgressContext = { previous: ProgressEnvelope | undefined };
 
 function useTvShowQueries(showId: number) {
   const enabled = !Number.isNaN(showId);
-  const { data, isLoading, error } = usePillarQuery<ShowEnvelope>(
-    'media',
-    ['tvShows', 'get'],
-    { id: showId },
-    { enabled }
-  );
-  const { data: seasonsData } = usePillarQuery<SeasonsEnvelope>(
-    'media',
-    ['tvShows', 'listSeasons'],
-    { tvShowId: showId },
-    { enabled }
-  );
-  const { data: progressData } = usePillarQuery<ProgressEnvelope>(
-    'media',
-    ['watchHistory', 'progress'],
-    { tvShowId: showId },
-    { enabled }
-  );
-  const { data: sonarrData } = usePillarQuery<SonarrEnvelope>(
-    'media',
-    ['arr', 'checkSeries'],
-    { tvdbId: data?.data?.tvdbId ?? 0 },
-    { enabled: !!data?.data?.tvdbId }
-  );
-  return { data, isLoading, error, seasonsData, progressData, sonarrData };
-}
-
-function useMonitoringMutation({
-  setOptimisticMonitoring,
-  setPendingSeasons,
-}: {
-  setOptimisticMonitoring: React.Dispatch<React.SetStateAction<Map<number, boolean>>>;
-  setPendingSeasons: React.Dispatch<React.SetStateAction<Set<number>>>;
-}) {
-  const utils = usePillarUtils('media');
-  return usePillarMutation<{ sonarrId: number; seasonNumber: number; monitored: boolean }, unknown>(
-    'media',
-    ['arr', 'updateSeasonMonitoring'],
-    {
-      onError: (err, variables) => {
-        setOptimisticMonitoring((prev) => {
-          const next = new Map(prev);
-          next.set(variables.seasonNumber, !variables.monitored);
-          return next;
-        });
-        toast.error(`Failed to update monitoring: ${err.message}`);
-      },
-      onSuccess: () => {
-        void utils.invalidate(['arr', 'checkSeries']);
-      },
-      onSettled: (_data, _err, variables) => {
-        setPendingSeasons((prev) => {
-          const next = new Set(prev);
-          next.delete(variables.seasonNumber);
-          return next;
-        });
-      },
-    }
-  );
-}
-
-function applyBatchOptimistic(
-  envelope: ProgressEnvelope | undefined
-): ProgressEnvelope | undefined {
-  if (!envelope?.data) return envelope;
-  const updatedSeasons = (envelope.data.seasons ?? []).map((s) => ({
-    ...s,
-    watched: s.total,
-    percentage: 100,
-  }));
-  const totalEpisodes = updatedSeasons.reduce((sum, s) => sum + s.total, 0);
-  return {
-    ...envelope,
-    data: {
-      ...envelope.data,
-      seasons: updatedSeasons,
-      overall: { watched: totalEpisodes, total: totalEpisodes, percentage: 100 },
-      nextEpisode: null,
-    },
-  };
-}
-
-function useBatchLogMutation(showId: number, utils: UsePillarUtilsResult) {
-  return usePillarMutation<
-    { mediaType: 'show'; mediaId: number },
-    { data: { logged: number } },
-    ProgressContext
-  >('media', ['watchHistory', 'batchLog'], {
-    onMutate: () => {
-      const previous = utils.setData<ProgressEnvelope>(
-        ['watchHistory', 'progress'],
-        { tvShowId: showId },
-        (prev) => applyBatchOptimistic(prev)
-      );
-      return { previous };
-    },
-    onSuccess: (result) => {
-      toast.success(
-        `Marked ${result.data.logged} episode${result.data.logged !== 1 ? 's' : ''} as watched`
-      );
-    },
-    onError: (err, _vars, context) => {
-      if (context) {
-        utils.setData<ProgressEnvelope | undefined>(
-          ['watchHistory', 'progress'],
-          { tvShowId: showId },
-          () => context.previous
-        );
-      }
-      toast.error(`Failed to mark all watched: ${err.message}`);
-    },
-    onSettled: () => {
-      void utils.invalidate(['watchHistory']);
-      void utils.invalidate(['tvShows', 'listSeasons']);
-    },
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['media', 'tvShows', 'get', { id: showId }],
+    queryFn: async (): Promise<ShowEnvelope> => unwrap(await tvShowsGet({ path: { id: showId } })),
+    enabled,
   });
+  const { data: seasonsData } = useQuery({
+    queryKey: ['media', 'tvShows', 'listSeasons', { tvShowId: showId }],
+    queryFn: async (): Promise<SeasonsEnvelope> =>
+      unwrap(await tvShowsListSeasons({ path: { tvShowId: showId } })),
+    enabled,
+  });
+  const { data: progressData } = useQuery({
+    queryKey: ['media', 'watchHistory', 'progress', { tvShowId: showId }],
+    queryFn: async (): Promise<ProgressEnvelope> =>
+      unwrap(await watchHistoryProgress({ path: { tvShowId: showId } })),
+    enabled,
+  });
+  const tvdbId = data?.data?.tvdbId ?? 0;
+  const { data: sonarrData } = useQuery({
+    queryKey: ['media', 'arr', 'checkSeries', { tvdbId }],
+    queryFn: async (): Promise<SonarrEnvelope> =>
+      unwrap(await arrCheckSeries({ path: { tvdbId } })),
+    enabled: !!data?.data?.tvdbId,
+  });
+  return { data, isLoading, error, seasonsData, progressData, sonarrData };
 }
 
 function sortSeasons<T extends { seasonNumber: number }>(rawSeasons: T[]): T[] {
@@ -162,7 +74,7 @@ function sortSeasons<T extends { seasonNumber: number }>(rawSeasons: T[]): T[] {
 }
 
 export function useTvShowDetailModel(showId: number) {
-  const utils = usePillarUtils('media');
+  const queryClient = useQueryClient();
   const queries = useTvShowQueries(showId);
   const [optimisticMonitoring, setOptimisticMonitoring] = useState<Map<number, boolean>>(new Map());
   const [pendingSeasons, setPendingSeasons] = useState<Set<number>>(new Set());
@@ -171,7 +83,7 @@ export function useTvShowDetailModel(showId: number) {
     setOptimisticMonitoring,
     setPendingSeasons,
   });
-  const batchLogMutation = useBatchLogMutation(showId, utils);
+  const batchLogMutation = useBatchLogMutation(showId, queryClient);
 
   const seasons = useMemo(
     () => sortSeasons(queries.seasonsData?.data ?? []),

--- a/packages/app-media/src/pages/tv-show-detail/useTvShowMutations.ts
+++ b/packages/app-media/src/pages/tv-show-detail/useTvShowMutations.ts
@@ -1,0 +1,119 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { unwrap } from '../../media-api-helpers.js';
+import { arrUpdateSeasonMonitoring, watchHistoryBatchLog } from '../../media-api/index.js';
+
+import type { Dispatch, SetStateAction } from 'react';
+
+import type { ProgressEnvelope } from './types';
+
+interface SeasonMonitoringInput {
+  sonarrId: number;
+  seasonNumber: number;
+  monitored: boolean;
+}
+
+export function useMonitoringMutation({
+  setOptimisticMonitoring,
+  setPendingSeasons,
+}: {
+  setOptimisticMonitoring: Dispatch<SetStateAction<Map<number, boolean>>>;
+  setPendingSeasons: Dispatch<SetStateAction<Set<number>>>;
+}) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (variables: SeasonMonitoringInput) =>
+      unwrap(
+        await arrUpdateSeasonMonitoring({
+          path: { sonarrId: variables.sonarrId, seasonNumber: variables.seasonNumber },
+          body: { monitored: variables.monitored },
+        })
+      ),
+    onError: (err: Error, variables) => {
+      setOptimisticMonitoring((prev) => {
+        const next = new Map(prev);
+        next.set(variables.seasonNumber, !variables.monitored);
+        return next;
+      });
+      toast.error(`Failed to update monitoring: ${err.message}`);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'arr', 'checkSeries'] });
+    },
+    onSettled: (_data, _err, variables) => {
+      setPendingSeasons((prev) => {
+        const next = new Set(prev);
+        next.delete(variables.seasonNumber);
+        return next;
+      });
+    },
+  });
+}
+
+function applyBatchOptimistic(
+  envelope: ProgressEnvelope | undefined
+): ProgressEnvelope | undefined {
+  if (!envelope?.data) return envelope;
+  const updatedSeasons = (envelope.data.seasons ?? []).map((s) => ({
+    ...s,
+    watched: s.total,
+    percentage: 100,
+  }));
+  const totalEpisodes = updatedSeasons.reduce((sum, s) => sum + s.total, 0);
+  return {
+    ...envelope,
+    data: {
+      ...envelope.data,
+      seasons: updatedSeasons,
+      overall: { watched: totalEpisodes, total: totalEpisodes, percentage: 100 },
+      nextEpisode: null,
+    },
+  };
+}
+
+interface BatchLogInput {
+  mediaType: 'show';
+  mediaId: number;
+}
+
+type ProgressContext = { previous: ProgressEnvelope | undefined };
+
+function progressKey(showId: number) {
+  return ['media', 'watchHistory', 'progress', { tvShowId: showId }] as const;
+}
+
+export function useBatchLogMutation(showId: number, queryClient: QueryClient) {
+  return useMutation<{ data: { logged: number } }, Error, BatchLogInput, ProgressContext>({
+    mutationFn: async (variables) =>
+      unwrap(
+        await watchHistoryBatchLog({
+          body: { mediaType: variables.mediaType, mediaId: variables.mediaId, completed: 1 },
+        })
+      ),
+    onMutate: () => {
+      const key = progressKey(showId);
+      const previous = queryClient.getQueryData<ProgressEnvelope>(key);
+      queryClient.setQueryData<ProgressEnvelope>(key, applyBatchOptimistic(previous));
+      return { previous };
+    },
+    onSuccess: (result) => {
+      toast.success(
+        `Marked ${result.data.logged} episode${result.data.logged !== 1 ? 's' : ''} as watched`
+      );
+    },
+    onError: (err, _vars, context) => {
+      if (context) {
+        queryClient.setQueryData<ProgressEnvelope | undefined>(
+          progressKey(showId),
+          context.previous
+        );
+      }
+      toast.error(`Failed to mark all watched: ${err.message}`);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['media', 'watchHistory'] });
+      void queryClient.invalidateQueries({ queryKey: ['media', 'tvShows', 'listSeasons'] });
+    },
+  });
+}


### PR DESCRIPTION
Phase D mop-up. Rewires useMovieDetailModel + useTvShowDetailModel (+ new useTvShowMutations split) + the two detail pages' not-found handling onto the Hey API SDK + react-query (moviesGet/tvShowsGet/tvShowsListSeasons/watchHistoryList/Progress/BatchLog/comparisonsGetStaleness/arrCheckSeries/UpdateSeasonMonitoring). 77/77 page tests; verified in isolation (fe-quality red-by-design), net +77 passing, no missing endpoints.