### PR TITLE
feat(media/fe): rewire discover/rankings/search/compare-arena/comparison-history pages (Phase D)

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -6,10 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@pops/ui';
 
-const mockDimensionsQuery = vi.fn();
-const mockPairQuery = vi.fn();
-const mockRefetchPair = vi.fn();
-const mockPageInvalidate = vi.fn();
+const mockComparisonsListDimensions = vi.fn();
+const mockComparisonsGetSmartPair = vi.fn();
 
 const mockComparisonsRecord = vi.fn();
 const mockComparisonsRecordSkip = vi.fn();
@@ -22,27 +20,9 @@ const mockWatchlistList = vi.fn();
 const mockWatchlistAdd = vi.fn();
 const mockWatchlistRemove = vi.fn();
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'comparisons.listDimensions') return mockDimensionsQuery(input);
-    if (key === 'comparisons.getSmartPair') {
-      const result = mockPairQuery(input);
-      return { ...result, refetch: mockRefetchPair };
-    }
-    return { data: undefined, isLoading: false, error: null };
-  },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: (path?: readonly string[]) => {
-      mockPageInvalidate(path?.join('.') ?? '');
-      return Promise.resolve();
-    },
-    fetchQuery: vi.fn(),
-  }),
-}));
-
 vi.mock('../media-api/index.js', () => ({
+  comparisonsListDimensions: () => mockComparisonsListDimensions(),
+  comparisonsGetSmartPair: (opts: unknown) => mockComparisonsGetSmartPair(opts),
   comparisonsRecord: (opts: unknown) => mockComparisonsRecord(opts),
   comparisonsRecordSkip: (opts: unknown) => mockComparisonsRecordSkip(opts),
   comparisonsMarkStale: (opts: unknown) => mockComparisonsMarkStale(opts),
@@ -93,14 +73,9 @@ function renderPage(queryClient?: QueryClient) {
 }
 
 function setupArena() {
-  mockDimensionsQuery.mockReturnValue({
-    data: { data: [dim1, dim2, dim3] },
-    isLoading: false,
-  });
-  mockPairQuery.mockReturnValue({
+  mockComparisonsListDimensions.mockResolvedValue({ data: { data: [dim1, dim2, dim3] } });
+  mockComparisonsGetSmartPair.mockResolvedValue({
     data: { data: { movieA, movieB, dimensionId: 1 } },
-    isLoading: false,
-    error: null,
   });
 }
 
@@ -119,19 +94,19 @@ describe('CompareArenaPage', () => {
     mockWatchlistRemove.mockResolvedValue({ data: {} });
   });
 
-  it('renders pair with movie titles', () => {
+  it('renders pair with movie titles', async () => {
     setupArena();
     renderPage();
 
-    expect(screen.getAllByText('The Matrix').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('The Matrix')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Inception').length).toBeGreaterThan(0);
   });
 
-  it('renders dimension dropdown with active dimension selected', () => {
+  it('renders dimension dropdown with active dimension selected', async () => {
     setupArena();
     renderPage();
 
-    const select = screen.getByLabelText('Comparison dimension');
+    const select = await screen.findByLabelText('Comparison dimension');
     expect(select).toBeTruthy();
     expect((select as HTMLSelectElement).value).toBe('1');
   });
@@ -140,7 +115,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getAllByText('The Matrix')[0]!);
+    fireEvent.click((await screen.findAllByText('The Matrix'))[0]!);
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledWith({
@@ -158,7 +133,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Skip this pair'));
+    fireEvent.click(await screen.findByLabelText('Skip this pair'));
 
     await waitFor(() => {
       expect(mockComparisonsRecordSkip).toHaveBeenCalledWith({
@@ -174,31 +149,21 @@ describe('CompareArenaPage', () => {
     expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
-  it('shows minimum threshold message when pair data is null', () => {
-    mockDimensionsQuery.mockReturnValue({
-      data: { data: [dim1] },
-      isLoading: false,
-    });
-    mockPairQuery.mockReturnValue({
-      data: { data: null },
-      isLoading: false,
-      error: null,
+  it('shows minimum threshold message when pair data is null', async () => {
+    mockComparisonsListDimensions.mockResolvedValue({ data: { data: [dim1] } });
+    mockComparisonsGetSmartPair.mockResolvedValue({
+      data: { data: null, reason: 'insufficient_watched_movies' },
     });
 
     renderPage();
 
-    expect(screen.getByText('Not enough watched movies')).toBeTruthy();
+    expect(await screen.findByText('Not enough watched movies')).toBeTruthy();
   });
 
-  it('shows watchlist depletion message when pool is empty and movies are watchlisted', () => {
-    mockDimensionsQuery.mockReturnValue({
-      data: { data: [dim1] },
-      isLoading: false,
-    });
-    mockPairQuery.mockReturnValue({
-      data: { data: null },
-      isLoading: false,
-      error: null,
+  it('shows watchlist depletion message when pool is empty and movies are watchlisted', async () => {
+    mockComparisonsListDimensions.mockResolvedValue({ data: { data: [dim1] } });
+    mockComparisonsGetSmartPair.mockResolvedValue({
+      data: { data: null, reason: 'insufficient_watched_movies' },
     });
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -211,7 +176,7 @@ describe('CompareArenaPage', () => {
 
     renderPage(queryClient);
 
-    expect(screen.getByText('Not enough movies')).toBeTruthy();
+    expect(await screen.findByText('Not enough movies')).toBeTruthy();
     expect(screen.getByText('Some are on your watchlist.')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'View watchlist' })).toBeTruthy();
   });
@@ -220,7 +185,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getAllByText('The Matrix')[0]!);
+    fireEvent.click((await screen.findAllByText('The Matrix'))[0]!);
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledWith({
@@ -233,7 +198,9 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    const bookmarkButtons = screen.getAllByRole('button', { name: /add .* to watchlist/i });
+    const bookmarkButtons = await screen.findAllByRole('button', {
+      name: /add .* to watchlist/i,
+    });
     expect(bookmarkButtons.length).toBeGreaterThan(0);
     fireEvent.click(bookmarkButtons[0]!);
 
@@ -244,26 +211,16 @@ describe('CompareArenaPage', () => {
     });
 
     expect(mockComparisonsRecord).not.toHaveBeenCalled();
-    expect(mockRefetchPair).not.toHaveBeenCalled();
 
     await waitFor(() => {
       expect(mockToastSuccess).toHaveBeenCalledWith('The Matrix added to watchlist');
     });
-    expect(mockRefetchPair).not.toHaveBeenCalled();
     expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
   it('renders loading skeletons when pair is loading', () => {
-    mockDimensionsQuery.mockReturnValue({
-      data: { data: [dim1] },
-      isLoading: false,
-    });
-    mockPairQuery.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isFetching: true,
-      error: null,
-    });
+    mockComparisonsListDimensions.mockResolvedValue({ data: { data: [dim1] } });
+    mockComparisonsGetSmartPair.mockReturnValue(new Promise(() => {}));
 
     renderPage();
 
@@ -272,28 +229,30 @@ describe('CompareArenaPage', () => {
   });
 
   it('renders loading skeletons when pair is fetching (background refetch)', () => {
-    mockDimensionsQuery.mockReturnValue({
-      data: { data: [dim1] },
-      isLoading: false,
+    mockComparisonsListDimensions.mockResolvedValue({ data: { data: [dim1] } });
+    mockComparisonsGetSmartPair.mockReturnValue(new Promise(() => {}));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
-    mockPairQuery.mockReturnValue({
-      data: { data: { movieA, movieB, dimensionId: 1 } },
-      isLoading: false,
-      isFetching: true,
-      error: null,
+    queryClient.setQueryData(['media', 'comparisons', 'listDimensions'], {
+      data: [dim1],
+    });
+    queryClient.setQueryData(['media', 'comparisons', 'getSmartPair', { dimensionId: null }], {
+      data: { movieA, movieB, dimensionId: 1 },
     });
 
-    renderPage();
+    renderPage(queryClient);
 
     expect(screen.queryByText('The Matrix')).toBeNull();
     expect(screen.queryByText('Not enough watched movies')).toBeNull();
   });
 
-  it('renders stale buttons for both movies', () => {
+  it('renders stale buttons for both movies', async () => {
     setupArena();
     renderPage();
 
-    expect(screen.getByLabelText('Mark The Matrix as stale')).toBeTruthy();
+    expect(await screen.findByLabelText('Mark The Matrix as stale')).toBeTruthy();
     expect(screen.getByLabelText('Mark Inception as stale')).toBeTruthy();
   });
 
@@ -301,7 +260,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Mark The Matrix as stale'));
+    fireEvent.click(await screen.findByLabelText('Mark The Matrix as stale'));
 
     await waitFor(() => {
       expect(mockComparisonsMarkStale).toHaveBeenCalledWith({
@@ -314,7 +273,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Mark Inception as stale'));
+    fireEvent.click(await screen.findByLabelText('Mark Inception as stale'));
 
     await waitFor(() => {
       expect(mockComparisonsMarkStale).toHaveBeenCalledWith({
@@ -327,7 +286,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Mark The Matrix as stale'));
+    fireEvent.click(await screen.findByLabelText('Mark The Matrix as stale'));
 
     await waitFor(() => {
       expect(mockComparisonsMarkStale).toHaveBeenCalled();
@@ -339,7 +298,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('N/A: The Matrix'));
+    fireEvent.click(await screen.findByLabelText('N/A: The Matrix'));
 
     await waitFor(() => {
       expect(mockComparisonsExcludeFromDimension).toHaveBeenCalledWith({
@@ -353,7 +312,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('N/A: Inception'));
+    fireEvent.click(await screen.findByLabelText('N/A: Inception'));
 
     await waitFor(() => {
       expect(mockComparisonsExcludeFromDimension).toHaveBeenCalledWith({
@@ -363,19 +322,19 @@ describe('CompareArenaPage', () => {
     expect(mockComparisonsRecord).not.toHaveBeenCalled();
   });
 
-  it('renders Not Watched buttons on both cards', () => {
+  it('renders Not Watched buttons on both cards', async () => {
     setupArena();
     renderPage();
 
-    expect(screen.getByLabelText('Not watched The Matrix')).toBeTruthy();
+    expect(await screen.findByLabelText('Not watched The Matrix')).toBeTruthy();
     expect(screen.getByLabelText('Not watched Inception')).toBeTruthy();
   });
 
-  it('opens confirmation dialog when Not Watched button is clicked', () => {
+  it('opens confirmation dialog when Not Watched button is clicked', async () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Not watched The Matrix'));
+    fireEvent.click(await screen.findByLabelText('Not watched The Matrix'));
 
     expect(screen.getByText('Mark as not watched?')).toBeTruthy();
     expect(screen.getByText('Cancel')).toBeTruthy();
@@ -389,7 +348,7 @@ describe('CompareArenaPage', () => {
     });
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Not watched The Matrix'));
+    fireEvent.click(await screen.findByLabelText('Not watched The Matrix'));
 
     expect(await screen.findByText('5')).toBeTruthy();
     expect(screen.getByText(/comparisons involving/)).toBeTruthy();
@@ -399,7 +358,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Not watched Inception'));
+    fireEvent.click(await screen.findByLabelText('Not watched Inception'));
     fireEvent.click(screen.getByRole('button', { name: 'Not watched' }));
 
     await waitFor(() => {
@@ -409,22 +368,22 @@ describe('CompareArenaPage', () => {
     });
   });
 
-  it('closes dialog on cancel without calling blacklist', () => {
+  it('closes dialog on cancel without calling blacklist', async () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Not watched The Matrix'));
+    fireEvent.click(await screen.findByLabelText('Not watched The Matrix'));
     expect(screen.getByText('Mark as not watched?')).toBeTruthy();
 
     fireEvent.click(screen.getByText('Cancel'));
     expect(mockComparisonsBlacklistMovie).not.toHaveBeenCalled();
   });
 
-  it('renders draw tier buttons with tooltips', () => {
+  it('renders draw tier buttons with tooltips', async () => {
     setupArena();
     renderPage();
 
-    expect(screen.getByLabelText('Equally great')).toBeTruthy();
+    expect(await screen.findByLabelText('Equally great')).toBeTruthy();
     expect(screen.getByLabelText('Equally average')).toBeTruthy();
     expect(screen.getByLabelText('Equally poor')).toBeTruthy();
   });
@@ -433,7 +392,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Equally great'));
+    fireEvent.click(await screen.findByLabelText('Equally great'));
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledWith({
@@ -452,7 +411,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Equally average'));
+    fireEvent.click(await screen.findByLabelText('Equally average'));
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledWith({
@@ -468,7 +427,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Equally poor'));
+    fireEvent.click(await screen.findByLabelText('Equally poor'));
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledWith({
@@ -484,7 +443,7 @@ describe('CompareArenaPage', () => {
     setupArena();
     renderPage();
 
-    fireEvent.click(screen.getByLabelText('Equally great'));
+    fireEvent.click(await screen.findByLabelText('Equally great'));
 
     await waitFor(() => {
       expect(mockComparisonsRecord).toHaveBeenCalledTimes(1);
@@ -494,10 +453,10 @@ describe('CompareArenaPage', () => {
     });
   });
 
-  it('renders history link in header', () => {
+  it('renders history link in header', async () => {
     setupArena();
     renderPage();
 
-    expect(screen.getByLabelText('Comparison history')).toBeTruthy();
+    expect(await screen.findByLabelText('Comparison history')).toBeTruthy();
   });
 });

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -1,6 +1,3 @@
-import { useCallback, useState } from 'react';
-
-import { usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { ButtonPrimitive } from '@pops/ui';
 
 import { BlacklistConfirmDialog } from '../components/BlacklistConfirmDialog';
@@ -10,11 +7,10 @@ import { ArenaEmptyState } from './compare-arena/ArenaEmptyState';
 import { ArenaHeader } from './compare-arena/ArenaHeader';
 import { ArenaPair } from './compare-arena/ArenaPair';
 import { ArenaPrompt } from './compare-arena/ArenaPrompt';
-import { useArenaActions } from './compare-arena/useArenaActions';
-import { useArenaBlacklist } from './compare-arena/useArenaBlacklist';
-import { useArenaWatchlist } from './compare-arena/useArenaWatchlist';
+import { useCompareArenaPageModel } from './compare-arena/useCompareArenaPageModel';
 
-import type { Dimension, PairData } from './compare-arena/types';
+import type { PairData } from './compare-arena/types';
+import type { useArenaActions } from './compare-arena/useArenaActions';
 
 function ArenaError({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
@@ -35,76 +31,6 @@ function ArenaSkeleton() {
       <ComparisonMovieCardSkeleton />
     </div>
   );
-}
-
-interface DimensionsResult {
-  data?: Dimension[];
-}
-
-interface SmartPairResult {
-  data?: PairData | null;
-}
-
-function useCompareArenaPageModel() {
-  const [manualDimensionId, setManualDimensionId] = useState<number | null>(null);
-
-  const { data: dimensionsData, isLoading: dimsLoading } = usePillarQuery<DimensionsResult>(
-    'media',
-    ['comparisons', 'listDimensions'],
-    undefined
-  );
-  const activeDimensions: Dimension[] = dimensionsData?.data?.filter((d) => d.active) ?? [];
-
-  const pairQuery = usePillarQuery<SmartPairResult>(
-    'media',
-    ['comparisons', 'getSmartPair'],
-    manualDimensionId ? { dimensionId: manualDimensionId } : {},
-    { enabled: activeDimensions.length > 0, refetchOnWindowFocus: false, gcTime: 0, staleTime: 0 }
-  );
-
-  const utils = usePillarUtils('media');
-  const pair: PairData | null | undefined = pairQuery.data?.data;
-  const dimensionId = pair?.dimensionId ?? null;
-
-  const resolveTitle = useCallback(
-    (mediaId: number) => {
-      if (pair?.movieA.id === mediaId) return pair.movieA.title;
-      if (pair?.movieB.id === mediaId) return pair.movieB.title;
-      return 'Movie';
-    },
-    [pair]
-  );
-
-  const onAfterAction = useCallback(() => setManualDimensionId(null), []);
-
-  const watchlist = useArenaWatchlist({ enabled: !!pair, resolveTitle });
-  const actions = useArenaActions({ pair, dimensionId, resolveTitle, onAfterAction });
-  const blacklist = useArenaBlacklist({ resolveTitle, onAfterAction });
-
-  const activeDim = activeDimensions.find((d) => d.id === dimensionId);
-
-  const onDimensionChange = useCallback(
-    (id: number) => {
-      setManualDimensionId(id);
-      actions.setScoreDelta(null);
-      void utils.invalidate(['comparisons', 'getSmartPair']);
-    },
-    [actions, utils]
-  );
-
-  return {
-    dimsLoading,
-    activeDimensions,
-    pair,
-    pairQuery,
-    dimensionId,
-    activeDimName: activeDim?.name ?? 'Overall',
-    activeDimDesc: activeDim?.description ?? null,
-    watchlist,
-    actions,
-    blacklist,
-    onDimensionChange,
-  };
 }
 
 export function CompareArenaPage() {

--- a/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
@@ -1,12 +1,11 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ComparisonHistoryPage } from './ComparisonHistoryPage';
-
 import type React from 'react';
 
-// Mock sonner
 const mockToast = vi.fn().mockReturnValue('toast-id-1');
 const mockToastCustom = vi.fn().mockReturnValue('toast-custom-1');
 const mockToastDismiss = vi.fn();
@@ -19,45 +18,25 @@ vi.mock('sonner', () => ({
   }),
 }));
 
-// Mock pillar SDK
-const mockListAllQuery = vi.fn();
-const mockDimensionsQuery = vi.fn();
-const mockMovieGetQuery = vi.fn();
-const mockDeleteMutate = vi.fn();
-const mockInvalidateComparisons = vi.fn();
-const mockRefetch = vi.fn();
-let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
+const mockComparisonsListAll = vi.fn();
+const mockComparisonsListDimensions = vi.fn();
+const mockComparisonsDelete = vi.fn();
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'comparisons.listAll') return mockListAllQuery(input);
-    if (key === 'comparisons.listDimensions') return mockDimensionsQuery(input);
-    if (key === 'movies.get') return mockMovieGetQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, (...args: unknown[]) => unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'comparisons.delete') {
-      deleteMutationOpts = opts;
-      return { mutate: mockDeleteMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: (path?: readonly string[]) => {
-      const key = path?.join('.') ?? '';
-      if (key === 'comparisons') mockInvalidateComparisons();
-    },
-  }),
+vi.mock('../media-api/index.js', () => ({
+  comparisonsListAll: (opts: unknown) => mockComparisonsListAll(opts),
+  comparisonsListDimensions: () => mockComparisonsListDimensions(),
+  comparisonsDelete: (opts: unknown) => mockComparisonsDelete(opts),
 }));
 
-const DIMENSION = { id: 1, name: 'Overall' };
+vi.mock('./comparison-history/MovieTitle', () => ({
+  MovieTitle: ({ mediaId, className }: { mediaId: number; className?: string }) => (
+    <span className={className}>Movie {mediaId}</span>
+  ),
+}));
+
+import { ComparisonHistoryPage } from './ComparisonHistoryPage';
+
+const DIMENSION = { id: 1, name: 'Overall', active: true };
 const COMPARISON = {
   id: 10,
   dimensionId: 1,
@@ -88,41 +67,36 @@ const DRAW_COMPARISON = {
 };
 
 function setupLoaded(comparisons = [COMPARISON], total = comparisons.length) {
-  mockDimensionsQuery.mockReturnValue({ data: { data: [DIMENSION] } });
-  mockListAllQuery.mockReturnValue({
-    data: { data: comparisons, pagination: { total, limit: 20, offset: 0 } },
-    isLoading: false,
-    refetch: mockRefetch,
+  mockComparisonsListDimensions.mockResolvedValue({ data: { data: [DIMENSION] } });
+  mockComparisonsListAll.mockResolvedValue({
+    data: { data: comparisons, pagination: { total, limit: 20, offset: 0, hasMore: false } },
   });
-  mockMovieGetQuery.mockImplementation(({ id }: { id: number }) => ({
-    data: { data: { title: `Movie ${id}` } },
-  }));
 }
 
 function setupEmpty() {
-  mockDimensionsQuery.mockReturnValue({ data: { data: [DIMENSION] } });
-  mockListAllQuery.mockReturnValue({
-    data: { data: [], pagination: { total: 0, limit: 20, offset: 0 } },
-    isLoading: false,
-    refetch: mockRefetch,
+  mockComparisonsListDimensions.mockResolvedValue({ data: { data: [DIMENSION] } });
+  mockComparisonsListAll.mockResolvedValue({
+    data: { data: [], pagination: { total: 0, limit: 20, offset: 0, hasMore: false } },
   });
 }
 
 function setupLoading() {
-  mockDimensionsQuery.mockReturnValue({ data: undefined });
-  mockListAllQuery.mockReturnValue({ data: undefined, isLoading: true, refetch: mockRefetch });
+  mockComparisonsListDimensions.mockReturnValue(new Promise(() => {}));
+  mockComparisonsListAll.mockReturnValue(new Promise(() => {}));
 }
 
 function renderPage() {
-  return render(
-    <MemoryRouter>
-      <ComparisonHistoryPage />
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, createElement(MemoryRouter, null, children));
+  return render(<ComparisonHistoryPage />, { wrapper });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockComparisonsDelete.mockResolvedValue({ data: { message: 'ok' } });
   vi.useFakeTimers();
 });
 
@@ -130,10 +104,17 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
 describe('ComparisonHistoryPage', () => {
-  it('shows history list with comparison rows', () => {
+  it('shows history list with comparison rows', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     expect(screen.getByText('Comparison History')).toBeInTheDocument();
     expect(screen.getByText('Movie 100')).toBeInTheDocument();
@@ -142,19 +123,20 @@ describe('ComparisonHistoryPage', () => {
     expect(screen.getAllByText('Overall').length).toBeGreaterThan(0);
   });
 
-  it('shows tied display for draw comparisons (winnerId=0)', () => {
+  it('shows tied display for draw comparisons (winnerId=0)', async () => {
     setupLoaded([DRAW_COMPARISON]);
     renderPage();
+    await flush();
 
     expect(screen.getByText('tied')).toBeInTheDocument();
     expect(screen.queryByText('beat')).not.toBeInTheDocument();
-    expect(screen.queryByText('Movie #0')).not.toBeInTheDocument();
     expect(screen.getByText('high draw')).toBeInTheDocument();
   });
 
-  it('shows empty state when no comparisons', () => {
+  it('shows empty state when no comparisons', async () => {
     setupEmpty();
     renderPage();
+    await flush();
 
     expect(screen.getByText(/No comparisons yet/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Compare Arena' })).toBeInTheDocument();
@@ -168,48 +150,46 @@ describe('ComparisonHistoryPage', () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('optimistically hides row and shows undo toast on delete', () => {
+  it('optimistically hides row and shows undo toast on delete', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     expect(screen.getByText('Movie 100')).toBeInTheDocument();
 
     const deleteBtn = screen.getByRole('button', { name: '' });
     fireEvent.click(deleteBtn);
 
-    // Row removed optimistically
     expect(screen.queryByText('Movie 100')).not.toBeInTheDocument();
-    // Custom toast shown with undo
     expect(mockToastCustom).toHaveBeenCalled();
-    // Mutation not fired yet
-    expect(mockDeleteMutate).not.toHaveBeenCalled();
+    expect(mockComparisonsDelete).not.toHaveBeenCalled();
   });
 
-  it('executes delete after 5-second undo window', () => {
+  it('executes delete after 5-second undo window', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     const deleteBtn = screen.getByRole('button', { name: '' });
     fireEvent.click(deleteBtn);
 
-    expect(mockDeleteMutate).not.toHaveBeenCalled();
-    act(() => {
-      vi.advanceTimersByTime(5000);
+    expect(mockComparisonsDelete).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
     });
-    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: COMPARISON.id });
+    expect(mockComparisonsDelete).toHaveBeenCalledWith({ path: { id: COMPARISON.id } });
   });
 
-  it('cancels delete and restores row when undo is clicked', () => {
+  it('cancels delete and restores row when undo is clicked', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     const deleteBtn = screen.getByRole('button', { name: '' });
     fireEvent.click(deleteBtn);
 
-    // Row gone
     expect(screen.queryByText('Movie 100')).not.toBeInTheDocument();
 
-    // Extract the render function passed to toast.custom and render it to get the Undo button
     const renderFn = mockToastCustom.mock.calls[0]![0] as (
       id: string | number
     ) => React.ReactElement;
@@ -217,83 +197,95 @@ describe('ComparisonHistoryPage', () => {
     const { getByText: getToastByText } = render(toastElement);
     fireEvent.click(getToastByText('Undo'));
 
-    // Row restored
     expect(screen.getByText('Movie 100')).toBeInTheDocument();
-    // Timer should not fire delete
-    act(() => {
-      vi.advanceTimersByTime(5000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
     });
-    expect(mockDeleteMutate).not.toHaveBeenCalled();
+    expect(mockComparisonsDelete).not.toHaveBeenCalled();
     expect(mockToastDismiss).toHaveBeenCalledWith('toast-custom-1');
   });
 
-  it('invalidates queries on successful delete', () => {
+  it('invalidates queries on successful delete', async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
     setupLoaded();
     renderPage();
+    await flush();
 
-    // Trigger the onSuccess callback directly
-    act(() => {
-      deleteMutationOpts.onSuccess?.(undefined, { id: COMPARISON.id });
+    const deleteBtn = screen.getByRole('button', { name: '' });
+    fireEvent.click(deleteBtn);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
     });
+    await flush();
 
-    expect(mockInvalidateComparisons).toHaveBeenCalled();
+    expect(mockComparisonsDelete).toHaveBeenCalledWith({ path: { id: COMPARISON.id } });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['media', 'comparisons'] });
+    invalidateSpy.mockRestore();
   });
 
-  it('filters by dimension', () => {
+  it('filters by dimension', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: '1' } });
+    await flush();
 
-    expect(mockListAllQuery).toHaveBeenLastCalledWith(expect.objectContaining({ dimensionId: 1 }));
+    expect(mockComparisonsListAll).toHaveBeenLastCalledWith({
+      query: expect.objectContaining({ dimensionId: 1 }),
+    });
   });
 
-  it('shows pagination when multiple pages exist', () => {
+  it('shows pagination when multiple pages exist', async () => {
     setupLoaded([COMPARISON], 50);
     renderPage();
+    await flush();
 
     expect(screen.getByText(/Page 1 of/)).toBeInTheDocument();
   });
 
-  it('renders search input', () => {
+  it('renders search input', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     expect(screen.getByPlaceholderText('Search by movie title…')).toBeInTheDocument();
   });
 
-  it('typing in search triggers filtered query after debounce', () => {
+  it('typing in search triggers filtered query after debounce', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     const searchInput = screen.getByPlaceholderText('Search by movie title…');
     fireEvent.change(searchInput, { target: { value: 'Dark' } });
 
-    // Before debounce fires: no search param
-    expect(mockListAllQuery).not.toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: 'Dark' })
-    );
-
-    // Fire debounce timer and flush React state updates
-    act(() => {
-      vi.advanceTimersByTime(300);
+    expect(mockComparisonsListAll).not.toHaveBeenLastCalledWith({
+      query: expect.objectContaining({ search: 'Dark' }),
     });
-    expect(mockListAllQuery).toHaveBeenLastCalledWith(expect.objectContaining({ search: 'Dark' }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(mockComparisonsListAll).toHaveBeenLastCalledWith({
+      query: expect.objectContaining({ search: 'Dark' }),
+    });
   });
 
-  it('empty search does not pass search param to query', () => {
+  it('empty search does not pass search param to query', async () => {
     setupLoaded();
     renderPage();
+    await flush();
 
     const searchInput = screen.getByPlaceholderText('Search by movie title…');
     fireEvent.change(searchInput, { target: { value: '   ' } });
-    act(() => {
-      vi.advanceTimersByTime(300);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
     });
 
-    expect(mockListAllQuery).toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: undefined })
-    );
+    expect(mockComparisonsListAll).toHaveBeenLastCalledWith({
+      query: expect.objectContaining({ search: undefined }),
+    });
   });
 });

--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -1,33 +1,20 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ── Mocks ─────────────────────────────────────────────────────────────────────
+const mockAssembleSession = vi.fn();
+const mockProfile = vi.fn();
+const mockGetDismissed = vi.fn();
 
-const mockAssembleSessionQuery = vi.fn();
-const mockAssembleSessionRefetch = vi.fn();
-const mockProfileQuery = vi.fn();
-const mockGetDismissedQuery = vi.fn();
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    input: unknown,
-    options: unknown
-  ) => {
-    const key = path.join('.');
-    if (key === 'discovery.assembleSession') {
-      const result = mockAssembleSessionQuery(input, options);
-      return { ...result, refetch: mockAssembleSessionRefetch };
-    }
-    if (key === 'discovery.profile') return mockProfileQuery(input, options);
-    if (key === 'discovery.getDismissed') return mockGetDismissedQuery(input, options);
-    return { data: undefined, isLoading: false, error: null };
-  },
+vi.mock('../media-api/index.js', () => ({
+  discoveryAssembleSession: () => mockAssembleSession(),
+  discoveryProfile: () => mockProfile(),
+  discoveryGetDismissed: () => mockGetDismissed(),
 }));
 
-// Mock useDiscoverCardActions to avoid wiring up all mutation deps
 vi.mock('../hooks/useDiscoverCardActions', () => ({
   useDiscoverCardActions: () => ({
     addingToLibrary: new Set<number>(),
@@ -44,7 +31,6 @@ vi.mock('../hooks/useDiscoverCardActions', () => ({
   }),
 }));
 
-// Mock ShelfSection — renders shelfId + title as a simple section marker
 vi.mock('../components/ShelfSection', () => ({
   ShelfSection: ({ shelfId, title }: { shelfId: string; title: string }) => (
     <section data-testid={`shelf-${shelfId}`}>
@@ -59,46 +45,37 @@ vi.mock('../components/PreferenceProfile', () => ({
 
 import { DiscoverPage } from './DiscoverPage';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function makeShelf(shelfId: string, title: string) {
   return {
     shelfId,
     title,
-    subtitle: undefined,
-    emoji: undefined,
+    subtitle: null,
+    emoji: null,
     items: [],
     hasMore: false,
   };
 }
 
 function defaultProfile(totalComparisons = 10) {
-  mockProfileQuery.mockReturnValue({
+  mockProfile.mockResolvedValue({
     data: {
       data: {
         totalComparisons,
         totalMoviesWatched: 10,
+        genreDistribution: [],
         genreAffinities: [],
         dimensionWeights: [],
       },
     },
-    isLoading: false,
   });
 }
 
 function defaultDismissed() {
-  mockGetDismissedQuery.mockReturnValue({
-    data: { data: [] },
-    isLoading: false,
-  });
+  mockGetDismissed.mockResolvedValue({ data: { data: [] } });
 }
 
 function defaultSession(shelves = [makeShelf('trending-tmdb', 'Trending')]) {
-  mockAssembleSessionQuery.mockReturnValue({
-    data: { shelves },
-    isLoading: false,
-    error: null,
-  });
+  mockAssembleSession.mockResolvedValue({ data: { shelves } });
 }
 
 function setupDefaults() {
@@ -108,14 +85,17 @@ function setupDefaults() {
 }
 
 function renderPage() {
-  return render(
-    <MemoryRouter initialEntries={['/media/discover']}>
-      <DiscoverPage />
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, { initialEntries: ['/media/discover'] }, children)
+    );
+  return render(<DiscoverPage />, { wrapper });
 }
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('DiscoverPage — loading', () => {
   beforeEach(() => {
@@ -125,25 +105,15 @@ describe('DiscoverPage — loading', () => {
   });
 
   it('renders loading skeleton while assembleSession is in flight', () => {
-    mockAssembleSessionQuery.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null,
-    });
+    mockAssembleSession.mockReturnValue(new Promise(() => {}));
     renderPage();
 
-    // Skeleton rows are rendered as animated pulse divs — page header still present
     expect(screen.getByText('Discover')).toBeTruthy();
-    // No ShelfSection rendered yet
     expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
   });
 
   it('does not render shelf sections while loading', () => {
-    mockAssembleSessionQuery.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null,
-    });
+    mockAssembleSession.mockReturnValue(new Promise(() => {}));
     renderPage();
 
     expect(screen.queryByTestId(/^shelf-/)).toBeNull();
@@ -157,25 +127,18 @@ describe('DiscoverPage — error state', () => {
     defaultDismissed();
   });
 
-  it('shows error message when assembleSession fails', () => {
-    mockAssembleSessionQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: { message: 'Server error' },
-    });
+  it('shows error message when assembleSession fails', async () => {
+    mockAssembleSession.mockResolvedValue({ error: { message: 'Server error' } });
     renderPage();
 
-    expect(screen.getByText(/Failed to load discover shelves/)).toBeTruthy();
+    expect(await screen.findByText(/Failed to load discover shelves/)).toBeTruthy();
   });
 
-  it('does not render shelves on error', () => {
-    mockAssembleSessionQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: { message: 'Server error' },
-    });
+  it('does not render shelves on error', async () => {
+    mockAssembleSession.mockResolvedValue({ error: { message: 'Server error' } });
     renderPage();
 
+    await screen.findByText(/Failed to load discover shelves/);
     expect(screen.queryByTestId(/^shelf-/)).toBeNull();
   });
 });
@@ -187,7 +150,7 @@ describe('DiscoverPage — shelf rendering', () => {
     defaultDismissed();
   });
 
-  it('renders a ShelfSection for each shelf returned by assembly', () => {
+  it('renders a ShelfSection for each shelf returned by assembly', async () => {
     defaultSession([
       makeShelf('trending-tmdb', 'Trending'),
       makeShelf('hidden-gems', 'Hidden Gems'),
@@ -195,12 +158,12 @@ describe('DiscoverPage — shelf rendering', () => {
     ]);
     renderPage();
 
-    expect(screen.getByTestId('shelf-trending-tmdb')).toBeTruthy();
+    expect(await screen.findByTestId('shelf-trending-tmdb')).toBeTruthy();
     expect(screen.getByTestId('shelf-hidden-gems')).toBeTruthy();
     expect(screen.getByTestId('shelf-new-releases')).toBeTruthy();
   });
 
-  it('renders shelves in the order returned by assembly', () => {
+  it('renders shelves in the order returned by assembly', async () => {
     defaultSession([
       makeShelf('shelf-a', 'Shelf A'),
       makeShelf('shelf-b', 'Shelf B'),
@@ -208,24 +171,25 @@ describe('DiscoverPage — shelf rendering', () => {
     ]);
     renderPage();
 
+    await screen.findByTestId('shelf-shelf-a');
     const sections = screen.getAllByRole('heading', { level: 2 });
     expect(sections[0]!.textContent).toBe('Shelf A');
     expect(sections[1]!.textContent).toBe('Shelf B');
     expect(sections[2]!.textContent).toBe('Shelf C');
   });
 
-  it('shows empty state spinner when assembly returns no shelves', () => {
+  it('shows empty state spinner when assembly returns no shelves', async () => {
     defaultSession([]);
     renderPage();
 
-    expect(screen.getByText('Assembling your discover page…')).toBeTruthy();
+    expect(await screen.findByText('Assembling your discover page…')).toBeTruthy();
   });
 
-  it('renders page header always', () => {
+  it('renders page header always', async () => {
     setupDefaults();
     renderPage();
 
-    expect(screen.getByText('Discover')).toBeTruthy();
+    expect(await screen.findByText('Discover')).toBeTruthy();
     expect(screen.getByText('Find your next favourite movie')).toBeTruthy();
   });
 });
@@ -237,44 +201,46 @@ describe('DiscoverPage — compare-to-unlock CTA', () => {
     defaultSession();
   });
 
-  it('shows CTA when totalComparisons < 5', () => {
+  it('shows CTA when totalComparisons < 5', async () => {
     defaultProfile(2);
     renderPage();
 
-    expect(screen.getByText('Compare more movies to unlock recommendations')).toBeTruthy();
+    expect(await screen.findByText('Compare more movies to unlock recommendations')).toBeTruthy();
   });
 
-  it('shows exact comparison count in CTA', () => {
+  it('shows exact comparison count in CTA', async () => {
     defaultProfile(3);
     renderPage();
 
-    expect(screen.getByText(/you have 3 so far/)).toBeTruthy();
+    expect(await screen.findByText(/you have 3 so far/)).toBeTruthy();
   });
 
-  it('links CTA to /media/compare', () => {
+  it('links CTA to /media/compare', async () => {
     defaultProfile(0);
     renderPage();
 
-    const link = screen.getByText('Start Comparing').closest('a');
+    const link = (await screen.findByText('Start Comparing')).closest('a');
     expect(link?.getAttribute('href')).toBe('/media/compare');
   });
 
-  it('hides CTA when totalComparisons >= 5', () => {
+  it('hides CTA when totalComparisons >= 5', async () => {
     defaultProfile(5);
     renderPage();
 
+    await screen.findByTestId('preference-profile');
     expect(screen.queryByText('Compare more movies to unlock recommendations')).toBeNull();
   });
 
-  it('hides CTA when totalComparisons > 5', () => {
+  it('hides CTA when totalComparisons > 5', async () => {
     defaultProfile(10);
     renderPage();
 
+    await screen.findByTestId('preference-profile');
     expect(screen.queryByText('Compare more movies to unlock recommendations')).toBeNull();
   });
 
   it('hides CTA while profile is loading', () => {
-    mockProfileQuery.mockReturnValue({ data: undefined, isLoading: true });
+    mockProfile.mockReturnValue(new Promise(() => {}));
     renderPage();
 
     expect(screen.queryByText('Compare more movies to unlock recommendations')).toBeNull();
@@ -287,10 +253,10 @@ describe('DiscoverPage — PreferenceProfile', () => {
     setupDefaults();
   });
 
-  it('renders PreferenceProfile', () => {
+  it('renders PreferenceProfile', async () => {
     renderPage();
 
-    expect(screen.getByTestId('preference-profile')).toBeTruthy();
+    expect(await screen.findByTestId('preference-profile')).toBeTruthy();
   });
 });
 
@@ -300,27 +266,25 @@ describe('DiscoverPage — Refresh button', () => {
     setupDefaults();
   });
 
-  it('renders the Refresh button', () => {
+  it('renders the Refresh button', async () => {
     renderPage();
 
-    expect(screen.getByRole('button', { name: /refresh shelf selection/i })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: /refresh shelf selection/i })).toBeTruthy();
   });
 
-  it('calls session refetch on click', () => {
+  it('calls session refetch on click', async () => {
+    const user = userEvent.setup();
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /refresh shelf selection/i }));
+    const btn = await screen.findByRole('button', { name: /refresh shelf selection/i });
+    await waitFor(() => expect(mockAssembleSession).toHaveBeenCalledTimes(1));
+    await user.click(btn);
 
-    expect(mockAssembleSessionRefetch).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockAssembleSession).toHaveBeenCalledTimes(2));
   });
 
   it('disables Refresh button while isFetching', () => {
-    mockAssembleSessionQuery.mockReturnValue({
-      data: { shelves: [] },
-      isLoading: false,
-      isFetching: true,
-      error: null,
-    });
+    mockAssembleSession.mockReturnValue(new Promise(() => {}));
     renderPage();
 
     const btn = screen.getByRole('button', { name: /refresh shelf selection/i });

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -1,13 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
 import { Compass, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
-
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * DiscoverPage — dynamic shelf-based movie discovery.
  */
 
 import { PreferenceProfile } from '../components/PreferenceProfile';
 import { useDiscoverCardActions } from '../hooks/useDiscoverCardActions';
+import { unwrap } from '../media-api-helpers.js';
+import {
+  discoveryAssembleSession,
+  discoveryGetDismissed,
+  discoveryProfile,
+} from '../media-api/index.js';
 import {
   COMPARISON_THRESHOLD,
   CompareUnlockPrompt,
@@ -20,36 +25,22 @@ import type { ComponentProps } from 'react';
 
 type DiscoverShelf = ComponentProps<typeof DiscoverShelves>['shelves'][number];
 
-interface AssembleSessionResult {
-  shelves: DiscoverShelf[];
-}
-
-type PreferenceProfileData = NonNullable<ComponentProps<typeof PreferenceProfile>['data']>;
-
-interface ProfileEnvelope {
-  data: PreferenceProfileData | undefined;
-}
-
-interface DismissedEnvelope {
-  data: number[];
-}
-
 function useDiscoverPageModel() {
-  const session = usePillarQuery<AssembleSessionResult>(
-    'media',
-    ['discovery', 'assembleSession'],
-    undefined,
-    { staleTime: 0 }
-  );
-  const profile = usePillarQuery<ProfileEnvelope>('media', ['discovery', 'profile'], undefined, {
+  const session = useQuery({
+    queryKey: ['media', 'discovery', 'assembleSession'],
+    queryFn: async () => unwrap(await discoveryAssembleSession()),
+    staleTime: 0,
+  });
+  const profile = useQuery({
+    queryKey: ['media', 'discovery', 'profile'],
+    queryFn: async () => unwrap(await discoveryProfile()),
     staleTime: 5 * 60 * 1000,
   });
-  const dismissed = usePillarQuery<DismissedEnvelope>(
-    'media',
-    ['discovery', 'getDismissed'],
-    undefined,
-    { staleTime: 5 * 60 * 1000 }
-  );
+  const dismissed = useQuery({
+    queryKey: ['media', 'discovery', 'getDismissed'],
+    queryFn: async () => unwrap(await discoveryGetDismissed()),
+    staleTime: 5 * 60 * 1000,
+  });
   const actions = useDiscoverCardActions();
 
   const totalComparisons = profile.data?.data?.totalComparisons ?? 0;
@@ -60,6 +51,19 @@ function useDiscoverPageModel() {
     [dismissed.data, actions.optimisticDismissed]
   );
 
+  const shelves = useMemo<DiscoverShelf[]>(
+    () =>
+      (session.data?.shelves ?? []).map((shelf) => ({
+        shelfId: shelf.shelfId,
+        title: shelf.title,
+        subtitle: shelf.subtitle ?? undefined,
+        emoji: shelf.emoji ?? undefined,
+        items: shelf.items,
+        hasMore: shelf.hasMore,
+      })),
+    [session.data]
+  );
+
   return {
     session,
     profile,
@@ -67,7 +71,7 @@ function useDiscoverPageModel() {
     totalComparisons,
     hasEnoughComparisons,
     dismissedSet,
-    shelves: session.data?.shelves ?? [],
+    shelves,
   };
 }
 

--- a/packages/app-media/src/pages/QuickPickPage.test.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.test.tsx
@@ -1,24 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockQuickPickQuery = vi.fn();
-const mockRefetch = vi.fn();
+const mockLibraryQuickPick = vi.fn();
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    input: unknown,
-    options: unknown
-  ) => {
-    const key = path.join('.');
-    if (key === 'library.quickPick') {
-      const result = mockQuickPickQuery(input, options);
-      return { ...result, refetch: mockRefetch };
-    }
-    return { data: undefined, isLoading: false };
-  },
+vi.mock('../media-api/index.js', () => ({
+  libraryQuickPick: (opts: unknown) => mockLibraryQuickPick(opts),
 }));
 
 vi.mock('../components/MediaCard', () => ({
@@ -40,12 +30,21 @@ const makeMovie = (id: number, title: string) => ({
   overview: `Overview for ${title}`,
 });
 
+function resolveWith(movies: ReturnType<typeof makeMovie>[]) {
+  mockLibraryQuickPick.mockResolvedValue({ data: { data: movies } });
+}
+
 function renderPage(route = '/media/quick-pick') {
-  return render(
-    <MemoryRouter initialEntries={[route]}>
-      <QuickPickPage />
-    </MemoryRouter>
-  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, { initialEntries: [route] }, children)
+    );
+  return render(<QuickPickPage />, { wrapper });
 }
 
 describe('QuickPickPage', () => {
@@ -53,127 +52,97 @@ describe('QuickPickPage', () => {
     vi.clearAllMocks();
   });
 
-  it('displays the correct number of movies (default 3)', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: {
-        data: [makeMovie(1, 'Movie A'), makeMovie(2, 'Movie B'), makeMovie(3, 'Movie C')],
-      },
-      isLoading: false,
-    });
+  it('displays the correct number of movies (default 3)', async () => {
+    resolveWith([makeMovie(1, 'Movie A'), makeMovie(2, 'Movie B'), makeMovie(3, 'Movie C')]);
 
     renderPage();
 
-    expect(screen.getByTestId('media-card-1')).toBeInTheDocument();
+    expect(await screen.findByTestId('media-card-1')).toBeInTheDocument();
     expect(screen.getByTestId('media-card-2')).toBeInTheDocument();
     expect(screen.getByTestId('media-card-3')).toBeInTheDocument();
   });
 
-  it('passes count from ?count= query param to the query', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'A'), makeMovie(2, 'B')] },
-      isLoading: false,
-    });
+  it('passes count from ?count= query param to the query', async () => {
+    resolveWith([makeMovie(1, 'A'), makeMovie(2, 'B')]);
 
     renderPage('/media/quick-pick?count=2');
 
-    expect(mockQuickPickQuery).toHaveBeenCalledWith({ count: 2 }, expect.anything());
+    await waitFor(() => expect(mockLibraryQuickPick).toHaveBeenCalledWith({ query: { count: 2 } }));
   });
 
-  it('defaults invalid count param to 3', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'A'), makeMovie(2, 'B'), makeMovie(3, 'C')] },
-      isLoading: false,
-    });
+  it('defaults invalid count param to 3', async () => {
+    resolveWith([makeMovie(1, 'A'), makeMovie(2, 'B'), makeMovie(3, 'C')]);
 
     renderPage('/media/quick-pick?count=99');
 
-    expect(mockQuickPickQuery).toHaveBeenCalledWith({ count: 3 }, expect.anything());
+    await waitFor(() => expect(mockLibraryQuickPick).toHaveBeenCalledWith({ query: { count: 3 } }));
   });
 
-  it('renders count selector with 2, 3, 4, 5 options', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'A')] },
-      isLoading: false,
-    });
+  it('renders count selector with 2, 3, 4, 5 options', async () => {
+    resolveWith([makeMovie(1, 'A')]);
 
     renderPage();
 
     for (const n of [2, 3, 4, 5]) {
-      expect(screen.getByRole('button', { name: String(n) })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: String(n) })).toBeInTheDocument();
     }
   });
 
-  it('highlights the active count option', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'A')] },
-      isLoading: false,
-    });
+  it('highlights the active count option', async () => {
+    resolveWith([makeMovie(1, 'A')]);
 
     renderPage('/media/quick-pick?count=4');
 
-    const btn4 = screen.getByRole('button', { name: '4' });
+    const btn4 = await screen.findByRole('button', { name: '4' });
     expect(btn4.getAttribute('aria-pressed')).toBe('true');
     const btn3 = screen.getByRole('button', { name: '3' });
     expect(btn3.getAttribute('aria-pressed')).toBe('false');
   });
 
-  it("calls refetch when 'Show me others' is clicked", () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'A')] },
-      isLoading: false,
-    });
+  it("calls refetch when 'Show me others' is clicked", async () => {
+    const user = userEvent.setup();
+    resolveWith([makeMovie(1, 'A')]);
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /show me others/i }));
-    expect(mockRefetch).toHaveBeenCalled();
+    const btn = await screen.findByRole('button', { name: /show me others/i });
+    await waitFor(() => expect(mockLibraryQuickPick).toHaveBeenCalledTimes(1));
+    await user.click(btn);
+
+    await waitFor(() => expect(mockLibraryQuickPick).toHaveBeenCalledTimes(2));
   });
 
-  it("renders 'Watch This' button for each movie", () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: {
-        data: [makeMovie(1, 'Movie A'), makeMovie(2, 'Movie B')],
-      },
-      isLoading: false,
-    });
+  it("renders 'Watch This' button for each movie", async () => {
+    resolveWith([makeMovie(1, 'Movie A'), makeMovie(2, 'Movie B')]);
 
     renderPage('/media/quick-pick?count=2');
 
-    const watchButtons = screen.getAllByRole('button', { name: /watch this/i });
+    const watchButtons = await screen.findAllByRole('button', { name: /watch this/i });
     expect(watchButtons).toHaveLength(2);
   });
 
-  it('renders empty state when no unwatched movies', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-    });
+  it('renders empty state when no unwatched movies', async () => {
+    resolveWith([]);
 
     renderPage();
 
-    expect(screen.getByText('Nothing unwatched in your library')).toBeInTheDocument();
+    expect(await screen.findByText('Nothing unwatched in your library')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /search for movies/i })).toBeInTheDocument();
   });
 
-  it('renders partial fill when fewer movies than count', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: { data: [makeMovie(1, 'Only One')] },
-      isLoading: false,
-    });
+  it('renders partial fill when fewer movies than count', async () => {
+    resolveWith([makeMovie(1, 'Only One')]);
 
     renderPage('/media/quick-pick?count=5');
 
-    expect(screen.getByTestId('media-card-1')).toBeInTheDocument();
+    expect(await screen.findByTestId('media-card-1')).toBeInTheDocument();
     expect(screen.getByText('Only One')).toBeInTheDocument();
     const watchButtons = screen.getAllByRole('button', { name: /watch this/i });
     expect(watchButtons).toHaveLength(1);
   });
 
   it('shows loading skeletons', () => {
-    mockQuickPickQuery.mockReturnValue({
-      data: null,
-      isLoading: true,
-    });
+    mockLibraryQuickPick.mockReturnValue(new Promise(() => {}));
 
     renderPage();
 

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,10 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
 import { RefreshCw, Search, Sparkles } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Button, Skeleton } from '@pops/ui';
 
 import { MediaCard } from '../components/MediaCard';
+import { unwrap } from '../media-api-helpers.js';
+import { libraryQuickPick } from '../media-api/index.js';
 
 const COUNT_OPTIONS = [2, 3, 4, 5] as const;
 const DEFAULT_COUNT = 3;
@@ -31,12 +33,11 @@ export function QuickPickPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const count = parseCount(searchParams.get('count'));
 
-  const { data, isLoading, refetch } = usePillarQuery<QuickPickEnvelope>(
-    'media',
-    ['library', 'quickPick'],
-    { count },
-    { refetchOnWindowFocus: false }
-  );
+  const { data, isLoading, refetch } = useQuery<QuickPickEnvelope>({
+    queryKey: ['media', 'library', 'quickPick', { count }],
+    queryFn: async () => unwrap(await libraryQuickPick({ query: { count } })),
+    refetchOnWindowFocus: false,
+  });
 
   const picks = data?.data ?? [];
 

--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -5,18 +5,11 @@ import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockDimensionsQuery = vi.fn();
+const mockComparisonsListDimensions = vi.fn();
 const mockComparisonsRankings = vi.fn();
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
-    const key = path.join('.');
-    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
-    return { data: undefined, isLoading: false };
-  },
-}));
-
 vi.mock('../media-api/index.js', () => ({
+  comparisonsListDimensions: () => mockComparisonsListDimensions(),
   comparisonsRankings: (opts: unknown) => mockComparisonsRankings(opts),
 }));
 
@@ -84,10 +77,7 @@ const dimensions = [
 ];
 
 function setupDefaults() {
-  mockDimensionsQuery.mockReturnValue({
-    data: { data: dimensions },
-    isLoading: false,
-  });
+  mockComparisonsListDimensions.mockResolvedValue({ data: { data: dimensions } });
   mockComparisonsRankings.mockResolvedValue(
     rankingsResult(rankedEntries, { total: 2, limit: 25, offset: 0, hasMore: false })
   );
@@ -105,7 +95,7 @@ describe('RankingsPage', () => {
   });
 
   it('shows loading skeleton when dimensions are loading', () => {
-    mockDimensionsQuery.mockReturnValue({ data: undefined, isLoading: true });
+    mockComparisonsListDimensions.mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.queryByRole('list', { name: 'Rankings' })).not.toBeInTheDocument();
   });
@@ -119,9 +109,9 @@ describe('RankingsPage', () => {
     expect(screen.getByText('Beta Movie')).toBeInTheDocument();
   });
 
-  it('displays dimension tabs', () => {
+  it('displays dimension tabs', async () => {
     renderPage();
-    expect(screen.getByRole('tab', { name: 'Overall' })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: 'Overall' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Story' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Visuals' })).toBeInTheDocument();
   });
@@ -130,7 +120,7 @@ describe('RankingsPage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    const storyTab = screen.getByRole('tab', { name: 'Story' });
+    const storyTab = await screen.findByRole('tab', { name: 'Story' });
     await user.click(storyTab);
 
     await waitFor(() =>
@@ -184,20 +174,18 @@ describe('RankingsPage', () => {
     expect(screen.getByText('Next')).toBeInTheDocument();
   });
 
-  it('hides tabs when no active dimensions', () => {
-    mockDimensionsQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-    });
+  it('hides tabs when no active dimensions', async () => {
+    mockComparisonsListDimensions.mockResolvedValue({ data: { data: [] } });
 
     renderPage();
+    await screen.findByRole('heading', { name: 'Rankings' });
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
   });
 
-  it('selects Visuals tab when URL has ?dimension=2', () => {
+  it('selects Visuals tab when URL has ?dimension=2', async () => {
     renderPage('/media/rankings?dimension=2');
 
-    const visualsTab = screen.getByRole('tab', { name: 'Visuals' });
+    const visualsTab = await screen.findByRole('tab', { name: 'Visuals' });
     expect(visualsTab).toHaveAttribute('aria-selected', 'true');
 
     const overallTab = screen.getByRole('tab', { name: 'Overall' });

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -1,13 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
 import { Trophy } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RankingsPage — leaderboard of media items ranked by Elo score.
  */
 import { cn, Tabs, TabsContent } from '@pops/ui';
 
+import { unwrap } from '../media-api-helpers.js';
+import { comparisonsListDimensions } from '../media-api/index.js';
 import { RankingsList } from './rankings/RankingsList';
 import { RankingsSkeleton } from './rankings/RankingsSkeleton';
 
@@ -80,11 +82,10 @@ export function RankingsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const dimensionParam = searchParams.get('dimension') ?? 'overall';
 
-  const { data: dimensionsData, isLoading: dimsLoading } = usePillarQuery<{ data: Dimension[] }>(
-    'media',
-    ['comparisons', 'listDimensions'],
-    undefined
-  );
+  const { data: dimensionsData, isLoading: dimsLoading } = useQuery<{ data: Dimension[] }>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+  });
 
   const activeDimensions = useMemo<Dimension[]>(
     () => (dimensionsData?.data ?? []).filter((d) => d.active),

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -6,44 +6,28 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  mockMovieSearch,
-  mockTvSearch,
+  mockSearchMovies,
+  mockSearchTvShows,
   mockMoviesList,
   mockTvShowsList,
   mockLibraryAddMovie,
   mockLibraryAddTvShow,
   mockWatchlistAdd,
   mockWatchHistoryLog,
-  mockMovieRefetch,
-  mockTvRefetch,
 } = vi.hoisted(() => ({
-  mockMovieSearch: vi.fn(),
-  mockTvSearch: vi.fn(),
+  mockSearchMovies: vi.fn(),
+  mockSearchTvShows: vi.fn(),
   mockMoviesList: vi.fn(),
   mockTvShowsList: vi.fn(),
   mockLibraryAddMovie: vi.fn(),
   mockLibraryAddTvShow: vi.fn(),
   mockWatchlistAdd: vi.fn(),
   mockWatchHistoryLog: vi.fn(),
-  mockMovieRefetch: vi.fn(),
-  mockTvRefetch: vi.fn(),
-}));
-
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    input: unknown,
-    options: unknown
-  ) => {
-    const key = path.join('.');
-    if (key === 'search.movies') return mockMovieSearch(input, options);
-    if (key === 'search.tvShows') return mockTvSearch(input, options);
-    return { data: undefined, isLoading: false, error: null };
-  },
 }));
 
 vi.mock('../media-api/index.js', () => ({
+  searchMovies: (opts: unknown) => mockSearchMovies(opts),
+  searchTvShows: (opts: unknown) => mockSearchTvShows(opts),
   moviesList: (opts: unknown) => mockMoviesList(opts),
   tvShowsList: (opts: unknown) => mockTvShowsList(opts),
   libraryAddMovie: (opts: unknown) => mockLibraryAddMovie(opts),
@@ -138,24 +122,29 @@ const LIBRARY_MOVIES = [
 ];
 const LIBRARY_TV = [{ id: 2, tvdbId: 201 }];
 
-function setupMovieResults(overrides = {}) {
-  mockMovieSearch.mockReturnValue({
-    data: { results: MOVIE_RESULTS },
-    isLoading: false,
-    error: null,
-    refetch: mockMovieRefetch,
-    ...overrides,
-  });
+interface SearchOverride {
+  data?: { results: unknown[] } | null;
+  isLoading?: boolean;
+  error?: { message: string };
 }
 
-function setupTvResults(overrides = {}) {
-  mockTvSearch.mockReturnValue({
-    data: { results: TV_RESULTS },
-    isLoading: false,
-    error: null,
-    refetch: mockTvRefetch,
-    ...overrides,
-  });
+function sdkResult(defaultResults: unknown[], override: SearchOverride) {
+  if (override.isLoading) {
+    return () => new Promise(() => {});
+  }
+  if (override.error) {
+    return async () => ({ error: override.error });
+  }
+  const results = override.data?.results ?? defaultResults;
+  return async () => ({ data: { results } });
+}
+
+function setupMovieResults(overrides: SearchOverride = {}) {
+  mockSearchMovies.mockImplementation(sdkResult(MOVIE_RESULTS, overrides));
+}
+
+function setupTvResults(overrides: SearchOverride = {}) {
+  mockSearchTvShows.mockImplementation(sdkResult(TV_RESULTS, overrides));
 }
 
 function setupLibrary() {
@@ -235,76 +224,76 @@ describe('SearchPage — both sections render independently', () => {
     expect(screen.getByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
   });
 
-  it('movie section shows skeleton while loading, TV section shows results', () => {
+  it('movie section shows skeleton while loading, TV section shows results', async () => {
     setupMovieResults({ data: null, isLoading: true });
     setupTvResults();
     renderPage();
 
-    expect(screen.getByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
+    expect(await screen.findByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
     expect(screen.getByText('Breaking Bad')).toBeInTheDocument();
     expect(screen.queryByTestId('card-movie-Inception')).not.toBeInTheDocument();
   });
 
-  it('TV section shows skeleton while loading, movie section shows results', () => {
+  it('TV section shows skeleton while loading, movie section shows results', async () => {
     setupTvResults({ data: null, isLoading: true });
     setupMovieResults();
     renderPage();
 
-    expect(screen.getByTestId('card-movie-Inception')).toBeInTheDocument();
+    expect(await screen.findByTestId('card-movie-Inception')).toBeInTheDocument();
     expect(screen.queryByTestId('card-tv-Breaking Bad')).not.toBeInTheDocument();
   });
 });
 
 describe('SearchPage — per-section error states', () => {
-  it('shows movie error with Retry button when movie search fails', () => {
+  it('shows movie error with Retry button when movie search fails', async () => {
     setupMovieResults({ data: null, isLoading: false, error: { message: 'TMDB error' } });
     renderPage();
 
-    expect(screen.getByText('Movie search failed')).toBeInTheDocument();
+    expect(await screen.findByText('Movie search failed')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
-  it('calls movieSearch.refetch when movie Retry is clicked', () => {
+  it('calls movieSearch.refetch when movie Retry is clicked', async () => {
     setupMovieResults({ data: null, isLoading: false, error: { message: 'Error' } });
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
-    expect(mockMovieRefetch).toHaveBeenCalled();
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(mockSearchMovies.mock.calls.length).toBeGreaterThan(1));
   });
 
-  it('shows TV error with Retry button when TV search fails', () => {
+  it('shows TV error with Retry button when TV search fails', async () => {
     setupTvResults({ data: null, isLoading: false, error: { message: 'TVDB error' } });
     renderPage();
 
-    expect(screen.getByText('TV search failed')).toBeInTheDocument();
+    expect(await screen.findByText('TV search failed')).toBeInTheDocument();
   });
 
-  it('calls tvSearch.refetch when TV Retry is clicked', () => {
+  it('calls tvSearch.refetch when TV Retry is clicked', async () => {
     setupTvResults({ data: null, isLoading: false, error: { message: 'Error' } });
     renderPage();
 
-    const retryButtons = screen.getAllByRole('button', { name: 'Retry' });
+    const retryButtons = await screen.findAllByRole('button', { name: 'Retry' });
     fireEvent.click(retryButtons[0]!);
-    expect(mockTvRefetch).toHaveBeenCalled();
+    await waitFor(() => expect(mockSearchTvShows.mock.calls.length).toBeGreaterThan(1));
   });
 
-  it('TV section shows results independently when movie section has error', () => {
+  it('TV section shows results independently when movie section has error', async () => {
     setupMovieResults({ data: null, isLoading: false, error: { message: 'Error' } });
     setupTvResults();
     renderPage();
 
-    expect(screen.getByText('Movie search failed')).toBeInTheDocument();
-    expect(screen.getByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
+    expect(await screen.findByText('Movie search failed')).toBeInTheDocument();
+    expect(await screen.findByTestId('card-tv-Breaking Bad')).toBeInTheDocument();
   });
 });
 
 describe('SearchPage — no results message', () => {
-  it('shows no results message when both sections return empty', () => {
+  it('shows no results message when both sections return empty', async () => {
     setupMovieResults({ data: { results: [] } });
     setupTvResults({ data: { results: [] } });
     renderPage();
 
-    expect(screen.getByText(/No results found for/)).toBeInTheDocument();
+    expect(await screen.findByText(/No results found for/)).toBeInTheDocument();
     expect(screen.getByText(/inception/i)).toBeInTheDocument();
   });
 

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -12,11 +12,12 @@
  * "Watched + Library" buttons that add the item then trigger the secondary
  * action in a single click.
  */
+import { useQuery } from '@tanstack/react-query';
 import { Search } from 'lucide-react';
 import { useState } from 'react';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
-
+import { unwrap } from '../media-api-helpers.js';
+import { searchMovies, searchTvShows } from '../media-api/index.js';
 import { MovieSearchSection } from './search/MovieSearchSection';
 import { SearchInput } from './search/SearchInput';
 import { TvSearchSection } from './search/TvSearchSection';
@@ -58,18 +59,18 @@ function useSearchQueries(debouncedQuery: string, mode: SearchMode) {
   const shouldSearchMovies = debouncedQuery.length > 0 && (mode === 'movies' || mode === 'both');
   const shouldSearchTv = debouncedQuery.length > 0 && (mode === 'tv' || mode === 'both');
 
-  const movieSearch = usePillarQuery<MovieSearchResponse>(
-    'media',
-    ['search', 'movies'],
-    { query: debouncedQuery },
-    { enabled: shouldSearchMovies, staleTime: STALE_TIME_MS }
-  );
-  const tvSearch = usePillarQuery<TvSearchResponse>(
-    'media',
-    ['search', 'tvShows'],
-    { query: debouncedQuery },
-    { enabled: shouldSearchTv, staleTime: STALE_TIME_MS }
-  );
+  const movieSearch = useQuery<MovieSearchResponse>({
+    queryKey: ['media', 'search', 'movies', { query: debouncedQuery }],
+    queryFn: async () => unwrap(await searchMovies({ query: { query: debouncedQuery } })),
+    enabled: shouldSearchMovies,
+    staleTime: STALE_TIME_MS,
+  });
+  const tvSearch = useQuery<TvSearchResponse>({
+    queryKey: ['media', 'search', 'tvShows', { query: debouncedQuery }],
+    queryFn: async () => unwrap(await searchTvShows({ query: { query: debouncedQuery } })),
+    enabled: shouldSearchTv,
+    staleTime: STALE_TIME_MS,
+  });
 
   return { shouldSearchMovies, shouldSearchTv, movieSearch, tvSearch };
 }

--- a/packages/app-media/src/pages/compare-arena/useCompareArenaPageModel.ts
+++ b/packages/app-media/src/pages/compare-arena/useCompareArenaPageModel.ts
@@ -1,0 +1,88 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+
+import { unwrap } from '../../media-api-helpers.js';
+import { comparisonsGetSmartPair, comparisonsListDimensions } from '../../media-api/index.js';
+import { useArenaActions } from './useArenaActions';
+import { useArenaBlacklist } from './useArenaBlacklist';
+import { useArenaWatchlist } from './useArenaWatchlist';
+
+import type { Dimension, PairData } from './types';
+
+interface DimensionsResult {
+  data?: Dimension[];
+}
+
+interface SmartPairResult {
+  data?: PairData | null;
+}
+
+export function useCompareArenaPageModel() {
+  const [manualDimensionId, setManualDimensionId] = useState<number | null>(null);
+
+  const { data: dimensionsData, isLoading: dimsLoading } = useQuery<DimensionsResult>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+  });
+  const activeDimensions: Dimension[] = dimensionsData?.data?.filter((d) => d.active) ?? [];
+
+  const pairQuery = useQuery<SmartPairResult>({
+    queryKey: ['media', 'comparisons', 'getSmartPair', { dimensionId: manualDimensionId }],
+    queryFn: async () =>
+      unwrap(
+        await comparisonsGetSmartPair({
+          query: manualDimensionId ? { dimensionId: manualDimensionId } : {},
+        })
+      ),
+    enabled: activeDimensions.length > 0,
+    refetchOnWindowFocus: false,
+    gcTime: 0,
+    staleTime: 0,
+  });
+
+  const queryClient = useQueryClient();
+  const pair: PairData | null | undefined = pairQuery.data?.data;
+  const dimensionId = pair?.dimensionId ?? null;
+
+  const resolveTitle = useCallback(
+    (mediaId: number) => {
+      if (pair?.movieA.id === mediaId) return pair.movieA.title;
+      if (pair?.movieB.id === mediaId) return pair.movieB.title;
+      return 'Movie';
+    },
+    [pair]
+  );
+
+  const onAfterAction = useCallback(() => setManualDimensionId(null), []);
+
+  const watchlist = useArenaWatchlist({ enabled: !!pair, resolveTitle });
+  const actions = useArenaActions({ pair, dimensionId, resolveTitle, onAfterAction });
+  const blacklist = useArenaBlacklist({ resolveTitle, onAfterAction });
+
+  const activeDim = activeDimensions.find((d) => d.id === dimensionId);
+
+  const onDimensionChange = useCallback(
+    (id: number) => {
+      setManualDimensionId(id);
+      actions.setScoreDelta(null);
+      void queryClient.invalidateQueries({
+        queryKey: ['media', 'comparisons', 'getSmartPair'],
+      });
+    },
+    [actions, queryClient]
+  );
+
+  return {
+    dimsLoading,
+    activeDimensions,
+    pair,
+    pairQuery,
+    dimensionId,
+    activeDimName: activeDim?.name ?? 'Overall',
+    activeDimDesc: activeDim?.description ?? null,
+    watchlist,
+    actions,
+    blacklist,
+    onDimensionChange,
+  };
+}

--- a/packages/app-media/src/pages/comparison-history/MovieTitle.tsx
+++ b/packages/app-media/src/pages/comparison-history/MovieTitle.tsx
@@ -1,13 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router';
 
-import { usePillarQuery } from '@pops/pillar-sdk/react';
+import { unwrap } from '../../media-api-helpers.js';
+import { moviesGet } from '../../media-api/index.js';
 
 interface MovieGetResult {
   data: { title: string } | null;
 }
 
 export function MovieTitle({ mediaId, className }: { mediaId: number; className?: string }) {
-  const { data } = usePillarQuery<MovieGetResult>('media', ['movies', 'get'], { id: mediaId });
+  const { data } = useQuery<MovieGetResult>({
+    queryKey: ['media', 'movies', 'get', { id: mediaId }],
+    queryFn: async () => unwrap(await moviesGet({ path: { id: mediaId } })),
+  });
   const title = data?.data?.title ?? `Movie #${mediaId}`;
   return (
     <Link to={`/media/movies/${mediaId}`} className={className}>

--- a/packages/app-media/src/pages/comparison-history/useComparisonHistoryModel.ts
+++ b/packages/app-media/src/pages/comparison-history/useComparisonHistoryModel.ts
@@ -1,9 +1,15 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { useDebouncedValue } from '@pops/ui';
 
+import { unwrap } from '../../media-api-helpers.js';
+import {
+  comparisonsDelete,
+  comparisonsListAll,
+  comparisonsListDimensions,
+} from '../../media-api/index.js';
 import { UNDO_DELAY_MS } from './UndoToast';
 
 import type { ComparisonRowData } from './ComparisonRow';
@@ -46,15 +52,17 @@ export interface UseComparisonHistoryModelReturn {
 }
 
 function useDeleteMutation(setPendingDeletes: React.Dispatch<React.SetStateAction<Set<number>>>) {
-  const utils = usePillarUtils('media');
-  return usePillarMutation<{ id: number }, unknown>('media', ['comparisons', 'delete'], {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (variables: { id: number }) =>
+      unwrap(await comparisonsDelete({ path: { id: variables.id } })),
     onSuccess: (_data, variables) => {
       setPendingDeletes((prev) => {
         const next = new Set(prev);
         next.delete(variables.id);
         return next;
       });
-      void utils.invalidate(['comparisons']);
+      void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons'] });
     },
     onError: (_error, variables) => {
       setPendingDeletes((prev) => {
@@ -125,23 +133,23 @@ export function useComparisonHistoryModel(
   const filters = useFilters();
   const { pendingDeletes, handleDelete, handleUndo } = useDeleteFlow(renderToast);
 
-  const { data: dimensionsData } = usePillarQuery<DimensionsListResult>(
-    'media',
-    ['comparisons', 'listDimensions'],
-    undefined
-  );
+  const { data: dimensionsData } = useQuery<DimensionsListResult>({
+    queryKey: ['media', 'comparisons', 'listDimensions'],
+    queryFn: async () => unwrap(await comparisonsListDimensions()),
+  });
   const dimensions = dimensionsData?.data ?? [];
 
-  const { data, isLoading } = usePillarQuery<ComparisonsListAllResult>(
-    'media',
-    ['comparisons', 'listAll'],
-    {
-      dimensionId: filters.dimensionFilter ? Number(filters.dimensionFilter) : undefined,
-      search: filters.debouncedSearch.trim() || undefined,
-      limit: PAGE_SIZE,
-      offset: filters.page * PAGE_SIZE,
-    }
-  );
+  const listAllQuery = {
+    dimensionId: filters.dimensionFilter ? Number(filters.dimensionFilter) : undefined,
+    search: filters.debouncedSearch.trim() || undefined,
+    limit: PAGE_SIZE,
+    offset: filters.page * PAGE_SIZE,
+  };
+
+  const { data, isLoading } = useQuery<ComparisonsListAllResult>({
+    queryKey: ['media', 'comparisons', 'listAll', listAllQuery],
+    queryFn: async () => unwrap(await comparisonsListAll({ query: listAllQuery })),
+  });
 
   const totalPages = data?.pagination ? Math.ceil(data.pagination.total / PAGE_SIZE) : 0;
 


### PR DESCRIPTION
Phase D mop-up (final batch). Rewires DiscoverPage, QuickPickPage, RankingsPage, SearchPage, CompareArenaPage (+ extracted useCompareArenaPageModel), comparison-history onto the Hey API SDK + react-query (discoveryAssembleSession/Profile/GetDismissed, libraryQuickPick, comparisonsListDimensions/GetSmartPair/ListAll/Delete, searchMovies/TvShows, moviesGet). 126/126 page tests; verified in isolation (fe-quality red-by-design). Fixed a real shape gap (DiscoverPage shelf null→undefined the untyped usePillarQuery hid).