### PR TITLE
test(media/fe): rewire the last 3 stale page-test mocks onto the Hey API client (Phase D)

### DIFF
--- a/packages/app-media/src/pages/LibraryPage.test.tsx
+++ b/packages/app-media/src/pages/LibraryPage.test.tsx
@@ -1,25 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockListQuery = vi.fn();
-const mockGenresQuery = vi.fn();
-const mockRefetch = vi.fn();
+const { libraryListMock, libraryGenresMock } = vi.hoisted(() => ({
+  libraryListMock: vi.fn(),
+  libraryGenresMock: vi.fn(),
+}));
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'library.list') return mockListQuery(input);
-    if (key === 'library.genres') return mockGenresQuery();
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: vi.fn(),
-    fetchQuery: vi.fn(),
-  }),
+vi.mock('../media-api/index.js', () => ({
+  libraryList: (...args: unknown[]) => libraryListMock(...args),
+  libraryGenres: (...args: unknown[]) => libraryGenresMock(...args),
 }));
 
 vi.mock('../components/MediaGrid', () => ({
@@ -46,89 +39,98 @@ vi.mock('../components/QuickPickDialog', () => ({
 
 import { LibraryPage } from './LibraryPage';
 
-function renderPage(initialPath = '/media') {
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderPage(initialPath = '/media', queryClient = makeQueryClient()) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/media" element={<LibraryPage />} />
         <Route path="/media/search" element={<div data-testid="search-page" />} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
+    { wrapper }
   );
 }
 
-const emptyList = {
-  data: {
-    data: [],
-    pagination: { page: 1, pageSize: 24, total: 0, totalPages: 0, hasMore: false },
-  },
-  isLoading: false,
-  error: null,
-  refetch: mockRefetch,
-};
+function listEnvelope(
+  items: unknown[],
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+    hasMore: boolean;
+  }
+) {
+  return ok({ data: items, pagination });
+}
 
-const populatedList = {
-  data: {
-    data: [
-      {
-        id: 1,
-        type: 'movie',
-        title: 'Inception',
-        year: 2010,
-        posterUrl: null,
-        genres: ['Sci-Fi'],
-        voteAverage: 8.8,
-        createdAt: '2026-01-01',
-        releaseDate: '2010-07-16',
-      },
-      {
-        id: 2,
-        type: 'tv',
-        title: 'Breaking Bad',
-        year: 2008,
-        posterUrl: null,
-        genres: ['Drama'],
-        voteAverage: 9.5,
-        createdAt: '2026-01-02',
-        releaseDate: '2008-01-20',
-      },
-    ],
-    pagination: { page: 1, pageSize: 24, total: 2, totalPages: 1, hasMore: false },
-  },
-  isLoading: false,
-  error: null,
-  refetch: mockRefetch,
-};
+const emptyEnvelope = listEnvelope([], {
+  page: 1,
+  pageSize: 24,
+  total: 0,
+  totalPages: 0,
+  hasMore: false,
+});
+
+const populatedEnvelope = listEnvelope(
+  [
+    {
+      id: 1,
+      type: 'movie',
+      title: 'Inception',
+      year: 2010,
+      posterUrl: null,
+      genres: ['Sci-Fi'],
+      voteAverage: 8.8,
+      createdAt: '2026-01-01',
+      releaseDate: '2010-07-16',
+    },
+    {
+      id: 2,
+      type: 'tv',
+      title: 'Breaking Bad',
+      year: 2008,
+      posterUrl: null,
+      genres: ['Drama'],
+      voteAverage: 9.5,
+      createdAt: '2026-01-02',
+      releaseDate: '2008-01-20',
+    },
+  ],
+  { page: 1, pageSize: 24, total: 2, totalPages: 1, hasMore: false }
+);
 
 describe('LibraryPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGenresQuery.mockReturnValue({ data: { data: ['Drama', 'Sci-Fi'] } });
+    libraryGenresMock.mockResolvedValue(ok({ data: ['Drama', 'Sci-Fi'] }));
+    libraryListMock.mockResolvedValue(emptyEnvelope);
   });
 
   describe('Loading state', () => {
     it('renders skeleton cards while loading', () => {
-      mockListQuery.mockReturnValue({
-        data: null,
-        isLoading: true,
-        error: null,
-        refetch: mockRefetch,
-      });
+      libraryListMock.mockReturnValue(new Promise(() => {}));
       renderPage();
 
       const grid = screen.getByTestId('media-grid');
-      // Default page size is 24, so 24 skeleton groups (each with 3 Skeleton divs)
       const skeletons = grid.querySelectorAll('.space-y-2');
       expect(skeletons.length).toBe(24);
     });
 
     it('renders skeleton count matching pageSize param', () => {
-      mockListQuery.mockReturnValue({
-        data: null,
-        isLoading: true,
-        error: null,
-        refetch: mockRefetch,
-      });
+      libraryListMock.mockReturnValue(new Promise(() => {}));
       renderPage('/media?pageSize=48');
 
       const grid = screen.getByTestId('media-grid');
@@ -138,122 +140,93 @@ describe('LibraryPage', () => {
   });
 
   describe('Error state', () => {
-    it('renders error message with retry button', () => {
-      mockListQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new Error('Network error'),
-        refetch: mockRefetch,
-      });
+    it('renders error message with retry button', async () => {
+      libraryListMock.mockRejectedValue(new Error('Network error'));
       renderPage();
 
-      expect(screen.getByText('Something went wrong loading your library.')).toBeInTheDocument();
+      expect(
+        await screen.findByText('Something went wrong loading your library.')
+      ).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     });
 
-    it('calls refetch when Retry is clicked', async () => {
-      mockListQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new Error('Network error'),
-        refetch: mockRefetch,
-      });
+    it('calls the library API again when Retry is clicked', async () => {
+      libraryListMock.mockRejectedValue(new Error('Network error'));
       renderPage();
 
+      await screen.findByRole('button', { name: 'Retry' });
+      libraryListMock.mockClear();
       await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
-      expect(mockRefetch).toHaveBeenCalled();
+      await waitFor(() => expect(libraryListMock).toHaveBeenCalled());
     });
 
-    it('does not expose technical error details', () => {
-      mockListQuery.mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: new Error('TRPC_INTERNAL_ERROR: connection refused at postgres:5432'),
-        refetch: mockRefetch,
-      });
+    it('does not expose technical error details', async () => {
+      libraryListMock.mockRejectedValue(
+        new Error('TRPC_INTERNAL_ERROR: connection refused at postgres:5432')
+      );
       renderPage();
 
+      expect(
+        await screen.findByText('Something went wrong loading your library.')
+      ).toBeInTheDocument();
       expect(screen.queryByText(/TRPC_INTERNAL_ERROR/)).not.toBeInTheDocument();
       expect(screen.queryByText(/postgres/)).not.toBeInTheDocument();
-      expect(screen.getByText('Something went wrong loading your library.')).toBeInTheDocument();
     });
   });
 
   describe('Empty state', () => {
-    it('shows empty library message when no items exist', () => {
-      mockListQuery.mockReturnValue(emptyList);
+    it('shows empty library message when no items exist', async () => {
+      libraryListMock.mockResolvedValue(emptyEnvelope);
       renderPage();
 
       expect(
-        screen.getByText('Your library is empty. Search for movies and shows to get started.')
+        await screen.findByText(
+          'Your library is empty. Search for movies and shows to get started.'
+        )
       ).toBeInTheDocument();
       expect(screen.getByText('Search for media')).toBeInTheDocument();
     });
 
-    it('links to search page from empty state', () => {
-      mockListQuery.mockReturnValue(emptyList);
+    it('links to search page from empty state', async () => {
+      libraryListMock.mockResolvedValue(emptyEnvelope);
       renderPage();
 
-      const link = screen.getByText('Search for media');
+      const link = await screen.findByText('Search for media');
       expect(link.closest('a')).toHaveAttribute('href', '/media/search');
     });
   });
 
   describe('Empty search state', () => {
-    it("shows 'No results for' message with the search query", () => {
-      mockListQuery.mockReturnValue({
-        data: {
-          data: [],
-          pagination: { page: 1, pageSize: 24, total: 0, totalPages: 0, hasMore: false },
-        },
-        isLoading: false,
-        error: null,
-        refetch: mockRefetch,
-      });
+    it("shows 'No results for' message with the search query", async () => {
+      libraryListMock.mockResolvedValue(emptyEnvelope);
       renderPage('/media?q=xyznonexistent');
 
-      expect(screen.getByText(/No results for/)).toBeInTheDocument();
+      expect(await screen.findByText(/No results for/)).toBeInTheDocument();
       expect(screen.getByText(/xyznonexistent/)).toBeInTheDocument();
     });
 
-    it('shows Clear search button when search has no results', () => {
-      mockListQuery.mockReturnValue({
-        data: {
-          data: [],
-          pagination: { page: 1, pageSize: 24, total: 0, totalPages: 0, hasMore: false },
-        },
-        isLoading: false,
-        error: null,
-        refetch: mockRefetch,
-      });
+    it('shows Clear search button when search has no results', async () => {
+      libraryListMock.mockResolvedValue(emptyEnvelope);
       renderPage('/media?q=xyznonexistent');
 
-      expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Clear search' })).toBeInTheDocument();
     });
 
-    it('shows generic filter message when no search query', () => {
-      mockListQuery.mockReturnValue({
-        data: {
-          data: [],
-          pagination: { page: 1, pageSize: 24, total: 0, totalPages: 0, hasMore: false },
-        },
-        isLoading: false,
-        error: null,
-        refetch: mockRefetch,
-      });
+    it('shows generic filter message when no search query', async () => {
+      libraryListMock.mockResolvedValue(emptyEnvelope);
       renderPage('/media?type=movie&genre=Horror');
 
-      expect(screen.getByText('No results match your filters.')).toBeInTheDocument();
+      expect(await screen.findByText('No results match your filters.')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
     });
   });
 
   describe('Populated state', () => {
-    it('renders media cards when data is loaded', () => {
-      mockListQuery.mockReturnValue(populatedList);
+    it('renders media cards when data is loaded', async () => {
+      libraryListMock.mockResolvedValue(populatedEnvelope);
       renderPage();
 
-      expect(screen.getByText('Inception')).toBeInTheDocument();
+      expect(await screen.findByText('Inception')).toBeInTheDocument();
       expect(screen.getByText('Breaking Bad')).toBeInTheDocument();
     });
   });

--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -1,52 +1,42 @@
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockWatchlistQuery = vi.fn();
-const mockMoviesQuery = vi.fn();
-const mockTvShowsQuery = vi.fn();
-const mockRemoveMutate = vi.fn();
-const mockReorderMutate = vi.fn();
-const mockUpdateMutate = vi.fn();
-const mockInvalidate = vi.fn();
-const capturedOpts: Record<string, Record<string, unknown>> = {};
+const {
+  watchlistListMock,
+  moviesListMock,
+  tvShowsListMock,
+  watchlistRemoveMock,
+  watchlistReorderMock,
+  watchlistUpdateMock,
+  plexGetActiveSyncJobsMock,
+  plexGetSyncJobStatusMock,
+  plexStartSyncJobMock,
+} = vi.hoisted(() => ({
+  watchlistListMock: vi.fn(),
+  moviesListMock: vi.fn(),
+  tvShowsListMock: vi.fn(),
+  watchlistRemoveMock: vi.fn(),
+  watchlistReorderMock: vi.fn(),
+  watchlistUpdateMock: vi.fn(),
+  plexGetActiveSyncJobsMock: vi.fn(),
+  plexGetSyncJobStatusMock: vi.fn(),
+  plexStartSyncJobMock: vi.fn(),
+}));
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
-    const key = path.join('.');
-    if (key === 'plex.getActiveSyncJobs') return { data: { data: [] }, isLoading: false };
-    if (key === 'plex.getSyncJobStatus') return { data: undefined, isLoading: false };
-    if (key === 'watchlist.list') return mockWatchlistQuery(input);
-    if (key === 'movies.list') return mockMoviesQuery(input);
-    if (key === 'tvShows.list') return mockTvShowsQuery(input);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, unknown> = {}
-  ) => {
-    const key = path.join('.');
-    if (key === 'watchlist.remove') {
-      capturedOpts.remove = opts;
-      return { mutate: mockRemoveMutate, isPending: false };
-    }
-    if (key === 'watchlist.reorder') {
-      capturedOpts.reorder = opts;
-      return { mutate: mockReorderMutate, isPending: false };
-    }
-    if (key === 'watchlist.update') {
-      capturedOpts.update = opts;
-      return { mutate: mockUpdateMutate, isPending: false, variables: null };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
-  usePillarUtils: () => ({
-    setData: vi.fn(),
-    invalidate: mockInvalidate,
-    fetchQuery: vi.fn(),
-  }),
+vi.mock('../media-api/index.js', () => ({
+  watchlistList: (...args: unknown[]) => watchlistListMock(...args),
+  moviesList: (...args: unknown[]) => moviesListMock(...args),
+  tvShowsList: (...args: unknown[]) => tvShowsListMock(...args),
+  watchlistRemove: (...args: unknown[]) => watchlistRemoveMock(...args),
+  watchlistReorder: (...args: unknown[]) => watchlistReorderMock(...args),
+  watchlistUpdate: (...args: unknown[]) => watchlistUpdateMock(...args),
+  plexGetActiveSyncJobs: (...args: unknown[]) => plexGetActiveSyncJobsMock(...args),
+  plexGetSyncJobStatus: (...args: unknown[]) => plexGetSyncJobStatusMock(...args),
+  plexStartSyncJob: (...args: unknown[]) => plexStartSyncJobMock(...args),
 }));
 
 vi.mock('sonner', () => ({
@@ -61,11 +51,24 @@ vi.mock('../components/LeavingBadge', () => ({
 
 import { WatchlistPage } from './WatchlistPage';
 
-function renderPage() {
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderPage(queryClient = makeQueryClient()) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return render(
     <MemoryRouter>
       <WatchlistPage />
-    </MemoryRouter>
+    </MemoryRouter>,
+    { wrapper }
   );
 }
 
@@ -97,154 +100,138 @@ const entry3 = {
 };
 
 function setupMultipleEntries() {
-  mockWatchlistQuery.mockReturnValue({
-    data: { data: [entry1, entry2, entry3] },
-    isLoading: false,
-    error: null,
-  });
-  mockMoviesQuery.mockReturnValue({
-    data: {
+  watchlistListMock.mockResolvedValue(ok({ data: [entry1, entry2, entry3] }));
+  moviesListMock.mockResolvedValue(
+    ok({
       data: [
         { id: 10, title: 'The Matrix', releaseDate: '1999-03-31', posterUrl: null },
         { id: 30, title: 'Inception', releaseDate: '2010-07-16', posterUrl: null },
       ],
-    },
-    isLoading: false,
-  });
-  mockTvShowsQuery.mockReturnValue({
-    data: {
-      data: [{ id: 20, name: 'Breaking Bad', firstAirDate: '2008-01-20', posterUrl: null }],
-    },
-    isLoading: false,
-  });
+    })
+  );
+  tvShowsListMock.mockResolvedValue(
+    ok({ data: [{ id: 20, name: 'Breaking Bad', firstAirDate: '2008-01-20', posterUrl: null }] })
+  );
 }
 
 function setupSingleEntry() {
-  mockWatchlistQuery.mockReturnValue({
-    data: { data: [entry1] },
-    isLoading: false,
-    error: null,
-  });
-  mockMoviesQuery.mockReturnValue({
-    data: {
-      data: [{ id: 10, title: 'The Matrix', releaseDate: '1999-03-31', posterUrl: null }],
-    },
-    isLoading: false,
-  });
-  mockTvShowsQuery.mockReturnValue({
-    data: { data: [] },
-    isLoading: false,
-  });
+  watchlistListMock.mockResolvedValue(ok({ data: [entry1] }));
+  moviesListMock.mockResolvedValue(
+    ok({ data: [{ id: 10, title: 'The Matrix', releaseDate: '1999-03-31', posterUrl: null }] })
+  );
+  tvShowsListMock.mockResolvedValue(ok({ data: [] }));
 }
 
 describe('WatchlistPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    plexGetActiveSyncJobsMock.mockResolvedValue(ok({ data: [] }));
+    plexGetSyncJobStatusMock.mockResolvedValue(ok({ data: undefined }));
+    plexStartSyncJobMock.mockResolvedValue(ok({ data: { jobId: 'job-1' } }));
+    watchlistListMock.mockResolvedValue(ok({ data: [] }));
+    moviesListMock.mockResolvedValue(ok({ data: [] }));
+    tvShowsListMock.mockResolvedValue(ok({ data: [] }));
   });
 
-  it('renders watchlist entries with titles', () => {
+  it('renders watchlist entries with titles', async () => {
     setupMultipleEntries();
     renderPage();
 
-    expect(screen.getAllByText('The Matrix').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('The Matrix')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Breaking Bad').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Inception').length).toBeGreaterThan(0);
   });
 
-  it('renders grab handle on desktop cards for multiple items', () => {
+  it('renders grab handle on desktop cards for multiple items', async () => {
     setupMultipleEntries();
     renderPage();
 
-    const handles = screen.getAllByLabelText(/Drag to reorder/);
+    const handles = await screen.findAllByLabelText(/Drag to reorder/);
     expect(handles.length).toBeGreaterThan(0);
   });
 
-  it('hides reorder controls for single-item list', () => {
+  it('hides reorder controls for single-item list', async () => {
     setupSingleEntry();
     renderPage();
 
+    await screen.findAllByText('The Matrix');
     expect(screen.queryByLabelText(/Move .* up/)).toBeNull();
     expect(screen.queryByLabelText(/Move .* down/)).toBeNull();
     expect(screen.queryByLabelText(/Drag to reorder/)).toBeNull();
   });
 
-  it('renders up/down buttons for mobile with multiple items', () => {
+  it('renders up/down buttons for mobile with multiple items', async () => {
     setupMultipleEntries();
     renderPage();
 
-    const upButtons = screen.getAllByLabelText(/Move .* up/);
+    const upButtons = await screen.findAllByLabelText(/Move .* up/);
     const downButtons = screen.getAllByLabelText(/Move .* down/);
     expect(upButtons.length).toBe(3);
     expect(downButtons.length).toBe(3);
   });
 
-  it('disables up button on first item and down button on last item', () => {
+  it('disables up button on first item and down button on last item', async () => {
     setupMultipleEntries();
     renderPage();
 
-    const upButtons = screen.getAllByLabelText(/Move .* up/);
+    const upButtons = await screen.findAllByLabelText(/Move .* up/);
     const downButtons = screen.getAllByLabelText(/Move .* down/);
 
-    // First item's up button should be disabled
     expect(upButtons[0]).toBeDisabled();
-    // Last item's down button should be disabled
     expect(downButtons.at(-1)).toBeDisabled();
   });
 
-  it('renders empty state when watchlist is empty', () => {
-    mockWatchlistQuery.mockReturnValue({
-      data: { data: [] },
-      isLoading: false,
-      error: null,
-    });
-    mockMoviesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
-    mockTvShowsQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+  it('renders empty state when watchlist is empty', async () => {
+    watchlistListMock.mockResolvedValue(ok({ data: [] }));
+    moviesListMock.mockResolvedValue(ok({ data: [] }));
+    tvShowsListMock.mockResolvedValue(ok({ data: [] }));
 
     renderPage();
 
-    expect(screen.getByText(/Your watchlist is empty/)).toBeTruthy();
+    expect(await screen.findByText(/Your watchlist is empty/)).toBeInTheDocument();
   });
 
-  it('renders priority badges on desktop cards', () => {
+  it('renders priority badges on desktop cards', async () => {
     setupMultipleEntries();
     renderPage();
 
-    expect(screen.getAllByText('#1').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('#1')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('#2').length).toBeGreaterThan(0);
     expect(screen.getAllByText('#3').length).toBeGreaterThan(0);
   });
 
-  it('renders priority numbers on mobile list items', () => {
+  it('renders priority numbers on mobile list items', async () => {
     setupMultipleEntries();
     renderPage();
 
-    // Mobile items show numeric priority (1, 2, 3) without # prefix
-    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('1')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('2').length).toBeGreaterThan(0);
     expect(screen.getAllByText('3').length).toBeGreaterThan(0);
   });
 
-  it('renders notes text on watchlist items', () => {
+  it('renders notes text on watchlist items', async () => {
     setupMultipleEntries();
     renderPage();
 
-    // entry2 has notes "Great show"
-    expect(screen.getAllByText('Great show').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Great show')).length).toBeGreaterThan(0);
   });
 
   describe('filter tabs', () => {
-    it('renders All, Movies, TV Shows filter tabs', () => {
+    it('renders All, Movies, TV Shows filter tabs', async () => {
       setupMultipleEntries();
       renderPage();
-      expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
+      expect(await screen.findByRole('tab', { name: 'All' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Movies' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'TV Shows' })).toBeInTheDocument();
     });
 
-    it('All tab is selected by default', () => {
+    it('All tab is selected by default', async () => {
       setupMultipleEntries();
       renderPage();
-      expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'true');
+      expect(await screen.findByRole('tab', { name: 'All' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
       expect(screen.getByRole('tab', { name: 'Movies' })).toHaveAttribute('aria-selected', 'false');
     });
 
@@ -253,11 +240,13 @@ describe('WatchlistPage', () => {
       const user = userEvent.setup();
       renderPage();
 
-      await user.click(screen.getByRole('tab', { name: 'Movies' }));
+      await user.click(await screen.findByRole('tab', { name: 'Movies' }));
 
-      const calls = mockWatchlistQuery.mock.calls;
-      const lastCall = calls.at(-1)!;
-      expect(lastCall[0]).toEqual(expect.objectContaining({ mediaType: 'movie' }));
+      await waitFor(() =>
+        expect(watchlistListMock).toHaveBeenCalledWith({
+          query: expect.objectContaining({ mediaType: 'movie' }),
+        })
+      );
     });
 
     it('clicking TV Shows tab calls API with tv_show filter', async () => {
@@ -265,11 +254,13 @@ describe('WatchlistPage', () => {
       const user = userEvent.setup();
       renderPage();
 
-      await user.click(screen.getByRole('tab', { name: 'TV Shows' }));
+      await user.click(await screen.findByRole('tab', { name: 'TV Shows' }));
 
-      const calls = mockWatchlistQuery.mock.calls;
-      const lastCall = calls.at(-1)!;
-      expect(lastCall[0]).toEqual(expect.objectContaining({ mediaType: 'tv_show' }));
+      await waitFor(() =>
+        expect(watchlistListMock).toHaveBeenCalledWith({
+          query: expect.objectContaining({ mediaType: 'tv_show' }),
+        })
+      );
     });
 
     it('clicking All tab removes mediaType filter', async () => {
@@ -277,12 +268,20 @@ describe('WatchlistPage', () => {
       const user = userEvent.setup();
       renderPage();
 
-      await user.click(screen.getByRole('tab', { name: 'Movies' }));
+      await user.click(await screen.findByRole('tab', { name: 'Movies' }));
+      await waitFor(() =>
+        expect(watchlistListMock).toHaveBeenCalledWith({
+          query: expect.objectContaining({ mediaType: 'movie' }),
+        })
+      );
+
+      watchlistListMock.mockClear();
       await user.click(screen.getByRole('tab', { name: 'All' }));
 
-      const calls = mockWatchlistQuery.mock.calls;
-      const lastCall = calls.at(-1)!;
-      expect(lastCall[0]).not.toHaveProperty('mediaType');
+      await waitFor(() => expect(watchlistListMock).toHaveBeenCalled());
+      const lastCall = watchlistListMock.mock.calls.at(-1)!;
+      const lastQuery = (lastCall[0] as { query: Record<string, unknown> }).query;
+      expect(lastQuery).not.toHaveProperty('mediaType');
     });
 
     it('shows filter-specific empty state for movies', async () => {
@@ -290,15 +289,12 @@ describe('WatchlistPage', () => {
       const user = userEvent.setup();
       renderPage();
 
-      mockWatchlistQuery.mockReturnValue({
-        data: { data: [] },
-        isLoading: false,
-        error: null,
-      });
+      await screen.findByRole('tab', { name: 'Movies' });
+      watchlistListMock.mockResolvedValue(ok({ data: [] }));
 
       await user.click(screen.getByRole('tab', { name: 'Movies' }));
 
-      expect(screen.getByText('No movies on your watchlist.')).toBeInTheDocument();
+      expect(await screen.findByText('No movies on your watchlist.')).toBeInTheDocument();
     });
 
     it('shows filter-specific empty state for TV shows', async () => {
@@ -306,27 +302,20 @@ describe('WatchlistPage', () => {
       const user = userEvent.setup();
       renderPage();
 
-      mockWatchlistQuery.mockReturnValue({
-        data: { data: [] },
-        isLoading: false,
-        error: null,
-      });
+      await screen.findByRole('tab', { name: 'TV Shows' });
+      watchlistListMock.mockResolvedValue(ok({ data: [] }));
 
       await user.click(screen.getByRole('tab', { name: 'TV Shows' }));
 
-      expect(screen.getByText('No TV shows on your watchlist.')).toBeInTheDocument();
+      expect(await screen.findByText('No TV shows on your watchlist.')).toBeInTheDocument();
     });
   });
 
   describe('leaving badge', () => {
-    it('shows LeavingBadge for a movie with rotationStatus leaving', () => {
-      mockWatchlistQuery.mockReturnValue({
-        data: { data: [entry1] },
-        isLoading: false,
-        error: null,
-      });
-      mockMoviesQuery.mockReturnValue({
-        data: {
+    it('shows LeavingBadge for a movie with rotationStatus leaving', async () => {
+      watchlistListMock.mockResolvedValue(ok({ data: [entry1] }));
+      moviesListMock.mockResolvedValue(
+        ok({
           data: [
             {
               id: 10,
@@ -337,27 +326,19 @@ describe('WatchlistPage', () => {
               rotationExpiresAt: '2026-05-01T00:00:00Z',
             },
           ],
-        },
-        isLoading: false,
-      });
-      mockTvShowsQuery.mockReturnValue({
-        data: { data: [] },
-        isLoading: false,
-      });
+        })
+      );
+      tvShowsListMock.mockResolvedValue(ok({ data: [] }));
 
       renderPage();
 
-      expect(screen.getAllByTestId('leaving-badge').length).toBeGreaterThan(0);
+      expect((await screen.findAllByTestId('leaving-badge')).length).toBeGreaterThan(0);
     });
 
-    it('does not show LeavingBadge when rotationStatus is not leaving', () => {
-      mockWatchlistQuery.mockReturnValue({
-        data: { data: [entry1] },
-        isLoading: false,
-        error: null,
-      });
-      mockMoviesQuery.mockReturnValue({
-        data: {
+    it('does not show LeavingBadge when rotationStatus is not leaving', async () => {
+      watchlistListMock.mockResolvedValue(ok({ data: [entry1] }));
+      moviesListMock.mockResolvedValue(
+        ok({
           data: [
             {
               id: 10,
@@ -368,16 +349,13 @@ describe('WatchlistPage', () => {
               rotationExpiresAt: null,
             },
           ],
-        },
-        isLoading: false,
-      });
-      mockTvShowsQuery.mockReturnValue({
-        data: { data: [] },
-        isLoading: false,
-      });
+        })
+      );
+      tvShowsListMock.mockResolvedValue(ok({ data: [] }));
 
       renderPage();
 
+      await screen.findAllByText('The Matrix');
       expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
   });

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
@@ -1,37 +1,20 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockStartMutate = vi.fn();
-const mockGetActive = vi.fn();
-const mockGetStatus = vi.fn();
-let capturedStartOpts: Record<string, (...args: unknown[]) => unknown> = {};
+const { plexGetActiveSyncJobsMock, plexGetSyncJobStatusMock, plexStartSyncJobMock } = vi.hoisted(
+  () => ({
+    plexGetActiveSyncJobsMock: vi.fn(),
+    plexGetSyncJobStatusMock: vi.fn(),
+    plexStartSyncJobMock: vi.fn(),
+  })
+);
 
-vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (
-    _pillarId: string,
-    path: readonly string[],
-    input: unknown,
-    opts?: Record<string, unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'plex.getActiveSyncJobs') return mockGetActive(input, opts);
-    if (key === 'plex.getSyncJobStatus') return mockGetStatus(input, opts);
-    return { data: undefined, isLoading: false };
-  },
-  usePillarMutation: (
-    _pillarId: string,
-    path: readonly string[],
-    opts: Record<string, (...args: unknown[]) => unknown>
-  ) => {
-    const key = path.join('.');
-    if (key === 'plex.startSyncJob') {
-      capturedStartOpts = opts;
-      return { mutate: mockStartMutate, isPending: false };
-    }
-    return { mutate: vi.fn(), isPending: false };
-  },
+vi.mock('../../media-api/index.js', () => ({
+  plexGetActiveSyncJobs: (...args: unknown[]) => plexGetActiveSyncJobsMock(...args),
+  plexGetSyncJobStatus: (...args: unknown[]) => plexGetSyncJobStatusMock(...args),
+  plexStartSyncJob: (...args: unknown[]) => plexStartSyncJobMock(...args),
 }));
 
 const mockToastSuccess = vi.fn();
@@ -45,6 +28,10 @@ vi.mock('sonner', () => ({
 
 import { WatchlistPlexSyncButton } from './WatchlistPlexSyncButton';
 
+function ok<T>(data: T) {
+  return { data, error: undefined };
+}
+
 function renderButton() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -55,76 +42,88 @@ function renderButton() {
 }
 
 function setupIdle(): void {
-  mockGetActive.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockGetStatus.mockReturnValue({ data: undefined, isLoading: false });
+  plexGetActiveSyncJobsMock.mockResolvedValue(ok({ data: [] }));
+  plexGetSyncJobStatusMock.mockResolvedValue(ok({ data: undefined }));
 }
 
 function setupRunning(): void {
-  mockGetActive.mockReturnValue({ data: { data: [] }, isLoading: false });
-  mockGetStatus.mockReturnValue({
-    data: {
-      data: {
-        id: 'job-1',
-        jobType: 'plexSyncWatchlist',
-        status: 'running',
-        startedAt: '2026-04-26T00:00:00Z',
-        completedAt: null,
-        durationMs: null,
-        progress: { processed: 1, total: 10 },
-        result: null,
-        error: null,
-      },
-    },
-    isLoading: false,
-  });
+  plexGetActiveSyncJobsMock.mockResolvedValue(
+    ok({
+      data: [
+        {
+          id: 'job-1',
+          jobType: 'plexSyncWatchlist',
+          status: 'running',
+          startedAt: '2026-04-26T00:00:00Z',
+          completedAt: null,
+          durationMs: null,
+          progress: { processed: 1, total: 10 },
+          result: null,
+          error: null,
+        },
+      ],
+    })
+  );
+  plexGetSyncJobStatusMock.mockResolvedValue(ok({ data: undefined }));
 }
 
 describe('WatchlistPlexSyncButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    capturedStartOpts = {};
+    plexStartSyncJobMock.mockResolvedValue(ok({ data: { jobId: 'job-1' } }));
   });
 
-  it('renders the sync button with label "Sync with Plex" when idle', () => {
+  it('renders the sync button with label "Sync with Plex" when idle', async () => {
     setupIdle();
     renderButton();
     const button = screen.getByTestId('watchlist-plex-sync-button');
     expect(button).toBeInTheDocument();
+    await waitFor(() => expect(button).not.toBeDisabled());
     expect(button).toHaveTextContent('Sync with Plex');
-    expect(button).not.toBeDisabled();
   });
 
-  it('exposes an aria-label for assistive tech', () => {
+  it('exposes an aria-label for assistive tech', async () => {
     setupIdle();
     renderButton();
     expect(screen.getByRole('button', { name: 'Sync watchlist with Plex' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId('watchlist-plex-sync-button')).not.toBeDisabled()
+    );
   });
 
-  it('triggers a plexSyncWatchlist mutation when clicked', () => {
+  it('triggers a plexSyncWatchlist mutation when clicked', async () => {
     setupIdle();
     renderButton();
-    fireEvent.click(screen.getByTestId('watchlist-plex-sync-button'));
-    expect(mockStartMutate).toHaveBeenCalledTimes(1);
-    expect(mockStartMutate).toHaveBeenCalledWith({ jobType: 'plexSyncWatchlist' });
+    const button = screen.getByTestId('watchlist-plex-sync-button');
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+    await waitFor(() => expect(plexStartSyncJobMock).toHaveBeenCalledTimes(1));
+    expect(plexStartSyncJobMock).toHaveBeenCalledWith({ body: { jobType: 'plexSyncWatchlist' } });
   });
 
-  it('disables the button and swaps copy to "Syncing…" while a job is running', () => {
+  it('disables the button and swaps copy to "Syncing…" while a job is running', async () => {
     setupRunning();
     renderButton();
     const button = screen.getByTestId('watchlist-plex-sync-button');
-    expect(button).toBeDisabled();
+    await waitFor(() => expect(button).toBeDisabled());
     expect(button).toHaveTextContent('Syncing…');
   });
 
-  it('surfaces the start mutation error path via the hook (error toast)', () => {
+  it('surfaces the start mutation error path via the hook (error toast)', async () => {
     setupIdle();
+    plexStartSyncJobMock.mockResolvedValue({
+      data: undefined,
+      error: { message: 'queue down' },
+      response: { status: 503 } as Response,
+    });
     renderButton();
-    const onError = capturedStartOpts.onError;
-    expect(typeof onError).toBe('function');
-    if (typeof onError !== 'function') return;
-    onError({ message: 'queue down' });
-    expect(mockToastError).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to start Watchlist sync')
+    const button = screen.getByTestId('watchlist-plex-sync-button');
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to start Watchlist sync')
+      )
     );
   });
 });


### PR DESCRIPTION
Phase D cleanup. The source for LibraryPage/WatchlistPage/WatchlistPlexSyncButton was already migrated to REST, but their tests still mocked @pops/pillar-sdk/react (32 failures). Swapped to vi.mock('../media-api/index.js') + QueryClientProvider, asserting through the UI (mirrors SeasonDetailPage/WatchlistToggle tests). **app-media suite now fully green: 39/39 files, 632/632 tests.** oxlint/oxfmt clean; no pillar-sdk refs remain in the 3 files.