### PR TITLE
feat(media/fe): routing cutover — drop /trpc-media, route app-media to /media-api REST (Phase D tier 1)

### DIFF
--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -14,6 +14,7 @@ on:
       - "pillars/finance/openapi/**"
       - "pillars/food/openapi/**"
       - "pillars/cerebrum/openapi/**"
+      - "pillars/media/openapi/**"
       - "packages/db-types/**"
       - "packages/inventory-db/**"
       - "pillars/lists/db/**"
@@ -35,6 +36,7 @@ on:
       - "pillars/finance/openapi/**"
       - "pillars/food/openapi/**"
       - "pillars/cerebrum/openapi/**"
+      - "pillars/media/openapi/**"
       - "packages/db-types/**"
       - "packages/inventory-db/**"
       - "pillars/lists/db/**"
@@ -69,6 +71,7 @@ jobs:
               - 'pillars/finance/openapi/**'
               - 'pillars/food/openapi/**'
               - 'pillars/cerebrum/openapi/**'
+              - 'pillars/media/openapi/**'
               - 'pillars/lists/db/**'
               - 'pillars/lists/contract/**'
               - 'packages/navigation/**'

--- a/apps/pops-shell/src/lib/trpc.ts
+++ b/apps/pops-shell/src/lib/trpc.ts
@@ -46,7 +46,6 @@ function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit): Promise
  */
 const PILLAR_TRPC_URLS: Readonly<Record<TrpcPillarId, string>> = {
   core: '/trpc-core',
-  media: '/trpc-media',
 };
 
 /** Legacy pops-api URL — catches every procedure that isn't pillar-prefixed. */

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
       // existing endpoints keep answering. Once per-pillar APIs run as
       // separate processes the rewrite goes away and each prefix targets
       // its own upstream.
-      '^/trpc-(core|media)': {
+      '^/trpc-(core)': {
         target: 'http://localhost:3000',
         changeOrigin: true,
         rewrite: (urlPath: string) => urlPath.replace(/^\/trpc-[^/]+/, '/trpc'),
@@ -104,6 +104,11 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (urlPath: string) => urlPath.replace(/^\/food-api/, ''),
       },
+      '/media-api': {
+        target: 'http://localhost:3003',
+        changeOrigin: true,
+        rewrite: (urlPath: string) => urlPath.replace(/^\/media-api/, ''),
+      },
       '/cerebrum-api': {
         target: 'http://localhost:3007',
         changeOrigin: true,
@@ -121,7 +126,7 @@ export default defineConfig({
         changeOrigin: true,
       },
       '/media/images': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:3003',
         changeOrigin: true,
       },
       '/inventory/documents': {

--- a/packages/api-client/src/__tests__/split-link.test.ts
+++ b/packages/api-client/src/__tests__/split-link.test.ts
@@ -71,8 +71,6 @@ function dispatch(link: TRPCLink<AppRouter>, op: Operation): void {
 
 describe('pillarOfPath', () => {
   it('returns the namespace when it is a known tRPC pillar', () => {
-    expect(pillarOfPath('food.recipes.list')).toBe('food');
-    expect(pillarOfPath('media.movies.get')).toBe('media');
     expect(pillarOfPath('core.health')).toBe('core');
   });
 
@@ -80,8 +78,10 @@ describe('pillarOfPath', () => {
     expect(pillarOfPath('health')).toBeNull();
   });
 
-  it('returns null for finance paths now that finance left tRPC', () => {
+  it('returns null for pillars that left tRPC for a REST contract', () => {
     expect(pillarOfPath('finance.wishlist.list')).toBeNull();
+    expect(pillarOfPath('media.movies.get')).toBeNull();
+    expect(pillarOfPath('food.recipes.list')).toBeNull();
   });
 
   it('returns null for paths prefixed with a non-pillar namespace', () => {
@@ -95,23 +95,19 @@ describe('pillarOfPath', () => {
 });
 
 describe('createPillarSplitLink', () => {
-  it('routes finance.* operations to the legacy URL now that finance left tRPC', () => {
+  it('routes operations of pillars that left tRPC to the legacy URL', () => {
     const { link, records } = buildRecordingHarness();
 
     dispatch(link, makeOp('finance.wishlist.list', 1));
-
-    expect(records).toEqual([{ url: LEGACY_TRPC_URL, path: 'finance.wishlist.list' }]);
-  });
-
-  it('routes media.* operations to the media URL', () => {
-    const { link, records } = buildRecordingHarness();
-
     dispatch(link, makeOp('media.movies.get', 7));
 
-    expect(records).toEqual([{ url: PILLAR_TRPC_URLS.media, path: 'media.movies.get' }]);
+    expect(records).toEqual([
+      { url: LEGACY_TRPC_URL, path: 'finance.wishlist.list' },
+      { url: LEGACY_TRPC_URL, path: 'media.movies.get' },
+    ]);
   });
 
-  it('routes a mix of core and food ops to two distinct URLs', () => {
+  it('routes core ops to the core URL and non-tRPC pillars to the legacy URL', () => {
     const { link, records } = buildRecordingHarness();
 
     dispatch(link, makeOp('core.foo', 1));
@@ -119,7 +115,7 @@ describe('createPillarSplitLink', () => {
 
     expect(records).toEqual([
       { url: PILLAR_TRPC_URLS.core, path: 'core.foo' },
-      { url: PILLAR_TRPC_URLS.food, path: 'food.bar' },
+      { url: LEGACY_TRPC_URL, path: 'food.bar' },
     ]);
     const urls = new Set(records.map((r) => r.url));
     expect(urls.size).toBe(2);
@@ -161,7 +157,7 @@ describe('createPillarSplitLink', () => {
     const link = createPillarSplitLink({
       pillarUrls: {
         ...PILLAR_TRPC_URLS,
-        food: 'http://food-api:3005/trpc',
+        core: 'http://core-api:3000/trpc',
       },
       legacyUrl: 'http://legacy:3000/trpc',
       linkFor:
@@ -175,11 +171,11 @@ describe('createPillarSplitLink', () => {
           }),
     });
 
-    dispatch(link, makeOp('food.x', 1));
+    dispatch(link, makeOp('core.x', 1));
     dispatch(link, makeOp('unknown.y', 2));
 
     expect(records).toEqual([
-      { url: 'http://food-api:3005/trpc', path: 'food.x' },
+      { url: 'http://core-api:3000/trpc', path: 'core.x' },
       { url: 'http://legacy:3000/trpc', path: 'unknown.y' },
     ]);
   });

--- a/packages/api-client/src/split-link.ts
+++ b/packages/api-client/src/split-link.ts
@@ -18,7 +18,6 @@ import type { AppRouter } from '@pops/api';
  */
 export const PILLAR_TRPC_URLS: Readonly<Record<TrpcPillarId, string>> = {
   core: '/trpc-core',
-  media: '/trpc-media',
 };
 
 /** Legacy pops-api URL — catches every procedure that isn't pillar-prefixed. */

--- a/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
+++ b/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
@@ -35,7 +35,7 @@ export type KnownPillarId = (typeof PILLARS)[number];
  * any new pillar id added to {@link PILLARS} forces a deliberate choice
  * about its transport).
  */
-export const TRPC_PILLARS = ['core', 'media'] as const;
+export const TRPC_PILLARS = ['core'] as const;
 
 export type TrpcPillarId = (typeof TRPC_PILLARS)[number];
 


### PR DESCRIPTION
Phase D tier-1 (completes the FE migration). Mirrors the finance cutover (#3362):
- `TRPC_PILLARS` drops `media` (→ `['core']`); `media:'/trpc-media'` removed from both split-link maps (api-client + pops-shell).
- vite: `^/trpc-(core|media)`→`^/trpc-(core)`; added `/media-api`→:3003 proxy; retargeted `/media/images`→:3003.
- `fe-quality.yml`: added `pillars/media/openapi/**` to push/PR paths + the shell filter.
- repaired the api-client split-link test (already red from the food cutover) → now 32/32.

Verified: pillar-sdk 552/552, api-client 32/32 (was 30/3-fail), no new shell/typecheck errors (one fewer), `gen:nginx:check` exit 0, oxfmt/oxlint clean. Production nginx.conf /trpc-media + /media/images blocks left for Phase E infra cutover (finance/food precedent).