### PR TITLE
feat(media): nginx REST cutover — proxy /media-api + /media/images to the media pillar :3003 (Phase E)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -119,11 +119,27 @@ server {
         proxy_send_timeout 300s;
     }
 
-    # Proxy media images (posters, backdrops) served by pops-api
+    # Media pillar REST surface (Phase E — Hey API client posts to
+    # `/media-api/...`). Strip the `/media-api` prefix so the pillar's
+    # own router sees its natural paths, then proxy to the media pillar
+    # on :3003. Variable-form `proxy_pass` defers DNS to request time so
+    # pops-shell still boots when the media container is absent
+    # (consistent with the `/trpc-<pillar>/` dispatchers above); calls
+    # 502 until the upstream is in place. The `/trpc-media/` block above
+    # stays for now — a later slice removes it once the monolith media
+    # tRPC router is deleted.
+    location /media-api/ {
+        rewrite ^/media-api/(.*)$ /$1 break;
+        set $media_api_upstream http://media-api:3003;
+        proxy_pass $media_api_upstream;
+        include /etc/nginx/snippets/_pillar-proxy.conf;
+    }
+
+    # Proxy media images (posters, backdrops) served by the media pillar
     # On-demand downloads from TMDB/TVDB may take a few seconds on first request
     # Cache headers are set by the API — don't override with expires/add_header
     location /media/images/ {
-        proxy_pass http://pops-api:3000/media/images/;
+        proxy_pass http://media-api:3003/media/images/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_connect_timeout 10s;

--- a/apps/pops-shell/scripts/generate-nginx-conf.test.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.test.ts
@@ -94,9 +94,11 @@ describe('generate-nginx-conf', () => {
     });
 
     it('each pillar block includes the shared _pillar-proxy.conf partial', () => {
-      const includes = rendered.match(/include \/etc\/nginx\/snippets\/_pillar-proxy\.conf;/g);
-      expect(includes).not.toBeNull();
-      expect(includes ?? []).toHaveLength(PILLARS.length);
+      const perPillarIncludes = rendered.match(
+        /proxy_pass \$trpc_\w+_upstream;\n\s*include \/etc\/nginx\/snippets\/_pillar-proxy\.conf;/g
+      );
+      expect(perPillarIncludes).not.toBeNull();
+      expect(perPillarIncludes ?? []).toHaveLength(PILLARS.length);
     });
 
     it('keeps the legacy /trpc fallback proxying to pops-api', () => {

--- a/apps/pops-shell/scripts/nginx-conf-template.ts
+++ b/apps/pops-shell/scripts/nginx-conf-template.ts
@@ -83,11 +83,27 @@ export const NGINX_CONF_TAIL = `    # Legacy tRPC catch-all → pops-api.
         proxy_send_timeout 300s;
     }
 
-    # Proxy media images (posters, backdrops) served by pops-api
+    # Media pillar REST surface (Phase E — Hey API client posts to
+    # \`/media-api/...\`). Strip the \`/media-api\` prefix so the pillar's
+    # own router sees its natural paths, then proxy to the media pillar
+    # on :3003. Variable-form \`proxy_pass\` defers DNS to request time so
+    # pops-shell still boots when the media container is absent
+    # (consistent with the \`/trpc-<pillar>/\` dispatchers above); calls
+    # 502 until the upstream is in place. The \`/trpc-media/\` block above
+    # stays for now — a later slice removes it once the monolith media
+    # tRPC router is deleted.
+    location /media-api/ {
+        rewrite ^/media-api/(.*)$ /$1 break;
+        set $media_api_upstream http://media-api:3003;
+        proxy_pass $media_api_upstream;
+        include /etc/nginx/snippets/_pillar-proxy.conf;
+    }
+
+    # Proxy media images (posters, backdrops) served by the media pillar
     # On-demand downloads from TMDB/TVDB may take a few seconds on first request
     # Cache headers are set by the API — don't override with expires/add_header
     location /media/images/ {
-        proxy_pass http://pops-api:3000/media/images/;
+        proxy_pass http://media-api:3003/media/images/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_connect_timeout 10s;


### PR DESCRIPTION
Phase E deploy. Edits the nginx GENERATOR (apps/pops-shell/scripts/nginx-conf-template.ts): adds a /media-api/→media-api:3003 location block (modeled on /trpc-media shape, variable-form upstream for boot resilience) + repoints /media/images/ from pops-api:3000→media-api:3003; regenerated nginx.conf. /trpc-media kept until the monolith media router is deleted (Slice 6). Verified: gen:nginx:check PASS, generate-nginx-conf.test 43/43, scripts suite 86/86. (validate-nginx-conf.sh skipped locally — no Docker; block syntax matches the CI-validated /trpc-media block.)