### PR TITLE
refactor(core-db): inline syncJobResults schema, drop @pops/media-db dep (media Phase E prereq)

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -20,7 +20,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@pops/media-db": "workspace:*",
     "better-sqlite3": "^12.10.0",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -20,9 +20,5 @@ export { environments } from './schema/environments.js';
 export { pillarRegistry } from './schema/pillar-registry.js';
 export { serviceAccounts } from './schema/service-accounts.js';
 export { settings } from './schema/settings.js';
+export { syncJobResults } from './schema/sync-job-results.js';
 export { userSettings } from './schema/user-settings.js';
-
-// `syncJobResults` is owned by `@pops/media-db` (PRD-245 US-04) but the
-// historical sync-results service in this package writes to it. Re-exported
-// here so existing imports keep resolving.
-export { syncJobResults } from '@pops/media-db';

--- a/packages/core-db/src/schema/sync-job-results.ts
+++ b/packages/core-db/src/schema/sync-job-results.ts
@@ -1,0 +1,29 @@
+/**
+ * `sync_job_results` (PRD-186) — cross-pillar BullMQ result table owned by
+ * the core pillar. Created and migrated by core-db (`0060_sync_job_results.sql`)
+ * and read/written through the core handle via `syncResultsService`.
+ *
+ * The media pillar carries its own independent copy of this table; this is
+ * the canonical core-owned definition.
+ */
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const syncJobResults = sqliteTable(
+  'sync_job_results',
+  {
+    id: text('id').primaryKey(),
+    jobType: text('job_type').notNull(),
+    status: text('status').notNull(),
+    startedAt: text('started_at').notNull(),
+    completedAt: text('completed_at'),
+    durationMs: integer('duration_ms'),
+    progress: text('progress'),
+    result: text('result'),
+    error: text('error'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [index('idx_sync_job_results_type_completed').on(table.jobType, table.completedAt)]
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1529,9 +1529,6 @@ importers:
 
   packages/core-db:
     dependencies:
-      '@pops/media-db':
-        specifier: workspace:*
-        version: link:../media-db
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0


### PR DESCRIPTION
Phase E prereq. core-db re-exported syncJobResults from @pops/media-db (blocking media-db's retirement). Inlined the table def into packages/core-db/src/schema/sync-job-results.ts (columns copied exactly; migration 0060 already owns the table), dropped the @pops/media-db dep. core-db 144 tests pass; media bubble green via turbo (6/6 build+typecheck). The pillar's own syncJobResults copy is untouched.