### PR TITLE
chore(media): infra hygiene — dep-cruiser ban dead media pkgs + strip monolith Dockerfile (Phase C)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1021,5 +1021,1105 @@
       "severity": "error",
       "name": "no-dead-inventory-pkgs"
     }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/db/backfill-media-from-shared.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/db/media-db-handle.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/arr/download-and-protect.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/dimensions.service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/global-count.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/batch-record.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/comparison-queries.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/dimension-exclusion.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/score-management.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/skip-cooloff.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/submit-tier-list.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/pairs/movie-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/pairs/random-pair.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/pairs/smart-pair-fetch.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/rankings-overall.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/scores.service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/staleness.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/types-domain.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/context-picks-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/flags.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/flags.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/plex-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/router-shelf.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/router-tmdb.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/router.assemble-session.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service-library.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service-preference-profile.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service-rewatch.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/because-you-watched.shelf.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/credits-shelves.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/dimension-inspired.shelf.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-misc-shelves.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-runtime-shelves.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-score-shelves.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-shelves-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/local-watch-shelves.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/session.service.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/session.service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/shelf/top-dimension.shelf.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/tmdb-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/index.ts",
+    "to": "@pops/media-contract/settings",
+    "unresolvedTo": "@pops/media-contract/settings",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/library/list-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/library/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/library/tv-show-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/movies/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/movies/types.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/router-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/router-sync.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-check.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-episode.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-movie.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-show.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-watches.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-tv.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-watchlist.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/addition-gating.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/candidate-queue.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/download-candidate.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/exclusion-list.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/removal-selection.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-candidates-router.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-exclusions-router.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-log.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-log.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-scheduler-router.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-sources-router.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/selection-policy.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/selection-policy.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/source-crud.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/sync-all-sources.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/sync-source.test.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/sync-source.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/search/movies-adapter.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/search/tv-shows-adapter.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/thetvdb/refresh-episodes.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/thetvdb/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/thetvdb/types-inserts.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/episodes-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/seasons-service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/types-domain.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/types-mappers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/auto-remove-show.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/list-recent.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/log-watch-event.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/progress.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/types.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watchlist/plex-push.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watchlist/service.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watchlist/types.ts",
+    "to": "@pops/media-db",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-media-pkgs"
+    }
   }
 ]

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -82,6 +82,14 @@ module.exports = {
       from: { path: '.*' },
       to: { path: '^@pops/(cerebrum-db|cerebrum-contract|cerebrum-api)(/|$)' },
     },
+    {
+      name: 'no-dead-media-pkgs',
+      severity: 'error',
+      comment:
+        'Media is collapsing into `pillars/media/` — `@pops/app-media-db`, `@pops/media-db`, `@pops/media-contract`, and `@pops/media-api` are the retirement tombstone (deleted once the pops-api media module is gone). No new code may import them; consumers go through `@pops/media` (contract types + api-types + openapi) and the media REST API for cross-pillar calls. Existing pops-api media-module imports are grandfathered in the known-violations baseline until they are removed.',
+      from: { path: '.*' },
+      to: { path: '^@pops/(app-media-db|media-db|media-contract|media-api)(/|$)' },
+    },
     ...contractBoundaryRules,
   ],
   options: {

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -12,9 +12,7 @@ COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
 COPY packages/core-contract/package.json ./packages/core-contract/
-COPY packages/media-contract/package.json ./packages/media-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
-COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
@@ -32,15 +30,11 @@ COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.bu
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
-COPY packages/media-db/src ./packages/media-db/src
-COPY packages/media-db/tsconfig.json ./packages/media-db/
-COPY packages/media-db/migrations ./packages/media-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
 COPY packages/core-contract/ ./packages/core-contract/
-COPY packages/media-contract/ ./packages/media-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
@@ -50,8 +44,6 @@ COPY apps/pops-api/scripts ./apps/pops-api/scripts
 # packages own their schemas and `@pops/db-types` is a leaf constants
 # package — order between db-types and the pillars no longer matters.
 WORKDIR /app/packages/db-types
-RUN pnpm build
-WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
@@ -64,8 +56,6 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-contract
 RUN pnpm build
 WORKDIR /app/packages/core-contract
-RUN pnpm build
-WORKDIR /app/packages/media-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
@@ -101,9 +91,6 @@ COPY --from=builder /app/packages/module-registry/package.json ./node_modules/@p
 COPY --from=builder /app/packages/core-db/dist ./node_modules/@pops/core-db/dist
 COPY --from=builder /app/packages/core-db/package.json ./node_modules/@pops/core-db/
 COPY --from=builder /app/packages/core-db/migrations ./node_modules/@pops/core-db/migrations
-COPY --from=builder /app/packages/media-db/dist ./node_modules/@pops/media-db/dist
-COPY --from=builder /app/packages/media-db/package.json ./node_modules/@pops/media-db/
-COPY --from=builder /app/packages/media-db/migrations ./node_modules/@pops/media-db/migrations
 COPY --from=builder /app/packages/cerebrum-db/dist ./node_modules/@pops/cerebrum-db/dist
 COPY --from=builder /app/packages/cerebrum-db/package.json ./node_modules/@pops/cerebrum-db/
 COPY --from=builder /app/packages/cerebrum-db/migrations ./node_modules/@pops/cerebrum-db/migrations


### PR DESCRIPTION
Phase C infra hygiene (mirrors finance #3363 + cerebrum Phase C). Adds the no-dead-media-pkgs dep-cruiser rule (bans @pops/(app-media-db|media-db|media-contract|media-api); tombstone phrasing — monolith consumers grandfathered in the baseline until Slice 6 removes them). Strips media-db+media-contract COPY/build steps from apps/pops-api/Dockerfile (-13). Baseline +100/-0; lint:boundaries + verify exit 0; rule fires 0× on pillars/media. Baseline regenerated in the unbuilt state (the depcruise unresolvedTo gotcha).