### PR TITLE
feat(media): implement Plex-Discover — un-stub trendingPlex + restore the trending-plex shelf

### DIFF
--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -7674,9 +7674,81 @@
                   "additionalProperties": false,
                   "properties": {
                     "data": {
-                      "enum": [null],
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "backdropPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "genreIds": {
+                            "items": {
+                              "type": "number"
+                            },
+                            "type": "array"
+                          },
+                          "inLibrary": {
+                            "type": "boolean"
+                          },
+                          "isWatched": {
+                            "type": "boolean"
+                          },
+                          "onWatchlist": {
+                            "type": "boolean"
+                          },
+                          "overview": {
+                            "type": "string"
+                          },
+                          "popularity": {
+                            "type": "number"
+                          },
+                          "posterPath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "posterUrl": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "releaseDate": {
+                            "type": "string"
+                          },
+                          "rotationExpiresAt": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "tmdbId": {
+                            "type": "number"
+                          },
+                          "voteAverage": {
+                            "type": "number"
+                          },
+                          "voteCount": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "tmdbId",
+                          "title",
+                          "overview",
+                          "releaseDate",
+                          "posterPath",
+                          "posterUrl",
+                          "backdropPath",
+                          "voteAverage",
+                          "voteCount",
+                          "genreIds",
+                          "popularity",
+                          "inLibrary",
+                          "isWatched",
+                          "onWatchlist"
+                        ],
+                        "type": "object"
+                      },
                       "nullable": true,
-                      "type": "string"
+                      "type": "array"
                     }
                   },
                   "required": ["data"],
@@ -7687,7 +7759,7 @@
             "description": "200"
           }
         },
-        "summary": "Trending from Plex Discover (STUB: always null until the client lands)",
+        "summary": "Trending from Plex Discover (null when Plex is not connected)",
         "tags": ["discovery"]
       }
     },

--- a/pillars/media/src/api/__tests__/discovery.test.ts
+++ b/pillars/media/src/api/__tests__/discovery.test.ts
@@ -4,7 +4,7 @@
  * Covers the discover surface ported from the pops-api monolith: the dismiss
  * pile round-trip, the preference profile reflecting seeded scores + genres,
  * from-your-server excluding watched + ordering by profile, TMDB trending /
- * recommendations shape (client mocked), the trendingPlex null stub, session
+ * recommendations shape (client mocked), trendingPlex null without a token, session
  * assembly (shelves with items, impressions recorded, dismissed excluded), and
  * shelf paging.
  *
@@ -301,7 +301,7 @@ describe('discovery — TMDB-backed (client mocked)', () => {
     expect(res.results[0]).toHaveProperty('matchPercentage');
   });
 
-  it('stubs trendingPlex to null (Plex Discover client not ported)', async () => {
+  it('returns null trendingPlex when no Plex token is configured', async () => {
     const res = await client().discovery.trendingPlex({ limit: 20 });
     expect(res.data).toBeNull();
   });

--- a/pillars/media/src/api/__tests__/plex-discover.test.ts
+++ b/pillars/media/src/api/__tests__/plex-discover.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Integration tests for the Plex-Discover trending surface
+ * (`discovery.trendingPlex` + the `trending-plex` session shelf) via supertest.
+ *
+ * The Plex Discover provider endpoints are mocked at `globalThis.fetch` with a
+ * (method, url-substring) route table, so the assertions exercise the real
+ * discover client → service → handler → contract path with no network IO. The
+ * vitest suite runs `fileParallelism:false` + `unstubGlobals`, so the fetch
+ * stub can't bleed into the DB-only suites.
+ *
+ * Coverage:
+ *  - enriched results: inLibrary / isWatched / onWatchlist flags + poster URL
+ *    convention, dismissed + duplicate filtering, TMDB-less items dropped;
+ *  - `{ data: null }` when no Plex token is configured;
+ *  - the watchlist→hubs fallback when the popularity feed errors;
+ *  - assembleSession surfaces the shelf when Plex is connected and omits it
+ *    (gracefully, no throw) when Plex is not connected.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb, plexSettingsService, type OpenedMediaDb } from '../../db/index.js';
+import { createMediaApiApp } from '../app.js';
+import { TmdbClient } from '../clients/tmdb/client.js';
+import { makeClient } from './test-utils.js';
+
+const { getTmdbClientMock } = vi.hoisted(() => ({ getTmdbClientMock: vi.fn<() => TmdbClient>() }));
+
+vi.mock('../clients/tmdb/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../clients/tmdb/index.js')>(
+    '../clients/tmdb/index.js'
+  );
+  return { ...actual, getTmdbClient: getTmdbClientMock };
+});
+
+interface RouteResponse {
+  status?: number;
+  body: unknown;
+}
+type RouteHandler = () => RouteResponse;
+interface RouteRule {
+  method: string;
+  match: string;
+  handler: RouteHandler;
+}
+
+let routes: RouteRule[];
+let calls: { method: string; url: string }[];
+
+function route(method: string, match: string, handler: RouteHandler): void {
+  routes.push({ method, match, handler });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const method = (init?.method ?? 'GET').toUpperCase();
+  calls.push({ method, url });
+  const rule = routes.find((r) => r.method === method && url.includes(r.match));
+  if (!rule) return Promise.resolve(jsonResponse({ error: `unmatched ${method} ${url}` }, 404));
+  const res = rule.handler();
+  return Promise.resolve(jsonResponse(res.body, res.status ?? 200));
+});
+
+interface PlexDiscoverItem {
+  ratingKey: string;
+  type: string;
+  title: string;
+  year?: number;
+  summary?: string;
+  thumb?: string;
+  audienceRating?: number;
+  addedAt: number;
+  updatedAt: number;
+  Guid?: { id: string }[];
+}
+
+function discoverItem(
+  tmdbId: number | null,
+  overrides: Partial<PlexDiscoverItem> = {}
+): PlexDiscoverItem {
+  return {
+    ratingKey: `rk-${tmdbId ?? 'none'}`,
+    type: 'movie',
+    title: `Movie ${tmdbId ?? 'no-tmdb'}`,
+    year: 2021,
+    summary: 'plex summary',
+    thumb: 'https://plex.cdn/poster.jpg',
+    audienceRating: 8.4,
+    addedAt: 1700000000,
+    updatedAt: 1700000001,
+    Guid: tmdbId === null ? [] : [{ id: `tmdb://${tmdbId}` }],
+    ...overrides,
+  };
+}
+
+function stubWatchlistTrending(items: PlexDiscoverItem[]): void {
+  route('GET', 'discover.provider.plex.tv/library/sections/watchlist/all', () => ({
+    body: { MediaContainer: { Metadata: items } },
+  }));
+}
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+let tmdb: TmdbClient;
+let idSeq = 9000;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-plex-discover-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+  tmdb = new TmdbClient('test-key');
+  getTmdbClientMock.mockReturnValue(tmdb);
+  routes = [];
+  calls = [];
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+  delete process.env['PLEX_URL'];
+  delete process.env['ENCRYPTION_KEY'];
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  delete process.env['PLEX_URL'];
+  delete process.env['ENCRYPTION_KEY'];
+});
+
+function client() {
+  return makeClient(
+    createMediaApiApp({ mediaDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3003' })
+  );
+}
+
+function seedToken(): void {
+  plexSettingsService.setSetting(mediaDb.db, 'plex_token', 'raw-discover-token');
+}
+
+function nextId(): number {
+  idSeq += 1;
+  return idSeq;
+}
+
+async function makeMovie(title: string, tmdbId: number) {
+  return (await client().movies.create({ tmdbId, title })).data;
+}
+
+describe('discovery.trendingPlex — enrichment', () => {
+  it('returns enriched trending movies with library/watched/watchlist flags + poster URL', async () => {
+    const libMovie = await makeMovie('In Library', nextId());
+    const watchedMovie = await makeMovie('Watched', nextId());
+    const watchlistMovie = await makeMovie('On Watchlist', nextId());
+    await client().watchHistory.log({ mediaType: 'movie', mediaId: watchedMovie.id, completed: 1 });
+    await client().watchlist.add({ mediaType: 'movie', mediaId: watchlistMovie.id });
+
+    const freshId = 654321;
+    seedToken();
+    stubWatchlistTrending([
+      discoverItem(libMovie.tmdbId, { title: 'In Library' }),
+      discoverItem(watchedMovie.tmdbId, { title: 'Watched' }),
+      discoverItem(watchlistMovie.tmdbId, { title: 'On Watchlist' }),
+      discoverItem(freshId, { title: 'Fresh', thumb: 'https://plex.cdn/fresh.jpg' }),
+    ]);
+
+    const { data } = await client().discovery.trendingPlex({ limit: 20 });
+    expect(data).not.toBeNull();
+    const byId = new Map((data ?? []).map((r) => [r.tmdbId, r]));
+
+    expect(byId.get(libMovie.tmdbId)?.inLibrary).toBe(true);
+    expect(byId.get(libMovie.tmdbId)?.posterUrl).toBe(
+      `/media/images/movie/${libMovie.tmdbId}/poster.jpg`
+    );
+    expect(byId.get(watchedMovie.tmdbId)?.isWatched).toBe(true);
+    expect(byId.get(watchlistMovie.tmdbId)?.onWatchlist).toBe(true);
+
+    const fresh = byId.get(freshId);
+    expect(fresh?.inLibrary).toBe(false);
+    expect(fresh?.isWatched).toBe(false);
+    expect(fresh?.onWatchlist).toBe(false);
+    // Non-library items keep the Plex CDN thumb, not the local proxy URL.
+    expect(fresh?.posterUrl).toBe('https://plex.cdn/fresh.jpg');
+    expect(fresh?.voteAverage).toBe(8.4);
+    expect(fresh?.releaseDate).toBe('2021-01-01');
+
+    // Discover provider was actually hit (no live network).
+    expect(
+      calls.some(
+        (c) => c.url.includes('discover.provider.plex.tv') && c.url.includes('raw-discover-token')
+      )
+    ).toBe(true);
+  });
+
+  it('drops dismissed, duplicate, and TMDB-less items', async () => {
+    const dismissedId = 111;
+    await client().discovery.dismiss(dismissedId);
+    seedToken();
+    stubWatchlistTrending([
+      discoverItem(dismissedId, { title: 'Dismissed' }),
+      discoverItem(222, { title: 'Keep' }),
+      discoverItem(222, { ratingKey: 'rk-dup', title: 'Duplicate' }),
+      discoverItem(null, { title: 'No TMDB id' }),
+    ]);
+
+    const { data } = await client().discovery.trendingPlex();
+    const ids = (data ?? []).map((r) => r.tmdbId);
+    expect(ids).toEqual([222]);
+  });
+
+  it('falls back to the promoted hubs when the watchlist feed errors', async () => {
+    seedToken();
+    route('GET', 'discover.provider.plex.tv/library/sections/watchlist/all', () => ({
+      status: 500,
+      body: { error: 'boom' },
+    }));
+    route('GET', 'discover.provider.plex.tv/hubs/promoted', () => ({
+      body: {
+        MediaContainer: {
+          Hub: [
+            {
+              type: 'movie',
+              Metadata: [discoverItem(777, { title: 'From Hub' }), discoverItem(null)],
+            },
+          ],
+        },
+      },
+    }));
+
+    const { data } = await client().discovery.trendingPlex();
+    expect((data ?? []).map((r) => r.tmdbId)).toEqual([777]);
+    expect(calls.some((c) => c.url.includes('/hubs/promoted'))).toBe(true);
+  });
+
+  it('returns null when no Plex token is configured', async () => {
+    const { data } = await client().discovery.trendingPlex({ limit: 20 });
+    expect(data).toBeNull();
+    // No token → no discover call.
+    expect(calls.some((c) => c.url.includes('discover.provider.plex.tv'))).toBe(false);
+  });
+});
+
+describe('discovery — session assembly with the trending-plex shelf', () => {
+  async function seedRichLibrary(): Promise<void> {
+    const dims = await client().comparisons.listDimensions();
+    const dimId = dims.data[0]?.id;
+    if (dimId === undefined) throw new Error('expected a seeded dimension');
+    for (let i = 0; i < 6; i++) {
+      const a = (
+        await client().movies.create({
+          tmdbId: nextId(),
+          title: `Comfy ${i}`,
+          genres: ['Action'],
+          voteAverage: 8,
+        })
+      ).data;
+      const b = (
+        await client().movies.create({
+          tmdbId: nextId(),
+          title: `Other ${i}`,
+          genres: ['Drama'],
+          voteAverage: 5,
+        })
+      ).data;
+      await client().comparisons.record({
+        dimensionId: dimId,
+        mediaAType: 'movie',
+        mediaAId: a.id,
+        mediaBType: 'movie',
+        mediaBId: b.id,
+        winnerType: 'movie',
+        winnerId: a.id,
+      });
+      await client().watchHistory.log({ mediaType: 'movie', mediaId: a.id, completed: 1 });
+      await client().watchHistory.log({
+        mediaType: 'movie',
+        mediaId: a.id,
+        completed: 1,
+        watchedAt: new Date(Date.now() - i * 1000).toISOString(),
+      });
+    }
+    for (let i = 0; i < 8; i++) {
+      await client().movies.create({ tmdbId: nextId(), title: `New ${i}`, genres: ['Action'] });
+    }
+  }
+
+  function stubTmdbShelves(): void {
+    vi.spyOn(tmdb, 'getTrendingMovies').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+    vi.spyOn(tmdb, 'discoverMovies').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+    vi.spyOn(tmdb, 'getMovieRecommendations').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+    vi.spyOn(tmdb, 'getMovieSimilar').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+    vi.spyOn(tmdb, 'getMovieCredits').mockResolvedValue({ id: 0, cast: [], crew: [] });
+    vi.spyOn(tmdb, 'discoverMoviesByCrew').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+    vi.spyOn(tmdb, 'discoverMoviesByCast').mockResolvedValue({
+      results: [],
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+    });
+  }
+
+  it('registers + pages the trending-plex shelf when Plex is connected', async () => {
+    // Session selection is randomised + capped, so a specific shelf is not
+    // guaranteed to surface in a given session. The deterministic proof that
+    // the shelf is registered + wired is paging it directly by id.
+    await seedRichLibrary();
+    seedToken();
+    stubWatchlistTrending(
+      Array.from({ length: 10 }, (_, i) => discoverItem(500000 + i, { title: `Plex Trend ${i}` }))
+    );
+
+    const page = await client().discovery.getShelfPage('trending-plex', { limit: 5, offset: 0 });
+    expect(page.items.length).toBe(5);
+    expect(page.items.every((i) => !i.inLibrary)).toBe(true);
+    expect(page.items[0]?.posterUrl).toBe('https://plex.cdn/poster.jpg');
+
+    const next = await client().discovery.getShelfPage('trending-plex', { limit: 5, offset: 5 });
+    const firstIds = new Set(page.items.map((i) => i.tmdbId));
+    expect(next.items.every((i) => !firstIds.has(i.tmdbId))).toBe(true);
+  });
+
+  it('yields an empty trending-plex page (no throw) and assembles a session when Plex is off', async () => {
+    await seedRichLibrary();
+    stubTmdbShelves();
+    // No token seeded → getTrendingFromPlex returns null → shelf yields [].
+
+    const page = await client().discovery.getShelfPage('trending-plex', { limit: 5, offset: 0 });
+    expect(page.items).toEqual([]);
+
+    // Session assembly still works and never surfaces an empty external shelf.
+    const { shelves } = await client().discovery.assembleSession();
+    expect(shelves.length).toBeGreaterThan(0);
+    expect(shelves.find((s) => s.shelfId === 'trending-plex')).toBeUndefined();
+    // The Plex Discover endpoint was never called (no token short-circuits it).
+    expect(calls.some((c) => c.url.includes('discover.provider.plex.tv'))).toBe(false);
+  });
+});

--- a/pillars/media/src/api/__tests__/test-utils.ts
+++ b/pillars/media/src/api/__tests__/test-utils.ts
@@ -464,7 +464,7 @@ function makeDiscoveryClient(r: ReturnType<typeof supertest>) {
         r.get('/discovery/trending').query(query)
       ),
     trendingPlex: (query: { limit?: number } = {}) =>
-      send<{ data: null }>(r.get('/discovery/trending-plex').query(query)),
+      send<{ data: DiscoverResultWire[] | null }>(r.get('/discovery/trending-plex').query(query)),
     watchlistRecommendations: () =>
       send<{ results: ScoredDiscoverResultWire[]; sourceMovies: string[] }>(
         r.get('/discovery/watchlist-recommendations')

--- a/pillars/media/src/api/clients/plex/discover.ts
+++ b/pillars/media/src/api/clients/plex/discover.ts
@@ -1,0 +1,67 @@
+/**
+ * Plex Discover (cloud) trending client.
+ *
+ * Ported from the monolith `media/plex/client-discover.ts` (trending path
+ * only). Targets the Plex Discover provider endpoints (absolute cloud URLs
+ * with the token in the query string), so it reuses {@link getAbsolute} +
+ * {@link mapMediaItem} rather than the Plex Media Server `PlexClient`.
+ *
+ * Only the trending surface is ported here; the watchlist mutate / user-state /
+ * discover-search endpoints stay deferred (separate features).
+ */
+import { getAbsolute } from './client-http.js';
+import { mapMediaItem } from './client-mappers.js';
+
+import type { PlexMediaItem, RawPlexMediaItem } from './types.js';
+
+const DEFAULT_TRENDING_LIMIT = 20;
+
+/** Watchlist popularity feed — popular movies ranked by monthly popularity. */
+async function fetchTrendingViaWatchlist(token: string, limit: number): Promise<PlexMediaItem[]> {
+  const url =
+    `https://discover.provider.plex.tv/library/sections/watchlist/all` +
+    `?type=1` +
+    `&sort=popularityMonth:desc` +
+    `&limit=${limit}` +
+    `&includeGuids=1` +
+    `&X-Plex-Token=${token}`;
+  const data = await getAbsolute<{ MediaContainer: { Metadata?: RawPlexMediaItem[] } }>(url);
+  return (data.MediaContainer.Metadata ?? []).map(mapMediaItem);
+}
+
+/** Promoted hubs fallback — pull movie items out of the discover hubs. */
+async function fetchTrendingViaHubs(token: string, limit: number): Promise<PlexMediaItem[]> {
+  const hubUrl =
+    `https://discover.provider.plex.tv/hubs/promoted` +
+    `?count=${limit}` +
+    `&includeGuids=1` +
+    `&X-Plex-Token=${token}`;
+  const hubData = await getAbsolute<{
+    MediaContainer: { Hub?: Array<{ type: string; Metadata?: RawPlexMediaItem[] }> };
+  }>(hubUrl);
+  const hubs = hubData.MediaContainer.Hub ?? [];
+  const movieItems: PlexMediaItem[] = [];
+  for (const hub of hubs) {
+    for (const item of hub.Metadata ?? []) {
+      if (item.type === 'movie') movieItems.push(mapMediaItem(item));
+      if (movieItems.length >= limit) break;
+    }
+    if (movieItems.length >= limit) break;
+  }
+  return movieItems.slice(0, limit);
+}
+
+/**
+ * Fetch trending/popular movies from the Plex Discover API. Prefers the
+ * watchlist popularity feed and falls back to the promoted hubs on error.
+ */
+export async function getTrending(
+  token: string,
+  limit: number = DEFAULT_TRENDING_LIMIT
+): Promise<PlexMediaItem[]> {
+  try {
+    return await fetchTrendingViaWatchlist(token, limit);
+  } catch {
+    return fetchTrendingViaHubs(token, limit);
+  }
+}

--- a/pillars/media/src/api/clients/plex/index.ts
+++ b/pillars/media/src/api/clients/plex/index.ts
@@ -39,6 +39,8 @@ export {
 
 export { encryptToken, decryptToken, getEncryptionKey } from './crypto.js';
 
+export { getTrending as getPlexDiscoverTrending } from './discover.js';
+
 export {
   fetchPlexFriends,
   fetchFriendWatchlist,

--- a/pillars/media/src/api/modules/discovery/plex-trending.ts
+++ b/pillars/media/src/api/modules/discovery/plex-trending.ts
@@ -1,0 +1,95 @@
+/**
+ * Plex Discover trending orchestration — fetches trending movies from the Plex
+ * Discover API and annotates them with library / watched / watchlist flags,
+ * dropping dismissed items.
+ *
+ * Ported from the monolith `discovery/plex-service.getTrendingFromPlex`,
+ * converted to the pillar's `(db, …)` arg pattern: the Plex token is resolved
+ * (and decrypted) from `plex_settings` via {@link getPlexToken}, exactly like
+ * the rotation Plex sources. Returns `null` when no token is configured (parity
+ * with the monolith returning `null` when no Plex client is available).
+ */
+import { type MediaDb } from '../../../db/index.js';
+import { getPlexDiscoverTrending, getPlexToken } from '../../clients/plex/index.js';
+import { loadFlagSets } from './deps.js';
+
+import type { DiscoverResult } from '../../../db/index.js';
+import type { PlexMediaItem } from '../../clients/plex/index.js';
+import type { FlagSets } from './discover-result-mapper.js';
+
+const DEFAULT_PLEX_TRENDING_LIMIT = 20;
+/** Over-fetch so library / watched / dismissed filtering still fills the page. */
+const FILTER_HEADROOM = 10;
+
+/**
+ * Poster URL for a Plex Discover item: the local image proxy for in-library
+ * movies, the Plex CDN thumb otherwise. Unlike the TMDB poster builder, an
+ * in-library item always resolves to the proxy even without a Plex thumb.
+ */
+function plexPosterUrl(item: PlexMediaItem, tmdbId: number, inLibrary: boolean): string | null {
+  if (inLibrary) return `/media/images/movie/${tmdbId}/poster.jpg`;
+  return item.thumbUrl;
+}
+
+/** Extract a numeric TMDB id from a Plex item's external-id (Guid) array. */
+function extractTmdbId(item: PlexMediaItem): number | null {
+  const tmdbGuid = item.externalIds.find((id) => id.source === 'tmdb');
+  if (!tmdbGuid) return null;
+  const parsed = Number.parseInt(tmdbGuid.id, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** Map a Plex Discover item to a {@link DiscoverResult}, or null without a TMDB id. */
+function toDiscoverResult(item: PlexMediaItem, flags: FlagSets): DiscoverResult | null {
+  const tmdbId = extractTmdbId(item);
+  if (tmdbId === null) return null;
+
+  const inLibrary = flags.libraryIds.has(tmdbId);
+  return {
+    tmdbId,
+    title: item.title,
+    overview: item.summary ?? '',
+    releaseDate: item.year ? `${item.year}-01-01` : '',
+    posterPath: null,
+    posterUrl: plexPosterUrl(item, tmdbId, inLibrary),
+    backdropPath: null,
+    voteAverage: item.audienceRating ?? 0,
+    voteCount: 0,
+    genreIds: [],
+    popularity: 0,
+    inLibrary,
+    isWatched: flags.watchedIds.has(tmdbId),
+    onWatchlist: flags.watchlistIds.has(tmdbId),
+  };
+}
+
+/**
+ * Fetch trending movies from the Plex Discover API, enriched with library /
+ * watched / watchlist flags and with dismissed + duplicate items filtered out.
+ *
+ * Returns `null` when Plex is not connected (no token), so the caller can hide
+ * the surface entirely instead of rendering an empty shelf.
+ */
+export async function getTrendingFromPlex(
+  db: MediaDb,
+  limit: number = DEFAULT_PLEX_TRENDING_LIMIT
+): Promise<DiscoverResult[] | null> {
+  const token = getPlexToken(db);
+  if (token === null) return null;
+
+  const plexItems = await getPlexDiscoverTrending(token, limit + FILTER_HEADROOM);
+  const flags = loadFlagSets(db);
+
+  const results: DiscoverResult[] = [];
+  const seenTmdbIds = new Set<number>();
+  for (const item of plexItems) {
+    const result = toDiscoverResult(item, flags);
+    if (result === null) continue;
+    if (flags.dismissedIds.has(result.tmdbId)) continue;
+    if (seenTmdbIds.has(result.tmdbId)) continue;
+    seenTmdbIds.add(result.tmdbId);
+    results.push(result);
+    if (results.length >= limit) break;
+  }
+  return results;
+}

--- a/pillars/media/src/api/modules/discovery/shelf/existing-shelves.ts
+++ b/pillars/media/src/api/modules/discovery/shelf/existing-shelves.ts
@@ -1,17 +1,17 @@
 /**
  * Shelves wrapping the standalone discovery sections so they can participate in
- * session assembly: trending (TMDB), recommendations, from-your-watchlist,
- * worth-rewatching, from-your-server.
+ * session assembly: trending (TMDB), trending (Plex Discover), recommendations,
+ * from-your-watchlist, worth-rewatching, from-your-server.
  *
- * NOTE: the monolith's `trending-plex` shelf is a Plex-Discover-backed path.
- * The Plex Discover client is NOT ported yet (wave-3 follow-up), so that shelf
- * is intentionally omitted from the registry — the session simply has one
- * fewer external shelf until Plex-Discover lands.
+ * The `trending-plex` shelf contributes nothing (an empty page) when Plex is
+ * not connected — `getTrendingFromPlex` returns `null` then — so session
+ * assembly simply drops it under the variety threshold.
  *
  * Ported from the monolith `shelf/existing-shelves.ts`.
  */
 import { discoveryService } from '../../../../db/index.js';
 import { getFromYourServer } from '../basic.js';
+import { getTrendingFromPlex } from '../plex-trending.js';
 import { getRecommendations } from '../recommendations.js';
 import { getWatchlistRecommendations } from '../recommendations.js';
 import { getTrending } from '../trending.js';
@@ -60,6 +60,28 @@ export const trendingTmdbShelf: ShelfDefinition = {
           const { results } = await getTrending(deps, 'week', page);
           const start = offset % TMDB_PAGE_SIZE;
           return results.slice(start, start + limit);
+        },
+      },
+    ];
+  },
+};
+
+export const trendingPlexShelf: ShelfDefinition = {
+  id: 'trending-plex',
+  template: false,
+  category: 'external',
+  generate({ deps }: ShelfGenerateArgs): ShelfInstance[] {
+    return [
+      {
+        shelfId: 'trending-plex',
+        title: 'Trending on Plex',
+        subtitle: 'Popular on Plex Discover right now',
+        emoji: '📺',
+        score: 0.55,
+        query: async ({ limit, offset }) => {
+          const results = await getTrendingFromPlex(deps.db, limit + offset);
+          if (results === null) return [];
+          return results.slice(offset, offset + limit);
         },
       },
     ];

--- a/pillars/media/src/api/modules/discovery/shelf/registry.ts
+++ b/pillars/media/src/api/modules/discovery/shelf/registry.ts
@@ -4,9 +4,6 @@
  * Unlike the monolith (module-load-time `registerShelf` side-effects into a
  * mutable global), the pillar assembles the registry as a frozen array imported
  * explicitly here. Deterministic, test-friendly, no double-registration risk.
- *
- * The Plex-Discover-backed `trending-plex` shelf is intentionally absent
- * (Plex Discover client not ported — wave-3 follow-up).
  */
 import { becauseYouWatchedShelf } from './because-you-watched.js';
 import { contextShelfDefinition } from './context-shelf.js';
@@ -16,6 +13,7 @@ import {
   fromYourServerShelf,
   fromYourWatchlistShelf,
   recommendationsShelf,
+  trendingPlexShelf,
   trendingTmdbShelf,
   worthRewatchingShelf,
 } from './existing-shelves.js';
@@ -58,6 +56,7 @@ const SHELF_DEFINITIONS: readonly ShelfDefinition[] = Object.freeze([
   awardWinnersShelf,
   decadePicksShelf,
   trendingTmdbShelf,
+  trendingPlexShelf,
   recommendationsShelf,
   fromYourWatchlistShelf,
   worthRewatchingShelf,

--- a/pillars/media/src/api/rest/discovery-handlers.ts
+++ b/pillars/media/src/api/rest/discovery-handlers.ts
@@ -7,9 +7,8 @@
  * The TMDB client is resolved here via its env-configured factory and injected
  * into the orchestration as `{ db, tmdbClient }`.
  *
- * `trendingPlex` is a STUB returning `{ data: null }` — the monolith already
- * returned null when Plex was unavailable, and the Plex Discover client is not
- * ported yet (wave-3 follow-up).
+ * `trendingPlex` resolves the Plex token from `plex_settings` and returns the
+ * Plex Discover trending feed, or `{ data: null }` when Plex is not connected.
  */
 import {
   type MediaDb,
@@ -24,6 +23,7 @@ import { parseContextPages } from '../modules/discovery/context-pages.js';
 import { getContextPicks } from '../modules/discovery/context-picks.js';
 import { type DiscoveryDeps } from '../modules/discovery/deps.js';
 import { getGenreSpotlight, getGenreSpotlightPage } from '../modules/discovery/genre-spotlight.js';
+import { getTrendingFromPlex } from '../modules/discovery/plex-trending.js';
 import { toMovieQuickPick } from '../modules/discovery/quick-pick.js';
 import { getWatchlistRecommendations } from '../modules/discovery/recommendations.js';
 import { getTrending } from '../modules/discovery/trending.js';
@@ -38,6 +38,7 @@ type Req = ServerInferRequest<typeof mediaDiscoveryContract>;
 const DEFAULT_QUICK_PICK = 3;
 const DEFAULT_TRENDING_WINDOW = 'week' as const;
 const DEFAULT_TRENDING_PAGE = 1;
+const DEFAULT_TRENDING_PLEX_LIMIT = 20;
 const DEFAULT_SAMPLE_SIZE = 3;
 
 function deps(db: MediaDb): DiscoveryDeps {
@@ -98,7 +99,11 @@ export function makeDiscoveryHandlers(db: MediaDb) {
         ),
       })),
 
-    trendingPlex: () => runHttp(() => ({ status: 200 as const, body: { data: null } })),
+    trendingPlex: ({ query }: Req['trendingPlex']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: { data: await getTrendingFromPlex(db, query.limit ?? DEFAULT_TRENDING_PLEX_LIMIT) },
+      })),
 
     watchlistRecommendations: () =>
       runHttp(async () => ({

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -964,7 +964,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Trending from Plex Discover (STUB: always null until the client lands) */
+    /** Trending from Plex Discover (null when Plex is not connected) */
     get: operations['discovery.trendingPlex'];
     put?: never;
     post?: never;
@@ -5953,8 +5953,25 @@ export interface operations {
         };
         content: {
           'application/json': {
-            /** @enum {string|null} */
-            data: null;
+            data:
+              | {
+                  backdropPath: string | null;
+                  genreIds: number[];
+                  inLibrary: boolean;
+                  isWatched: boolean;
+                  onWatchlist: boolean;
+                  overview: string;
+                  popularity: number;
+                  posterPath: string | null;
+                  posterUrl: string | null;
+                  releaseDate: string;
+                  rotationExpiresAt?: string;
+                  title: string;
+                  tmdbId: number;
+                  voteAverage: number;
+                  voteCount: number;
+                }[]
+              | null;
           };
         };
       };

--- a/pillars/media/src/contract/rest-discovery.ts
+++ b/pillars/media/src/contract/rest-discovery.ts
@@ -5,9 +5,8 @@
  * assembly + paging.
  *
  * Ported from the monolith `media.discovery.*` tRPC routers (basic / tmdb /
- * shelf). Two paths are deliberately stubbed pending the Plex Discover client
- * (wave-3 follow-up): `trendingPlex` always returns `{ data: null }`, and the
- * Plex-backed `trending-plex` shelf is omitted from the session.
+ * shelf). `trendingPlex` returns the Plex Discover trending feed, or `null`
+ * when Plex is not connected (no token).
  *
  * Route order matters: literal sub-paths are declared before `:tmdbId` /
  * `:shelfId` params so the Express adapter doesn't capture them parametrically.
@@ -18,6 +17,7 @@ import { z } from 'zod';
 import {
   AssembleSessionResultSchema,
   ContextPicksResultSchema,
+  DiscoverResultSchema,
   DismissBody,
   GenreSpotlightPageQuery,
   GenreSpotlightPageResultSchema,
@@ -98,8 +98,8 @@ export const mediaDiscoveryContract = c.router({
     method: 'GET',
     path: '/discovery/trending-plex',
     query: z.object({ limit: z.coerce.number().int().positive().max(50).optional() }),
-    responses: { 200: z.object({ data: z.null() }) },
-    summary: 'Trending from Plex Discover (STUB: always null until the client lands)',
+    responses: { 200: z.object({ data: z.array(DiscoverResultSchema).nullable() }) },
+    summary: 'Trending from Plex Discover (null when Plex is not connected)',
   },
   watchlistRecommendations: {
     method: 'GET',


### PR DESCRIPTION
Closes the last deferred media item. Ports the monolith's Plex Discover client (getTrending via watchlist/hubs) into pillars/media/src/api/clients/plex/discover.ts + getTrendingFromPlex (enriches with library/watched/watchlist/dismissed flags, returns null when no Plex token — parity with the monolith's null-when-no-client). Un-stubs the trendingPlex handler + restores the trending-plex discovery shelf. Token via plex service decryptToken (same as rotation plex sources).

Contract: trendingPlex 200 z.object({data: z.array(DiscoverResultSchema).nullable()}) (was data:null); openapi/api-types regenerated + idempotent. 6 tests (417 total). Verified: typecheck ✓ build ✓ 417/417 ✓ oxfmt ✓ oxlint exit 0 ✓ idempotent ✓ no banned refs.