### PR TITLE
feat(cerebrum): pillar embeddings + curation worker (own embedding generation)

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -382,6 +382,40 @@ services:
       lists-api:
         condition: service_healthy
 
+  # Cerebrum pillar worker (ADR-026). Consumes the `pops-embeddings`
+  # (dense-vector index) + `pops-curation` (engram enrichment) queues the
+  # cerebrum pillar produces into. Same image the cerebrum-api ships, with
+  # the worker entrypoint as the command. Built from the pillar Dockerfile.
+  cerebrum-worker:
+    build:
+      context: ..
+      dockerfile: pillars/cerebrum/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-cerebrum-worker
+    restart: unless-stopped
+    command: ['node', 'dist/worker/index.js']
+    networks:
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+      - cerebrum-engrams-data:/data/cerebrum/engrams
+    environment:
+      NODE_ENV: production
+      REDIS_HOST: pops-redis
+      REDIS_PORT: '6379'
+      CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
+      CEREBRUM_ENGRAMS_DIR: /data/cerebrum/engrams
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      EMBEDDING_API_URL: ${EMBEDDING_API_URL:-}
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
+      EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006}
+    depends_on:
+      pops-redis:
+        condition: service_healthy
+
   # ── FRONTEND ─────────────────────────────────────────────────────
   pops-shell:
     build:
@@ -657,6 +691,8 @@ volumes:
     name: pops-paperless-consume
   paperless-redis:
     name: pops-paperless-redis
+  cerebrum-engrams-data:
+    name: pops-cerebrum-engrams-data
 
 secrets:
   notion_api_token:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -422,6 +422,43 @@ services:
       timeout: 5s
       retries: 3
 
+  # Cerebrum pillar worker (ADR-026). Consumes the `pops-embeddings`
+  # (dense-vector index) + `pops-curation` (engram enrichment) queues the
+  # cerebrum pillar produces into. Runs the SAME image the cerebrum-api
+  # ships, swapping the command to the worker entrypoint. Built from the
+  # pillar Dockerfile because cerebrum has no published image yet.
+  cerebrum-worker:
+    build:
+      context: ..
+      dockerfile: pillars/cerebrum/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-cerebrum-worker
+    restart: unless-stopped
+    command: ['node', 'dist/worker/index.js']
+    networks:
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+      - cerebrum-engrams-data:/data/cerebrum/engrams
+    environment:
+      NODE_ENV: production
+      REDIS_HOST: pops-redis
+      REDIS_PORT: '6379'
+      CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
+      CEREBRUM_ENGRAMS_DIR: /data/cerebrum/engrams
+      # The pillar LLM + embedding clients read these straight from the
+      # process env (no /run/secrets convention), so surface them here.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      EMBEDDING_API_URL: ${EMBEDDING_API_URL:-}
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
+      EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006}
+    depends_on:
+      pops-redis:
+        condition: service_healthy
+
   # ── FRONTEND ─────────────────────────────────────────────────────
   pops-shell:
     image: ghcr.io/knoxio/pops-shell:${POPS_IMAGE_TAG:-main}
@@ -656,6 +693,8 @@ volumes:
     name: pops-paperless-redis
   food-ingest-data:
     name: pops-food-ingest-data
+  cerebrum-engrams-data:
+    name: pops-cerebrum-engrams-data
 
 secrets:
   notion_api_token:

--- a/pillars/cerebrum/package.json
+++ b/pillars/cerebrum/package.json
@@ -29,6 +29,7 @@
     "build": "tsx scripts/verify-manifest.ts && tsc && cp -R src/api/modules/templates/defaults dist/api/modules/templates/ && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
+    "start:worker": "node dist/worker/index.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/pillars/cerebrum/src/worker/__tests__/curation-handler.test.ts
+++ b/pillars/cerebrum/src/worker/__tests__/curation-handler.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Offline tests for the curation worker handler.
+ *
+ * Drives `processCurationJob` directly (no BullMQ) against a per-test temp
+ * `cerebrum.db` + temp engram root, a real {@link EngramService} seeding a
+ * `capture` engram, and an injected fake {@link IngestLlm} (no Anthropic). The
+ * fake returns canned classify / extract / scope-inference responses so the
+ * enrichment runs through the SAME pipeline modules the API's `IngestService`
+ * uses, end to end.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { makeFakeIngestLlm } from '../../api/__tests__/test-utils.js';
+import { EngramService } from '../../api/modules/engrams/service.js';
+import { TemplateRegistry } from '../../api/modules/templates/registry.js';
+import { hashContent } from '../../api/modules/thalamus/chunker.js';
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { processCurationJob, type CurationHandlerDeps } from '../curation-handler.js';
+
+import type { IngestLlm } from '../../api/modules/ingest/llm.js';
+
+const TEMPLATES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'api',
+  'modules',
+  'templates',
+  'defaults'
+);
+const CLASSIFY_OP = 'cerebrum.classify';
+const EXTRACT_OP = 'cerebrum.extract-entities';
+const INFER_OP = 'cerebrum.infer-scopes';
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+let templates: TemplateRegistry;
+
+function makeDeps(llm: IngestLlm): CurationHandlerDeps {
+  return { db: cerebrumDb.db, engramRoot, templates, llm };
+}
+
+function seedCapture(body = 'We chose SQLite over Postgres for the embeddings store.') {
+  const service = new EngramService({ root: engramRoot, db: cerebrumDb.db, templates });
+  return service.create({
+    type: 'capture',
+    title: 'Captured thought',
+    body,
+    scopes: ['personal.captures'],
+  });
+}
+
+function readEngram(id: string) {
+  return new EngramService({ root: engramRoot, db: cerebrumDb.db, templates }).read(id);
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-worker-cur-db-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-worker-cur-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+  templates = new TemplateRegistry(TEMPLATES_DIR);
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+describe('processCurationJob', () => {
+  it('runs classify + extract + scope inference and writes them onto the engram', async () => {
+    const created = seedCapture();
+    const llm = makeFakeIngestLlm({
+      [CLASSIFY_OP]: () =>
+        JSON.stringify({
+          type: 'decision',
+          confidence: 0.95,
+          template: 'decision',
+          suggested_tags: ['architecture', 'database'],
+        }),
+      [EXTRACT_OP]: () =>
+        JSON.stringify([{ type: 'topic', value: 'sqlite', normalised: 'sqlite', confidence: 0.9 }]),
+      [INFER_OP]: () => JSON.stringify({ scopes: ['work.decisions'], confidence: 0.85 }),
+    });
+
+    const result = await processCurationJob(makeDeps(llm), {
+      type: 'classifyEngram',
+      engramId: created.id,
+    });
+    expect(result.enriched).toBe(true);
+
+    const { engram, body } = readEngram(created.id);
+    expect(engram.type).toBe('decision');
+    expect(engram.template).toBe('decision');
+    expect(engram.scopes).toEqual(['work.decisions']);
+    expect(engram.tags).toContain('topic:sqlite');
+    expect(engram.tags).toContain('architecture');
+    expect(engram.customFields['_enrichedHash']).toBe(hashContent(body));
+  });
+
+  it('is idempotent — a second run with unchanged content is skipped', async () => {
+    const created = seedCapture();
+    let extractCalls = 0;
+    const llm = makeFakeIngestLlm({
+      [CLASSIFY_OP]: () =>
+        JSON.stringify({ type: 'note', confidence: 0.9, template: null, suggested_tags: [] }),
+      [EXTRACT_OP]: () => {
+        extractCalls += 1;
+        return JSON.stringify([]);
+      },
+      [INFER_OP]: () => JSON.stringify({ scopes: ['personal.notes'], confidence: 0.7 }),
+    });
+    const deps = makeDeps(llm);
+
+    const first = await processCurationJob(deps, { type: 'classifyEngram', engramId: created.id });
+    expect(first.enriched).toBe(true);
+    expect(extractCalls).toBe(1);
+
+    const second = await processCurationJob(deps, { type: 'classifyEngram', engramId: created.id });
+    expect(second.enriched).toBe(false);
+    expect(extractCalls).toBe(1);
+  });
+
+  it('reconciles user-supplied scopes when _reconcile_scopes is set', async () => {
+    const service = new EngramService({ root: engramRoot, db: cerebrumDb.db, templates });
+    const created = service.create({
+      type: 'capture',
+      title: 'Reconcile me',
+      body: 'A capture with user scopes that should be preserved.',
+      scopes: ['work.projct.alpha'],
+      customFields: { _reconcile_scopes: true },
+    });
+
+    const llm = makeFakeIngestLlm({
+      [CLASSIFY_OP]: () =>
+        JSON.stringify({ type: 'note', confidence: 0.9, template: null, suggested_tags: [] }),
+      [EXTRACT_OP]: () => JSON.stringify([]),
+    });
+
+    await processCurationJob(makeDeps(llm), { type: 'classifyEngram', engramId: created.id });
+
+    const { engram, body } = readEngram(created.id);
+    expect(engram.scopes).toEqual(['work.projct.alpha']);
+    expect(engram.customFields['_enrichedHash']).toBe(hashContent(body));
+  });
+});

--- a/pillars/cerebrum/src/worker/__tests__/embeddings-handler.test.ts
+++ b/pillars/cerebrum/src/worker/__tests__/embeddings-handler.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Offline tests for the embeddings worker handler.
+ *
+ * Drives `processEmbeddingJob` directly (no BullMQ) against a per-test temp
+ * `cerebrum.db` (sqlite-vec loaded so `embeddings_vec` is real), a fake
+ * {@link EmbeddingPort} (no network), a fake {@link PeerClients} (no HTTP), and
+ * a real {@link EngramService} writing to a temp engram root.
+ *
+ * Covers: engram + transaction embedding writes (metadata + vec rows), skip on
+ * unknown / unavailable source, and content-hash dedup on a re-run.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EngramService } from '../../api/modules/engrams/service.js';
+import { TemplateRegistry } from '../../api/modules/templates/registry.js';
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { processEmbeddingJob, type EmbeddingsHandlerDeps } from '../embeddings-handler.js';
+
+import type { PeerClients } from '../../api/modules/retrieval/peer-clients.js';
+import type { EmbeddingPort } from '../embedding-client.js';
+
+const TEMPLATES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'api',
+  'modules',
+  'templates',
+  'defaults'
+);
+// The `embeddings_vec` virtual table is fixed at 1536 dims by `openCerebrumDb`,
+// so the fake embedder must emit 1536-length vectors or the insert is rejected.
+const DIMENSIONS = 1536;
+
+let tmpDir: string;
+let engramRoot: string;
+let cerebrumDb: OpenedCerebrumDb;
+let templates: TemplateRegistry;
+
+function fakeEmbedder(): EmbeddingPort {
+  return {
+    model: 'fake-embed',
+    dimensions: DIMENSIONS,
+    embedDocument: vi.fn(async () => Array.from<number>({ length: DIMENSIONS }).fill(0.1)),
+  };
+}
+
+function makeDeps(overrides: Partial<EmbeddingsHandlerDeps> = {}): EmbeddingsHandlerDeps {
+  return {
+    db: cerebrumDb.db,
+    raw: cerebrumDb.raw,
+    vecAvailable: cerebrumDb.vecAvailable,
+    engramRoot,
+    templates,
+    peers: {},
+    embedder: fakeEmbedder(),
+    ...overrides,
+  };
+}
+
+function countMetadata(sourceType: string, sourceId: string): number {
+  return cerebrumDb.raw
+    .prepare('SELECT COUNT(*) FROM embeddings WHERE source_type = ? AND source_id = ?')
+    .pluck()
+    .get(sourceType, sourceId) as number;
+}
+
+function countVectors(): number {
+  return cerebrumDb.raw.prepare('SELECT COUNT(*) FROM embeddings_vec').pluck().get() as number;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-worker-embed-db-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-worker-embed-root-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: true });
+  templates = new TemplateRegistry(TEMPLATES_DIR);
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+describe('processEmbeddingJob', () => {
+  it('requires sqlite-vec', async () => {
+    await expect(
+      processEmbeddingJob(makeDeps({ vecAvailable: false }), {
+        sourceType: 'engram',
+        sourceId: 'x',
+      })
+    ).rejects.toThrow(/sqlite-vec/);
+  });
+
+  it('embeds an engram from the pillar engram store (metadata + vec rows)', async () => {
+    const service = new EngramService({ root: engramRoot, db: cerebrumDb.db, templates });
+    const engram = service.create({
+      type: 'note',
+      title: 'Embeddable',
+      body: '# Embeddable\n\nThis engram has body text to embed.',
+      scopes: ['personal.notes'],
+    });
+
+    const deps = makeDeps();
+    const result = await processEmbeddingJob(deps, { sourceType: 'engram', sourceId: engram.id });
+
+    expect(result.chunksProcessed).toBe(1);
+    expect(result.tokensUsed).toBe(0);
+    expect(countMetadata('engram', engram.id)).toBe(1);
+    expect(countVectors()).toBe(1);
+    expect(deps.embedder.embedDocument).toHaveBeenCalledOnce();
+  });
+
+  it('embeds a transaction resolved via the finance peer', async () => {
+    const peers: PeerClients = {
+      finance: {
+        getTransaction: vi.fn(async () => ({
+          description: 'Coffee at the corner cafe',
+          notes: 'morning fuel',
+        })),
+        listTransactions: vi.fn(async () => ({ rows: [], hasMore: false })),
+      },
+    };
+    const deps = makeDeps({ peers });
+
+    const result = await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_1',
+    });
+
+    expect(result.chunksProcessed).toBe(1);
+    expect(countMetadata('transaction', 'txn_1')).toBe(1);
+    expect(countVectors()).toBe(1);
+    expect(peers.finance?.getTransaction).toHaveBeenCalledWith('txn_1');
+  });
+
+  it('uses inline job content without hitting the source', async () => {
+    const deps = makeDeps();
+    const result = await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_inline',
+      content: 'Inline content provided by the producer.',
+    });
+
+    expect(result.chunksProcessed).toBe(1);
+    expect(countMetadata('transaction', 'txn_inline')).toBe(1);
+  });
+
+  it('skips an unknown source type (no peer, no crash)', async () => {
+    const deps = makeDeps();
+    const result = await processEmbeddingJob(deps, { sourceType: 'mystery', sourceId: 'm1' });
+
+    expect(result).toEqual({
+      chunksProcessed: 0,
+      chunksSkipped: 0,
+      chunksDeleted: 0,
+      tokensUsed: 0,
+    });
+    expect(countVectors()).toBe(0);
+    expect(deps.embedder.embedDocument).not.toHaveBeenCalled();
+  });
+
+  it('skips when the peer is absent for the source type', async () => {
+    const deps = makeDeps({ peers: {} });
+    const result = await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_absent',
+    });
+
+    expect(result.chunksProcessed).toBe(0);
+    expect(countMetadata('transaction', 'txn_absent')).toBe(0);
+  });
+
+  it('skips when the peer returns 404 (null record)', async () => {
+    const peers: PeerClients = {
+      finance: {
+        getTransaction: vi.fn(async () => null),
+        listTransactions: vi.fn(async () => ({ rows: [], hasMore: false })),
+      },
+    };
+    const result = await processEmbeddingJob(makeDeps({ peers }), {
+      sourceType: 'transaction',
+      sourceId: 'gone',
+    });
+    expect(result.chunksProcessed).toBe(0);
+    expect(countMetadata('transaction', 'gone')).toBe(0);
+  });
+
+  it('dedups by content hash on a re-run (no re-embed)', async () => {
+    const deps = makeDeps();
+    const job = {
+      sourceType: 'transaction' as const,
+      sourceId: 'txn_dedup',
+      content: 'Stable content that does not change between runs.',
+    };
+
+    const first = await processEmbeddingJob(deps, job);
+    expect(first.chunksProcessed).toBe(1);
+
+    const second = await processEmbeddingJob(deps, job);
+    expect(second.chunksProcessed).toBe(0);
+    expect(second.chunksSkipped).toBe(1);
+    expect(deps.embedder.embedDocument).toHaveBeenCalledOnce();
+    expect(countMetadata('transaction', 'txn_dedup')).toBe(1);
+    expect(countVectors()).toBe(1);
+  });
+
+  it('re-embeds and updates the vector when content changes', async () => {
+    const deps = makeDeps();
+    await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_mut',
+      content: 'first version',
+    });
+    const second = await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_mut',
+      content: 'second different version',
+    });
+
+    expect(second.chunksProcessed).toBe(1);
+    expect(countMetadata('transaction', 'txn_mut')).toBe(1);
+    expect(countVectors()).toBe(1);
+  });
+
+  it('deletes existing embeddings when content resolves empty', async () => {
+    const deps = makeDeps();
+    await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_clear',
+      content: 'will be cleared',
+    });
+    expect(countMetadata('transaction', 'txn_clear')).toBe(1);
+
+    const cleared = await processEmbeddingJob(deps, {
+      sourceType: 'transaction',
+      sourceId: 'txn_clear',
+      content: '   ',
+    });
+    expect(cleared.chunksDeleted).toBe(1);
+    expect(countMetadata('transaction', 'txn_clear')).toBe(0);
+    expect(countVectors()).toBe(0);
+  });
+});

--- a/pillars/cerebrum/src/worker/curation-handler.ts
+++ b/pillars/cerebrum/src/worker/curation-handler.ts
@@ -1,0 +1,181 @@
+/**
+ * Curation handler for the cerebrum worker.
+ *
+ * Consumes `pops-curation` jobs `{ type: 'classifyEngram', engramId }` and runs
+ * the pillar's existing ingest enrichment pipeline against a stored engram —
+ * classify + entity-extract + scope resolution — then writes the result back
+ * onto the engram (type/template/tags/scopes/referenced_dates).
+ *
+ * Lifted from the monolith `jobs/handlers/curation.ts`. The classify / extract
+ * / scope-inference / scope-reconciliation collaborators are the SAME modules
+ * the pillar's `IngestService` (`src/api/modules/ingest`) drives — reused here
+ * directly rather than reimplemented, with the injectable {@link IngestLlm} so
+ * tests run offline.
+ *
+ * Idempotent: skips enrichment when the engram body hash matches the
+ * `_enrichedHash` recorded on the last run (body hash, not `engram.contentHash`
+ * — see the guard in `processCurationJob`).
+ */
+import { createScopeReconciliationService } from '../api/modules/engrams/scope-reconciliation.js';
+import { ScopeRuleEngine } from '../api/modules/engrams/scope-rules.js';
+import { listScopes } from '../api/modules/engrams/scopes.js';
+import { EngramService, type UpdateEngramInput } from '../api/modules/engrams/service.js';
+import { CortexClassifier } from '../api/modules/ingest/classifier.js';
+import { CortexEntityExtractor } from '../api/modules/ingest/entity-extractor.js';
+import { createScopeInferenceService } from '../api/modules/ingest/scope-inference.js';
+import { hashContent } from '../api/modules/thalamus/chunker.js';
+
+import type { ScopeSuggestion } from '../api/modules/engrams/scope-reconciliation.js';
+import type { Engram } from '../api/modules/engrams/types.js';
+import type { IngestLlm } from '../api/modules/ingest/llm.js';
+import type { TemplateRegistry } from '../api/modules/templates/registry.js';
+import type { CerebrumDb } from '../db/index.js';
+
+export interface CurationJobData {
+  type: 'classifyEngram';
+  engramId: string;
+}
+
+export interface CurationHandlerDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  llm: IngestLlm;
+}
+
+export interface CurationResult {
+  engramId: string;
+  enriched: boolean;
+}
+
+interface ScopeResolution {
+  scopes: string[];
+  reconciled: boolean;
+  suggestions: ScopeSuggestion[];
+}
+
+function engramService(deps: CurationHandlerDeps): EngramService {
+  return new EngramService({
+    root: deps.engramRoot,
+    db: deps.db,
+    templates: deps.templates,
+    scopeRuleEngine: new ScopeRuleEngine(deps.engramRoot),
+  });
+}
+
+/** Run the curation enrichment for one engram. Returns `enriched: false` when the idempotency guard skips it. */
+export async function processCurationJob(
+  deps: CurationHandlerDeps,
+  job: CurationJobData
+): Promise<CurationResult> {
+  const service = engramService(deps);
+  const { engram, body } = service.read(job.engramId);
+
+  // Idempotency is keyed on the BODY hash, not `engram.contentHash`: the latter
+  // covers frontmatter too, so writing the enrichment result (scopes/tags/
+  // `_enrichedHash`) would itself change it and the guard would never trip. The
+  // body is stable across enrichment writes, so hashing it gives a guard that
+  // actually skips an unchanged engram on re-run.
+  const bodyHash = hashContent(body);
+  const previousHash = engram.customFields['_enrichedHash'];
+  if (typeof previousHash === 'string' && previousHash === bodyHash) {
+    return { engramId: job.engramId, enriched: false };
+  }
+
+  const classifier = new CortexClassifier(deps.llm);
+  const entityExtractor = new CortexEntityExtractor(deps.llm);
+  const referenceDate = engram.created.slice(0, 10);
+
+  const classification = await classifier.classify(body, engram.title);
+  const { tags: entityTags, referencedDates } = await entityExtractor.extract(
+    body,
+    engram.tags,
+    referenceDate
+  );
+  const mergedTags = dedupe([...engram.tags, ...entityTags, ...classification.suggestedTags]);
+
+  const scopeResolution = await resolveScopes({
+    deps,
+    engram,
+    body,
+    classifiedType: classification.type,
+    mergedTags,
+  });
+  const customFields = buildCustomFields(engram, bodyHash, referencedDates, scopeResolution);
+
+  const updateInput: UpdateEngramInput = {
+    scopes: scopeResolution.scopes,
+    tags: mergedTags.length > 0 ? mergedTags : undefined,
+    customFields,
+  };
+  if (classification.template) updateInput.template = classification.template;
+  service.update(job.engramId, updateInput);
+
+  if (classification.type !== engram.type) {
+    service.changeType(job.engramId, classification.type);
+  }
+
+  return { engramId: job.engramId, enriched: true };
+}
+
+function buildCustomFields(
+  engram: Engram,
+  bodyHash: string,
+  referencedDates: string[],
+  scopeResolution: ScopeResolution
+): Record<string, unknown> {
+  const customFields: Record<string, unknown> = { ...engram.customFields };
+  if (referencedDates.length > 0) customFields['referenced_dates'] = referencedDates;
+  customFields['_enrichedHash'] = bodyHash;
+
+  if (scopeResolution.reconciled && scopeResolution.suggestions.length > 0) {
+    customFields['_scope_suggestions'] = scopeResolution.suggestions;
+  } else {
+    delete customFields['_scope_suggestions'];
+  }
+  return customFields;
+}
+
+interface ResolveScopesArgs {
+  deps: CurationHandlerDeps;
+  engram: Engram;
+  body: string;
+  classifiedType: string;
+  mergedTags: string[];
+}
+
+/**
+ * Resolve scopes for the engram. When it opted into reconciliation
+ * (`_reconcile_scopes: true`), keep the user's scopes and propose canonical
+ * alternatives; otherwise run the standard scope-inference pipeline.
+ */
+async function resolveScopes(args: ResolveScopesArgs): Promise<ScopeResolution> {
+  const { deps, engram, body, classifiedType, mergedTags } = args;
+  if (engram.customFields['_reconcile_scopes'] === true) {
+    const dismissed = engram.customFields['_scope_suggestions_dismissed'];
+    const dismissedKeys = Array.isArray(dismissed)
+      ? dismissed.filter((v): v is string => typeof v === 'string')
+      : [];
+    const { suggestions } = createScopeReconciliationService().reconcile({
+      suggestedScopes: engram.scopes,
+      knownScopes: listScopes(deps.db),
+      dismissedSegmentSetKeys: dismissedKeys,
+    });
+    return { scopes: engram.scopes, reconciled: true, suggestions };
+  }
+
+  const ruleEngine = new ScopeRuleEngine(deps.engramRoot);
+  const scopeService = createScopeInferenceService(ruleEngine.getConfig(), deps.llm);
+  const { scopes } = await scopeService.infer({
+    body,
+    type: classifiedType,
+    tags: mergedTags,
+    source: engram.source,
+    explicitScopes: undefined,
+  });
+  return { scopes, reconciled: false, suggestions: [] };
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/pillars/cerebrum/src/worker/embedding-client.ts
+++ b/pillars/cerebrum/src/worker/embedding-client.ts
@@ -1,0 +1,145 @@
+/**
+ * Document-embedding API client for the cerebrum worker (OpenAI- / Voyage-
+ * compatible), lifted from the monolith `apps/pops-api/src/shared/embedding-
+ * client.ts`.
+ *
+ * The retrieval slice already ships a *query*-embedding client
+ * (`src/api/modules/retrieval/embedding-client.ts`, `embedQuery`, `input_type:
+ * 'query'`). This is its write-side counterpart — it embeds *documents*
+ * (`input_type: 'document'`) for the index, exposing the monolith's
+ * `getEmbedding` / `getEmbeddingConfig` / `isEmbeddingConfigured` surface so the
+ * embeddings handler can chunk-and-store.
+ *
+ * Configured entirely via environment variables so the model choice is not
+ * baked into code:
+ *   EMBEDDING_API_URL    — base URL (default https://api.openai.com/v1)
+ *   EMBEDDING_API_KEY    — API key (required for real embedding)
+ *   EMBEDDING_MODEL      — model name (default text-embedding-3-small)
+ *   EMBEDDING_DIMENSIONS — vector dimensions (default 1536, matches the
+ *                          `embeddings_vec` virtual table)
+ *
+ * `getEmbedding` takes the config + an injected `fetchImpl` so tests drive it
+ * without a live provider; the handler injects an {@link EmbeddingPort} so it
+ * never touches the network in unit tests.
+ */
+export type EmbeddingProvider = 'openai' | 'voyage';
+
+export type EmbeddingInputType = 'query' | 'document';
+
+export interface EmbeddingConfig {
+  apiUrl: string;
+  apiKey: string;
+  model: string;
+  dimensions: number;
+  provider: EmbeddingProvider;
+}
+
+/** Detect the provider from the configured base URL. Defaults to openai. */
+export function detectProvider(apiUrl: string): EmbeddingProvider {
+  return apiUrl.includes('voyageai.com') ? 'voyage' : 'openai';
+}
+
+/** Read the embedding config from the environment, with OpenAI defaults. */
+export function getEmbeddingConfig(env: NodeJS.ProcessEnv = process.env): EmbeddingConfig {
+  const apiUrl = env['EMBEDDING_API_URL'] ?? 'https://api.openai.com/v1';
+  return {
+    apiUrl,
+    apiKey: env['EMBEDDING_API_KEY'] ?? '',
+    model: env['EMBEDDING_MODEL'] ?? 'text-embedding-3-small',
+    dimensions: Number.parseInt(env['EMBEDDING_DIMENSIONS'] ?? '1536', 10),
+    provider: detectProvider(apiUrl),
+  };
+}
+
+/** Returns true when `EMBEDDING_API_KEY` is present and non-empty. */
+export function isEmbeddingConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env['EMBEDDING_API_KEY']);
+}
+
+function buildRequestBody(
+  text: string,
+  config: EmbeddingConfig,
+  inputType: EmbeddingInputType
+): Record<string, unknown> {
+  if (config.provider === 'voyage') {
+    return {
+      input: text,
+      model: config.model,
+      output_dimension: config.dimensions,
+      input_type: inputType,
+    };
+  }
+  return { input: text, model: config.model, dimensions: config.dimensions };
+}
+
+export interface GetEmbeddingOptions {
+  /**
+   * Whether the text is a retrieval query or a document being indexed. Voyage
+   * uses this to pick the embedding head; OpenAI ignores it. Defaults to
+   * 'document' (the index write path).
+   */
+  inputType?: EmbeddingInputType;
+}
+
+type FetchImpl = typeof globalThis.fetch;
+
+/** Embed a single text into a dense vector via the configured provider. */
+export async function getEmbedding(
+  text: string,
+  config: EmbeddingConfig,
+  options: GetEmbeddingOptions = {},
+  fetchImpl: FetchImpl = globalThis.fetch
+): Promise<number[]> {
+  if (!text.trim()) throw new Error('Cannot embed empty text');
+  if (!config.apiKey) throw new Error('EMBEDDING_API_KEY is not configured');
+
+  const inputType = options.inputType ?? 'document';
+  const response = await fetchImpl(`${config.apiUrl}/embeddings`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.apiKey}`,
+    },
+    body: JSON.stringify(buildRequestBody(text, config, inputType)),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Embedding API error ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as { data: { embedding: number[] }[] };
+  const vector = data.data[0]?.embedding;
+  if (!vector) throw new Error('Embedding API returned no vector');
+  return vector;
+}
+
+/**
+ * Injection port for the embeddings handler: embed one document chunk into a
+ * dense vector, exposing the active model + dimensions for the metadata write.
+ * The env-backed default is built by {@link resolveEmbeddingPortFromEnv}; tests
+ * inject a fake.
+ */
+export interface EmbeddingPort {
+  embedDocument(text: string): Promise<number[]>;
+  model: string;
+  dimensions: number;
+}
+
+/**
+ * Build the env-driven {@link EmbeddingPort}, or `undefined` when no
+ * `EMBEDDING_API_KEY` is configured (the worker then skips embedding jobs
+ * rather than throwing on every chunk).
+ */
+export function resolveEmbeddingPortFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: FetchImpl = globalThis.fetch
+): EmbeddingPort | undefined {
+  if (!isEmbeddingConfigured(env)) return undefined;
+  const config = getEmbeddingConfig(env);
+  return {
+    model: config.model,
+    dimensions: config.dimensions,
+    embedDocument: (text) => getEmbedding(text, config, { inputType: 'document' }, fetchImpl),
+  };
+}

--- a/pillars/cerebrum/src/worker/embeddings-content.ts
+++ b/pillars/cerebrum/src/worker/embeddings-content.ts
@@ -1,0 +1,95 @@
+/**
+ * Content resolution for the embeddings worker.
+ *
+ * Maps a `{ sourceType, sourceId }` to the embeddable text for that record.
+ * `engram` resolves from the pillar's filesystem-backed {@link EngramService};
+ * the cross-pillar types resolve over REST via the retrieval peer clients'
+ * by-id getters, formatted with the same text builders the thalamus
+ * cross-source indexer hashes against. An absent peer, an unknown type, or a
+ * 404 yields `null` so the handler skips rather than crashes.
+ */
+import { EngramService } from '../api/modules/engrams/service.js';
+import {
+  toInventoryText,
+  toMovieText,
+  toTransactionText,
+  toTvShowText,
+} from '../api/modules/thalamus/cross-source.js';
+
+import type { PeerClients } from '../api/modules/retrieval/peer-clients.js';
+import type { TemplateRegistry } from '../api/modules/templates/registry.js';
+import type { CerebrumDb } from '../db/index.js';
+
+export interface ContentResolutionDeps {
+  db: CerebrumDb;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  peers: PeerClients;
+}
+
+/**
+ * Resolve the embeddable text for a source, or `null` when it is unknown /
+ * unavailable / missing.
+ */
+export async function resolveContent(
+  deps: ContentResolutionDeps,
+  sourceType: string,
+  sourceId: string
+): Promise<string | null> {
+  switch (sourceType) {
+    case 'engram':
+      return resolveEngramContent(deps, sourceId);
+    case 'transaction':
+      return resolveTransactionContent(deps.peers, sourceId);
+    case 'movie':
+      return resolveMovieContent(deps.peers, sourceId);
+    case 'tv_show':
+      return resolveTvShowContent(deps.peers, sourceId);
+    case 'inventory':
+      return resolveInventoryContent(deps.peers, sourceId);
+    default:
+      return null;
+  }
+}
+
+function resolveEngramContent(deps: ContentResolutionDeps, engramId: string): string | null {
+  const service = new EngramService({
+    root: deps.engramRoot,
+    db: deps.db,
+    templates: deps.templates,
+  });
+  try {
+    const { engram, body } = service.read(engramId);
+    return [engram.title, body].filter(Boolean).join('\n');
+  } catch {
+    return null;
+  }
+}
+
+async function resolveTransactionContent(peers: PeerClients, id: string): Promise<string | null> {
+  const row = await peers.finance?.getTransaction(id);
+  if (row === undefined || row === null) return null;
+  return toTransactionText({ ...row, id });
+}
+
+async function resolveMovieContent(peers: PeerClients, id: string): Promise<string | null> {
+  const numericId = Number.parseInt(id, 10);
+  if (!Number.isInteger(numericId)) return null;
+  const row = await peers.media?.getMovie(numericId);
+  if (row === undefined || row === null) return null;
+  return toMovieText({ ...row, id: numericId });
+}
+
+async function resolveTvShowContent(peers: PeerClients, id: string): Promise<string | null> {
+  const numericId = Number.parseInt(id, 10);
+  if (!Number.isInteger(numericId)) return null;
+  const row = await peers.media?.getTvShow(numericId);
+  if (row === undefined || row === null) return null;
+  return toTvShowText({ ...row, id: numericId });
+}
+
+async function resolveInventoryContent(peers: PeerClients, id: string): Promise<string | null> {
+  const row = await peers.inventory?.getItem(id);
+  if (row === undefined || row === null) return null;
+  return toInventoryText({ ...row, id });
+}

--- a/pillars/cerebrum/src/worker/embeddings-handler.ts
+++ b/pillars/cerebrum/src/worker/embeddings-handler.ts
@@ -1,0 +1,223 @@
+/**
+ * Embeddings generation handler for the cerebrum worker.
+ *
+ * Consumes `pops-embeddings` jobs `{ sourceType, sourceId, content? }` and
+ * writes the dense-vector index for that source into the pillar's own
+ * `cerebrum.db` (`embeddings` metadata + `embeddings_vec` vectors). Lifted from
+ * the monolith `jobs/handlers/embeddings*.ts`, with content resolution
+ * (`./embeddings-content.ts`) extended beyond transactions to every source type
+ * the pillar's `thalamus/cross-source.ts` enqueues (engram + transaction /
+ * movie / tv_show / inventory).
+ *
+ * Dedup is by SHA-256 content hash per chunk: an unchanged chunk is skipped.
+ * Orphaned chunks (index beyond the new chunk count) are pruned. The vector
+ * lands in `embeddings_vec` keyed by the metadata row's id — bound as `BigInt`
+ * because sqlite-vec's `rowid` insert rejects a plain JS number.
+ *
+ * Deviation from the monolith: the `ai_usage` write (shared pops.db) is a no-op
+ * here — the pillar has no shared handle and no usage table, and usage tracking
+ * is not load-bearing for the index. See {@link EmbedJobResult.tokensUsed}.
+ */
+import { and, eq, gt } from 'drizzle-orm';
+
+import { chunkText, hashContent, type TextChunk } from '../api/modules/thalamus/chunker.js';
+import { type CerebrumDb, embeddings } from '../db/index.js';
+import { resolveContent } from './embeddings-content.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { PeerClients } from '../api/modules/retrieval/peer-clients.js';
+import type { TemplateRegistry } from '../api/modules/templates/registry.js';
+import type { EmbeddingPort } from './embedding-client.js';
+
+const CONTENT_PREVIEW_LENGTH = 200;
+
+export interface EmbeddingsJobData {
+  sourceType: string;
+  sourceId: string;
+  content?: string;
+}
+
+export interface EmbeddingsHandlerDeps {
+  db: CerebrumDb;
+  raw: Database;
+  vecAvailable: boolean;
+  engramRoot: string;
+  templates: TemplateRegistry;
+  peers: PeerClients;
+  embedder: EmbeddingPort;
+}
+
+export interface EmbedJobResult {
+  chunksProcessed: number;
+  chunksSkipped: number;
+  chunksDeleted: number;
+  /** Always 0 — usage tracking is a no-op in the pillar (no shared pops.db). */
+  tokensUsed: number;
+}
+
+/**
+ * Process one embedding job. Resolves content (from the job payload or the
+ * source), chunks + embeds the changed chunks, persists vectors, and prunes
+ * orphans. Returns counts; never throws on an unavailable source (skips).
+ */
+export async function processEmbeddingJob(
+  deps: EmbeddingsHandlerDeps,
+  job: EmbeddingsJobData
+): Promise<EmbedJobResult> {
+  if (!deps.vecAvailable) {
+    throw new Error('sqlite-vec extension not available — cannot store vectors');
+  }
+
+  const { sourceType, sourceId } = job;
+  const text = job.content ?? (await resolveContent(deps, sourceType, sourceId));
+  if (text === null || !text.trim()) {
+    const chunksDeleted = deleteEmbeddingsForSource(deps, sourceType, sourceId);
+    return { chunksProcessed: 0, chunksSkipped: 0, chunksDeleted, tokensUsed: 0 };
+  }
+
+  const chunks = chunkText(text);
+  let chunksProcessed = 0;
+  let chunksSkipped = 0;
+
+  for (const chunk of chunks) {
+    const processed = await processChunk(deps, sourceType, sourceId, chunk);
+    if (processed) chunksProcessed++;
+    else chunksSkipped++;
+  }
+
+  const chunksDeleted = pruneOrphanChunks(deps, sourceType, sourceId, chunks.length);
+  return { chunksProcessed, chunksSkipped, chunksDeleted, tokensUsed: 0 };
+}
+
+interface ExistingEmbedding {
+  id: number;
+  contentHash: string;
+}
+
+function loadExisting(
+  deps: EmbeddingsHandlerDeps,
+  sourceType: string,
+  sourceId: string,
+  chunkIndex: number
+): ExistingEmbedding | undefined {
+  return deps.db
+    .select({ id: embeddings.id, contentHash: embeddings.contentHash })
+    .from(embeddings)
+    .where(
+      and(
+        eq(embeddings.sourceType, sourceType),
+        eq(embeddings.sourceId, sourceId),
+        eq(embeddings.chunkIndex, chunkIndex)
+      )
+    )
+    .get();
+}
+
+async function processChunk(
+  deps: EmbeddingsHandlerDeps,
+  sourceType: string,
+  sourceId: string,
+  chunk: TextChunk
+): Promise<boolean> {
+  const contentHash = hashContent(chunk.text);
+  const existing = loadExisting(deps, sourceType, sourceId, chunk.index);
+  if (existing?.contentHash === contentHash) return false;
+
+  const vector = await deps.embedder.embedDocument(chunk.text);
+  upsertChunkEmbedding(deps, {
+    sourceType,
+    sourceId,
+    chunk,
+    contentHash,
+    contentPreview: chunk.text.slice(0, CONTENT_PREVIEW_LENGTH),
+    vector,
+    existing,
+  });
+  return true;
+}
+
+interface UpsertArgs {
+  sourceType: string;
+  sourceId: string;
+  chunk: TextChunk;
+  contentHash: string;
+  contentPreview: string;
+  vector: number[];
+  existing: ExistingEmbedding | undefined;
+}
+
+function persistVector(raw: Database, rowId: number, vector: number[]): void {
+  const blob = Buffer.from(new Float32Array(vector).buffer);
+  raw.prepare('DELETE FROM embeddings_vec WHERE rowid = ?').run(BigInt(rowId));
+  raw.prepare('INSERT INTO embeddings_vec (rowid, vector) VALUES (?, ?)').run(BigInt(rowId), blob);
+}
+
+function upsertChunkEmbedding(deps: EmbeddingsHandlerDeps, args: UpsertArgs): void {
+  const now = new Date().toISOString();
+  const { model, dimensions } = deps.embedder;
+
+  if (args.existing) {
+    deps.db
+      .update(embeddings)
+      .set({
+        contentHash: args.contentHash,
+        contentPreview: args.contentPreview,
+        model,
+        dimensions,
+        createdAt: now,
+      })
+      .where(eq(embeddings.id, args.existing.id))
+      .run();
+    persistVector(deps.raw, args.existing.id, args.vector);
+    return;
+  }
+
+  const result = deps.db
+    .insert(embeddings)
+    .values({
+      sourceType: args.sourceType,
+      sourceId: args.sourceId,
+      chunkIndex: args.chunk.index,
+      contentHash: args.contentHash,
+      contentPreview: args.contentPreview,
+      model,
+      dimensions,
+      createdAt: now,
+    })
+    .returning({ id: embeddings.id })
+    .get();
+  persistVector(deps.raw, result.id, args.vector);
+}
+
+function pruneOrphanChunks(
+  deps: EmbeddingsHandlerDeps,
+  sourceType: string,
+  sourceId: string,
+  validChunkCount: number
+): number {
+  const predicate = and(
+    eq(embeddings.sourceType, sourceType),
+    eq(embeddings.sourceId, sourceId),
+    gt(embeddings.chunkIndex, validChunkCount - 1)
+  );
+
+  const orphans = deps.db.select({ id: embeddings.id }).from(embeddings).where(predicate).all();
+  for (const orphan of orphans) {
+    deps.raw.prepare('DELETE FROM embeddings_vec WHERE rowid = ?').run(BigInt(orphan.id));
+  }
+  return deps.db.delete(embeddings).where(predicate).run().changes;
+}
+
+function deleteEmbeddingsForSource(
+  deps: EmbeddingsHandlerDeps,
+  sourceType: string,
+  sourceId: string
+): number {
+  const predicate = and(eq(embeddings.sourceType, sourceType), eq(embeddings.sourceId, sourceId));
+  const rows = deps.db.select({ id: embeddings.id }).from(embeddings).where(predicate).all();
+  for (const row of rows) {
+    deps.raw.prepare('DELETE FROM embeddings_vec WHERE rowid = ?').run(BigInt(row.id));
+  }
+  return deps.db.delete(embeddings).where(predicate).run().changes;
+}

--- a/pillars/cerebrum/src/worker/index.ts
+++ b/pillars/cerebrum/src/worker/index.ts
@@ -1,0 +1,167 @@
+/**
+ * Entry point for the cerebrum pillar worker.
+ *
+ * Boots BullMQ `Worker`s for the two queues the pillar's HTTP server produces
+ * into but never consumes: `pops-embeddings` (dense-vector index generation)
+ * and `pops-curation` (engram classify/extract/scope enrichment). It opens the
+ * pillar's own `cerebrum.db` (the same handle the API server opens) and
+ * constructs the peer clients, embedding client, and ingest LLM from env —
+ * mirroring `src/api/server.ts`.
+ *
+ * Lifecycle:
+ *   - Redis unconfigured (`REDIS_URL` / `REDIS_HOST` absent) → log + clean exit
+ *     (never crash). Embedding generation simply doesn't run.
+ *   - `EMBEDDING_API_KEY` absent → the embeddings worker is not started (no
+ *     embedder); the curation worker still runs.
+ *   - SIGTERM / SIGINT → close both workers + the Redis connection, then close
+ *     the db handle, then exit.
+ *
+ * This file runs as `node dist/worker/index.js` from the SAME image the API
+ * server ships (the Dockerfile copies all of `dist`).
+ */
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Worker, type Job } from 'bullmq';
+import { Redis } from 'ioredis';
+
+import { resolveCerebrumSqlitePath } from '../api/cerebrum-sqlite-path.js';
+import { resolveEngramRoot } from '../api/modules/engrams/instance.js';
+import { AnthropicIngestLlm } from '../api/modules/ingest/llm.js';
+import { CURATION_QUEUE_NAME } from '../api/modules/ingest/queue.js';
+import { resolvePeerClientsFromEnv } from '../api/modules/retrieval/peer-clients.js';
+import { TemplateRegistry } from '../api/modules/templates/registry.js';
+import { EMBEDDINGS_QUEUE_NAME } from '../api/modules/thalamus/queue.js';
+import { openCerebrumDb } from '../db/index.js';
+import { processCurationJob, type CurationJobData } from './curation-handler.js';
+import { resolveEmbeddingPortFromEnv } from './embedding-client.js';
+import {
+  processEmbeddingJob,
+  type EmbeddingsHandlerDeps,
+  type EmbeddingsJobData,
+} from './embeddings-handler.js';
+
+function resolveRedisUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const url = env['REDIS_URL'];
+  if (url !== undefined && url.length > 0) return url;
+  const host = env['REDIS_HOST'];
+  if (host === undefined || host.length === 0) return null;
+  return `redis://${host}:${env['REDIS_PORT'] ?? '6379'}`;
+}
+
+function resolveTemplatesDir(): string {
+  const envDir = process.env['CEREBRUM_TEMPLATES_DIR'];
+  if (envDir) return envDir;
+  return resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'api',
+    'modules',
+    'templates',
+    'defaults'
+  );
+}
+
+type OpenedDb = ReturnType<typeof openCerebrumDb>;
+
+interface WorkerRuntime {
+  db: OpenedDb;
+  templates: TemplateRegistry;
+  engramRoot: string;
+  peers: ReturnType<typeof resolvePeerClientsFromEnv>;
+  connection: Redis;
+}
+
+function buildWorkers(rt: WorkerRuntime): Worker[] {
+  const { db, templates, engramRoot, peers, connection } = rt;
+  const opts = { connection, stalledInterval: 30_000 } as const;
+  const workers: Worker[] = [];
+
+  const embedder = resolveEmbeddingPortFromEnv();
+  if (embedder === undefined) {
+    console.warn('[cerebrum-worker] EMBEDDING_API_KEY not set — embeddings worker disabled.');
+  } else {
+    const embedDeps: EmbeddingsHandlerDeps = {
+      db: db.db,
+      raw: db.raw,
+      vecAvailable: db.vecAvailable,
+      engramRoot,
+      templates,
+      peers,
+      embedder,
+    };
+    workers.push(
+      new Worker<EmbeddingsJobData>(
+        EMBEDDINGS_QUEUE_NAME,
+        (job: Job<EmbeddingsJobData>) => processEmbeddingJob(embedDeps, job.data),
+        opts
+      )
+    );
+  }
+
+  const curationDeps = { db: db.db, engramRoot, templates, llm: new AnthropicIngestLlm() };
+  workers.push(
+    new Worker<CurationJobData>(
+      CURATION_QUEUE_NAME,
+      (job: Job<CurationJobData>) => processCurationJob(curationDeps, job.data),
+      opts
+    )
+  );
+
+  for (const worker of workers) {
+    worker.on('failed', (job, err) => {
+      console.error(
+        `[cerebrum-worker] job failed (${worker.name}/${job?.id ?? '?'}): ${err.message}`
+      );
+    });
+  }
+  return workers;
+}
+
+function installShutdown(workers: Worker[], connection: Redis, db: OpenedDb): void {
+  const shutdown = (signal: NodeJS.Signals): void => {
+    console.warn(`[cerebrum-worker] shutting down (${signal})`);
+    Promise.all(workers.map((w) => w.close()))
+      .then(() => connection.quit())
+      .then(() => {
+        db.raw.close();
+        process.exit(0);
+      })
+      .catch((err: unknown) => {
+        console.error('[cerebrum-worker] shutdown error', err);
+        process.exit(1);
+      });
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+function main(): void {
+  const redisUrl = resolveRedisUrl();
+  if (redisUrl === null) {
+    console.warn(
+      '[cerebrum-worker] Redis not configured (REDIS_URL/REDIS_HOST) — nothing to consume; exiting.'
+    );
+    return;
+  }
+
+  const db = openCerebrumDb(resolveCerebrumSqlitePath());
+  const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
+  const workers = buildWorkers({
+    db,
+    templates: new TemplateRegistry(resolveTemplatesDir()),
+    engramRoot: resolveEngramRoot(),
+    peers: resolvePeerClientsFromEnv(),
+    connection,
+  });
+
+  console.warn(`[cerebrum-worker] started (queues: ${workers.map((w) => w.name).join(', ')})`);
+  installShutdown(workers, connection, db);
+}
+
+try {
+  main();
+} catch (err: unknown) {
+  console.error('[cerebrum-worker] bootstrap failed', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## What

Adds an **embeddings + curation worker** to `pillars/cerebrum` so the pillar owns embedding generation end-to-end. The pillar already had queue **producers** (`pops-curation`, `pops-embeddings`) but nothing consuming them — today the monolith `apps/pops-api` worker does. This lifts that capability into the pillar. **Additive only** — nothing in the monolith is deleted (later slice).

## Lifted from the monolith

| Monolith | Pillar |
| --- | --- |
| `shared/embedding-client.ts` | `src/worker/embedding-client.ts` (document side; `getEmbedding`/`getEmbeddingConfig`/`isEmbeddingConfigured` + injectable `EmbeddingPort`) |
| `jobs/handlers/embeddings*.ts` | `src/worker/embeddings-handler.ts` + `embeddings-content.ts` |
| `jobs/handlers/curation.ts` | `src/worker/curation-handler.ts` |
| `worker.ts` | `src/worker/index.ts` |

## Content resolution

- **engram** → the pillar's `EngramService.read()` (filesystem body + title).
- **transaction / movie / tv_show / inventory** → the retrieval peer clients' by-id getters (`peer-clients.ts`), formatted with the SAME `to*Text` builders the thalamus cross-source indexer hashes against. Absent peer / unknown type / 404 → `null` → the job **skips** (no crash). This extends the monolith's transactions-only `fetchContent` to every type `thalamus/cross-source.ts` enqueues.

## Embeddings write

Chunk (pillar `chunker.ts`) → SHA-256 per chunk → skip unchanged chunks → embed via the injected `EmbeddingPort` → write `embeddings` metadata (drizzle) + `embeddings_vec` vectors (raw) into the pillar's **own** `cerebrum.db` (`openCerebrumDb` handle's `.db`/`.raw`). Orphan chunks beyond the new count are pruned. `embeddings_vec` rowid is bound as **`BigInt`** on every insert/delete (sqlite-vec quirk).

## Curation

Reuses the pillar's existing ingest enrichment modules (`CortexClassifier`, `CortexEntityExtractor`, `createScopeInferenceService`, `ScopeReconciliationService`, `EngramService`) — the same ones `IngestService` drives — to classify + extract + resolve scopes on a stored engram, then `update`/`changeType`. Not reimplemented.

## Worker entry & deploy

- `src/worker/index.ts` boots BullMQ `Worker`s for both queues; Redis unconfigured → log + clean exit (never crash); `EMBEDDING_API_KEY` absent → embeddings worker disabled, curation still runs; SIGTERM/SIGINT → graceful close.
- `start:worker` script (`node dist/worker/index.js`). The pillar Dockerfile already copies all of `dist`, so the same image runs the worker with a different CMD.
- New `cerebrum-worker` service in both `infra/docker-compose.yml` + `infra/docker-compose.dev.yml` (build from `pillars/cerebrum/Dockerfile`, `command: ["node","dist/worker/index.js"]`, REDIS + EMBEDDING_* + ANTHROPIC_API_KEY + POPS_PILLARS + CEREBRUM_SQLITE_PATH + CEREBRUM_ENGRAMS_DIR), mirroring the food worker + cerebrum-api env conventions.

## Tests

`src/worker/__tests__/` — offline (fake embedder, fake peers, fake `IngestLlm`, temp `cerebrum.db`, no Redis), driving the handler functions directly:
- embeddings: engram + transaction writes (metadata + vec), inline content, skip unknown/absent-peer/404 source, hash dedup, re-embed on change, delete-on-empty.
- curation: full enrichment via the (faked) ingest pipeline, idempotency, scope reconciliation.

## Deviations

- **`ai_usage` no-op**: the monolith writes embedding usage to shared `pops.db`; the pillar has no shared handle / usage table, so usage tracking is dropped (`tokensUsed` is always 0). Documented in the handler.
- **Curation idempotency keyed on body hash, not `engram.contentHash`**: the full-file content hash includes frontmatter, so writing the enrichment result would change it and the guard could never trip. Hashing the (stable) body makes the idempotency guard actually skip an unchanged engram on re-run. Documented inline.

## Prove green (local)

`oxfmt --check`, `oxlint` (exit 0), `typecheck`, `build`, `generate:openapi` + `generate:manifest` (snapshots unchanged — worker adds no REST routes), full test suite (**608 passed**), and `docker compose config --quiet` on both compose files all pass. No new deps; lockfile unchanged.
