### PR TITLE
feat(cerebrum): ai-alerts nudge dispatch goes through the pillar POST /nudges

### DIFF
--- a/apps/pops-api/src/modules/core/ai-alerts/dispatch.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatch.ts
@@ -59,7 +59,7 @@ export async function dispatchAlert(
       if (channel === 'nudge') {
         delivered = options.nudgeDispatcher
           ? await options.nudgeDispatcher(alert)
-          : dispatchNudge(alert);
+          : await dispatchNudge(alert);
       } else if (channel === 'telegram') {
         delivered = options.telegramDispatcher
           ? await options.telegramDispatcher(alert)

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/cerebrum-nudge-client.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/cerebrum-nudge-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Cross-pillar HTTP client for the cerebrum pillar — used by the ai-alerts
+ * nudge dispatcher to write an alert nudge over REST instead of reaching into
+ * the cerebrum DB. Pillars trust the docker network, so no per-request auth
+ * header is sent. The base URL is resolved from the `POPS_PILLARS` registry
+ * (mirrors the food→lists `lists-client` precedent).
+ *
+ * When the cerebrum pillar is absent from `POPS_PILLARS` (e.g. a dev box that
+ * never booted it) the client is treated as not configured: {@link
+ * resolveCerebrumBaseUrl} returns `null` and {@link createCerebrumNudgeClient}
+ * returns `null`, so the dispatcher fails soft rather than crashing the alert
+ * pipeline.
+ */
+import { parsePillarsEnv } from '../../pillars/env.js';
+
+export type NudgeActionTypeWire = 'consolidate' | 'archive' | 'review' | 'link';
+
+export interface CerebrumNudgeAction {
+  type: NudgeActionTypeWire;
+  label: string;
+  params: Record<string, unknown>;
+}
+
+export interface CreateNudgeBody {
+  type?: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+  title: string;
+  body: string;
+  priority: 'low' | 'medium' | 'high';
+  engramIds?: string[];
+  expiresAt?: string | null;
+  action?: CerebrumNudgeAction | null;
+}
+
+export interface CreatedNudge {
+  id: string;
+}
+
+export interface CerebrumNudgeClient {
+  createNudge(body: CreateNudgeBody): Promise<CreatedNudge>;
+}
+
+type FetchImpl = typeof globalThis.fetch;
+
+/**
+ * Resolve the cerebrum pillar's base URL from `POPS_PILLARS`, or `null` when
+ * the pillar is not registered (the dispatcher then no-ops).
+ */
+export function resolveCerebrumBaseUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const entry = parsePillarsEnv(env['POPS_PILLARS']).find((p) => p.id === 'cerebrum');
+  return entry?.baseUrl ?? null;
+}
+
+async function readMessage(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  return text.length === 0 ? '' : text;
+}
+
+/**
+ * Bare-`fetch` cerebrum nudge client. `fetchImpl` is injectable so the
+ * ai-alerts tests can drive the flow without a live cerebrum-api.
+ */
+export function createCerebrumNudgeHttpClient(
+  baseUrl: string,
+  fetchImpl: FetchImpl = globalThis.fetch
+): CerebrumNudgeClient {
+  const root = baseUrl.replace(/\/$/, '');
+
+  return {
+    async createNudge(body) {
+      const res = await fetchImpl(`${root}/nudges`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(`cerebrum POST /nudges → HTTP ${res.status}: ${await readMessage(res)}`);
+      }
+      const json = (await res.json().catch(() => null)) as { nudge: CreatedNudge } | null;
+      if (!json?.nudge) throw new Error('cerebrum POST /nudges → malformed response (no nudge)');
+      return json.nudge;
+    },
+  };
+}
+
+/**
+ * Build the default cerebrum nudge client from the environment, or `null` when
+ * the pillar is not present in `POPS_PILLARS`.
+ */
+export function createCerebrumNudgeClient(
+  env: NodeJS.ProcessEnv = process.env
+): CerebrumNudgeClient | null {
+  const baseUrl = resolveCerebrumBaseUrl(env);
+  if (baseUrl === null) return null;
+  return createCerebrumNudgeHttpClient(baseUrl);
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.test.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the cerebrum nudge dispatcher (PRD-092 US-07, PRD-084).
+ *
+ * The dispatcher now writes the alert nudge over the cerebrum pillar's
+ * `POST /nudges` REST endpoint instead of inserting into the cerebrum DB. The
+ * cerebrum nudge client is injected so these tests assert the exact POST
+ * payload and the fail-soft contract (cerebrum absent / POST failure → log +
+ * return false, never throw) without a live cerebrum-api.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createCerebrumNudgeHttpClient,
+  resolveCerebrumBaseUrl,
+  type CerebrumNudgeClient,
+  type CreateNudgeBody,
+} from './cerebrum-nudge-client.js';
+import { dispatchNudge } from './nudge.js';
+
+import type { FiredAlert } from '../types.js';
+
+function buildAlert(over: Partial<FiredAlert> = {}): FiredAlert {
+  return {
+    id: 7,
+    ruleId: 3,
+    type: 'budget-threshold',
+    message: 'Spend crossed the cap',
+    severity: 'critical',
+    scopeDetail: 'budget:global',
+    metricValue: 120,
+    thresholdValue: 100,
+    acknowledged: false,
+    acknowledgedAt: null,
+    createdAt: '2026-06-18T00:00:00.000Z',
+    ...over,
+  };
+}
+
+function fakeClient(): { client: CerebrumNudgeClient; calls: CreateNudgeBody[] } {
+  const calls: CreateNudgeBody[] = [];
+  return {
+    calls,
+    client: {
+      createNudge: (body) => {
+        calls.push(body);
+        return Promise.resolve({ id: 'nudge_20260618_0000_insight_abc123' });
+      },
+    },
+  };
+}
+
+describe('dispatchNudge', () => {
+  it('POSTs an insight nudge carrying the alert fields (critical → high)', async () => {
+    const { client, calls } = fakeClient();
+    const alert = buildAlert({ severity: 'critical', scopeDetail: 'budget:global' });
+
+    const delivered = await dispatchNudge(alert, { nudgeClient: client });
+
+    expect(delivered).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      type: 'insight',
+      title: 'AI alert: budget-threshold',
+      body: 'Spend crossed the cap (budget:global)',
+      priority: 'high',
+      engramIds: [],
+    });
+  });
+
+  it('maps a warning alert to medium priority and omits the scope suffix when null', async () => {
+    const { client, calls } = fakeClient();
+    const alert = buildAlert({ severity: 'warning', scopeDetail: null, message: 'errors up' });
+
+    await dispatchNudge(alert, { nudgeClient: client });
+
+    expect(calls[0]).toMatchObject({ priority: 'medium', body: 'errors up' });
+  });
+
+  it('returns false (no throw) when cerebrum is not configured', async () => {
+    const delivered = await dispatchNudge(buildAlert(), { nudgeClient: null });
+    expect(delivered).toBe(false);
+  });
+
+  it('fails soft: a client error is logged and returns false', async () => {
+    const client: CerebrumNudgeClient = {
+      createNudge: () => Promise.reject(new Error('cerebrum POST /nudges → HTTP 503')),
+    };
+    const delivered = await dispatchNudge(buildAlert(), { nudgeClient: client });
+    expect(delivered).toBe(false);
+  });
+});
+
+describe('resolveCerebrumBaseUrl', () => {
+  it('resolves the cerebrum origin from POPS_PILLARS', () => {
+    const url = resolveCerebrumBaseUrl({
+      POPS_PILLARS: 'food:http://food-api:3000,cerebrum:http://cerebrum-api:3007',
+    });
+    expect(url).toBe('http://cerebrum-api:3007');
+  });
+
+  it('returns null when cerebrum is absent', () => {
+    expect(resolveCerebrumBaseUrl({ POPS_PILLARS: 'food:http://food-api:3000' })).toBeNull();
+    expect(resolveCerebrumBaseUrl({})).toBeNull();
+  });
+});
+
+describe('createCerebrumNudgeHttpClient', () => {
+  it('POSTs /nudges with the JSON body and parses the created nudge', async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ nudge: { id: 'nudge_1' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const client = createCerebrumNudgeHttpClient('http://cerebrum-api:3007/', fetchImpl);
+
+    const result = await client.createNudge({
+      type: 'insight',
+      title: 't',
+      body: 'b',
+      priority: 'high',
+      engramIds: [],
+    });
+
+    expect(result).toEqual({ id: 'nudge_1' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe('http://cerebrum-api:3007/nudges');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(String(init?.body))).toMatchObject({ type: 'insight', priority: 'high' });
+  });
+
+  it('throws on a non-2xx response', async () => {
+    const fetchImpl = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response('nope', { status: 500 }));
+    const client = createCerebrumNudgeHttpClient('http://cerebrum-api:3007', fetchImpl);
+
+    await expect(client.createNudge({ title: 't', body: 'b', priority: 'low' })).rejects.toThrow(
+      /HTTP 500/
+    );
+  });
+});

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts
@@ -1,19 +1,20 @@
 /**
  * Cerebrum nudge dispatcher (PRD-092 US-07, PRD-084).
  *
- * Persists the alert as a nudge_log row using the existing nudge persistence
- * schema (no engram IDs — these nudges are observability events, not engram
- * recommendations). The nudge type is the fixed string `insight` since
- * PRD-084 reserves the four canonical detector types.
+ * Surfaces the alert as a nudge by POSTing to the cerebrum pillar's
+ * `POST /nudges` endpoint (the pillar owns `nudge_log` now). The nudge type is
+ * the fixed string `insight` since PRD-084 reserves the four canonical
+ * detector types; these nudges are observability events, not engram
+ * recommendations, so `engramIds` is empty.
  *
- * The Cerebrum nudge surfaces query the nudge_log directly, so writing a row
- * here is enough to make the alert visible alongside other proactive
- * nudges.
+ * The cerebrum surfaces query `nudge_log` directly, so creating a row there is
+ * enough to make the alert visible alongside other proactive nudges. If the
+ * cerebrum pillar is absent from `POPS_PILLARS` (e.g. a dev box) or the POST
+ * fails, the dispatcher fails soft — logs and returns `false` — so a cerebrum
+ * outage never crashes the alert pipeline.
  */
-import { nudgeLog } from '@pops/cerebrum-db';
-
-import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
 import { logger } from '../../../../lib/logger.js';
+import { createCerebrumNudgeClient, type CerebrumNudgeClient } from './cerebrum-nudge-client.js';
 
 import type { FiredAlert } from '../types.js';
 
@@ -22,51 +23,54 @@ function priorityFor(severity: FiredAlert['severity']): 'low' | 'medium' | 'high
   return severity === 'critical' ? 'high' : 'medium';
 }
 
-/** Build the nudge ID — mirrors `generateNudgeId` shape for consistency. */
-function buildNudgeId(now: Date, alertId: number): string {
-  const pad = (n: number, len: number): string => String(n).padStart(len, '0');
-  const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
-  const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}`;
-  return `nudge_${date}_${time}_aiAlert_${alertId}`;
-}
-
 export interface DispatchNudgeOptions {
-  now?: () => Date;
+  /**
+   * Override the cerebrum nudge client (for tests). When omitted the default
+   * client is built from `POPS_PILLARS`; if cerebrum is not registered the
+   * dispatch no-ops and returns `false`.
+   */
+  nudgeClient?: CerebrumNudgeClient | null;
 }
 
 /**
- * Dispatch the alert by writing a nudge_log row. Returns `true` when the
- * nudge was created. Throws on DB errors.
+ * Dispatch the alert by creating a nudge over the cerebrum REST API. Returns
+ * `true` when the nudge was created, `false` when cerebrum is unavailable or
+ * the create failed (the failure is logged, never thrown, so `dispatchAlert`
+ * records a non-delivery rather than aborting the channel loop).
  */
-export function dispatchNudge(alert: FiredAlert, options: DispatchNudgeOptions = {}): boolean {
-  const now = options.now ?? (() => new Date());
-  const db = getCerebrumDrizzle();
-  const id = buildNudgeId(now(), alert.id);
+export async function dispatchNudge(
+  alert: FiredAlert,
+  options: DispatchNudgeOptions = {}
+): Promise<boolean> {
+  const client =
+    options.nudgeClient === undefined ? createCerebrumNudgeClient() : options.nudgeClient;
+  if (!client) {
+    logger.debug(
+      { alertId: alert.id },
+      '[ai-alerts/nudge] Cerebrum pillar not configured — skipping nudge dispatch'
+    );
+    return false;
+  }
+
   const title = `AI alert: ${alert.type}`;
   const body = alert.scopeDetail ? `${alert.message} (${alert.scopeDetail})` : alert.message;
 
-  db.insert(nudgeLog)
-    .values({
-      id,
+  try {
+    const nudge = await client.createNudge({
       type: 'insight',
       title,
       body,
-      engramIds: JSON.stringify([]),
       priority: priorityFor(alert.severity),
-      status: 'pending',
-      createdAt: now().toISOString(),
-      expiresAt: null,
-      actionType: null,
-      actionLabel: null,
-      actionParams: JSON.stringify({
-        source: 'ai-alert',
-        alertId: alert.id,
-        ruleId: alert.ruleId,
-        alertType: alert.type,
-        severity: alert.severity,
-      }),
-    })
-    .run();
-  logger.debug({ nudgeId: id, alertId: alert.id }, '[ai-alerts/nudge] Nudge created');
-  return true;
+      engramIds: [],
+    });
+    logger.debug({ nudgeId: nudge.id, alertId: alert.id }, '[ai-alerts/nudge] Nudge created');
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      { alertId: alert.id, error: message },
+      '[ai-alerts/nudge] Failed to create nudge via cerebrum'
+    );
+    return false;
+  }
 }

--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -7566,6 +7566,163 @@
         "tags": ["ingest"]
       }
     },
+    "/nudges": {
+      "post": {
+        "operationId": "nudges.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "action": {
+                    "additionalProperties": false,
+                    "nullable": true,
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "params": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "type": {
+                        "enum": ["consolidate", "archive", "review", "link"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["type", "label", "params"],
+                    "type": "object"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "engramIds": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "expiresAt": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "priority": {
+                    "enum": ["low", "medium", "high"],
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": ["consolidation", "staleness", "pattern", "insight"],
+                    "type": "string"
+                  }
+                },
+                "required": ["title", "body", "priority"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nudge": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "actedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "action": {
+                          "additionalProperties": false,
+                          "nullable": true,
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "params": {
+                              "additionalProperties": {},
+                              "type": "object"
+                            },
+                            "type": {
+                              "enum": ["consolidate", "archive", "review", "link"],
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "label", "params"],
+                          "type": "object"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "engramIds": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "expiresAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "enum": ["low", "medium", "high"],
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": ["pending", "dismissed", "acted", "expired"],
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": ["consolidation", "staleness", "pattern", "insight"],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "title",
+                        "body",
+                        "engramIds",
+                        "priority",
+                        "status",
+                        "createdAt",
+                        "expiresAt",
+                        "actedAt",
+                        "action"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["nudge"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Create a single nudge (alert-driven; no cooldown dedup).",
+        "tags": ["nudges"]
+      }
+    },
     "/nudges/configure": {
       "post": {
         "operationId": "nudges.configure",

--- a/pillars/cerebrum/src/api/__tests__/nudges.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/nudges.test.ts
@@ -139,6 +139,75 @@ function engramService(now?: () => Date): EngramService {
   });
 }
 
+describe('cerebrum.nudges.create', () => {
+  it('persists an insight nudge and surfaces it in get/list', async () => {
+    const c = client();
+
+    const { nudge } = await c.nudges.create({
+      title: 'AI alert: budget-threshold',
+      body: 'Monthly spend exceeded the cap (provider=openai)',
+      priority: 'high',
+      action: {
+        type: 'review',
+        label: 'Inspect alert',
+        params: { source: 'ai-alert', alertId: 42 },
+      },
+    });
+
+    expect(nudge).toMatchObject({
+      type: 'insight',
+      title: 'AI alert: budget-threshold',
+      body: 'Monthly spend exceeded the cap (provider=openai)',
+      priority: 'high',
+      status: 'pending',
+      engramIds: [],
+      expiresAt: null,
+      actedAt: null,
+      action: {
+        type: 'review',
+        label: 'Inspect alert',
+        params: { source: 'ai-alert', alertId: 42 },
+      },
+    });
+    expect(nudge.id).toMatch(/^nudge_\d{8}_\d{4}_insight_/);
+
+    const fetched = await c.nudges.get(nudge.id);
+    expect(fetched.nudge).toMatchObject({ id: nudge.id, title: 'AI alert: budget-threshold' });
+
+    const listed = await c.nudges.list({ type: 'insight' });
+    expect(listed.total).toBe(1);
+    expect(listed.nudges[0]?.id).toBe(nudge.id);
+  });
+
+  it('defaults type to insight, engramIds to [], action to null', async () => {
+    const c = client();
+    const { nudge } = await c.nudges.create({
+      title: 'Bare nudge',
+      body: 'no action, no engrams',
+      priority: 'medium',
+    });
+    expect(nudge.type).toBe('insight');
+    expect(nudge.engramIds).toEqual([]);
+    expect(nudge.action).toBeNull();
+    expect(nudge.status).toBe('pending');
+  });
+
+  it('does not dedup repeated alert-driven creates (no cooldown)', async () => {
+    const c = client();
+    const payload = {
+      title: 'AI alert: error-spike',
+      body: 'errors spiking',
+      priority: 'high' as const,
+    };
+    const first = await c.nudges.create(payload);
+    const second = await c.nudges.create(payload);
+    expect(first.nudge.id).not.toBe(second.nudge.id);
+
+    const { total } = await c.nudges.list({ type: 'insight' });
+    expect(total).toBe(2);
+  });
+});
+
 describe('cerebrum.nudges.list', () => {
   it('returns an empty page when nudge_log is empty', async () => {
     const { nudges, total } = await client().nudges.list();

--- a/pillars/cerebrum/src/api/__tests__/test-utils.ts
+++ b/pillars/cerebrum/src/api/__tests__/test-utils.ts
@@ -339,6 +339,20 @@ export interface ListNudgesFilters {
   offset?: number;
 }
 
+export interface CreateNudgeInput {
+  type?: NudgeTypeWire;
+  title: string;
+  body: string;
+  priority: NudgePriorityWire;
+  engramIds?: string[];
+  expiresAt?: string | null;
+  action?: {
+    type: 'consolidate' | 'archive' | 'review' | 'link';
+    label: string;
+    params: Record<string, unknown>;
+  } | null;
+}
+
 export interface ListContradictionsFilters {
   status?: NudgeStatusWire | null;
   limit?: number;
@@ -565,6 +579,8 @@ export function makeClient(app: Express) {
         ),
     },
     nudges: {
+      create: (input: CreateNudgeInput) =>
+        send<{ nudge: NudgeWire }>(r.post('/nudges').send(input)),
       list: (filters: ListNudgesFilters = {}) =>
         send<{ nudges: NudgeWire[]; total: number }>(r.post('/nudges/search').send(filters)),
       get: (id: string) => send<{ nudge: NudgeWire }>(r.get(`/nudges/${id}`)),

--- a/pillars/cerebrum/src/api/rest/nudges-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/nudges-handlers.ts
@@ -16,7 +16,7 @@
 import { initServer } from '@ts-rest/express';
 
 import { cerebrumNudgesContract } from '../../contract/rest-nudges.js';
-import { type CerebrumDb } from '../../db/index.js';
+import { type CerebrumDb, nudgeLogService } from '../../db/index.js';
 import { extractContradiction } from '../modules/nudges/contradiction.js';
 import { createNudgeReadService } from '../modules/nudges/service.js';
 import { createNudgeWriteService, type ThresholdsStore } from '../modules/nudges/write-service.js';
@@ -51,6 +51,21 @@ export function makeNudgesHandlers(
   });
 
   return server.router(cerebrumNudgesContract, {
+    create: async ({ body }) => ({
+      status: 200,
+      body: {
+        nudge: nudgeLogService.createNudge(deps.db, {
+          type: body.type,
+          title: body.title,
+          body: body.body,
+          priority: body.priority,
+          engramIds: body.engramIds,
+          expiresAt: body.expiresAt,
+          action: body.action,
+        }),
+      },
+    }),
+
     list: async ({ body }) => ({
       status: 200,
       body: service.list(body),

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -958,6 +958,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/nudges': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a single nudge (alert-driven; no cooldown dedup). */
+    post: operations['nudges.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/nudges/configure': {
     parameters: {
       query?: never;
@@ -4803,6 +4820,72 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'nudges.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          action?: {
+            label: string;
+            params: {
+              [key: string]: unknown;
+            };
+            /** @enum {string} */
+            type: 'consolidate' | 'archive' | 'review' | 'link';
+          } | null;
+          body: string;
+          engramIds?: string[];
+          expiresAt?: string | null;
+          /** @enum {string} */
+          priority: 'low' | 'medium' | 'high';
+          title: string;
+          /** @enum {string} */
+          type?: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            nudge: {
+              actedAt: string | null;
+              action: {
+                label: string;
+                params: {
+                  [key: string]: unknown;
+                };
+                /** @enum {string} */
+                type: 'consolidate' | 'archive' | 'review' | 'link';
+              } | null;
+              body: string;
+              createdAt: string;
+              engramIds: string[];
+              expiresAt: string | null;
+              id: string;
+              /** @enum {string} */
+              priority: 'low' | 'medium' | 'high';
+              /** @enum {string} */
+              status: 'pending' | 'dismissed' | 'acted' | 'expired';
+              title: string;
+              /** @enum {string} */
+              type: 'consolidation' | 'staleness' | 'pattern' | 'insight';
+            };
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-nudges.ts
+++ b/pillars/cerebrum/src/contract/rest-nudges.ts
@@ -12,6 +12,7 @@
  *
  * The write surface completes the domain:
  *
+ *   - `create`    → POST /nudges            (alert-driven single insert, no dedup)
  *   - `scan`      → POST /nudges/scan       (runs detectors, persists nudges)
  *   - `act`       → POST /nudges/:id/act    (executes the suggested action)
  *   - `configure` → POST /nudges/configure  (updates detection thresholds)
@@ -101,6 +102,23 @@ export const nudgeConfigureSchema = z.object({
 export type NudgeConfigureWire = z.infer<typeof nudgeConfigureSchema>;
 
 export const cerebrumNudgesContract = c.router({
+  create: {
+    method: 'POST',
+    path: '/nudges',
+    summary: 'Create a single nudge (alert-driven; no cooldown dedup).',
+    body: z.object({
+      type: nudgeTypeSchema.optional(),
+      title: z.string(),
+      body: z.string(),
+      priority: nudgePrioritySchema,
+      engramIds: z.array(z.string()).optional(),
+      expiresAt: z.string().nullable().optional(),
+      action: nudgeActionSchema.nullable().optional(),
+    }),
+    responses: {
+      200: z.object({ nudge: nudgeSchema }),
+    },
+  },
   list: {
     method: 'POST',
     path: '/nudges/search',

--- a/pillars/cerebrum/src/db/services/nudge-log.ts
+++ b/pillars/cerebrum/src/db/services/nudge-log.ts
@@ -6,6 +6,7 @@
  * here cover the persistence-layer surface the pops-api `NudgeService`
  * needs from this package:
  *
+ *   - {@link createNudge} — insert one alert-driven nudge (no cooldown dedup).
  *   - {@link persistCandidates} — insert new nudges with cooldown dedup.
  *   - {@link listContradictions} — paginated read of contradiction-pattern
  *     nudges, with the SQL-side `json_extract` filter that prevents
@@ -32,10 +33,63 @@ import { generateNudgeId, rowToNudge } from './nudge-log-helpers.js';
 import type { CerebrumDb } from './internal.js';
 import type {
   Nudge,
+  NudgeAction,
   NudgeCandidate,
   NudgePersistenceThresholds,
+  NudgePriority,
   NudgeStatus,
+  NudgeType,
 } from './nudge-log-types.js';
+
+/** Input for {@link createNudge} — a single alert-driven nudge insert. */
+export interface CreateNudgeInput {
+  type?: NudgeType;
+  title: string;
+  body: string;
+  priority: NudgePriority;
+  engramIds?: string[];
+  expiresAt?: string | null;
+  action?: NudgeAction | null;
+}
+
+/**
+ * Insert exactly one nudge and return it as a {@link Nudge}.
+ *
+ * Unlike {@link persistCandidates}, this path applies NO cooldown dedup: the
+ * caller (the ai-alerts pipeline) wants every alert to surface a row rather
+ * than be silently swallowed by a same-type/same-engrams cooldown window.
+ */
+export function createNudge(
+  db: CerebrumDb,
+  input: CreateNudgeInput,
+  now: () => Date = () => new Date()
+): Nudge {
+  const timestamp = now();
+  const type = input.type ?? 'insight';
+  const action = input.action ?? null;
+  const id = generateNudgeId(type, timestamp);
+
+  db.insert(nudgeLog)
+    .values({
+      id,
+      type,
+      title: input.title,
+      body: input.body,
+      engramIds: JSON.stringify(input.engramIds ?? []),
+      priority: input.priority,
+      status: 'pending',
+      createdAt: timestamp.toISOString(),
+      expiresAt: input.expiresAt ?? null,
+      actionType: action?.type ?? null,
+      actionLabel: action?.label ?? null,
+      actionParams: action ? JSON.stringify(action.params) : null,
+    })
+    .run();
+
+  const [row] = db.select().from(nudgeLog).where(eq(nudgeLog.id, id)).all();
+  if (!row) throw new Error(`createNudge: inserted nudge '${id}' not found on read-back`);
+  return rowToNudge(row);
+}
 
 /** Insert new nudges, skipping any whose (type, sorted engramIds) pair is
  * still inside the cooldown window. Returns the number created.


### PR DESCRIPTION
## What

Repoints the last live non-cerebrum consumer of the cerebrum DB — `apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts` — off `getCerebrumDrizzle()` / `@pops/cerebrum-db` onto the cerebrum pillar's REST.

### Part A — Pillar: additive `POST /nudges` (create)
- `contract/rest-nudges.ts`: new `create` route (`nudges.create`), body `{ type?, title, body, priority, engramIds?, expiresAt?, action? }`, response `{ nudge }`.
- `db/services/nudge-log.ts`: new `createNudge(db, input, now?)` — inserts ONE `nudge_log` row via `generateNudgeId` (`status:'pending'`, `createdAt: now`), maps `action` → action columns, returns the row via `rowToNudge`. Deliberately does **not** use `persistCandidates` (its cooldown dedup is wrong for alert-driven creates).
- `api/rest/nudges-handlers.ts`: `create` handler over `deps.db`.
- `test-utils.ts`: `nudges.create` client method.
- `nudges.test.ts`: create insight nudge → persists, returns, appears in `get`/`list`; defaults; no-dedup.
- Regenerated openapi + api-types (deterministic; verified identical on a 2nd regen).

### Part B — pops-api: repoint the dispatcher
- New `dispatchers/cerebrum-nudge-client.ts`: bare-`fetch` cerebrum client; base URL resolved from `POPS_PILLARS` (`find(p => p.id === 'cerebrum')`), no auth (docker-net trust). Mirrors the food→lists `lists-client` precedent. Fails soft when cerebrum is absent (returns `null`).
- `dispatchers/nudge.ts`: `dispatchNudge` is now async, POSTs to `POST /nudges` with the same title/body/priority it built before (`type:'insight'`, `engramIds:[]`). Client is injectable via `DispatchNudgeOptions.nudgeClient`. On client-missing or POST error → log + return `false` (the dispatcher failure contract). No more `@pops/cerebrum-db` / `getCerebrumDrizzle` / `nudgeLog` imports.
- `dispatch.ts`: default nudge call is now `await dispatchNudge(alert)`.
- `dispatchers/nudge.test.ts`: injects a fake client + asserts the POST payload and the fail-soft paths.

## Green
- oxfmt --check + oxlint (exit 0) on `pillars/cerebrum/src` and `apps/pops-api/src/modules/core/ai-alerts`.
- `@pops/cerebrum {typecheck,build,test}` green — 611 tests pass.
- openapi regen deterministic (same md5 on 2nd run).
- pops-api whole-app typecheck is red-by-design on lake; ai-alerts errors went 12 → 11 (only the removed `nudge.ts → @pops/cerebrum-db` error dropped; no new errors). New files typecheck clean.
- `nudge.test.ts` (pops-api) passes (8/8). `evaluator.test.ts` fails to load on both baseline and this branch due to the pre-existing `@pops/core-db` resolution gap — unrelated.