### PR TITLE
docs(runbook): mark 04 Phase 0 done; record stale-premise findings + docker-build.yml follow-up

### DIFF
--- a/docs/runbooks/04-ci-docker-infra.md
+++ b/docs/runbooks/04-ci-docker-infra.md
@@ -17,6 +17,25 @@ remnants. Split into:
 
 ## Phase 0 — immediate (parallel, gated on nothing)
 
+> **Status — done (landed in #3444).** P0-2, P0-3, P0-4, P0-6 shipped. Two list items were
+> already satisfied and needed no change:
+>
+> - **P0-1** is obsolete as written. `cerebrum` collapsed into `pillars/cerebrum` (single root
+>   `package.json`, no `contract/` subpackage), so the boundary-rule generator deliberately does
+>   **not** discover it — `PILLARS = ['core']`, the generated file is in sync, and
+>   `pnpm lint:boundaries:verify` is green. There is no missing `…-cerebrum` rule. (The local
+>   `pnpm lint:boundaries` run can show phantom `core-db` reach-ins, but only from a stale
+>   `packages/core-db/dist`; CI installs `--frozen-lockfile` with no build, so the imports are
+>   unresolvable and produce no violation.)
+> - **P0-5** was already removed from git — only untracked local crud (`.turbo`/`node_modules`/
+>   `dist`) remained in the shell dirs; cleaned locally, no commit.
+>
+> The Phase 0 gate (V0-1…V0-4) holds. **Follow-up outside Phase 0:** `docker-build.yml` is
+> independently stale (Phase-E fallout) — the committed `apps/pops-core-api/Dockerfile` has drifted
+> from `generate-pillar-dockerfile.mjs`, and the job still `docker build`s the retired
+> `apps/pops-{inventory,finance,food}-api` + `pillars/lists/api` Dockerfiles. Its `docker-build`
+> job fails on any Dockerfile-touching PR; not addressed here.
+
 CI is **currently red** and several routed services would 502. Every item below is independent —
 land them as separate small PRs in parallel.
 


### PR DESCRIPTION
Records the outcome of [`docs/runbooks/04-ci-docker-infra.md`](docs/runbooks/04-ci-docker-infra.md) **Phase 0** (the work landed in #3444).

- Marks P0-2/P0-3/P0-4/P0-6 done.
- **P0-1** documented as obsolete: `cerebrum` is a collapsed pillar, deliberately excluded from boundary-rule generation (`PILLARS = ['core']`), so `lint:boundaries:verify` is already green — there is no missing `…-cerebrum` rule. Notes the stale-local-`dist` phantom for the `lint:boundaries` run.
- **P0-5** documented as already removed from git (only untracked local crud remained).
- Records the **out-of-Phase-0 follow-up**: `docker-build.yml` is independently stale (core Dockerfile generator drift + `docker build` of retired `apps/pops-*-api` / `pillars/lists/api` Dockerfiles).

Docs-only.