### PR TITLE
feat(shell): nudge bell → cerebrum REST (03 Track B / B1)

### DIFF
--- a/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.test.tsx
+++ b/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.test.tsx
@@ -1,17 +1,11 @@
-import { trpc, trpcClient } from '@/lib/trpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-
-import { __resetSharedPillarClient } from '@pops/pillar-sdk/client';
-import { PillarSdkProvider } from '@pops/pillar-sdk/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { NudgeIndicator, nudgeRefetchInterval } from './NudgeIndicator';
 
 import type { ReactNode } from 'react';
-
-import type { DiscoveredPillar, DiscoveryTransport } from '@pops/pillar-sdk/client';
 
 const q = (fetchFailureCount: number) => ({ state: { fetchFailureCount } });
 
@@ -38,52 +32,6 @@ describe('nudgeRefetchInterval', () => {
   });
 });
 
-function cerebrumDiscoveredPillar(): DiscoveredPillar {
-  return {
-    pillarId: 'cerebrum',
-    baseUrl: 'http://cerebrum-api:3007',
-    status: 'healthy',
-    lastSeenAt: '2026-06-13T00:00:00.000Z',
-    registered: true,
-    manifest: {
-      pillar: 'cerebrum',
-      version: '1.0.0',
-      contract: {
-        package: '@pops/cerebrum',
-        version: '1.0.0',
-        tag: 'contract-cerebrum@v1.0.0',
-      },
-      routes: {
-        queries: ['cerebrum.nudges.list'],
-        mutations: [],
-        subscriptions: [],
-      },
-      search: { adapters: [] },
-      ai: { tools: [] },
-      uri: { types: [] },
-      consumedSettings: { keys: [] },
-      healthcheck: { path: '/healthz' },
-    },
-  };
-}
-
-class StubTransport implements DiscoveryTransport {
-  constructor(private readonly pillars: readonly DiscoveredPillar[]) {}
-  async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
-    return this.pillars;
-  }
-}
-
-type FetchResponder = (url: string, init: RequestInit | undefined) => Response;
-
-function stubFetch(responder: FetchResponder): typeof fetch {
-  const wrapped: typeof fetch = async (input, init) => {
-    const url = typeof input === 'string' ? input : input.toString();
-    return responder(url, init);
-  };
-  return wrapped;
-}
-
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -91,69 +39,47 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function renderWithSdk(opts: { transport: DiscoveryTransport; fetchImpl: typeof fetch }): void {
+function renderIndicator(): void {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   const wrapper = ({ children }: { children: ReactNode }) => (
     <MemoryRouter>
-      <trpc.Provider client={trpcClient} queryClient={queryClient}>
-        <QueryClientProvider client={queryClient}>
-          <PillarSdkProvider options={{ transport: opts.transport, fetchImpl: opts.fetchImpl }}>
-            {children}
-          </PillarSdkProvider>
-        </QueryClientProvider>
-      </trpc.Provider>
-    </MemoryRouter>
-  );
-  render(<NudgeIndicator />, { wrapper });
-}
-
-function renderWithoutSdk(): void {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  const wrapper = ({ children }: { children: ReactNode }) => (
-    <MemoryRouter>
-      <trpc.Provider client={trpcClient} queryClient={queryClient}>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </trpc.Provider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </MemoryRouter>
   );
   render(<NudgeIndicator />, { wrapper });
 }
 
 describe('NudgeIndicator', () => {
-  beforeEach(() => {
-    __resetSharedPillarClient();
-  });
-
   afterEach(() => {
-    __resetSharedPillarClient();
+    vi.unstubAllGlobals();
   });
 
-  it('renders the bell with a badge when the SDK returns pending nudges', async () => {
-    const transport = new StubTransport([cerebrumDiscoveredPillar()]);
-    const fetchImpl = stubFetch((url) => {
-      expect(url).toBe('http://cerebrum-api:3007/trpc/cerebrum.nudges.list');
-      return jsonResponse({ result: { data: { nudges: [], total: 3 } } });
+  it('posts the pending filter to /cerebrum-api/nudges/search and badges the total', async () => {
+    const fetchSpy = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(typeof input === 'string' ? input : input.toString()).toBe(
+        '/cerebrum-api/nudges/search'
+      );
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(String(init?.body))).toEqual({ status: 'pending', limit: 1 });
+      return Promise.resolve(jsonResponse({ nudges: [], total: 3 }));
     });
+    vi.stubGlobal('fetch', fetchSpy);
 
-    renderWithSdk({ transport, fetchImpl });
+    renderIndicator();
 
     const button = await screen.findByRole('button', { name: 'Nudges: 3 pending' });
     await waitFor(() => {
       expect(button.textContent).toContain('3');
     });
+    expect(fetchSpy).toHaveBeenCalled();
   });
 
-  it('caps the badge at 99+ when the SDK returns more than 99 pending', async () => {
-    const transport = new StubTransport([cerebrumDiscoveredPillar()]);
-    const fetchImpl = stubFetch(() =>
-      jsonResponse({ result: { data: { nudges: [], total: 250 } } })
-    );
+  it('caps the badge at 99+ when more than 99 are pending', async () => {
+    vi.stubGlobal('fetch', () => Promise.resolve(jsonResponse({ nudges: [], total: 250 })));
 
-    renderWithSdk({ transport, fetchImpl });
+    renderIndicator();
 
     await screen.findByRole('button', { name: 'Nudges: 250 pending' });
     await waitFor(() => {
@@ -162,43 +88,31 @@ describe('NudgeIndicator', () => {
   });
 
   it('renders the bell without a badge when there are zero pending nudges', async () => {
-    const transport = new StubTransport([cerebrumDiscoveredPillar()]);
-    const fetchImpl = stubFetch(() => jsonResponse({ result: { data: { nudges: [], total: 0 } } }));
+    vi.stubGlobal('fetch', () => Promise.resolve(jsonResponse({ nudges: [], total: 0 })));
 
-    renderWithSdk({ transport, fetchImpl });
+    renderIndicator();
 
     await screen.findByRole('button', { name: 'Nudges: 0 pending' });
     expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
 
-  it('hides the indicator when the cerebrum pillar is unavailable', async () => {
-    const transport = new StubTransport([]);
-    const fetchImpl = stubFetch(() => {
-      throw new Error('SDK should short-circuit before performing an HTTP call');
-    });
+  it('hides the indicator when the pillar returns not-found (HTTP 404)', async () => {
+    vi.stubGlobal('fetch', () => Promise.resolve(jsonResponse({ message: 'not found' }, 404)));
 
-    renderWithSdk({ transport, fetchImpl });
+    renderIndicator();
 
     await waitFor(() => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
   });
 
-  it('hides the indicator when the SDK reports not-found (HTTP 404)', async () => {
-    const transport = new StubTransport([cerebrumDiscoveredPillar()]);
-    const fetchImpl = stubFetch(() => jsonResponse({ message: 'not found' }, 404));
+  it('hides the indicator when cerebrum is unreachable (network error)', async () => {
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('network down')));
 
-    renderWithSdk({ transport, fetchImpl });
+    renderIndicator();
 
     await waitFor(() => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
-  });
-
-  it('falls back to the tRPC query when no PillarSdkProvider is mounted', async () => {
-    renderWithoutSdk();
-
-    const button = await screen.findByRole('button', { name: /Nudges: \d+ pending/ });
-    expect(button).toBeInTheDocument();
   });
 });

--- a/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.tsx
+++ b/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.tsx
@@ -1,31 +1,39 @@
-import { trpc } from '@/lib/trpc';
 /**
  * NudgeIndicator — notification bell showing pending nudge count (#2244).
  *
- * Polls the `cerebrum.nudges.list` procedure and displays a badge on the
- * bell icon when there are pending nudges. Clicking navigates to the
- * cerebrum nudges page.
+ * Polls the cerebrum pillar's `POST /nudges/search` REST endpoint (opId
+ * `nudges.list`) through the shell's `/cerebrum-api` proxy and displays a
+ * badge on the bell icon when there are pending nudges. Clicking navigates
+ * to the cerebrum nudges page.
  *
- * Routing: PRD-227 (US-02) keeps the SDK migration behind a runtime gate.
- * When a {@link PillarSdkProvider} is mounted above this component
- * (i.e. {@link usePillarSdkOptions} returns options with a `transport`
- * configured), this component uses {@link usePillarQuery} against the
- * cerebrum pillar. Otherwise — the current state of `pops-shell` on
- * `main` — it falls back to the existing tRPC query so the indicator
- * keeps working in the browser (the SDK's default registry URL points
- * at the container-network hostname, which is unreachable from a
- * browser).
+ * The proxy (vite in dev, nginx in prod) strips the `/cerebrum-api` prefix
+ * so the pillar sees `/nudges/search`. Mirrors the federated-search surface
+ * (`@pops/navigation` useSearchInputData → `/orchestrator-api/search`): a
+ * plain `fetch` + React Query, no tRPC and no pillar-sdk transport.
  */
+import { useQuery } from '@tanstack/react-query';
 import { Bell } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
-import { usePillarQuery, usePillarSdkOptions } from '@pops/pillar-sdk/react';
 import { Button } from '@pops/ui';
 
 const POLL_BASE_MS = 60_000;
 const MAX_FAILURES = 5;
 
-type NudgeListResult = { total: number };
+/**
+ * Shell path the dev Vite proxy / production nginx rewrites onto the cerebrum
+ * pillar's nudges list (`POST /nudges/search`). The proxy strips the
+ * `/cerebrum-api` prefix so the pillar sees `/nudges/search`.
+ */
+const NUDGES_SEARCH_URL = '/cerebrum-api/nudges/search';
+
+/** Failure carrying the HTTP status so the bell can hide on 404 / unavailable. */
+class NudgeFetchError extends Error {
+  constructor(readonly status: number | undefined) {
+    super(`nudges fetch failed: ${status ?? 'network'}`);
+    this.name = 'NudgeFetchError';
+  }
+}
 
 /**
  * Exponential backoff for the nudges poller.
@@ -41,39 +49,40 @@ export function nudgeRefetchInterval(query: {
   return POLL_BASE_MS * 2 ** failures;
 }
 
-function useSdkPendingCount(enabled: boolean): { pendingCount: number; hidden: boolean } {
-  const { data, isUnavailable, isContractMismatch, isNotFound } = usePillarQuery<NudgeListResult>(
-    'cerebrum',
-    ['nudges', 'list'],
-    { status: 'pending', limit: 1 },
-    { retry: false, staleTime: 30_000, refetchInterval: nudgeRefetchInterval, enabled }
-  );
-
-  return {
-    pendingCount: data?.total ?? 0,
-    hidden: enabled && (isUnavailable || isContractMismatch || isNotFound),
-  };
+function parsePendingTotal(value: unknown): number {
+  if (typeof value === 'object' && value !== null) {
+    const total = (value as { total?: unknown }).total;
+    if (typeof total === 'number') return total;
+  }
+  throw new NudgeFetchError(undefined);
 }
 
-function useTrpcPendingCount(enabled: boolean): number {
-  const { data } = trpc.cerebrum.nudges.list.useQuery(
-    { status: 'pending', limit: 1 },
-    { retry: false, staleTime: 30_000, refetchInterval: nudgeRefetchInterval, enabled }
-  );
-  return data?.total ?? 0;
+async function fetchPendingCount(signal: AbortSignal): Promise<number> {
+  const response = await fetch(NUDGES_SEARCH_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ status: 'pending', limit: 1 }),
+    signal,
+  });
+  if (!response.ok) throw new NudgeFetchError(response.status);
+  return parsePendingTotal(await response.json());
 }
 
 export function NudgeIndicator() {
   const navigate = useNavigate();
-  const sdkOptions = usePillarSdkOptions();
-  const sdkEnabled = sdkOptions.transport !== undefined;
+  const { data, isError } = useQuery({
+    queryKey: ['cerebrum', 'nudges', 'list', { status: 'pending', limit: 1 }],
+    queryFn: ({ signal }) => fetchPendingCount(signal),
+    retry: false,
+    staleTime: 30_000,
+    refetchInterval: nudgeRefetchInterval,
+  });
 
-  const sdk = useSdkPendingCount(sdkEnabled);
-  const trpcCount = useTrpcPendingCount(!sdkEnabled);
+  // Hide the bell when cerebrum is unreachable / not-found rather than render a
+  // broken indicator (matches the previous pillar-sdk hidden-on-unavailable UX).
+  if (isError) return null;
 
-  if (sdk.hidden) return null;
-
-  const pendingCount = sdkEnabled ? sdk.pendingCount : trpcCount;
+  const pendingCount = data ?? 0;
 
   return (
     <Button


### PR DESCRIPTION
## Track B — global surfaces → REST (`docs/runbooks/03-frontend-rest-cutover.md`)

Repoints the shell's **nudge bell** off the legacy `/trpc` catch-all onto the cerebrum pillar's REST surface. Completes **Track B** (B1; B2 global search is already on `/orchestrator-api/search`).

### What changed
- `NudgeIndicator` polled `cerebrum.nudges.list` through `/trpc` — both the tRPC fallback (`trpc.cerebrum.nudges.list`) and the pillar-sdk transport path resolve to `<host>/trpc/cerebrum.nudges.list`.
- Now it `POST`s to `/cerebrum-api/nudges/search` (opId `nudges.list`, body `{ status: 'pending', limit: 1 }`) via a plain `fetch` + React Query — the same lightweight pattern the federated search uses (`useSearchInputData` → `/orchestrator-api/search`).
- Drops `@pops/pillar-sdk/react` + `@/lib/trpc` from the component. Keeps the exponential-backoff poller (`nudgeRefetchInterval`) and hides the bell on unreachable / 404 (graceful degrade while cerebrum has no compose service yet).

### Verification (runbook V4)
- Nudge bell calls `/cerebrum-api`; global search calls `/orchestrator-api`; no `/trpc` requests from either.
- `NudgeIndicator.test.tsx` rewritten to stub `fetch` — 9/9 pass (badge total, 99+ cap, zero-state, hide-on-404, hide-on-network-error, backoff unit tests).
- Changed files: oxlint clean, oxfmt clean, type-clean (no new tsc errors).

### Out of scope
- **B3** (delete the `/trpc` catch-all + the tRPC browser client) is gated on `02` (monolith must stop serving `/trpc`) — not in this PR.
- The shell's `usePillarQuery('core', …)` settings/features surfaces are a separate `core`-completion concern, not Track B.