### PR TITLE
chore(pillars): drop AnyTRPCRouter shims + @trpc/server (03 Track C)

### DIFF
--- a/pillars/finance/package.json
+++ b/pillars/finance/package.json
@@ -41,7 +41,6 @@
     "@pops/pillar-sdk": "workspace:*",
     "@pops/shared-schema": "workspace:*",
     "@pops/types": "workspace:*",
-    "@trpc/server": "^11.17.0",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",
     "@ts-rest/open-api": "3.53.0-rc.1",

--- a/pillars/finance/src/contract/router.ts
+++ b/pillars/finance/src/contract/router.ts
@@ -1,19 +1,13 @@
-import type { AnyTRPCRouter } from '@trpc/server';
-
 /**
- * Opaque tRPC router type for the finance pillar. Until PRD-155 ships the
- * declaration bundler, `FinanceRouter` is the generic `AnyTRPCRouter` —
- * consumers using `pillar<FinanceRouter>('finance')` get a fully opaque
+ * Opaque router type for the finance pillar. `@pops/finance` speaks REST now,
+ * so there is no concrete tRPC router to import — `FinanceRouter` is `unknown`,
+ * meaning consumers using `pillar<FinanceRouter>('finance')` get a fully opaque
  * `PillarHandle` with no route or procedure keys preserved. The committed
  * OpenAPI snapshot at `openapi/finance.openapi.json` is the wire-typed
- * alternative until PRD-155 lands.
+ * alternative (e.g. for the generated Hey API clients).
  *
- * This shape was previously `typeof financeRouter` (re-exporting from
- * `@pops/finance-api`), but that import-type closed a build-graph cycle
- * (pillar-sdk → finance-contract → finance-api → pillar-sdk) that broke
- * turbo's `^build` chain and forced every CI workflow to manually
- * pre-build packages in order. PRD-155's declaration bundler will
- * restore the concrete per-procedure types without re-introducing the
- * cycle.
+ * The type name is retained because the generated manifest and the manifest
+ * generator scripts reference it as the `router` field type. Mirrors the
+ * food-contract `FoodRouter = unknown` shape.
  */
-export type FinanceRouter = AnyTRPCRouter;
+export type FinanceRouter = unknown;

--- a/pillars/inventory/package.json
+++ b/pillars/inventory/package.json
@@ -42,7 +42,6 @@
     "@pops/core-contract": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
-    "@trpc/server": "^11.17.0",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",
     "@ts-rest/open-api": "3.53.0-rc.1",

--- a/pillars/inventory/src/api/cron/reconcile-cross-pillar.ts
+++ b/pillars/inventory/src/api/cron/reconcile-cross-pillar.ts
@@ -28,17 +28,16 @@ import {
 import { crossPillarUrisService, type InventoryDb } from '../../db/index.js';
 import { reconcileUriBatch, type ReconcileLogger } from './reconcile-cross-pillar-runner.js';
 
-import type { AnyTRPCRouter } from '@trpc/server';
-
 import type { CoreRouter } from '@pops/core-contract';
 
 /**
  * Opaque cross-pillar router type for the finance proxy. `@pops/finance`
- * speaks REST now, so there is no concrete tRPC router to import — the
- * proxy is fully opaque (parity with the source `@pops/finance-contract`
- * `FinanceRouter = AnyTRPCRouter` it replaces).
+ * speaks REST now, so there is no concrete tRPC router to import — the proxy
+ * is fully opaque (`unknown`), matching the source `@pops/finance` contract's
+ * `FinanceRouter = unknown`. `PillarHandle<unknown>` resolves to a fully opaque
+ * handle with no procedure keys.
  */
-export type FinanceRouter = AnyTRPCRouter;
+export type FinanceRouter = unknown;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/pillars/inventory/src/contract/router.ts
+++ b/pillars/inventory/src/contract/router.ts
@@ -1,18 +1,13 @@
-import type { AnyTRPCRouter } from '@trpc/server';
-
 /**
- * Opaque tRPC router type for the inventory pillar. Mirrors the
- * media-contract pattern: `InventoryRouter` is `AnyTRPCRouter`, so
- * consumers using `pillar<InventoryRouter>('inventory')` get a fully
- * opaque `PillarHandle` with no route or procedure keys preserved. The
+ * Opaque router type for the inventory pillar. `@pops/inventory` speaks REST
+ * now, so there is no concrete tRPC router to import — `InventoryRouter` is
+ * `unknown`, meaning consumers using `pillar<InventoryRouter>('inventory')` get
+ * a fully opaque `PillarHandle` with no route or procedure keys preserved. The
  * committed OpenAPI snapshot at `openapi/inventory.openapi.json` is the
- * wire-typed alternative until PRD-155 ships the declaration bundler.
+ * wire-typed alternative (e.g. for the generated Hey API clients).
  *
- * Previously `typeof inventoryRouter` re-exported from
- * `@pops/inventory-api`, but PRD-239 had `inventory-api` consume
- * `inventoryManifest` from `@pops/inventory-contract/settings`, closing
- * a `inventory-contract → inventory-api → inventory-contract`
- * build-graph cycle that broke standalone Docker builds that don't ship
- * `apps/pops-inventory-api/src`.
+ * The type name is retained because the generated manifest and the manifest
+ * generator scripts reference it as the `router` field type. Mirrors the
+ * food-contract `FoodRouter = unknown` shape.
  */
-export type InventoryRouter = AnyTRPCRouter;
+export type InventoryRouter = unknown;

--- a/pillars/media/package.json
+++ b/pillars/media/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
-    "@trpc/server": "^11.17.0",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",
     "@ts-rest/open-api": "3.53.0-rc.1",

--- a/pillars/media/src/contract/router.ts
+++ b/pillars/media/src/contract/router.ts
@@ -1,19 +1,13 @@
-import type { AnyTRPCRouter } from '@trpc/server';
-
 /**
- * Opaque tRPC router type for the media pillar. Mirrors the finance-contract
- * pattern: until PRD-155 ships the declaration bundler, `MediaRouter` is the
- * generic `AnyTRPCRouter` — consumers using `pillar<MediaRouter>('media')` get
- * a fully opaque `PillarHandle` with no route or procedure keys preserved.
- * The committed OpenAPI snapshot at `openapi/media.openapi.json` is the
- * wire-typed alternative until PRD-155 lands.
+ * Opaque router type for the media pillar. `@pops/media` speaks REST now, so
+ * there is no concrete tRPC router to import — `MediaRouter` is `unknown`,
+ * meaning consumers using `pillar<MediaRouter>('media')` get a fully opaque
+ * `PillarHandle` with no route or procedure keys preserved. The committed
+ * OpenAPI snapshot at `openapi/media.openapi.json` is the wire-typed
+ * alternative (e.g. for the generated Hey API clients).
  *
- * This shape was previously `typeof mediaRouter` (re-exporting from
- * `@pops/media-api`), but that import-type closed a build-graph cycle
- * (pillar-sdk → media-contract → media-api → pillar-sdk) once
- * `@pops/pillar-sdk/settings` started pulling `arrManifest`, `plexManifest`,
- * `rotationManifest`, and `mediaOperationalManifest` from this package
- * (PRD-239 US-05). PRD-155's declaration bundler will restore the concrete
- * per-procedure types without re-introducing the cycle.
+ * The type name is retained because the generated manifest and the manifest
+ * generator scripts reference it as the `router` field type. Mirrors the
+ * food-contract `FoodRouter = unknown` shape.
  */
-export type MediaRouter = AnyTRPCRouter;
+export type MediaRouter = unknown;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2059,9 +2059,6 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
-      '@trpc/server':
-        specifier: ^11.17.0
-        version: 11.17.0(typescript@6.0.3)
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@25.9.3)
@@ -2220,9 +2217,6 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
-      '@trpc/server':
-        specifier: ^11.17.0
-        version: 11.17.0(typescript@6.0.3)
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@25.9.3)
@@ -2354,9 +2348,6 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
-      '@trpc/server':
-        specifier: ^11.17.0
-        version: 11.17.0(typescript@6.0.3)
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@25.9.3)


### PR DESCRIPTION
## Track C — type-only shim cleanup (`docs/runbooks/03-frontend-rest-cutover.md`)

Deletes the dead `AnyTRPCRouter` router shims and the `@trpc/server` dependency from the leaf pillars that no longer have any live tRPC.

### What changed
- `pillars/{finance,media,inventory}/src/contract/router.ts`: `export type <Pillar>Router = AnyTRPCRouter` → `= unknown` (drops the `@trpc/server` type import). Mirrors the existing food-contract `FoodRouter = unknown` shape. The **type name is retained** because `manifest.generated.ts` and the manifest generator/render scripts reference it as the `router` field type — so no manifest regeneration is required.
- `pillars/inventory/src/api/cron/reconcile-cross-pillar.ts`: the local `FinanceRouter = AnyTRPCRouter` proxy alias → `unknown`. `PillarHandle<unknown>` resolves to a fully opaque handle (identical opacity to the `AnyTRPCRouter` form), so the cross-pillar reconcile proxy types are unchanged in behaviour. The `CoreRouter` import from `@pops/core-contract` stays (core is runbook 01 scope).
- Drops `@trpc/server` from `pillars/{finance,media,inventory}/package.json` + updates the lockfile.

After this, `rg @trpc pillars/{finance,media,inventory}/src` → **0**.

### Verification
- finance / media / inventory typecheck: **no new errors** (diffed against the lake baseline — empty diff; finance's 2 pre-existing errors are an un-built `@pops/shared-schema` locally + a pre-existing `pillar-lookup` enum drift, both unrelated).
- Changed files: oxlint clean, oxfmt clean.
- Type-only change — `AnyTRPCRouter`/`unknown` are both erased at runtime; no behavioural change.

### Out of scope (deferred)
- `lists` + `food` were already `@trpc`-free; `core` + `cerebrum` keep `@trpc` (core still mounts `/trpc` — runbook **01**).
- Removing `TRPC_PILLARS` / `PILLAR_TRPC_URLS` + the split-link plumbing is **gated on the remaining `usePillarQuery` callers** (the shell's `core` settings/features surfaces + `app-finance` Track A) cutting over — deferred with Track A.