### PR TITLE
feat(finance): serve corrections ChangeSet over REST (C1-a)

### DIFF
--- a/docs/themes/13-pillar-finale/notes/c1-finance-reclaim-delta-2026-06-18.md
+++ b/docs/themes/13-pillar-finale/notes/c1-finance-reclaim-delta-2026-06-18.md
@@ -1,0 +1,110 @@
+# C1 (finance reclaim / epic 08a) — delta audit
+
+Snapshot 2026-06-18, branch `lake-migration` (after #3448). Supersedes the
+pre-lake [`corrections-finance-coupling.md`](./corrections-finance-coupling.md)
+(which assumed the `pops-finance-api` predecessor + tRPC namespace renames).
+
+**Purpose:** measure what actually remains for C1 ("finance pillar owns
+`corrections` / `tag-rules` / the `entities↔transactions` join") now that
+`pillars/finance` is a clean REST pillar. C1 is the single gate in front of
+Track A (last FE hybrid) and `02` (monolith + `pops-core-api` + `pops.db` delete).
+
+## TL;DR
+
+C1 is **not** a 4.7k-LOC from-scratch reclaim — finance already owns the
+deterministic foundation. The genuine delta is three buckets:
+
+1. **Corrections ChangeSet + AI cluster** — not yet on finance.
+2. **`entities↔transactions` join** (`transactionCount`/orphaned) — not in finance at all.
+3. **FE cutover** of 13 corrections call-sites (Track A) + the `finance-api` client regen.
+
+**tag-rules is done** — finance REST is complete (deterministic) and the FE is
+already on it (`tagRulesPropose/Apply/Reject`). No tag-rules work remains.
+
+## Corrections — capability matrix (monolith proc → finance status → action)
+
+Monolith `core.corrections.*` = 16 procs, ~3010 non-test LOC. Finance already
+serves 8 deterministic REST routes (`pillars/finance/src/contract/rest-corrections.ts`
+
+- `corrections-handlers.ts`).
+
+| Monolith proc                                                                        | Kind                                                  | Finance REST                                                                                                                                      | Action                                        |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `list`, `get`, `findMatch`, `createOrUpdate`, `update`, `delete`, `adjustConfidence` | CRUD                                                  | ✅ present                                                                                                                                        | none                                          |
+| `previewMatches`                                                                     | match-preview                                         | ✅ present                                                                                                                                        | none                                          |
+| `applyChangeSet`                                                                     | deterministic                                         | ⚠️ engine exists (`api/modules/corrections/service.ts`) but only reachable via `imports.applyChangeSetAndReevaluate`, not a `corrections.*` route | **expose as REST**                            |
+| `previewChangeSet`                                                                   | deterministic                                         | ⚠️ pure engine exists (`pure.ts` `applyChangeSetToRules` + impact helpers) but no route                                                           | **expose as REST**                            |
+| `listMerged`                                                                         | deterministic (folds pending changesets)              | ❌ absent (only plain `list`)                                                                                                                     | **new route OR client-side merge**            |
+| `analyzeCorrection`                                                                  | AI (Haiku)                                            | ❌ absent                                                                                                                                         | **port**                                      |
+| `generateRules`                                                                      | AI (Haiku, batch)                                     | ❌ absent                                                                                                                                         | **port**                                      |
+| `proposeChangeSet`                                                                   | AI-assisted                                           | ❌ absent                                                                                                                                         | **port**                                      |
+| `reviseChangeSet`                                                                    | AI (Haiku)                                            | ❌ absent                                                                                                                                         | **port**                                      |
+| `rejectChangeSet`                                                                    | persists feedback to **core** settings + AI interpret | ❌ absent                                                                                                                                         | **port (+ cross-pillar settings, see below)** |
+
+**LOC to port** (monolith, non-test): AI cluster ~836 (`handlers/ai-inference.ts` 191,
+`ai-revise.ts` 173, `compute-changeset.ts` 107, `changeset-builders.ts` 80, `lib/rule-generator.ts` 128,
+`lib/analyze-correction.ts` 157); ChangeSet preview/diff ~234 (`changeset-impact.ts` 127 + glue);
+much of the pure-engine layer already has a finance twin.
+
+## entities↔transactions join
+
+`core.entities.list` returns `transactionCount` per entity via a `LEFT JOIN
+transactions` (+ `orphanedOnly` HAVING) — `apps/pops-api/src/modules/core/entities/service.ts`
+`fetchEntitiesPage`/`countEntities`, ~58 LOC. The `entities` **table** is core-owned
+(`@pops/shared-schema`); core's REST `entities` contract **correctly omits**
+`transactionCount` (core can't read `finance.transactions`). So the entity-usage
+rollup must live in **finance** (reads `entities` from shared-schema + joins finance
+`transactions`). Finance has **no** entities surface today → new finance REST route + join.
+
+## Consumer cutover (Track A) — 13 corrections call-sites, 8 files, all monolith tRPC
+
+All via `usePillar*('core', ['corrections', …])` → `/trpc/core.corrections.*` on the
+**monolith** (`pops-api:3000`, the nginx `/trpc` catch-all). The `finance-api` FE client
+does **not** export corrections ops yet (`sdk.gen.ts` has zero `/corrections`).
+
+- **Directly cuttable once client regenerated** (finance REST route exists): `list` (×2),
+  `delete`, `createOrUpdate`, `update`, `previewMatches`, `adjustConfidence`.
+- **Blocked on the backend slices above**: `analyzeCorrection`, `previewChangeSet`,
+  `proposeChangeSet`, `reviseChangeSet`, `rejectChangeSet`, `listMerged`.
+- Type-only couplings to the monolith `AppRouter` (`correction-proposal/types.ts`,
+  `tag-rule-dialog/types.ts`, `lib/merged-state.ts`) retarget to the finance contract types.
+
+No other consumers: pops-mcp / pops-cli / moltbot have **zero** references; **no**
+cross-pillar server-SDK caller of `.corrections.*`/`.tagRules.*`.
+
+## Key design decisions (these make C1 real work, not mechanical)
+
+1. **AI cluster ↔ core settings.** The rejection-feedback store (`corrections.changeSetRejections:*`)
+   - AI model config (`finance.ruleGen.*`, `core.corrections.minPatternLength`) live in
+     **core** settings (`getCoreDrizzle` + `settingsService`). Finance can't read `core.db`.
+     Options: (a) reach them via the REST settings SDK `pillar('core').settings.{get,set,getMany}`
+     — **now works because of #3448**; or (b) relocate finance-owned keys into finance settings.
+     Recommendation: (a) for the cross-pillar `core.*` keys; consider moving `finance.ruleGen.*`
+     into finance settings.
+2. **Anthropic key in finance.** The AI procs need `getAnthropicApiKey()` + Haiku
+   (`claude-haiku-4-5-20251001`), skipped in named-env contexts. Finance pillar needs that
+   access wired (mirror the monolith's `getAnthropicApiKey`).
+3. **`listMerged`** — fold pending ChangeSets server-side (new route) vs client-side merge
+   (finance already exposes the pure `applyChangeSetToRules`). Client-side merge is lighter.
+4. **Unify ChangeSet contracts** — corrections (`changeset-types.ts`) and tag-rules
+   (`tag-rules/types.ts`) are structurally-parallel separate copies; optional consolidation.
+
+## Proposed slices
+
+| Slice              | Scope                                                                                                                                                                       | Deps           | Risk         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------ |
+| **C1-a**           | corrections ChangeSet REST (deterministic): expose `previewChangeSet` + `applyChangeSet` + `listMerged` on finance `corrections.*` (engines already in finance)             | —              | low          |
+| **C1-b**           | corrections AI cluster: `analyzeCorrection`, `generateRules`, `proposeChangeSet`, `reviseChangeSet`, `rejectChangeSet` (Haiku + core-settings via REST SDK + Anthropic key) | decision #1/#2 | high         |
+| **C1-c**           | `entities↔transactions` join: finance entity-usage REST (entities + `transactionCount` + orphaned)                                                                          | —              | medium       |
+| **C1-d (Track A)** | regen `finance-api` client w/ corrections ops; cut 13 FE call-sites tRPC→REST; retarget type couplings                                                                      | C1-a/b/c       | medium-large |
+
+C1-a ∥ C1-c (disjoint routes); C1-b is the heavy one; C1-d gated on a/b/c. The monolith
+`modules/core/{corrections,tag-rules,entities}` delete + boot-backfill drop stays in **02**.
+
+## Done when (C1)
+
+- finance REST serves the full corrections surface (CRUD ✅ + ChangeSet + AI) at parity with `core.corrections.*`.
+- finance serves the entity-usage (`transactionCount`/orphaned) rollup.
+- all 13 FE corrections call-sites use the `finance-api` REST client; no `usePillar*('core', ['corrections'…])` remain.
+- `rg "core\.corrections|core\.tagRules" packages/app-finance apps/pops-shell` → type-only or 0.
+- monolith `modules/core/{corrections,tag-rules,entities}` is dead (deleted in `02`).

--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -1217,6 +1217,373 @@
         "tags": ["corrections"]
       }
     },
+    "/corrections/apply-changeset": {
+      "post": {
+        "operationId": "corrections.applyChangeSet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "default": [],
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  }
+                },
+                "required": ["changeSet"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "entityName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "location": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "number"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "timesApplied": {
+                            "type": "number"
+                          },
+                          "transactionType": {
+                            "enum": ["purchase", "transfer", "income"],
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "descriptionPattern",
+                          "matchType",
+                          "entityId",
+                          "entityName",
+                          "location",
+                          "tags",
+                          "transactionType",
+                          "isActive",
+                          "priority",
+                          "confidence",
+                          "timesApplied",
+                          "createdAt",
+                          "lastUsedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Apply a correction-rule ChangeSet atomically; returns the full rule set",
+        "tags": ["corrections"]
+      }
+    },
     "/corrections/find-match": {
       "post": {
         "operationId": "corrections.findMatch",
@@ -1411,6 +1778,1016 @@
           }
         },
         "summary": "Find the winning correction for a description (null when none match)",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/list-merged": {
+      "post": {
+        "operationId": "corrections.listMerged",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 50000,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "pendingChangeSets": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "changeSet": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "ops": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "default": "exact",
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "default": [],
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["descriptionPattern", "matchType", "tags"],
+                                        "type": "object"
+                                      },
+                                      "op": {
+                                        "enum": ["add"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["edit"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["disable"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["remove"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ops"],
+                          "type": "object"
+                        }
+                      },
+                      "required": ["changeSet"],
+                      "type": "object"
+                    },
+                    "maxItems": 200,
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "entityName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "location": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "number"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "timesApplied": {
+                            "type": "number"
+                          },
+                          "transactionType": {
+                            "enum": ["purchase", "transfer", "income"],
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "descriptionPattern",
+                          "matchType",
+                          "entityId",
+                          "entityName",
+                          "location",
+                          "tags",
+                          "transactionType",
+                          "isActive",
+                          "priority",
+                          "confidence",
+                          "timesApplied",
+                          "createdAt",
+                          "lastUsedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "pagination": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "hasMore": {
+                          "type": "boolean"
+                        },
+                        "limit": {
+                          "type": "number"
+                        },
+                        "offset": {
+                          "type": "number"
+                        },
+                        "total": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["total", "limit", "offset", "hasMore"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data", "pagination"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List corrections with pending (un-persisted) ChangeSets folded in (temp: rows included), paginated",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/preview-changeset": {
+      "post": {
+        "operationId": "corrections.previewChangeSet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "default": [],
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "minConfidence": {
+                    "default": 0.7,
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "pendingChangeSets": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "changeSet": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "ops": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "default": "exact",
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "default": [],
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["descriptionPattern", "matchType", "tags"],
+                                        "type": "object"
+                                      },
+                                      "op": {
+                                        "enum": ["add"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "entityName": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "location": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "matchType": {
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "transactionType": {
+                                            "enum": ["purchase", "transfer", "income"],
+                                            "nullable": true,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["edit"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["disable"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["remove"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ops"],
+                          "type": "object"
+                        }
+                      },
+                      "required": ["changeSet"],
+                      "type": "object"
+                    },
+                    "maxItems": 200,
+                    "type": "array"
+                  },
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["description"],
+                      "type": "object"
+                    },
+                    "maxItems": 2000,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": ["changeSet", "transactions", "minConfidence"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "diffs": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "after": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "confidence": {
+                                "nullable": true,
+                                "type": "number"
+                              },
+                              "matched": {
+                                "type": "boolean"
+                              },
+                              "ruleId": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain"],
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": ["matched", "status", "ruleId", "confidence"],
+                            "type": "object"
+                          },
+                          "before": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "confidence": {
+                                "nullable": true,
+                                "type": "number"
+                              },
+                              "matched": {
+                                "type": "boolean"
+                              },
+                              "ruleId": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "status": {
+                                "enum": ["matched", "uncertain"],
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": ["matched", "status", "ruleId", "confidence"],
+                            "type": "object"
+                          },
+                          "changed": {
+                            "type": "boolean"
+                          },
+                          "checksum": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["description", "before", "after", "changed"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "summary": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "netMatchedDelta": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "newMatches": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "removedMatches": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "statusChanges": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "total": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "total",
+                        "newMatches",
+                        "removedMatches",
+                        "statusChanges",
+                        "netMatchedDelta"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["diffs", "summary"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Preview the before/after match impact of a ChangeSet against caller-supplied transactions",
         "tags": ["corrections"]
       }
     },

--- a/pillars/finance/src/api/__tests__/corrections.test.ts
+++ b/pillars/finance/src/api/__tests__/corrections.test.ts
@@ -255,3 +255,229 @@ describe('corrections — request validation', () => {
     ).rejects.toMatchObject({ status: 400 });
   });
 });
+
+describe('corrections — applyChangeSet', () => {
+  it('applies add / edit / disable / remove ops atomically and returns the full rule set', async () => {
+    // Seed two rules to edit/disable later.
+    const seed = await client().corrections.applyChangeSet({
+      changeSet: {
+        ops: [
+          { op: 'add', data: { descriptionPattern: 'KEEP', matchType: 'contains', tags: ['a'] } },
+          { op: 'add', data: { descriptionPattern: 'DROP', matchType: 'exact' } },
+        ],
+      },
+    });
+    expect(seed.message).toBe('ChangeSet applied');
+    expect(seed.data).toHaveLength(2);
+    const keep = seed.data.find((c) => c.descriptionPattern === 'KEEP')!;
+    const drop = seed.data.find((c) => c.descriptionPattern === 'DROP')!;
+
+    const result = await client().corrections.applyChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'NEW', matchType: 'contains', confidence: 0.8 },
+          },
+          { op: 'edit', id: keep.id, data: { tags: ['a', 'b'], entityName: 'Acme' } },
+          { op: 'remove', id: drop.id },
+        ],
+      },
+    });
+
+    const byPattern = new Map(result.data.map((c) => [c.descriptionPattern, c]));
+    expect(byPattern.has('DROP')).toBe(false);
+    expect(byPattern.get('KEEP')).toMatchObject({ tags: ['a', 'b'], entityName: 'Acme' });
+    expect(byPattern.get('NEW')).toMatchObject({ matchType: 'contains', confidence: 0.8 });
+
+    // The persisted state matches what apply returned.
+    const list = await client().corrections.list();
+    expect(list.data.map((c) => c.descriptionPattern).toSorted()).toEqual(['KEEP', 'NEW']);
+  });
+
+  it('disable flips isActive without deleting the row', async () => {
+    const seed = await client().corrections.applyChangeSet({
+      changeSet: { ops: [{ op: 'add', data: { descriptionPattern: 'OFF', matchType: 'exact' } }] },
+    });
+    const id = seed.data[0]!.id;
+    await client().corrections.applyChangeSet({ changeSet: { ops: [{ op: 'disable', id }] } });
+    expect((await client().corrections.get(id)).data.isActive).toBe(false);
+  });
+
+  it('rolls the whole ChangeSet back when an op targets an unknown id (404)', async () => {
+    await expect(
+      client().corrections.applyChangeSet({
+        changeSet: {
+          ops: [
+            { op: 'add', data: { descriptionPattern: 'GHOST', matchType: 'exact' } },
+            { op: 'edit', id: 'does-not-exist', data: { tags: ['x'] } },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({ status: 404 });
+
+    // The add must NOT have landed — the transaction rolled back.
+    expect((await client().corrections.list()).pagination.total).toBe(0);
+  });
+
+  it('400s an empty ops array', async () => {
+    await expect(
+      client().corrections.applyChangeSet({ changeSet: { ops: [] } })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('corrections — previewChangeSet', () => {
+  it('diffs before/after match outcomes and rolls them up into a summary', async () => {
+    // Persisted baseline rule R1 (confidence 0.95 → matches at the 0.7 floor).
+    await client().corrections.applyChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'FOO', matchType: 'contains', confidence: 0.95 },
+          },
+        ],
+      },
+    });
+
+    const preview = await client().corrections.previewChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'BAR', matchType: 'contains', confidence: 0.95 },
+          },
+        ],
+      },
+      transactions: [{ description: 'FOO PURCHASE' }, { description: 'BAR SHOP' }],
+    });
+
+    const foo = preview.diffs.find((d) => d.description === 'FOO PURCHASE')!;
+    const bar = preview.diffs.find((d) => d.description === 'BAR SHOP')!;
+    expect(foo.before.matched).toBe(true);
+    expect(foo.changed).toBe(false); // R1 already matched FOO before and after
+    expect(bar.before.matched).toBe(false);
+    expect(bar.after.matched).toBe(true);
+    expect(bar.changed).toBe(true);
+    expect(preview.summary).toMatchObject({
+      total: 2,
+      newMatches: 1,
+      removedMatches: 0,
+      statusChanges: 0,
+      netMatchedDelta: 1,
+    });
+  });
+
+  it('folds pendingChangeSets into the baseline so `before` reflects un-persisted rules', async () => {
+    // R1 persisted; the preview removes it, but a pending add re-matches BAR.
+    const seed = await client().corrections.applyChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'FOO', matchType: 'contains', confidence: 0.95 },
+          },
+        ],
+      },
+    });
+    const r1 = seed.data[0]!.id;
+
+    const preview = await client().corrections.previewChangeSet({
+      changeSet: { ops: [{ op: 'remove', id: r1 }] },
+      transactions: [{ description: 'FOO PURCHASE' }, { description: 'BAR SHOP' }],
+      pendingChangeSets: [
+        {
+          changeSet: {
+            ops: [
+              {
+                op: 'add',
+                data: { descriptionPattern: 'BAR', matchType: 'contains', confidence: 0.95 },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const foo = preview.diffs.find((d) => d.description === 'FOO PURCHASE')!;
+    const bar = preview.diffs.find((d) => d.description === 'BAR SHOP')!;
+    // baseline (with the pending add) matched both; removing R1 only drops FOO.
+    expect(foo.before.matched).toBe(true);
+    expect(foo.after.matched).toBe(false);
+    expect(bar.before.matched).toBe(true);
+    expect(bar.after.matched).toBe(true);
+    expect(preview.summary).toMatchObject({
+      removedMatches: 1,
+      newMatches: 0,
+      netMatchedDelta: -1,
+    });
+  });
+
+  it('400s a preview with an empty transactions array', async () => {
+    await expect(
+      client().corrections.previewChangeSet({
+        changeSet: { ops: [{ op: 'add', data: { descriptionPattern: 'X', matchType: 'exact' } }] },
+        transactions: [],
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('corrections — listMerged', () => {
+  it('folds pending ChangeSets in, including un-persisted temp: add rows', async () => {
+    await client().corrections.createOrUpdate({
+      descriptionPattern: 'PERSISTED',
+      matchType: 'exact',
+    });
+
+    const merged = await client().corrections.listMerged({
+      pendingChangeSets: [
+        {
+          changeSet: {
+            ops: [{ op: 'add', data: { descriptionPattern: 'PENDING', matchType: 'contains' } }],
+          },
+        },
+      ],
+    });
+
+    expect(merged.pagination.total).toBe(2);
+    const patterns = merged.data.map((c) => c.descriptionPattern).toSorted();
+    expect(patterns).toEqual(['PENDING', 'PERSISTED']);
+    expect(merged.data.some((c) => c.id.startsWith('temp:'))).toBe(true);
+  });
+
+  it('reflects pending edit/disable ops over persisted rows', async () => {
+    const created = await client().corrections.createOrUpdate({
+      descriptionPattern: 'EDITME',
+      matchType: 'exact',
+      tags: ['old'],
+    });
+
+    const merged = await client().corrections.listMerged({
+      pendingChangeSets: [
+        { changeSet: { ops: [{ op: 'edit', id: created.data.id, data: { tags: ['new'] } }] } },
+      ],
+    });
+    expect(merged.data.find((c) => c.id === created.data.id)?.tags).toEqual(['new']);
+
+    // The persisted row is untouched — the fold is in-memory only.
+    expect((await client().corrections.get(created.data.id)).data.tags).toEqual(['old']);
+  });
+
+  it('paginates the merged set', async () => {
+    for (const p of ['A', 'B', 'C']) {
+      await client().corrections.createOrUpdate({ descriptionPattern: p, matchType: 'exact' });
+    }
+    const page = await client().corrections.listMerged({ limit: 2, offset: 0 });
+    expect(page.data).toHaveLength(2);
+    expect(page.pagination).toMatchObject({ total: 3, limit: 2, offset: 0, hasMore: true });
+  });
+
+  it('returns only persisted rows when no pending ChangeSets are supplied', async () => {
+    await client().corrections.createOrUpdate({ descriptionPattern: 'SOLO', matchType: 'exact' });
+    const merged = await client().corrections.listMerged();
+    expect(merged.pagination.total).toBe(1);
+    expect(merged.data[0]?.descriptionPattern).toBe('SOLO');
+  });
+});

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -172,6 +172,30 @@ interface PreviewMatchResult {
   truncated: boolean;
 }
 
+interface CorrectionMatchSummary {
+  matched: boolean;
+  status: 'matched' | 'uncertain' | null;
+  ruleId: string | null;
+  confidence: number | null;
+}
+
+interface ChangeSetPreviewResult {
+  diffs: {
+    checksum?: string;
+    description: string;
+    before: CorrectionMatchSummary;
+    after: CorrectionMatchSummary;
+    changed: boolean;
+  }[];
+  summary: {
+    total: number;
+    newMatches: number;
+    removedMatches: number;
+    statusChanges: number;
+    netMatchedDelta: number;
+  };
+}
+
 export interface CorrectionListQuery {
   minConfidence?: number;
   matchType?: 'exact' | 'contains' | 'regex';
@@ -260,6 +284,16 @@ export function makeClient(app: Express) {
         ),
       previewMatches: (body: Record<string, unknown>) =>
         send<{ data: PreviewMatchResult }>(r.post('/corrections/preview-matches').send(body)),
+      listMerged: (body: Record<string, unknown> = {}) =>
+        send<{ data: Correction[]; pagination: Pagination }>(
+          r.post('/corrections/list-merged').send(body)
+        ),
+      previewChangeSet: (body: Record<string, unknown>) =>
+        send<ChangeSetPreviewResult>(r.post('/corrections/preview-changeset').send(body)),
+      applyChangeSet: (body: Record<string, unknown>) =>
+        send<{ data: Correction[]; message: string }>(
+          r.post('/corrections/apply-changeset').send(body)
+        ),
     },
     imports: {
       processImport: (body: Record<string, unknown>) =>

--- a/pillars/finance/src/api/modules/corrections/index.ts
+++ b/pillars/finance/src/api/modules/corrections/index.ts
@@ -13,6 +13,14 @@ export {
   ruleMatchesDescription,
 } from './pure.js';
 export {
+  previewChangeSetImpact,
+  summarizeMatch,
+  type ChangeSetPreviewDiff,
+  type ChangeSetPreviewSummary,
+  type CorrectionMatchSummary,
+  type PreviewTransaction,
+} from './preview-impact.js';
+export {
   classifyCorrectionMatch,
   parseCorrectionTags,
   HIGH_CONFIDENCE_THRESHOLD,

--- a/pillars/finance/src/api/modules/corrections/preview-impact.ts
+++ b/pillars/finance/src/api/modules/corrections/preview-impact.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure, in-memory ChangeSet preview — the deterministic "what would change"
+ * diff the import wizard renders before a user approves a correction-rule
+ * ChangeSet.
+ *
+ * Ported (per the severance rules) from the monolith
+ * `core/corrections/pure-service.ts` (`summarizeMatch` + `previewChangeSetImpact`).
+ * No DB: the caller supplies the baseline rule set and the transactions to
+ * diff, so the result is reproducible and side-effect-free. Reuses the
+ * pillar's own `findMatchingCorrectionFromRules` / `applyChangeSetToRules`
+ * so a preview matches exactly what apply-time would produce.
+ */
+import { applyChangeSetToRules, findMatchingCorrectionFromRules } from './pure.js';
+
+import type { ChangeSet } from '../../../contract/rest-corrections.js';
+import type { CorrectionMatchResult, CorrectionMatchStatus, CorrectionRow } from './types.js';
+
+/** Per-transaction match outcome, collapsed to the fields a preview compares. */
+export interface CorrectionMatchSummary {
+  matched: boolean;
+  status: CorrectionMatchStatus | null;
+  ruleId: string | null;
+  confidence: number | null;
+}
+
+export interface ChangeSetPreviewDiff {
+  checksum?: string;
+  description: string;
+  before: CorrectionMatchSummary;
+  after: CorrectionMatchSummary;
+  changed: boolean;
+}
+
+export interface ChangeSetPreviewSummary {
+  total: number;
+  newMatches: number;
+  removedMatches: number;
+  statusChanges: number;
+  netMatchedDelta: number;
+}
+
+export interface PreviewTransaction {
+  checksum?: string;
+  description: string;
+}
+
+export function summarizeMatch(match: CorrectionMatchResult | null): CorrectionMatchSummary {
+  if (!match) return { matched: false, status: null, ruleId: null, confidence: null };
+  return {
+    matched: true,
+    status: match.status,
+    ruleId: match.correction.id,
+    confidence: match.correction.confidence,
+  };
+}
+
+/**
+ * Diff the winning correction match for each transaction before vs after a
+ * ChangeSet is (hypothetically) applied to `rules`. `changed` flags any shift
+ * in matched / status / winning rule; the summary rolls those up.
+ */
+export function previewChangeSetImpact(args: {
+  rules: CorrectionRow[];
+  changeSet: ChangeSet;
+  transactions: PreviewTransaction[];
+  minConfidence: number;
+}): { diffs: ChangeSetPreviewDiff[]; summary: ChangeSetPreviewSummary } {
+  const rulesAfter = applyChangeSetToRules(args.rules, args.changeSet);
+
+  const diffs: ChangeSetPreviewDiff[] = args.transactions.map((t) => {
+    const before = summarizeMatch(
+      findMatchingCorrectionFromRules(t.description, args.rules, args.minConfidence)
+    );
+    const after = summarizeMatch(
+      findMatchingCorrectionFromRules(t.description, rulesAfter, args.minConfidence)
+    );
+    const changed =
+      before.matched !== after.matched ||
+      before.status !== after.status ||
+      before.ruleId !== after.ruleId;
+
+    return {
+      ...(t.checksum !== undefined && { checksum: t.checksum }),
+      description: t.description,
+      before,
+      after,
+      changed,
+    };
+  });
+
+  const newMatches = diffs.filter((d) => !d.before.matched && d.after.matched).length;
+  const removedMatches = diffs.filter((d) => d.before.matched && !d.after.matched).length;
+  const statusChanges = diffs.filter(
+    (d) => d.before.matched && d.after.matched && d.before.status !== d.after.status
+  ).length;
+
+  return {
+    diffs,
+    summary: {
+      total: diffs.length,
+      newMatches,
+      removedMatches,
+      statusChanges,
+      netMatchedDelta: newMatches - removedMatches,
+    },
+  };
+}

--- a/pillars/finance/src/api/rest/corrections-handlers-support.ts
+++ b/pillars/finance/src/api/rest/corrections-handlers-support.ts
@@ -1,0 +1,179 @@
+/**
+ * Projection + read helpers shared by the corrections handlers.
+ *
+ * Split out of `corrections-handlers.ts` so the handler factory stays under the
+ * line cap. Pure-ish data shaping over the finance-owned `transaction_corrections`
+ * / `transactions` tables — no HTTP concerns beyond translating the package's
+ * `TransactionCorrectionNotFoundError` to the in-tree `NotFoundError` (→ 404).
+ */
+import { desc } from 'drizzle-orm';
+
+import {
+  type FinanceDb,
+  type TransactionCorrectionMatchType,
+  type TransactionCorrectionRow,
+  type TransactionRow,
+  TransactionCorrectionNotFoundError,
+  transactionCorrectionsService,
+  transactions,
+} from '../../db/index.js';
+import {
+  applyChangeSetToRules,
+  parseCorrectionTags,
+  type CorrectionRow,
+} from '../modules/corrections/index.js';
+import { NotFoundError } from '../shared/errors.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { ChangeSet } from '../../contract/rest-corrections.js';
+import type { financeCorrectionsContract } from '../../contract/rest-corrections.js';
+
+type Req = ServerInferRequest<typeof financeCorrectionsContract>;
+
+export const DEFAULT_LIMIT = 50;
+export const DEFAULT_OFFSET = 0;
+const PREVIEW_DEFAULT_LIMIT = 25;
+const PREVIEW_HARD_LIMIT = 200;
+const ALL_RULES_LIMIT = 50_000;
+
+export interface Correction {
+  id: string;
+  descriptionPattern: string;
+  matchType: TransactionCorrectionMatchType;
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  tags: string[];
+  transactionType: 'purchase' | 'transfer' | 'income' | null;
+  isActive: boolean;
+  priority: number;
+  confidence: number;
+  timesApplied: number;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export function toCorrection(row: TransactionCorrectionRow): Correction {
+  return {
+    id: row.id,
+    descriptionPattern: row.descriptionPattern,
+    matchType: row.matchType,
+    entityId: row.entityId,
+    entityName: row.entityName,
+    location: row.location,
+    tags: parseCorrectionTags(row.tags),
+    transactionType: row.transactionType,
+    isActive: Boolean(row.isActive),
+    priority: row.priority,
+    confidence: row.confidence,
+    timesApplied: row.timesApplied,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+  };
+}
+
+/**
+ * Verify a candidate `(pattern, matchType)` matches a description after
+ * normalisation. Mirrors the monolith `patternMatchesDescription` so a preview
+ * matches exactly what the rule would match at apply time (both pattern and
+ * description are normalised for `exact`/`contains`; `regex` runs against the
+ * normalised description with the raw pattern).
+ */
+function patternMatchesDescription(
+  pattern: string,
+  matchType: TransactionCorrectionMatchType,
+  description: string
+): boolean {
+  const { normalizeDescription } = transactionCorrectionsService;
+  const normalizedDescription = normalizeDescription(description);
+  const normalizedPattern = matchType === 'regex' ? pattern : normalizeDescription(pattern);
+  if (normalizedPattern.length === 0) return false;
+  if (matchType === 'exact') return normalizedPattern === normalizedDescription;
+  if (matchType === 'contains') return normalizedDescription.includes(normalizedPattern);
+  try {
+    return new RegExp(normalizedPattern).test(normalizedDescription);
+  } catch {
+    return false;
+  }
+}
+
+export interface PreviewMatchTransactionView {
+  id: string;
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  tags: string[];
+}
+
+export interface PreviewMatchesResult {
+  matches: PreviewMatchTransactionView[];
+  total: number;
+  scanned: number;
+  truncated: boolean;
+}
+
+function previewMatchTransaction(row: TransactionRow): PreviewMatchTransactionView {
+  return {
+    id: row.id,
+    description: row.description,
+    account: row.account,
+    amount: row.amount,
+    date: row.date,
+    entityName: row.entityName,
+    tags: parseCorrectionTags(row.tags ?? '[]'),
+  };
+}
+
+export function previewMatches(
+  db: FinanceDb,
+  input: Req['previewMatches']['body']
+): PreviewMatchesResult {
+  const limit = Math.min(input.limit ?? PREVIEW_DEFAULT_LIMIT, PREVIEW_HARD_LIMIT);
+  const rows = db.select().from(transactions).orderBy(desc(transactions.date)).all();
+
+  const matched = rows.filter((row) =>
+    patternMatchesDescription(input.descriptionPattern, input.matchType, row.description)
+  );
+
+  const truncated = matched.length > limit;
+  const sliced = truncated ? matched.slice(0, limit) : matched;
+
+  return {
+    matches: sliced.map(previewMatchTransaction),
+    total: matched.length,
+    scanned: rows.length,
+    truncated,
+  };
+}
+
+/**
+ * All persisted rules with any pending (un-persisted) ChangeSets folded in,
+ * in the service's stable order with `temp:` adds appended. Shared by
+ * `listMerged` and the `previewChangeSet` baseline so both see the same
+ * pending state. A pending op targeting an unknown id throws `NotFoundError`
+ * (→ 404 via `runHttp`).
+ */
+export function mergedRules(
+  db: FinanceDb,
+  pendingChangeSets?: { changeSet: ChangeSet }[]
+): CorrectionRow[] {
+  const { rows } = transactionCorrectionsService.listTransactionCorrections(db, {
+    limit: ALL_RULES_LIMIT,
+    offset: 0,
+  });
+  if (!pendingChangeSets || pendingChangeSets.length === 0) return rows;
+  return pendingChangeSets.reduce<CorrectionRow[]>(
+    (acc, pcs) => applyChangeSetToRules(acc, pcs.changeSet),
+    rows
+  );
+}
+
+export function translateCorrectionError(err: unknown, id?: string): never {
+  if (err instanceof TransactionCorrectionNotFoundError) {
+    throw new NotFoundError('Correction', id ?? err.id);
+  }
+  throw err;
+}

--- a/pillars/finance/src/api/rest/corrections-handlers.ts
+++ b/pillars/finance/src/api/rest/corrections-handlers.ts
@@ -1,31 +1,28 @@
 /**
- * Handlers for the `corrections.*` sub-router — deterministic CRUD over the
- * finance-owned `transaction_corrections` table.
+ * Handlers for the `corrections.*` sub-router — deterministic CRUD plus the
+ * ChangeSet preview/apply/merged-list surface over the finance-owned
+ * `transaction_corrections` table.
  *
- * Wraps `transactionCorrectionsService` (the finance-db data layer) in
- * `runHttp` so a `TransactionCorrectionNotFoundError` (missing id on get /
- * update / delete / adjustConfidence) maps to 404 via the shared `HttpError`
- * path. `findMatch` and `previewMatches` are read-only computations against
- * the corrections / transactions tables.
- *
- * The ChangeSet propose/preview/apply machinery and the AI procedures from the
- * monolith `core.corrections.*` router are intentionally NOT served here — see
- * `contract/rest-corrections.ts` for why.
+ * Read/projection helpers live in `corrections-handlers-support.ts`; the AI
+ * propose/revise/reject + rule-generator procedures from the monolith
+ * `core.corrections.*` router are intentionally NOT served here yet — see
+ * `contract/rest-corrections.ts`.
  */
-import { desc } from 'drizzle-orm';
-
+import { type FinanceDb, transactionCorrectionsService } from '../../db/index.js';
 import {
-  type FinanceDb,
-  type TransactionCorrectionMatchType,
-  type TransactionCorrectionRow,
-  type TransactionRow,
-  TransactionCorrectionNotFoundError,
-  transactionCorrectionsService,
-  transactions,
-} from '../../db/index.js';
-import { classifyCorrectionMatch, parseCorrectionTags } from '../modules/corrections/index.js';
-import { NotFoundError } from '../shared/errors.js';
+  applyChangeSet as applyCorrectionChangeSet,
+  classifyCorrectionMatch,
+  previewChangeSetImpact,
+} from '../modules/corrections/index.js';
 import { paginationMeta } from '../shared/pagination.js';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_OFFSET,
+  mergedRules,
+  previewMatches,
+  toCorrection,
+  translateCorrectionError,
+} from './corrections-handlers-support.js';
 import { runHttp } from './error-mapping.js';
 
 import type { ServerInferRequest } from '@ts-rest/core';
@@ -33,110 +30,6 @@ import type { ServerInferRequest } from '@ts-rest/core';
 import type { financeCorrectionsContract } from '../../contract/rest-corrections.js';
 
 type Req = ServerInferRequest<typeof financeCorrectionsContract>;
-
-const DEFAULT_LIMIT = 50;
-const DEFAULT_OFFSET = 0;
-const PREVIEW_DEFAULT_LIMIT = 25;
-const PREVIEW_HARD_LIMIT = 200;
-
-interface Correction {
-  id: string;
-  descriptionPattern: string;
-  matchType: TransactionCorrectionMatchType;
-  entityId: string | null;
-  entityName: string | null;
-  location: string | null;
-  tags: string[];
-  transactionType: 'purchase' | 'transfer' | 'income' | null;
-  isActive: boolean;
-  priority: number;
-  confidence: number;
-  timesApplied: number;
-  createdAt: string;
-  lastUsedAt: string | null;
-}
-
-function toCorrection(row: TransactionCorrectionRow): Correction {
-  return {
-    id: row.id,
-    descriptionPattern: row.descriptionPattern,
-    matchType: row.matchType,
-    entityId: row.entityId,
-    entityName: row.entityName,
-    location: row.location,
-    tags: parseCorrectionTags(row.tags),
-    transactionType: row.transactionType,
-    isActive: Boolean(row.isActive),
-    priority: row.priority,
-    confidence: row.confidence,
-    timesApplied: row.timesApplied,
-    createdAt: row.createdAt,
-    lastUsedAt: row.lastUsedAt,
-  };
-}
-
-/**
- * Verify a candidate `(pattern, matchType)` matches a description after
- * normalisation. Mirrors the monolith `patternMatchesDescription` so a preview
- * matches exactly what the rule would match at apply time (both pattern and
- * description are normalised for `exact`/`contains`; `regex` runs against the
- * normalised description with the raw pattern).
- */
-function patternMatchesDescription(
-  pattern: string,
-  matchType: TransactionCorrectionMatchType,
-  description: string
-): boolean {
-  const { normalizeDescription } = transactionCorrectionsService;
-  const normalizedDescription = normalizeDescription(description);
-  const normalizedPattern = matchType === 'regex' ? pattern : normalizeDescription(pattern);
-  if (normalizedPattern.length === 0) return false;
-  if (matchType === 'exact') return normalizedPattern === normalizedDescription;
-  if (matchType === 'contains') return normalizedDescription.includes(normalizedPattern);
-  try {
-    return new RegExp(normalizedPattern).test(normalizedDescription);
-  } catch {
-    return false;
-  }
-}
-
-function previewMatchTransaction(row: TransactionRow) {
-  return {
-    id: row.id,
-    description: row.description,
-    account: row.account,
-    amount: row.amount,
-    date: row.date,
-    entityName: row.entityName,
-    tags: parseCorrectionTags(row.tags ?? '[]'),
-  };
-}
-
-function previewMatches(db: FinanceDb, input: Req['previewMatches']['body']) {
-  const limit = Math.min(input.limit ?? PREVIEW_DEFAULT_LIMIT, PREVIEW_HARD_LIMIT);
-  const rows = db.select().from(transactions).orderBy(desc(transactions.date)).all();
-
-  const matched = rows.filter((row) =>
-    patternMatchesDescription(input.descriptionPattern, input.matchType, row.description)
-  );
-
-  const truncated = matched.length > limit;
-  const sliced = truncated ? matched.slice(0, limit) : matched;
-
-  return {
-    matches: sliced.map(previewMatchTransaction),
-    total: matched.length,
-    scanned: rows.length,
-    truncated,
-  };
-}
-
-function translateCorrectionError(err: unknown, id?: string): never {
-  if (err instanceof TransactionCorrectionNotFoundError) {
-    throw new NotFoundError('Correction', id ?? err.id);
-  }
-  throw err;
-}
 
 export function makeCorrectionsHandlers(db: FinanceDb) {
   return {
@@ -180,10 +73,7 @@ export function makeCorrectionsHandlers(db: FinanceDb) {
       }),
 
     previewMatches: ({ body }: Req['previewMatches']) =>
-      runHttp(() => ({
-        status: 200 as const,
-        body: { data: previewMatches(db, body) },
-      })),
+      runHttp(() => ({ status: 200 as const, body: { data: previewMatches(db, body) } })),
 
     createOrUpdate: ({ body }: Req['createOrUpdate']) =>
       runHttp(() => {
@@ -234,5 +124,40 @@ export function makeCorrectionsHandlers(db: FinanceDb) {
           translateCorrectionError(err, params.id);
         }
       }),
+
+    listMerged: ({ body }: Req['listMerged']) =>
+      runHttp(() => {
+        const limit = body.limit ?? DEFAULT_LIMIT;
+        const offset = body.offset ?? DEFAULT_OFFSET;
+        const merged = mergedRules(db, body.pendingChangeSets);
+        const page = merged.slice(offset, offset + limit);
+        return {
+          status: 200 as const,
+          body: {
+            data: page.map(toCorrection),
+            pagination: paginationMeta(merged.length, limit, offset),
+          },
+        };
+      }),
+
+    previewChangeSet: ({ body }: Req['previewChangeSet']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: previewChangeSetImpact({
+          rules: mergedRules(db, body.pendingChangeSets),
+          changeSet: body.changeSet,
+          transactions: body.transactions,
+          minConfidence: body.minConfidence,
+        }),
+      })),
+
+    applyChangeSet: ({ body }: Req['applyChangeSet']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: {
+          data: applyCorrectionChangeSet(db, body.changeSet).map(toCorrection),
+          message: 'ChangeSet applied',
+        },
+      })),
   };
 }

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -58,6 +58,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/corrections/apply-changeset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Apply a correction-rule ChangeSet atomically; returns the full rule set */
+    post: operations['corrections.applyChangeSet'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/corrections/find-match': {
     parameters: {
       query?: never;
@@ -69,6 +86,40 @@ export interface paths {
     put?: never;
     /** Find the winning correction for a description (null when none match) */
     post: operations['corrections.findMatch'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/list-merged': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List corrections with pending (un-persisted) ChangeSets folded in (temp: rows included), paginated */
+    post: operations['corrections.listMerged'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/preview-changeset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Preview the before/after match impact of a ChangeSet against caller-supplied transactions */
+    post: operations['corrections.previewChangeSet'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1047,6 +1098,148 @@ export interface operations {
       };
     };
   };
+  'corrections.applyChangeSet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              confidence: number;
+              createdAt: string;
+              descriptionPattern: string;
+              entityId: string | null;
+              entityName: string | null;
+              id: string;
+              isActive: boolean;
+              lastUsedAt: string | null;
+              location: string | null;
+              /** @enum {string} */
+              matchType: 'exact' | 'contains' | 'regex';
+              priority: number;
+              tags: string[];
+              timesApplied: number;
+              /** @enum {string|null} */
+              transactionType: 'purchase' | 'transfer' | 'income' | null;
+            }[];
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'corrections.findMatch': {
     parameters: {
       query?: never;
@@ -1092,6 +1285,371 @@ export interface operations {
             } | null;
             /** @enum {string|null} */
             status: 'matched' | 'uncertain' | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.listMerged': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          limit?: number;
+          offset?: number;
+          pendingChangeSets?: {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      /** @default [] */
+                      tags: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern?: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /** @enum {string} */
+                      matchType?: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags?: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              confidence: number;
+              createdAt: string;
+              descriptionPattern: string;
+              entityId: string | null;
+              entityName: string | null;
+              id: string;
+              isActive: boolean;
+              lastUsedAt: string | null;
+              location: string | null;
+              /** @enum {string} */
+              matchType: 'exact' | 'contains' | 'regex';
+              priority: number;
+              tags: string[];
+              timesApplied: number;
+              /** @enum {string|null} */
+              transactionType: 'purchase' | 'transfer' | 'income' | null;
+            }[];
+            pagination: {
+              hasMore: boolean;
+              limit: number;
+              offset: number;
+              total: number;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.previewChangeSet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          /** @default 0.7 */
+          minConfidence: number;
+          pendingChangeSets?: {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      /** @default [] */
+                      tags: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern?: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /** @enum {string} */
+                      matchType?: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags?: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+          }[];
+          transactions: {
+            checksum?: string;
+            description: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            diffs: {
+              after: {
+                confidence: number | null;
+                matched: boolean;
+                ruleId: string | null;
+                /** @enum {string|null} */
+                status: 'matched' | 'uncertain' | null;
+              };
+              before: {
+                confidence: number | null;
+                matched: boolean;
+                ruleId: string | null;
+                /** @enum {string|null} */
+                status: 'matched' | 'uncertain' | null;
+              };
+              changed: boolean;
+              checksum?: string;
+              description: string;
+            }[];
+            summary: {
+              netMatchedDelta: number;
+              newMatches: number;
+              removedMatches: number;
+              statusChanges: number;
+              total: number;
+            };
           };
         };
       };

--- a/pillars/finance/src/contract/rest-corrections-schemas.ts
+++ b/pillars/finance/src/contract/rest-corrections-schemas.ts
@@ -1,0 +1,171 @@
+/**
+ * Zod schemas for the `corrections.*` REST contract — split out of
+ * `rest-corrections.ts` so the contract router stays under the line cap.
+ *
+ * The ChangeSet schemas also feed the in-pillar imports pipeline
+ * (`api/modules/corrections`), so they are re-exported from `rest-corrections.ts`
+ * to keep that import path stable.
+ */
+import { z } from 'zod';
+
+import { LimitQuery, OffsetQuery } from './rest-schemas.js';
+
+export const MatchTypeSchema = z.enum(['exact', 'contains', 'regex']);
+export const TransactionTypeSchema = z.enum(['purchase', 'transfer', 'income']);
+
+/** Body of a correction `add` op (create-shape + ChangeSet-only confidence/isActive). */
+export const CreateCorrectionSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema.default('exact'),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional().default([]),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+/** Body of a correction `edit` op (all fields optional patch). */
+export const UpdateCorrectionSchema = z.object({
+  descriptionPattern: z.string().min(1).optional(),
+  matchType: MatchTypeSchema.optional(),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+  isActive: z.boolean().optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+const CorrectionRuleDataSchema = CreateCorrectionSchema.extend({
+  confidence: z.number().min(0).max(1).optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const ChangeSetOpSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('add'), data: CorrectionRuleDataSchema }),
+  z.object({ op: z.literal('edit'), id: z.string().min(1), data: UpdateCorrectionSchema }),
+  z.object({ op: z.literal('disable'), id: z.string().min(1) }),
+  z.object({ op: z.literal('remove'), id: z.string().min(1) }),
+]);
+
+export const ChangeSetSchema = z.object({
+  source: z.string().optional(),
+  reason: z.string().optional(),
+  ops: z.array(ChangeSetOpSchema).min(1),
+});
+
+export type ChangeSetOp = z.infer<typeof ChangeSetOpSchema>;
+export type ChangeSet = z.infer<typeof ChangeSetSchema>;
+
+/**
+ * Persisted correction row as served by the handlers (`toCorrection`): `tags`
+ * is parsed to a `string[]` (the column stores JSON), `isActive` is a real
+ * boolean. Mirrors the monolith `Correction` projection.
+ */
+export const CorrectionSchema = z.object({
+  id: z.string(),
+  descriptionPattern: z.string(),
+  matchType: MatchTypeSchema,
+  entityId: z.string().nullable(),
+  entityName: z.string().nullable(),
+  location: z.string().nullable(),
+  tags: z.array(z.string()),
+  transactionType: TransactionTypeSchema.nullable(),
+  isActive: z.boolean(),
+  priority: z.number(),
+  confidence: z.number(),
+  timesApplied: z.number(),
+  createdAt: z.string(),
+  lastUsedAt: z.string().nullable(),
+});
+
+export const CorrectionMutation = z.object({ data: CorrectionSchema, message: z.string() });
+
+export const CorrectionListQuery = z.object({
+  minConfidence: z.coerce.number().min(0).max(1).optional(),
+  matchType: MatchTypeSchema.optional(),
+  limit: LimitQuery,
+  offset: OffsetQuery,
+});
+
+export const FindMatchBody = z.object({
+  description: z.string().min(1),
+  minConfidence: z.number().min(0).max(1).default(0.7),
+});
+
+export const FindMatchResult = z.object({
+  data: CorrectionSchema.nullable(),
+  status: z.enum(['matched', 'uncertain']).nullable(),
+});
+
+export const PreviewMatchesBody = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema,
+  limit: z.number().int().positive().max(200).optional(),
+});
+
+/** A transaction row a candidate rule would match, with `tags` parsed to a `string[]`. */
+const PreviewMatchTransactionSchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  account: z.string(),
+  amount: z.number(),
+  date: z.string(),
+  entityName: z.string().nullable(),
+  tags: z.array(z.string()),
+});
+
+export const PreviewMatchResultSchema = z.object({
+  matches: z.array(PreviewMatchTransactionSchema),
+  total: z.number(),
+  scanned: z.number(),
+  truncated: z.boolean(),
+});
+
+/** A pending (un-persisted) ChangeSet folded into the baseline before a preview / merged list. */
+const PendingChangeSetSchema = z.object({ changeSet: ChangeSetSchema });
+
+/** A caller-supplied transaction to diff in a ChangeSet preview (description + optional dedupe checksum). */
+const PreviewChangeSetTransactionSchema = z.object({
+  checksum: z.string().optional(),
+  description: z.string().min(1),
+});
+
+export const PreviewChangeSetBody = z.object({
+  changeSet: ChangeSetSchema,
+  transactions: z.array(PreviewChangeSetTransactionSchema).min(1).max(2000),
+  minConfidence: z.number().min(0).max(1).default(0.7),
+  pendingChangeSets: z.array(PendingChangeSetSchema).max(200).optional(),
+});
+
+const CorrectionMatchSummarySchema = z.object({
+  matched: z.boolean(),
+  status: z.enum(['matched', 'uncertain']).nullable(),
+  ruleId: z.string().nullable(),
+  confidence: z.number().nullable(),
+});
+
+export const ChangeSetPreviewDiffSchema = z.object({
+  checksum: z.string().optional(),
+  description: z.string(),
+  before: CorrectionMatchSummarySchema,
+  after: CorrectionMatchSummarySchema,
+  changed: z.boolean(),
+});
+
+export const ChangeSetPreviewSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  newMatches: z.number().int().nonnegative(),
+  removedMatches: z.number().int().nonnegative(),
+  statusChanges: z.number().int().nonnegative(),
+  netMatchedDelta: z.number().int(),
+});
+
+export const ListMergedBody = z.object({
+  pendingChangeSets: z.array(PendingChangeSetSchema).max(200).optional(),
+  limit: z.number().int().positive().max(50000).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});

--- a/pillars/finance/src/contract/rest-corrections.ts
+++ b/pillars/finance/src/contract/rest-corrections.ts
@@ -1,151 +1,51 @@
 /**
  * `corrections.*` sub-router — the learned transaction-correction rule surface.
  *
- * This domain is finance-owned (the `transaction_corrections` table lives in
- * the finance db) but is served today from the monolith's `core.corrections.*`
- * tRPC router. The REST shape here is the migration target; only the
- * deterministic CRUD procedures that map directly to
- * `transactionCorrectionsService` are modelled.
- *
- * Deferred (kept in the monolith for now): the ChangeSet propose/preview/
- * apply/revise/reject machinery and the four AI procedures
- * (analyzeCorrection / generateRules / proposal AIs). Those pull in the
- * Anthropic SDK, the changeset-impact engine, and a cross-pillar core.db
- * settings write gated on the C4 REST transport — out of scope for this slice.
- * The ChangeSet zod schemas this file still exports feed the in-pillar
- * imports pipeline (`api/modules/corrections`), not a REST route.
+ * Finance-owned (the `transaction_corrections` table lives in the finance db).
+ * Serves the deterministic CRUD + the ChangeSet preview/apply/merged-list
+ * surface. Deferred (kept in the monolith for now): the AI procedures
+ * (analyzeCorrection / generateRules / propose / revise / reject) — they pull
+ * in the Anthropic SDK and a cross-pillar core.db settings write.
  *
  * tRPC `query` procedures that carry a request body (`findMatch`,
- * `previewMatches`) become `POST` here — a GET cannot carry the body, and a
- * static path also keeps them clear of the `/corrections/:id` param route.
+ * `previewMatches`, `listMerged`, `previewChangeSet`) become `POST` here — a GET
+ * cannot carry the body, and static paths keep them clear of `/corrections/:id`.
+ *
+ * Schemas live in `rest-corrections-schemas.ts`; the ChangeSet schemas are
+ * re-exported here because the in-pillar imports pipeline imports them from
+ * this path.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
 import {
-  ERR_RESPONSES,
-  LimitQuery,
-  MessageSchema,
-  OffsetQuery,
-  PaginationMetaSchema,
-} from './rest-schemas.js';
+  ChangeSetPreviewDiffSchema,
+  ChangeSetPreviewSummarySchema,
+  ChangeSetSchema,
+  CorrectionListQuery,
+  CorrectionMutation,
+  CorrectionSchema,
+  CreateCorrectionSchema,
+  FindMatchBody,
+  FindMatchResult,
+  ListMergedBody,
+  PreviewChangeSetBody,
+  PreviewMatchesBody,
+  PreviewMatchResultSchema,
+  UpdateCorrectionSchema,
+} from './rest-corrections-schemas.js';
+import { ERR_RESPONSES, MessageSchema, PaginationMetaSchema } from './rest-schemas.js';
+
+export {
+  ChangeSetOpSchema,
+  ChangeSetSchema,
+  CreateCorrectionSchema,
+  UpdateCorrectionSchema,
+  type ChangeSet,
+  type ChangeSetOp,
+} from './rest-corrections-schemas.js';
 
 const c = initContract();
-
-const MatchTypeSchema = z.enum(['exact', 'contains', 'regex']);
-const TransactionTypeSchema = z.enum(['purchase', 'transfer', 'income']);
-
-/** Body of a correction `add` op (create-shape + ChangeSet-only confidence/isActive). */
-export const CreateCorrectionSchema = z.object({
-  descriptionPattern: z.string().min(1),
-  matchType: MatchTypeSchema.default('exact'),
-  entityId: z.string().nullable().optional(),
-  entityName: z.string().nullable().optional(),
-  location: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional().default([]),
-  transactionType: TransactionTypeSchema.nullable().optional(),
-  priority: z.number().int().nonnegative().optional(),
-});
-
-/** Body of a correction `edit` op (all fields optional patch). */
-export const UpdateCorrectionSchema = z.object({
-  descriptionPattern: z.string().min(1).optional(),
-  matchType: MatchTypeSchema.optional(),
-  entityId: z.string().nullable().optional(),
-  entityName: z.string().nullable().optional(),
-  location: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional(),
-  transactionType: TransactionTypeSchema.nullable().optional(),
-  isActive: z.boolean().optional(),
-  confidence: z.number().min(0).max(1).optional(),
-  priority: z.number().int().nonnegative().optional(),
-});
-
-const CorrectionRuleDataSchema = CreateCorrectionSchema.extend({
-  confidence: z.number().min(0).max(1).optional(),
-  isActive: z.boolean().optional(),
-});
-
-export const ChangeSetOpSchema = z.discriminatedUnion('op', [
-  z.object({ op: z.literal('add'), data: CorrectionRuleDataSchema }),
-  z.object({ op: z.literal('edit'), id: z.string().min(1), data: UpdateCorrectionSchema }),
-  z.object({ op: z.literal('disable'), id: z.string().min(1) }),
-  z.object({ op: z.literal('remove'), id: z.string().min(1) }),
-]);
-
-export const ChangeSetSchema = z.object({
-  source: z.string().optional(),
-  reason: z.string().optional(),
-  ops: z.array(ChangeSetOpSchema).min(1),
-});
-
-export type ChangeSetOp = z.infer<typeof ChangeSetOpSchema>;
-export type ChangeSet = z.infer<typeof ChangeSetSchema>;
-
-/**
- * Persisted correction row as served by the handlers (`toCorrection`): `tags`
- * is parsed to a `string[]` (the column stores JSON), `isActive` is a real
- * boolean. Mirrors the monolith `Correction` projection.
- */
-export const CorrectionSchema = z.object({
-  id: z.string(),
-  descriptionPattern: z.string(),
-  matchType: MatchTypeSchema,
-  entityId: z.string().nullable(),
-  entityName: z.string().nullable(),
-  location: z.string().nullable(),
-  tags: z.array(z.string()),
-  transactionType: TransactionTypeSchema.nullable(),
-  isActive: z.boolean(),
-  priority: z.number(),
-  confidence: z.number(),
-  timesApplied: z.number(),
-  createdAt: z.string(),
-  lastUsedAt: z.string().nullable(),
-});
-
-const CorrectionMutation = z.object({ data: CorrectionSchema, message: z.string() });
-
-const CorrectionListQuery = z.object({
-  minConfidence: z.coerce.number().min(0).max(1).optional(),
-  matchType: MatchTypeSchema.optional(),
-  limit: LimitQuery,
-  offset: OffsetQuery,
-});
-
-const FindMatchBody = z.object({
-  description: z.string().min(1),
-  minConfidence: z.number().min(0).max(1).default(0.7),
-});
-
-const FindMatchResult = z.object({
-  data: CorrectionSchema.nullable(),
-  status: z.enum(['matched', 'uncertain']).nullable(),
-});
-
-const PreviewMatchesBody = z.object({
-  descriptionPattern: z.string().min(1),
-  matchType: MatchTypeSchema,
-  limit: z.number().int().positive().max(200).optional(),
-});
-
-/** A transaction row a candidate rule would match, with `tags` parsed to a `string[]`. */
-const PreviewMatchTransactionSchema = z.object({
-  id: z.string(),
-  description: z.string(),
-  account: z.string(),
-  amount: z.number(),
-  date: z.string(),
-  entityName: z.string().nullable(),
-  tags: z.array(z.string()),
-});
-
-const PreviewMatchResultSchema = z.object({
-  matches: z.array(PreviewMatchTransactionSchema),
-  total: z.number(),
-  scanned: z.number(),
-  truncated: z.boolean(),
-});
 
 export const financeCorrectionsContract = c.router({
   list: {
@@ -209,5 +109,40 @@ export const financeCorrectionsContract = c.router({
     body: z.object({ delta: z.number().min(-1).max(1) }),
     responses: { 200: MessageSchema, ...ERR_RESPONSES },
     summary: 'Nudge a correction confidence by delta (deletes the row when it drops below 0.3)',
+  },
+  listMerged: {
+    method: 'POST',
+    path: '/corrections/list-merged',
+    body: ListMergedBody,
+    responses: {
+      200: z.object({ data: z.array(CorrectionSchema), pagination: PaginationMetaSchema }),
+      ...ERR_RESPONSES,
+    },
+    summary:
+      'List corrections with pending (un-persisted) ChangeSets folded in (temp: rows included), paginated',
+  },
+  previewChangeSet: {
+    method: 'POST',
+    path: '/corrections/preview-changeset',
+    body: PreviewChangeSetBody,
+    responses: {
+      200: z.object({
+        diffs: z.array(ChangeSetPreviewDiffSchema),
+        summary: ChangeSetPreviewSummarySchema,
+      }),
+      ...ERR_RESPONSES,
+    },
+    summary:
+      'Preview the before/after match impact of a ChangeSet against caller-supplied transactions',
+  },
+  applyChangeSet: {
+    method: 'POST',
+    path: '/corrections/apply-changeset',
+    body: z.object({ changeSet: ChangeSetSchema }),
+    responses: {
+      200: z.object({ data: z.array(CorrectionSchema), message: z.string() }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Apply a correction-rule ChangeSet atomically; returns the full rule set',
   },
 });


### PR DESCRIPTION
## Summary

First slice of **C1** (finance reclaim / epic 08a). Exposes the **deterministic** corrections ChangeSet surface on the finance pillar's REST API at parity with the monolith `core.corrections.*`, so the import-wizard FE can later cut over (Track A) and the monolith copy becomes a clean `02` delete.

Scoped per the audit note added here (`docs/themes/13-pillar-finale/notes/c1-finance-reclaim-delta-2026-06-18.md`).

## Routes added to `financeCorrectionsContract`

- `POST /corrections/preview-changeset` → `{ diffs, summary }` — pure before/after impact diff over caller-supplied transactions, folding `pendingChangeSets` into the baseline. Ports `previewChangeSetImpact` + match summary; reuses the in-pillar matchers.
- `POST /corrections/apply-changeset` → `{ data: Correction[], message }` — wires the existing atomic `applyChangeSet(db, changeSet)` engine; unknown edit/disable/remove id → 404 rollback.
- `POST /corrections/list-merged` → `{ data, pagination }` — folds pending ChangeSets via `applyChangeSetToRules` (incl. `temp:` add rows), paginated.

## Out of scope (tracked)

- **C1-b** — the AI cluster (`analyzeCorrection`/`generateRules`/`proposeChangeSet`/`reviseChangeSet`/`rejectChangeSet`).
- **C1-c** — the `entities↔transactions` join (`transactionCount`/orphaned).
- **C1-d (Track A)** — the FE cutover of the 13 corrections call-sites.

## Verification

`@pops/finance`: typecheck ✓, **321 tests** ✓, `generate:openapi`+`generate:api-types` idempotent (`git diff --exit-code` clean) ✓, oxfmt/oxlint clean ✓. No `as any`/suppressions. Nothing touched outside `pillars/finance` (+ the audit note).

Pre-existing red-by-design checks (monolith typecheck, Affected/Semver core-db→shared-schema, Validate Docker `app-lists-db`, Duplication, E2E) are unrelated to this PR — same set merged on #3444–#3448.