### PR TITLE
feat(finance): entities↔transactions usage rollup over REST (C1-c)

### DIFF
--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -3620,6 +3620,221 @@
         "tags": ["corrections"]
       }
     },
+    "/entity-usage": {
+      "get": {
+        "operationId": "entityUsage.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "enum": ["company", "person", "government", "bank", "place", "brand", "organisation"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "orphanedOnly",
+            "schema": {
+              "enum": ["true", "false"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "abn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "aliases": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "defaultTags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "defaultTransactionType": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "lastEditedTime": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "transactionCount": {
+                            "type": "number"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "type",
+                          "abn",
+                          "aliases",
+                          "defaultTransactionType",
+                          "defaultTags",
+                          "notes",
+                          "lastEditedTime",
+                          "transactionCount"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "pagination": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "hasMore": {
+                          "type": "boolean"
+                        },
+                        "limit": {
+                          "type": "number"
+                        },
+                        "offset": {
+                          "type": "number"
+                        },
+                        "total": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["total", "limit", "offset", "hasMore"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data", "pagination"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List entities with per-entity transactionCount; orphanedOnly=true returns count===0",
+        "tags": ["entityUsage"]
+      }
+    },
     "/imports/apply-changeset-reevaluate": {
       "post": {
         "operationId": "imports.applyChangeSetAndReevaluate",

--- a/pillars/finance/src/api/__tests__/entity-usage.test.ts
+++ b/pillars/finance/src/api/__tests__/entity-usage.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration tests for the `entityUsage.*` REST surface — entities LEFT JOINed
+ * to finance `transactions` for a per-entity `transactionCount`, with the
+ * orphaned / search / type filters, pagination, and the aliases/defaultTags
+ * projection. Mirrors the monolith `core.entities.list` semantics.
+ *
+ * Entities + transactions are seeded directly through the finance-db handle so
+ * the join runs against real rows.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  entities,
+  openFinanceDb,
+  transactionsService,
+  type OpenedFinanceDb,
+} from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-entity-usage-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createFinanceApiApp({ financeDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3004' })
+  );
+}
+
+function seedEntity(opts: {
+  id: string;
+  name: string;
+  type?: string;
+  aliases?: string | null;
+  defaultTags?: string | null;
+}): void {
+  financeDb.db
+    .insert(entities)
+    .values({
+      id: opts.id,
+      name: opts.name,
+      type: opts.type ?? 'company',
+      aliases: opts.aliases ?? null,
+      defaultTags: opts.defaultTags ?? null,
+      lastEditedTime: '2026-01-01T00:00:00.000Z',
+    })
+    .run();
+}
+
+function seedTxn(entityId: string, description: string, date: string): void {
+  transactionsService.createTransaction(financeDb.db, {
+    description,
+    account: 'checking',
+    amount: -10,
+    date,
+    entityId,
+  });
+}
+
+beforeEach(() => {
+  seedEntity({
+    id: 'ent-alpha',
+    name: 'Alpha',
+    type: 'company',
+    aliases: 'Alpha Co, ALP',
+    defaultTags: JSON.stringify(['groceries']),
+  });
+  seedEntity({ id: 'ent-bravo', name: 'Bravo', type: 'person' });
+  seedEntity({ id: 'ent-charlie', name: 'Charlie', type: 'company' });
+  seedTxn('ent-alpha', 'ALPHA STORE 1', '2026-01-01');
+  seedTxn('ent-alpha', 'ALPHA STORE 2', '2026-01-02');
+  seedTxn('ent-charlie', 'CHARLIE CAFE', '2026-01-03');
+});
+
+describe('entityUsage — transactionCount rollup', () => {
+  it('lists every entity with its transactionCount, ordered by name', async () => {
+    const { data, pagination } = await client().entityUsage.list();
+    expect(data.map((e) => e.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    const counts = new Map(data.map((e) => [e.name, e.transactionCount]));
+    expect(counts.get('Alpha')).toBe(2);
+    expect(counts.get('Bravo')).toBe(0);
+    expect(counts.get('Charlie')).toBe(1);
+    expect(pagination.total).toBe(3);
+  });
+
+  it('orphanedOnly=true returns only entities with zero transactions', async () => {
+    const { data, pagination } = await client().entityUsage.list({ orphanedOnly: 'true' });
+    expect(data.map((e) => e.name)).toEqual(['Bravo']);
+    expect(data[0]?.transactionCount).toBe(0);
+    expect(pagination.total).toBe(1);
+  });
+
+  it('orphanedOnly=false returns all entities (count===0 not filtered)', async () => {
+    const { data } = await client().entityUsage.list({ orphanedOnly: 'false' });
+    expect(data).toHaveLength(3);
+  });
+
+  it('filters by search (name LIKE)', async () => {
+    const { data } = await client().entityUsage.list({ search: 'lph' });
+    expect(data.map((e) => e.name)).toEqual(['Alpha']);
+    expect(data[0]?.transactionCount).toBe(2);
+  });
+
+  it('filters by type', async () => {
+    const { data } = await client().entityUsage.list({ type: 'company' });
+    expect(data.map((e) => e.name)).toEqual(['Alpha', 'Charlie']);
+  });
+
+  it('paginates while preserving the total', async () => {
+    const page1 = await client().entityUsage.list({ limit: 2, offset: 0 });
+    expect(page1.data.map((e) => e.name)).toEqual(['Alpha', 'Bravo']);
+    expect(page1.pagination).toMatchObject({ total: 3, limit: 2, offset: 0, hasMore: true });
+
+    const page2 = await client().entityUsage.list({ limit: 2, offset: 2 });
+    expect(page2.data.map((e) => e.name)).toEqual(['Charlie']);
+    expect(page2.pagination).toMatchObject({ total: 3, hasMore: false });
+  });
+
+  it('projects aliases (comma-split) and defaultTags (JSON) to arrays', async () => {
+    const { data } = await client().entityUsage.list({ search: 'Alpha' });
+    const alpha = data[0];
+    expect(alpha?.aliases).toEqual(['Alpha Co', 'ALP']);
+    expect(alpha?.defaultTags).toEqual(['groceries']);
+  });
+});

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -203,6 +203,27 @@ export interface CorrectionListQuery {
   offset?: number;
 }
 
+export interface EntityUsage {
+  id: string;
+  name: string;
+  type: string;
+  abn: string | null;
+  aliases: string[];
+  defaultTransactionType: string | null;
+  defaultTags: string[];
+  notes: string | null;
+  lastEditedTime: string;
+  transactionCount: number;
+}
+
+export interface EntityUsageQuery {
+  search?: string;
+  type?: string;
+  orphanedOnly?: 'true' | 'false';
+  limit?: number;
+  offset?: number;
+}
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
@@ -294,6 +315,10 @@ export function makeClient(app: Express) {
         send<{ data: Correction[]; message: string }>(
           r.post('/corrections/apply-changeset').send(body)
         ),
+    },
+    entityUsage: {
+      list: (query: EntityUsageQuery = {}) =>
+        send<{ data: EntityUsage[]; pagination: Pagination }>(r.get('/entity-usage').query(query)),
     },
     imports: {
       processImport: (body: Record<string, unknown>) =>

--- a/pillars/finance/src/api/rest/entity-usage-handlers.ts
+++ b/pillars/finance/src/api/rest/entity-usage-handlers.ts
@@ -1,0 +1,72 @@
+/**
+ * Handler for the `entityUsage.*` sub-router — the entities + `transactionCount`
+ * rollup over the finance-owned join. Projects the shared-schema entity row to
+ * core's `EntitySchema` shape (aliases comma-split, defaultTags JSON-parsed),
+ * plus the joined `transactionCount`.
+ */
+import { type EntityUsageRow, type FinanceDb, listEntityUsage } from '../../db/index.js';
+import { paginationMeta } from '../shared/pagination.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { financeEntityUsageContract } from '../../contract/rest-entity-usage.js';
+
+type Req = ServerInferRequest<typeof financeEntityUsageContract>;
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+function parseAliases(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseDefaultTags(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function toEntityUsage(row: EntityUsageRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    abn: row.abn,
+    aliases: parseAliases(row.aliases),
+    defaultTransactionType: row.defaultTransactionType,
+    defaultTags: parseDefaultTags(row.defaultTags),
+    notes: row.notes,
+    lastEditedTime: row.lastEditedTime,
+    transactionCount: row.transactionCount,
+  };
+}
+
+export function makeEntityUsageHandlers(db: FinanceDb) {
+  return {
+    list: ({ query }: Req['list']) =>
+      runHttp(() => {
+        const limit = query.limit ?? DEFAULT_LIMIT;
+        const offset = query.offset ?? DEFAULT_OFFSET;
+        const { rows, total } = listEntityUsage(db, {
+          search: query.search,
+          type: query.type,
+          orphanedOnly: query.orphanedOnly === 'true',
+          limit,
+          offset,
+        });
+        return {
+          status: 200 as const,
+          body: { data: rows.map(toEntityUsage), pagination: paginationMeta(total, limit, offset) },
+        };
+      }),
+  };
+}

--- a/pillars/finance/src/api/rest/handlers.ts
+++ b/pillars/finance/src/api/rest/handlers.ts
@@ -11,6 +11,7 @@ import { financeContract } from '../../contract/rest.js';
 import { type OpenedFinanceDb } from '../../db/index.js';
 import { makeBudgetsHandlers } from './budgets-handlers.js';
 import { makeCorrectionsHandlers } from './corrections-handlers.js';
+import { makeEntityUsageHandlers } from './entity-usage-handlers.js';
 import { makeImportsHandlers } from './imports-handlers.js';
 import { makeSearchHandlers } from './search-handlers.js';
 import { makeTagRulesHandlers } from './tag-rules-handlers.js';
@@ -29,6 +30,7 @@ export function makeFinanceRestHandlers(deps: {
     transactions: makeTransactionsHandlers(db),
     tagRules: makeTagRulesHandlers(db),
     corrections: makeCorrectionsHandlers(db),
+    entityUsage: makeEntityUsageHandlers(db),
     imports: makeImportsHandlers(db),
     search: makeSearchHandlers(db),
   });

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -179,6 +179,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/entity-usage': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List entities with per-entity transactionCount; orphanedOnly=true returns count===0 */
+    get: operations['entityUsage.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/imports/apply-changeset-reevaluate': {
     parameters: {
       query?: never;
@@ -2051,6 +2068,90 @@ export interface operations {
         content: {
           'application/json': {
             message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'entityUsage.list': {
+    parameters: {
+      query?: {
+        search?: string;
+        type?: 'company' | 'person' | 'government' | 'bank' | 'place' | 'brand' | 'organisation';
+        orphanedOnly?: 'true' | 'false';
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              abn: string | null;
+              aliases: string[];
+              defaultTags: string[];
+              defaultTransactionType: string | null;
+              id: string;
+              lastEditedTime: string;
+              name: string;
+              notes: string | null;
+              transactionCount: number;
+              type: string;
+            }[];
+            pagination: {
+              hasMore: boolean;
+              limit: number;
+              offset: number;
+              total: number;
+            };
           };
         };
       };

--- a/pillars/finance/src/contract/rest-entity-usage.ts
+++ b/pillars/finance/src/contract/rest-entity-usage.ts
@@ -1,0 +1,55 @@
+/**
+ * `entityUsage.*` sub-router — entities enriched with their per-entity
+ * `transactionCount` (+ an orphaned filter).
+ *
+ * The `entities` table is core-owned, but this rollup joins finance
+ * `transactions`, so it is finance-served: core's REST `entities` contract
+ * deliberately omits `transactionCount`. Mirrors the monolith
+ * `core.entities.list` response shape (entity projection + `transactionCount`)
+ * so the entity-management FE is a transport swap.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ENTITY_TYPES } from '@pops/shared-schema';
+
+import { ERR_RESPONSES, LimitQuery, OffsetQuery, PaginationMetaSchema } from './rest-schemas.js';
+
+const c = initContract();
+
+/** Entity projection (mirrors core's `EntitySchema`) plus the finance-owned count. */
+export const EntityUsageSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  abn: z.string().nullable(),
+  aliases: z.array(z.string()),
+  defaultTransactionType: z.string().nullable(),
+  defaultTags: z.array(z.string()),
+  notes: z.string().nullable(),
+  lastEditedTime: z.string(),
+  transactionCount: z.number(),
+});
+
+const EntityUsageQuery = z.object({
+  search: z.string().optional(),
+  type: z.enum(ENTITY_TYPES).optional(),
+  // Query params arrive as strings; the handler coerces "true" → boolean. A
+  // transform here would break OpenAPI JSON-Schema generation.
+  orphanedOnly: z.enum(['true', 'false']).optional(),
+  limit: LimitQuery,
+  offset: OffsetQuery,
+});
+
+export const financeEntityUsageContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/entity-usage',
+    query: EntityUsageQuery,
+    responses: {
+      200: z.object({ data: z.array(EntityUsageSchema), pagination: PaginationMetaSchema }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'List entities with per-entity transactionCount; orphanedOnly=true returns count===0',
+  },
+});

--- a/pillars/finance/src/contract/rest.ts
+++ b/pillars/finance/src/contract/rest.ts
@@ -14,6 +14,7 @@ import { initContract } from '@ts-rest/core';
 
 import { financeBudgetsContract } from './rest-budgets.js';
 import { financeCorrectionsContract } from './rest-corrections.js';
+import { financeEntityUsageContract } from './rest-entity-usage.js';
 import { financeImportsContract } from './rest-imports.js';
 import { financeSearchContract } from './rest-search.js';
 import { financeTagRulesContract } from './rest-tag-rules.js';
@@ -29,6 +30,7 @@ export const financeContract = c.router(
     transactions: financeTransactionsContract,
     tagRules: financeTagRulesContract,
     corrections: financeCorrectionsContract,
+    entityUsage: financeEntityUsageContract,
     imports: financeImportsContract,
     search: financeSearchContract,
   },

--- a/pillars/finance/src/db/index.ts
+++ b/pillars/finance/src/db/index.ts
@@ -89,3 +89,11 @@ export {
 } from './services/transaction-corrections.js';
 
 export * as crossPillarService from './services/cross-pillar.js';
+
+export { listEntityUsage } from './services/entity-usage.js';
+
+export type {
+  EntityUsageRow,
+  EntityUsageListResult,
+  ListEntityUsageOptions,
+} from './services/entity-usage.js';

--- a/pillars/finance/src/db/services/entity-usage.ts
+++ b/pillars/finance/src/db/services/entity-usage.ts
@@ -1,0 +1,98 @@
+/**
+ * Entity-usage rollup — entities enriched with their per-entity
+ * `transactionCount` via a LEFT JOIN onto finance `transactions`.
+ *
+ * The `entities` table is core-owned (re-exported from `@pops/shared-schema`),
+ * but this join is finance-domain: only the finance pillar can count
+ * `finance.transactions` per entity. Ported from the monolith
+ * `core/entities/service.ts` `fetchEntitiesPage`/`countEntities`, rewritten to
+ * take a `FinanceDb` handle (core's REST `entities` contract deliberately omits
+ * `transactionCount`).
+ */
+import { and, count, eq, like, sql, type SQL } from 'drizzle-orm';
+
+import { entities, transactions } from '../schema.js';
+import { type FinanceDb } from './internal.js';
+
+export type EntityUsageRow = typeof entities.$inferSelect & { transactionCount: number };
+
+export interface ListEntityUsageOptions {
+  search?: string;
+  type?: string;
+  orphanedOnly?: boolean;
+  limit: number;
+  offset: number;
+}
+
+export interface EntityUsageListResult {
+  rows: EntityUsageRow[];
+  total: number;
+}
+
+function buildEntityFilter(opts: ListEntityUsageOptions): SQL | undefined {
+  const conditions: SQL[] = [];
+  if (opts.search) conditions.push(like(entities.name, `%${opts.search}%`));
+  if (opts.type) conditions.push(eq(entities.type, opts.type));
+  if (conditions.length === 0) return undefined;
+  return and(...conditions);
+}
+
+function fetchEntitiesPage(
+  db: FinanceDb,
+  where: SQL | undefined,
+  opts: ListEntityUsageOptions
+): EntityUsageRow[] {
+  let query = db
+    .select({
+      id: entities.id,
+      notionId: entities.notionId,
+      name: entities.name,
+      type: entities.type,
+      abn: entities.abn,
+      aliases: entities.aliases,
+      defaultTransactionType: entities.defaultTransactionType,
+      defaultTags: entities.defaultTags,
+      notes: entities.notes,
+      lastEditedTime: entities.lastEditedTime,
+      ownerUri: entities.ownerUri,
+      ownerUriStaleAt: entities.ownerUriStaleAt,
+      transactionCount: sql<number>`CAST(COUNT(${transactions.id}) AS INTEGER)`,
+    })
+    .from(entities)
+    .leftJoin(transactions, eq(entities.id, transactions.entityId))
+    .where(where)
+    .groupBy(entities.id)
+    .orderBy(sql`${entities.name} COLLATE NOCASE`)
+    .$dynamic();
+
+  if (opts.orphanedOnly) query = query.having(sql`COUNT(${transactions.id}) = 0`);
+  return query.limit(opts.limit).offset(opts.offset).all();
+}
+
+function countEntities(db: FinanceDb, where: SQL | undefined, orphanedOnly?: boolean): number {
+  if (orphanedOnly) {
+    return db
+      .select({ id: entities.id })
+      .from(entities)
+      .leftJoin(transactions, eq(entities.id, transactions.entityId))
+      .where(where)
+      .groupBy(entities.id)
+      .having(sql`COUNT(${transactions.id}) = 0`)
+      .all().length;
+  }
+  let countQuery = db.select({ total: count() }).from(entities).$dynamic();
+  if (where) countQuery = countQuery.where(where);
+  return countQuery.all()[0]?.total ?? 0;
+}
+
+/** List entities with optional search / type / orphaned filters, including `transactionCount`. */
+export function listEntityUsage(
+  db: FinanceDb,
+  opts: ListEntityUsageOptions
+): EntityUsageListResult {
+  const where = buildEntityFilter(opts);
+  return {
+    rows: fetchEntitiesPage(db, where, opts),
+    total: countEntities(db, where, opts.orphanedOnly),
+  };
+}


### PR DESCRIPTION
## Summary

Second deterministic slice of **C1** (finance reclaim). Moves the per-entity `transactionCount` rollup — the `entities↔transactions` LEFT JOIN that lived only in the monolith `core.entities.list` — into the finance pillar's REST API. The `entities` table is core-owned, but only finance can count `finance.transactions`, so the rollup is finance-served (core's REST `entities` deliberately omits `transactionCount`).

## Added

- `GET /entity-usage` (`financeEntityUsageContract`) — entities + `transactionCount`, with `search` / `type` / `orphanedOnly` filters + pagination. Response mirrors the monolith `core.entities.list` shape (entity projection + count) so the entity-management FE cut-over is a transport swap.
- `listEntityUsage` db service — ports `fetchEntitiesPage`/`countEntities` onto a `FinanceDb` handle (`LEFT JOIN transactions … GROUP BY entities.id`, optional `HAVING COUNT=0`).

## Verification

`@pops/finance`: typecheck ✓, **328 tests** ✓ (7 new entity-usage cases: counts, orphaned, search, type, pagination, aliases/defaultTags projection), `generate:openapi`+`generate:api-types` idempotent ✓, oxfmt/oxlint clean ✓. No `as any`/suppressions. Only `pillars/finance` touched.

Together with #3449 (C1-a) this completes the C1 **deterministic backend** slices. Remaining: **C1-b** (AI cluster) and **C1-d / Track A** (FE call-site cut-over). Pre-existing red-by-design checks (monolith typecheck, etc.) are unrelated — same set merged on #3444–#3449.