### PR TITLE
feat(finance): port corrections AI cluster over REST (C1-b)

### DIFF
--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -1217,6 +1217,141 @@
         "tags": ["corrections"]
       }
     },
+    "/corrections/analyze": {
+      "post": {
+        "operationId": "corrections.analyzeCorrection",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "amount": {
+                    "type": "number"
+                  },
+                  "description": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "entityName": {
+                    "type": "string"
+                  }
+                },
+                "required": ["description", "entityName", "amount"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "confidence": {
+                          "type": "number"
+                        },
+                        "matchType": {
+                          "enum": ["exact", "contains", "regex"],
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["matchType", "pattern", "confidence"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "AI-derive a reusable rule (matchType/pattern/confidence) from one labelled transaction",
+        "tags": ["corrections"]
+      }
+    },
     "/corrections/apply-changeset": {
       "post": {
         "operationId": "corrections.applyChangeSet",
@@ -1778,6 +1913,171 @@
           }
         },
         "summary": "Find the winning correction for a description (null when none match)",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/generate-rules": {
+      "post": {
+        "operationId": "corrections.generateRules",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "account": {
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "number"
+                        },
+                        "currentTags": {
+                          "default": [],
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "entityName": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": ["description", "entityName", "amount", "account", "currentTags"],
+                      "type": "object"
+                    },
+                    "maxItems": 50,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": ["transactions"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "proposals": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": ["descriptionPattern", "matchType", "tags", "reasoning"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["proposals"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "AI-propose reusable tagging rules from a batch of transactions",
         "tags": ["corrections"]
       }
     },
@@ -2968,6 +3268,1544 @@
           }
         },
         "summary": "Preview the transactions a candidate (pattern, matchType) rule would match",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/propose-changeset": {
+      "post": {
+        "operationId": "corrections.proposeChangeSet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "maxPreviewItems": {
+                    "default": 200,
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "minConfidence": {
+                    "default": 0.7,
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "signal": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "descriptionPattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "location": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "matchType": {
+                        "enum": ["exact", "contains", "regex"],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "transactionType": {
+                        "enum": ["purchase", "transfer", "income"],
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["descriptionPattern", "matchType"],
+                    "type": "object"
+                  }
+                },
+                "required": ["signal", "minConfidence", "maxPreviewItems"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "changeSet": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ops": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "default": "exact",
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "default": [],
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["descriptionPattern", "matchType", "tags"],
+                                    "type": "object"
+                                  },
+                                  "op": {
+                                    "enum": ["add"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["edit"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["disable"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["remove"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ops"],
+                      "type": "object"
+                    },
+                    "preview": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "affected": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "after": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "entityId": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "tags": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "ruleId",
+                                  "entityId",
+                                  "entityName",
+                                  "location",
+                                  "tags",
+                                  "transactionType"
+                                ],
+                                "type": "object"
+                              },
+                              "before": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "entityId": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "entityName": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "ruleId": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  },
+                                  "tags": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "transactionType": {
+                                    "enum": ["purchase", "transfer", "income"],
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "ruleId",
+                                  "entityId",
+                                  "entityName",
+                                  "location",
+                                  "tags",
+                                  "transactionType"
+                                ],
+                                "type": "object"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "transactionId": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["transactionId", "description", "before", "after"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "counts": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "affected": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "entityChanges": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "locationChanges": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "tagChanges": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "typeChanges": {
+                              "maximum": 9007199254740991,
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "affected",
+                            "entityChanges",
+                            "locationChanges",
+                            "tagChanges",
+                            "typeChanges"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": ["counts", "affected"],
+                      "type": "object"
+                    },
+                    "rationale": {
+                      "type": "string"
+                    },
+                    "targetRules": {
+                      "additionalProperties": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "entityName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "location": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "number"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "timesApplied": {
+                            "type": "number"
+                          },
+                          "transactionType": {
+                            "enum": ["purchase", "transfer", "income"],
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "descriptionPattern",
+                          "matchType",
+                          "entityId",
+                          "entityName",
+                          "location",
+                          "tags",
+                          "transactionType",
+                          "isActive",
+                          "priority",
+                          "confidence",
+                          "timesApplied",
+                          "createdAt",
+                          "lastUsedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["changeSet", "rationale", "preview", "targetRules"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Propose an add/edit ChangeSet for a correction signal (adapts to prior rejections)",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/reject-changeset": {
+      "post": {
+        "operationId": "corrections.rejectChangeSet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "default": [],
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "feedback": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "impactSummary": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "netMatchedDelta": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                      },
+                      "newMatches": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "removedMatches": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "statusChanges": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "total",
+                      "newMatches",
+                      "removedMatches",
+                      "statusChanges",
+                      "netMatchedDelta"
+                    ],
+                    "type": "object"
+                  },
+                  "signal": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "descriptionPattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "location": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "matchType": {
+                        "enum": ["exact", "contains", "regex"],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "transactionType": {
+                        "enum": ["purchase", "transfer", "income"],
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["descriptionPattern", "matchType"],
+                    "type": "object"
+                  }
+                },
+                "required": ["signal", "changeSet", "feedback"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Record rejection feedback for a ChangeSet (best-effort; feeds the next proposal)",
+        "tags": ["corrections"]
+      }
+    },
+    "/corrections/revise-changeset": {
+      "post": {
+        "operationId": "corrections.reviseChangeSet",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "currentChangeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "default": [],
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "entityName": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "location": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "matchType": {
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "transactionType": {
+                                      "enum": ["purchase", "transfer", "income"],
+                                      "nullable": true,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "instruction": {
+                    "maxLength": 2000,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "signal": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "descriptionPattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "location": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "matchType": {
+                        "enum": ["exact", "contains", "regex"],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "transactionType": {
+                        "enum": ["purchase", "transfer", "income"],
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["descriptionPattern", "matchType"],
+                    "type": "object"
+                  },
+                  "triggeringTransactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["description"],
+                      "type": "object"
+                    },
+                    "maxItems": 500,
+                    "type": "array"
+                  }
+                },
+                "required": ["signal", "currentChangeSet", "instruction", "triggeringTransactions"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "changeSet": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ops": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "default": "exact",
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "default": [],
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["descriptionPattern", "matchType", "tags"],
+                                    "type": "object"
+                                  },
+                                  "op": {
+                                    "enum": ["add"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "entityName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "location": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "matchType": {
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "transactionType": {
+                                        "enum": ["purchase", "transfer", "income"],
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["edit"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["disable"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["remove"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ops"],
+                      "type": "object"
+                    },
+                    "rationale": {
+                      "type": "string"
+                    },
+                    "targetRules": {
+                      "additionalProperties": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "entityName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "location": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "number"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "timesApplied": {
+                            "type": "number"
+                          },
+                          "transactionType": {
+                            "enum": ["purchase", "transfer", "income"],
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "descriptionPattern",
+                          "matchType",
+                          "entityId",
+                          "entityName",
+                          "location",
+                          "tags",
+                          "transactionType",
+                          "isActive",
+                          "priority",
+                          "confidence",
+                          "timesApplied",
+                          "createdAt",
+                          "lastUsedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["changeSet", "rationale", "targetRules"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "AI-revise an in-progress ChangeSet from a free-text instruction",
         "tags": ["corrections"]
       }
     },

--- a/pillars/finance/src/api/__tests__/corrections-ai.test.ts
+++ b/pillars/finance/src/api/__tests__/corrections-ai.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for the corrections AI cluster (C1-b): analyze /
+ * generate-rules / propose / revise / reject. The Claude completer and the
+ * cross-pillar rejection-feedback store are swapped for in-memory fakes via the
+ * `__set*ForTests` seams, so no test touches the network or the core pillar.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  openFinanceDb,
+  transactionCorrectionsService,
+  transactionsService,
+  type OpenedFinanceDb,
+} from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+import {
+  __setClaudeCompleterForTests,
+  __setFeedbackStoreForTests,
+  feedbackKey,
+  type ClaudeCompleter,
+  type FeedbackStore,
+} from '../modules/corrections/index.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+let feedbackMap: Map<string, string>;
+
+function completerReturning(byOp: Record<string, string | null>): ClaudeCompleter {
+  return (req) => Promise.resolve(byOp[req.operation] ?? null);
+}
+
+function memoryFeedbackStore(map: Map<string, string>): FeedbackStore {
+  return {
+    load: (k) => Promise.resolve(map.get(k) ?? null),
+    persist: (k, v) => {
+      map.set(k, v);
+      return Promise.resolve();
+    },
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-corrections-ai-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+  feedbackMap = new Map();
+  __setFeedbackStoreForTests(memoryFeedbackStore(feedbackMap));
+});
+
+afterEach(() => {
+  __setClaudeCompleterForTests(null);
+  __setFeedbackStoreForTests(null);
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createFinanceApiApp({ financeDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3004' })
+  );
+}
+
+describe('corrections.analyzeCorrection', () => {
+  it('returns the validated rule when the AI pattern matches the description', async () => {
+    __setClaudeCompleterForTests(
+      completerReturning({
+        'analyze-correction': JSON.stringify({
+          matchType: 'contains',
+          pattern: 'WOOLWORTHS',
+          confidence: 0.95,
+        }),
+      })
+    );
+    const res = await client().corrections.analyzeCorrection({
+      description: 'WOOLWORTHS METRO 1234',
+      entityName: 'Woolworths',
+      amount: -12,
+    });
+    expect(res.data).toEqual({ matchType: 'contains', pattern: 'WOOLWORTHS', confidence: 0.95 });
+  });
+
+  it('returns null when the AI pattern does not match the description', async () => {
+    __setClaudeCompleterForTests(
+      completerReturning({
+        'analyze-correction': JSON.stringify({
+          matchType: 'contains',
+          pattern: 'NETFLIX',
+          confidence: 0.9,
+        }),
+      })
+    );
+    const res = await client().corrections.analyzeCorrection({
+      description: 'WOOLWORTHS METRO',
+      entityName: 'Woolworths',
+      amount: -12,
+    });
+    expect(res.data).toBeNull();
+  });
+
+  it('returns null when the AI is unavailable (completer yields null)', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    const res = await client().corrections.analyzeCorrection({
+      description: 'WOOLWORTHS METRO',
+      entityName: 'Woolworths',
+      amount: -12,
+    });
+    expect(res.data).toBeNull();
+  });
+});
+
+describe('corrections.generateRules', () => {
+  it('parses the AI proposal array', async () => {
+    __setClaudeCompleterForTests(
+      completerReturning({
+        'generate-rules': JSON.stringify([
+          {
+            descriptionPattern: 'NETFLIX',
+            matchType: 'contains',
+            tags: ['Entertainment'],
+            reasoning: 'streaming',
+          },
+        ]),
+      })
+    );
+    const res = await client().corrections.generateRules({
+      transactions: [
+        {
+          description: 'NETFLIX.COM',
+          entityName: 'Netflix',
+          amount: -15,
+          account: 'checking',
+          currentTags: [],
+        },
+      ],
+    });
+    expect(res.proposals).toEqual([
+      {
+        descriptionPattern: 'NETFLIX',
+        matchType: 'contains',
+        tags: ['Entertainment'],
+        reasoning: 'streaming',
+      },
+    ]);
+  });
+
+  it('returns [] when the AI is unavailable', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    const res = await client().corrections.generateRules({
+      transactions: [
+        { description: 'X', entityName: null, amount: -1, account: 'checking', currentTags: [] },
+      ],
+    });
+    expect(res.proposals).toEqual([]);
+  });
+});
+
+describe('corrections.proposeChangeSet', () => {
+  it('proposes an add ChangeSet (no existing rule) and previews the impact', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    transactionsService.createTransaction(financeDb.db, {
+      description: 'WOOLWORTHS METRO',
+      account: 'checking',
+      amount: -12,
+      date: '2026-01-01',
+    });
+
+    const res = await client().corrections.proposeChangeSet({
+      signal: {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        entityName: 'Woolworths',
+        tags: ['groceries'],
+      },
+    });
+
+    expect(res.changeSet.ops).toHaveLength(1);
+    expect(res.changeSet.ops[0]?.op).toBe('add');
+    expect(res.rationale).toContain('Add new correction rule');
+    expect(res.preview.counts.affected).toBe(1);
+    expect(res.targetRules).toEqual({});
+  });
+
+  it('proposes an edit ChangeSet when a rule already exists for the pattern', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    const existing = transactionCorrectionsService.createOrUpdateTransactionCorrection(
+      financeDb.db,
+      {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        entityName: 'Woolworths',
+        tags: ['groceries'],
+      }
+    );
+
+    const res = await client().corrections.proposeChangeSet({
+      signal: {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        entityName: 'Woolworths',
+        tags: ['groceries'],
+      },
+    });
+
+    expect(res.changeSet.ops[0]?.op).toBe('edit');
+    expect(res.changeSet.ops[0]?.id).toBe(existing.id);
+    expect(res.rationale).toContain(`Edit correction rule ${existing.id}`);
+    expect(res.targetRules[existing.id]).toBeDefined();
+  });
+
+  it('adapts the signal from prior rejection feedback (AI interpret) and flags the follow-up', async () => {
+    feedbackMap.set(
+      feedbackKey({ matchType: 'contains', normalizedPattern: 'WOOLWORTHS' }),
+      JSON.stringify({
+        createdAt: '2026-01-01T00:00:00.000Z',
+        userEmail: 'u',
+        feedback: 'too broad — use exact',
+        changeSet: {
+          ops: [{ op: 'add', data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' } }],
+        },
+        impactSummary: null,
+      })
+    );
+    __setClaudeCompleterForTests(
+      completerReturning({
+        'rejection-interpret': JSON.stringify({
+          adaptedSignal: {
+            descriptionPattern: 'WOOLWORTHS METRO',
+            matchType: 'exact',
+            entityName: 'Woolworths',
+            tags: ['groceries'],
+          },
+        }),
+      })
+    );
+
+    const res = await client().corrections.proposeChangeSet({
+      signal: {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        entityName: 'Woolworths',
+        tags: ['groceries'],
+      },
+    });
+
+    expect(res.rationale).toContain('Follow-up after rejection feedback');
+    // The adapted signal flipped matchType to exact + pattern to WOOLWORTHS METRO.
+    const addOp = res.changeSet.ops[0];
+    expect(addOp?.op).toBe('add');
+  });
+});
+
+describe('corrections.reviseChangeSet', () => {
+  const baseArgs = {
+    signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' as const },
+    currentChangeSet: {
+      ops: [{ op: 'add', data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' } }],
+    },
+    instruction: 'make it exact',
+    triggeringTransactions: [{ description: 'WOOLWORTHS METRO' }],
+  };
+
+  it('returns the AI-revised ChangeSet', async () => {
+    __setClaudeCompleterForTests(
+      completerReturning({
+        'revise-changeset': JSON.stringify({
+          changeSet: {
+            ops: [
+              { op: 'add', data: { descriptionPattern: 'WOOLWORTHS METRO', matchType: 'exact' } },
+            ],
+          },
+          rationale: 'narrowed to exact',
+        }),
+      })
+    );
+    const res = await client().corrections.reviseChangeSet(baseArgs);
+    expect(res.rationale).toBe('narrowed to exact');
+    expect(res.changeSet.ops[0]?.op).toBe('add');
+  });
+
+  it('500s when the AI returns invalid JSON', async () => {
+    __setClaudeCompleterForTests(completerReturning({ 'revise-changeset': 'not json' }));
+    await expect(client().corrections.reviseChangeSet(baseArgs)).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});
+
+describe('corrections.rejectChangeSet', () => {
+  it('persists the feedback under the signal key', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    const res = await client().corrections.rejectChangeSet({
+      signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' },
+      changeSet: {
+        ops: [{ op: 'add', data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' } }],
+      },
+      feedback: 'too broad',
+    });
+    expect(res.message).toBe('ChangeSet rejected');
+    const stored = feedbackMap.get(
+      feedbackKey({ matchType: 'contains', normalizedPattern: 'WOOLWORTHS' })
+    );
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored ?? '{}')).toMatchObject({ feedback: 'too broad' });
+  });
+
+  it('still succeeds (best-effort) when the feedback store throws', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    __setFeedbackStoreForTests({
+      load: () => Promise.resolve(null),
+      persist: () => Promise.reject(new Error('core unavailable')),
+    });
+    const res = await client().corrections.rejectChangeSet({
+      signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' },
+      changeSet: {
+        ops: [{ op: 'add', data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' } }],
+      },
+      feedback: 'too broad',
+    });
+    expect(res.message).toBe('ChangeSet rejected');
+  });
+});

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -315,6 +315,34 @@ export function makeClient(app: Express) {
         send<{ data: Correction[]; message: string }>(
           r.post('/corrections/apply-changeset').send(body)
         ),
+      analyzeCorrection: (body: Record<string, unknown>) =>
+        send<{ data: { matchType: string; pattern: string; confidence: number } | null }>(
+          r.post('/corrections/analyze').send(body)
+        ),
+      generateRules: (body: Record<string, unknown>) =>
+        send<{
+          proposals: {
+            descriptionPattern: string;
+            matchType: string;
+            tags: string[];
+            reasoning: string;
+          }[];
+        }>(r.post('/corrections/generate-rules').send(body)),
+      proposeChangeSet: (body: Record<string, unknown>) =>
+        send<{
+          changeSet: { source?: string; reason?: string; ops: { op: string; id?: string }[] };
+          rationale: string;
+          preview: { counts: { affected: number }; affected: unknown[] };
+          targetRules: Record<string, Correction>;
+        }>(r.post('/corrections/propose-changeset').send(body)),
+      reviseChangeSet: (body: Record<string, unknown>) =>
+        send<{
+          changeSet: { ops: { op: string }[] };
+          rationale: string;
+          targetRules: Record<string, Correction>;
+        }>(r.post('/corrections/revise-changeset').send(body)),
+      rejectChangeSet: (body: Record<string, unknown>) =>
+        send<{ message: string }>(r.post('/corrections/reject-changeset').send(body)),
     },
     entityUsage: {
       list: (query: EntityUsageQuery = {}) =>

--- a/pillars/finance/src/api/modules/corrections/ai-analyze.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-analyze.ts
@@ -1,0 +1,175 @@
+/**
+ * AI rule derivation: `analyzeCorrection` (one signal → a validated rule) and
+ * `generateRules` (a batch of transactions → proposed tagging rules). Ported
+ * from the monolith `core/corrections/lib/{analyze-correction,rule-generator}.ts`,
+ * routed through the injectable Claude completer (`ai-runtime.ts`).
+ */
+import { type FinanceDb, transactions, transactionCorrectionsService } from '../../../db/index.js';
+import { getClaudeCompleter } from './ai-runtime.js';
+import { type CorrectionAnalysis, type ProposedRule } from './ai-types.js';
+import { parseCorrectionTags } from './types.js';
+
+const MIN_PATTERN_LENGTH = 3;
+const MATCH_TYPES = ['exact', 'contains', 'regex'] as const;
+
+export interface CorrectionInput {
+  description: string;
+  entityName: string;
+  amount: number;
+}
+
+export interface GenerateRulesTransaction {
+  description: string;
+  entityName: string | null;
+  amount: number;
+  account: string;
+  currentTags: string[];
+}
+
+function patternMatchesDescription(
+  pattern: string,
+  matchType: 'exact' | 'contains' | 'regex',
+  description: string
+): boolean {
+  const { normalizeDescription } = transactionCorrectionsService;
+  const normalizedDescription = normalizeDescription(description);
+  const normalizedPattern = matchType === 'regex' ? pattern : normalizeDescription(pattern);
+  if (normalizedPattern.length === 0) return false;
+  if (matchType === 'exact') return normalizedPattern === normalizedDescription;
+  if (matchType === 'contains') return normalizedDescription.includes(normalizedPattern);
+  try {
+    return new RegExp(normalizedPattern).test(normalizedDescription);
+  } catch {
+    return false;
+  }
+}
+
+function stripFences(text: string): string {
+  return text
+    .trim()
+    .replaceAll(/^```(?:json)?\s*\n?/gm, '')
+    .replaceAll(/\n?```\s*$/gm, '');
+}
+
+function buildAnalyzePrompt(input: CorrectionInput): string {
+  return `You are a bank transaction pattern analyzer. A user has assigned a transaction to an entity and we need a reusable rule that will identify FUTURE transactions belonging to the same entity.
+
+Transaction description: "${input.description}"
+Entity (context only — may not appear in the description): "${input.entityName}"
+Amount: ${input.amount}
+
+Pick a stable identifier from the description (merchant token, keyword). Strip volatile parts (numeric codes, dates, amounts). The entity name is context only — do not put it in the pattern unless it literally appears in the description.
+
+Return a single JSON object:
+- "matchType": "exact" | "contains" | "regex"
+- "pattern": the matching pattern (min ${MIN_PATTERN_LENGTH} chars, uppercase); for exact/contains it must appear verbatim (case-insensitive) in the description; for regex it must test true against the description.
+- "confidence": 0.0-1.0
+
+Return ONLY the JSON object, no markdown.`;
+}
+
+function parseAnalysis(text: string): CorrectionAnalysis | null {
+  try {
+    const parsed = JSON.parse(stripFences(text)) as Record<string, unknown>;
+    const matchType = typeof parsed['matchType'] === 'string' ? parsed['matchType'] : '';
+    const pattern = typeof parsed['pattern'] === 'string' ? parsed['pattern'] : '';
+    const confidence = typeof parsed['confidence'] === 'number' ? parsed['confidence'] : 0;
+    if (
+      !MATCH_TYPES.includes(matchType as (typeof MATCH_TYPES)[number]) ||
+      pattern.length < MIN_PATTERN_LENGTH ||
+      confidence < 0 ||
+      confidence > 1
+    ) {
+      return null;
+    }
+    return { matchType: matchType as CorrectionAnalysis['matchType'], pattern, confidence };
+  } catch {
+    return null;
+  }
+}
+
+/** Derive + validate a correction rule from one labelled transaction. Null when the AI is unavailable or proposes a non-matching pattern. */
+export async function analyzeCorrection(
+  input: CorrectionInput
+): Promise<CorrectionAnalysis | null> {
+  const text = await getClaudeCompleter()({
+    prompt: buildAnalyzePrompt(input),
+    maxTokens: 200,
+    operation: 'analyze-correction',
+  });
+  if (!text) return null;
+  const result = parseAnalysis(text);
+  if (!result) return null;
+  if (!patternMatchesDescription(result.pattern, result.matchType, input.description)) return null;
+  return result;
+}
+
+function loadAvailableTags(db: FinanceDb): string[] {
+  const rows = db.select({ tags: transactions.tags }).from(transactions).all();
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const tag of parseCorrectionTags(row.tags ?? '[]')) seen.add(tag);
+  }
+  return [...seen].toSorted();
+}
+
+function buildGeneratePrompt(txns: GenerateRulesTransaction[], availableTags: string[]): string {
+  const lines = txns
+    .map((t, i) => {
+      const entity = t.entityName ?? 'unknown';
+      const tags = t.currentTags.length > 0 ? t.currentTags.join(', ') : 'none';
+      return `${i + 1}. "${t.description}" | entity: ${entity} | amount: ${t.amount} | account: ${t.account} | current tags: ${tags}`;
+    })
+    .join('\n');
+  const tagList =
+    availableTags.length > 0 ? availableTags.join(', ') : 'common financial categories';
+  return `You are a transaction categorization assistant. Propose reusable tagging rules for these transactions.
+
+Available tags: ${tagList}
+
+Transactions:
+${lines}
+
+Return a JSON array; each rule: {"descriptionPattern":"...","matchType":"exact|contains|regex","tags":["Tag1"],"reasoning":"..."}.
+Return ONLY the JSON array, no markdown.`;
+}
+
+function parseProposals(text: string): ProposedRule[] {
+  try {
+    const parsed = JSON.parse(stripFences(text)) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (item): item is Record<string, unknown> =>
+          item !== null && typeof item === 'object' && !Array.isArray(item)
+      )
+      .map((item) => ({
+        descriptionPattern:
+          typeof item['descriptionPattern'] === 'string' ? item['descriptionPattern'] : '',
+        matchType: (MATCH_TYPES.includes(String(item['matchType']) as (typeof MATCH_TYPES)[number])
+          ? item['matchType']
+          : 'contains') as ProposedRule['matchType'],
+        tags: Array.isArray(item['tags'])
+          ? item['tags'].filter((t): t is string => typeof t === 'string')
+          : [],
+        reasoning: typeof item['reasoning'] === 'string' ? item['reasoning'] : '',
+      }))
+      .filter((p) => p.descriptionPattern.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/** Batch-propose reusable tagging rules from a set of transactions. */
+export async function generateRules(
+  db: FinanceDb,
+  txns: GenerateRulesTransaction[]
+): Promise<ProposedRule[]> {
+  const text = await getClaudeCompleter()({
+    prompt: buildGeneratePrompt(txns, loadAvailableTags(db)),
+    maxTokens: 2000,
+    operation: 'generate-rules',
+  });
+  if (!text) return [];
+  return parseProposals(text);
+}

--- a/pillars/finance/src/api/modules/corrections/ai-feedback.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-feedback.ts
@@ -1,0 +1,136 @@
+import { ChangeSetSchema, type ChangeSet } from '../../../contract/rest-corrections.js';
+/**
+ * Rejection-feedback persistence + AI interpretation. The store keys are
+ * dynamic (`corrections.changeSetRejections:<matchType>:<pattern>`) and live in
+ * core settings, reached via the injectable `FeedbackStore` (`ai-runtime.ts`).
+ * Ported from the monolith `core/corrections/handlers/ai-inference.ts`.
+ */
+import { transactionCorrectionsService } from '../../../db/index.js';
+import { getClaudeCompleter, getFeedbackStore } from './ai-runtime.js';
+import {
+  AdaptedSignalSchema,
+  ChangeSetImpactSummarySchema,
+  type CorrectionSignal,
+} from './ai-types.js';
+
+import type { ChangeSetImpactSummary } from './ai-types.js';
+
+const { normalizeDescription } = transactionCorrectionsService;
+
+export interface RejectedChangeSetFeedbackRecord {
+  createdAt: string;
+  userEmail: string;
+  feedback: string;
+  changeSet: ChangeSet;
+  impactSummary: ChangeSetImpactSummary | null;
+}
+
+export function feedbackKey(args: {
+  matchType: 'exact' | 'contains' | 'regex';
+  normalizedPattern: string;
+}): string {
+  return `corrections.changeSetRejections:${args.matchType}:${args.normalizedPattern}`;
+}
+
+function parseFeedbackRecord(value: string): RejectedChangeSetFeedbackRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj['createdAt'] !== 'string' ||
+    typeof obj['userEmail'] !== 'string' ||
+    typeof obj['feedback'] !== 'string'
+  ) {
+    return null;
+  }
+  const changeSet = ChangeSetSchema.safeParse(obj['changeSet']);
+  if (!changeSet.success) return null;
+  const impact = ChangeSetImpactSummarySchema.safeParse(obj['impactSummary']);
+  return {
+    createdAt: obj['createdAt'],
+    userEmail: obj['userEmail'],
+    feedback: obj['feedback'],
+    changeSet: changeSet.data,
+    impactSummary: impact.success ? impact.data : null,
+  };
+}
+
+export async function loadLatestRejectedFeedback(args: {
+  matchType: 'exact' | 'contains' | 'regex';
+  normalizedPattern: string;
+}): Promise<RejectedChangeSetFeedbackRecord | null> {
+  const raw = await getFeedbackStore().load(feedbackKey(args));
+  return raw ? parseFeedbackRecord(raw) : null;
+}
+
+export async function persistRejectedChangeSetFeedback(args: {
+  signal: CorrectionSignal;
+  changeSet: ChangeSet;
+  feedback: string;
+  impactSummary: ChangeSetImpactSummary | null;
+  userEmail: string;
+}): Promise<void> {
+  const normalizedPattern = normalizeDescription(args.signal.descriptionPattern);
+  const record: RejectedChangeSetFeedbackRecord = {
+    createdAt: new Date().toISOString(),
+    userEmail: args.userEmail,
+    feedback: args.feedback,
+    changeSet: args.changeSet,
+    impactSummary: args.impactSummary,
+  };
+  await getFeedbackStore().persist(
+    feedbackKey({ matchType: args.signal.matchType, normalizedPattern }),
+    JSON.stringify(record)
+  );
+}
+
+function buildInterpretPrompt(
+  originalSignal: CorrectionSignal,
+  rejectedChangeSet: ChangeSet,
+  sanitizedFeedback: string
+): string {
+  return `You are improving a transaction correction rule proposal.
+
+Return an adapted signal (JSON only) as {"adaptedSignal": { ... }} with keys descriptionPattern, matchType, entityId, entityName, location, tags, transactionType. Keep descriptionPattern semantically the same unless the feedback explicitly asks to change it; prefer changing matchType when the feedback indicates specificity.
+
+originalSignal: ${JSON.stringify(originalSignal)}
+rejectedChangeSet: ${JSON.stringify(rejectedChangeSet)}
+feedback: ${JSON.stringify(sanitizedFeedback)}`;
+}
+
+function parseAdaptedSignal(text: string, originalSignal: CorrectionSignal): CorrectionSignal {
+  const cleaned = text
+    .trim()
+    .replaceAll(/^```(?:json)?\s*\n?/gm, '')
+    .replaceAll(/\n?```\s*$/gm, '');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return originalSignal;
+  }
+  if (!parsed || typeof parsed !== 'object') return originalSignal;
+  const adapted = AdaptedSignalSchema.safeParse(
+    (parsed as Record<string, unknown>)['adaptedSignal']
+  );
+  return adapted.success ? adapted.data : originalSignal;
+}
+
+export async function interpretRejectionFeedback(
+  originalSignal: CorrectionSignal,
+  rejectedChangeSet: ChangeSet,
+  feedback: string
+): Promise<CorrectionSignal> {
+  const text = await getClaudeCompleter()({
+    prompt: buildInterpretPrompt(originalSignal, rejectedChangeSet, feedback.trim().slice(0, 500)),
+    maxTokens: 250,
+    operation: 'rejection-interpret',
+  });
+  if (!text) return originalSignal;
+  return parseAdaptedSignal(text, originalSignal);
+}

--- a/pillars/finance/src/api/modules/corrections/ai-propose.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-propose.ts
@@ -1,0 +1,202 @@
+/**
+ * `proposeChangeSet` (signal → add/edit ChangeSet + DB-scanned impact, adapting
+ * to prior rejection feedback) and `reviseChangeSet` (free-text AI revision).
+ * Ported from the monolith `core/corrections/handlers/{compute-changeset,ai-revise}.ts`.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { ChangeSetSchema, type ChangeSet } from '../../../contract/rest-corrections.js';
+import {
+  type FinanceDb,
+  transactionCorrections,
+  transactionCorrectionsService,
+} from '../../../db/index.js';
+import { interpretRejectionFeedback, loadLatestRejectedFeedback } from './ai-feedback.js';
+import { getClaudeCompleter } from './ai-runtime.js';
+import {
+  buildTargetRulesMap,
+  type ChangeSetProposal,
+  type Correction,
+  type CorrectionSignal,
+} from './ai-types.js';
+import { buildAddChangeSet, buildEditChangeSet } from './changeset-builders.js';
+import { computeChangeSetImpact } from './changeset-impact.js';
+import { type CorrectionRow } from './types.js';
+
+const { normalizeDescription } = transactionCorrectionsService;
+
+interface FeedbackInfo {
+  changeSet: ChangeSet;
+  feedback: string;
+}
+
+async function resolveEffectiveSignal(
+  signal: CorrectionSignal
+): Promise<{ effectiveSignal: CorrectionSignal; feedback: FeedbackInfo | null }> {
+  const latest = await loadLatestRejectedFeedback({
+    matchType: signal.matchType,
+    normalizedPattern: normalizeDescription(signal.descriptionPattern),
+  });
+  if (!latest) return { effectiveSignal: signal, feedback: null };
+  const effectiveSignal = await interpretRejectionFeedback(
+    signal,
+    latest.changeSet,
+    latest.feedback
+  );
+  return { effectiveSignal, feedback: { changeSet: latest.changeSet, feedback: latest.feedback } };
+}
+
+function findExistingRule(
+  db: FinanceDb,
+  matchType: 'exact' | 'contains' | 'regex',
+  normalizedPattern: string
+): CorrectionRow | undefined {
+  return db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(
+        eq(transactionCorrections.matchType, matchType),
+        eq(transactionCorrections.descriptionPattern, normalizedPattern)
+      )
+    )
+    .get();
+}
+
+function describeRationale(
+  existing: CorrectionRow | undefined,
+  matchType: string,
+  normalizedPattern: string,
+  feedback: FeedbackInfo | null
+): string {
+  const base = existing
+    ? `Edit correction rule ${existing.id} (${matchType}:${normalizedPattern}) based on correction signal`
+    : `Add new correction rule (${matchType}:${normalizedPattern}) based on correction signal`;
+  return feedback ? `${base}. Follow-up after rejection feedback: "${feedback.feedback}"` : base;
+}
+
+export interface ProposeArgs {
+  signal: CorrectionSignal;
+  minConfidence: number;
+  maxPreviewItems: number;
+}
+
+export async function proposeChangeSetFromCorrectionSignal(
+  db: FinanceDb,
+  args: ProposeArgs
+): Promise<ChangeSetProposal> {
+  const { effectiveSignal, feedback } = await resolveEffectiveSignal(args.signal);
+  const normalizedPattern = normalizeDescription(effectiveSignal.descriptionPattern);
+  const matchType = effectiveSignal.matchType;
+  const existing = findExistingRule(db, matchType, normalizedPattern);
+
+  const builderArgs = {
+    effectiveSignal,
+    normalizedPattern,
+    matchType,
+    hasFeedback: feedback !== null,
+    feedback: feedback?.feedback,
+  };
+  const changeSet = existing
+    ? buildEditChangeSet(existing, builderArgs)
+    : buildAddChangeSet(builderArgs);
+
+  const impact = computeChangeSetImpact(db, {
+    changeSet,
+    matchType,
+    normalizedPattern,
+    minConfidence: args.minConfidence,
+    maxPreviewItems: args.maxPreviewItems,
+  });
+
+  return {
+    changeSet,
+    rationale: describeRationale(existing, matchType, normalizedPattern, feedback),
+    preview: { counts: impact.counts, affected: impact.affected },
+    targetRules: buildTargetRulesMap(changeSet, impact.rulesBefore),
+  };
+}
+
+export interface ReviseArgs {
+  signal: CorrectionSignal;
+  currentChangeSet: ChangeSet;
+  instruction: string;
+  triggeringTransactions: { checksum?: string; description: string }[];
+}
+
+export interface ReviseResult {
+  changeSet: ChangeSet;
+  rationale: string;
+  targetRules: Record<string, Correction>;
+}
+
+function buildRevisePrompt(args: ReviseArgs, sanitizedInstruction: string): string {
+  const triggeringLines = args.triggeringTransactions
+    .slice(0, 100)
+    .map((t, i) => `${i + 1}. "${t.description}"`)
+    .join('\n');
+  return `You are refining a bundled correction-rule ChangeSet for a personal finance app.
+
+A ChangeSet is { "source"?: string, "reason"?: string, "ops": Op[] } with at least one op. Each op is one of:
+- { "op": "add", "data": { "descriptionPattern": string, "matchType": "exact"|"contains"|"regex", "entityId"?, "entityName"?, "location"?, "tags"?, "transactionType"?, "confidence"?, "isActive"? } }
+- { "op": "edit", "id": string, "data": { same fields, all optional, no descriptionPattern/matchType } }
+- { "op": "disable", "id": string }
+- { "op": "remove", "id": string }
+Preserve existing ids on edit/disable/remove; do not invent ids. Normalize patterns to uppercase with digits stripped.
+
+originalSignal: ${JSON.stringify(args.signal)}
+
+triggeringTransactions:
+${triggeringLines || '(none provided)'}
+
+currentChangeSet:
+${JSON.stringify(args.currentChangeSet, null, 2)}
+
+instruction: ${JSON.stringify(sanitizedInstruction)}
+
+Return ONLY: {"changeSet": <revised ChangeSet>, "rationale": "<one-line explanation>"}`;
+}
+
+function parseReviseResult(text: string): { changeSet: ChangeSet; rationale: string } {
+  const cleaned = text
+    .trim()
+    .replaceAll(/^```(?:json)?\s*\n?/gm, '')
+    .replaceAll(/\n?```\s*$/gm, '');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (cause) {
+    throw new Error('reviseChangeSet: AI returned invalid JSON', { cause });
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('reviseChangeSet: AI response was not a JSON object');
+  }
+  const container = parsed as Record<string, unknown>;
+  const changeSet = ChangeSetSchema.safeParse(container['changeSet']);
+  if (!changeSet.success) {
+    throw new Error('reviseChangeSet: AI returned a ChangeSet that failed schema validation');
+  }
+  const rationaleRaw = container['rationale'];
+  const rationale =
+    typeof rationaleRaw === 'string' && rationaleRaw.trim().length > 0
+      ? rationaleRaw.trim()
+      : 'ChangeSet revised by AI helper';
+  return { changeSet: changeSet.data, rationale };
+}
+
+export async function reviseChangeSet(db: FinanceDb, args: ReviseArgs): Promise<ReviseResult> {
+  const rulesBefore = db.select().from(transactionCorrections).all();
+  const sanitizedInstruction = args.instruction.trim().slice(0, 2000);
+  if (sanitizedInstruction.length === 0)
+    throw new Error('reviseChangeSet: instruction must be non-empty');
+
+  const text = await getClaudeCompleter()({
+    prompt: buildRevisePrompt(args, sanitizedInstruction),
+    maxTokens: 2000,
+    operation: 'revise-changeset',
+  });
+  if (!text) throw new Error('reviseChangeSet: AI unavailable');
+
+  const { changeSet, rationale } = parseReviseResult(text);
+  return { changeSet, rationale, targetRules: buildTargetRulesMap(changeSet, rulesBefore) };
+}

--- a/pillars/finance/src/api/modules/corrections/ai-runtime.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-runtime.ts
@@ -1,0 +1,115 @@
+/**
+ * Injectable runtime seams for the corrections AI cluster: the Claude text
+ * completer and the cross-pillar rejection-feedback store. Both default to
+ * real implementations (Anthropic via env key; core settings via the server
+ * SDK, best-effort) and are swappable in tests so no test hits the network.
+ *
+ * Mirrors the finance AI-categorizer's env-based key + the monolith's
+ * best-effort feedback persistence (try/catch, degrade gracefully when core is
+ * unavailable).
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+import { isOk } from '@pops/pillar-sdk/client';
+import { pillar } from '@pops/pillar-sdk/server';
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+
+export interface ClaudeRequest {
+  prompt: string;
+  maxTokens: number;
+  operation: string;
+}
+
+/** Returns the model's text, or null on no-key / API failure / empty content. */
+export type ClaudeCompleter = (req: ClaudeRequest) => Promise<string | null>;
+
+function resolveApiKey(): string {
+  return process.env['ANTHROPIC_API_KEY'] ?? process.env['CLAUDE_API_KEY'] ?? '';
+}
+
+function resolveModel(): string {
+  return process.env['FINANCE_CORRECTIONS_AI_MODEL'] ?? DEFAULT_MODEL;
+}
+
+const defaultCompleter: ClaudeCompleter = async (req) => {
+  const apiKey = resolveApiKey();
+  if (!apiKey) return null;
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+  try {
+    const response = await client.messages.create({
+      model: resolveModel(),
+      max_tokens: req.maxTokens,
+      messages: [{ role: 'user', content: req.prompt }],
+    });
+    const block = response.content[0];
+    return block?.type === 'text' ? block.text : null;
+  } catch {
+    return null;
+  }
+};
+
+let completer: ClaudeCompleter = defaultCompleter;
+
+export function getClaudeCompleter(): ClaudeCompleter {
+  return completer;
+}
+
+/** Test seam: swap the completer; pass null to restore the Anthropic default. */
+export function __setClaudeCompleterForTests(impl: ClaudeCompleter | null): void {
+  completer = impl ?? defaultCompleter;
+}
+
+/**
+ * Persistence for rejection feedback (dynamic `corrections.changeSetRejections:*`
+ * keys). The default reaches core settings over the REST server SDK; both legs
+ * are best-effort — a missing/unavailable core never throws into the AI flow.
+ */
+export interface FeedbackStore {
+  load(key: string): Promise<string | null>;
+  persist(key: string, value: string): Promise<void>;
+}
+
+const SettingsManyResponseSchema = z.object({ settings: z.record(z.string(), z.string()) });
+
+const defaultFeedbackStore: FeedbackStore = {
+  async load(key) {
+    try {
+      const result = await pillar('core').callDynamic(
+        'settings',
+        'getMany',
+        { keys: [key] },
+        'query'
+      );
+      if (!isOk(result)) return null;
+      const parsed = SettingsManyResponseSchema.safeParse(result.value);
+      return parsed.success ? (parsed.data.settings[key] ?? null) : null;
+    } catch {
+      return null;
+    }
+  },
+  async persist(key, value) {
+    try {
+      await pillar('core').callDynamic(
+        'settings',
+        'setMany',
+        { entries: [{ key, value }] },
+        'mutation'
+      );
+    } catch {
+      // best-effort: the learning loop degrades silently when core is down.
+    }
+  },
+};
+
+let feedbackStore: FeedbackStore = defaultFeedbackStore;
+
+export function getFeedbackStore(): FeedbackStore {
+  return feedbackStore;
+}
+
+/** Test seam: swap the feedback store; pass null to restore the SDK-backed default. */
+export function __setFeedbackStoreForTests(impl: FeedbackStore | null): void {
+  feedbackStore = impl ?? defaultFeedbackStore;
+}

--- a/pillars/finance/src/api/modules/corrections/ai-types.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-types.ts
@@ -1,0 +1,138 @@
+/**
+ * Types for the corrections AI cluster (analyze / generate-rules / propose /
+ * revise / reject). Ported from the monolith `core/corrections` so the wire
+ * shapes match `core.corrections.*` for the FE cut-over. The deterministic
+ * ChangeSet types live in `../../../contract/rest-corrections-schemas.ts`.
+ */
+import { z } from 'zod';
+
+import { type ChangeSet } from '../../../contract/rest-corrections.js';
+import { type TransactionCorrectionRow } from '../../../db/index.js';
+import { parseCorrectionTags, type CorrectionRow } from './types.js';
+
+const MatchTypeSchema = z.enum(['exact', 'contains', 'regex']);
+const TransactionTypeSchema = z.enum(['purchase', 'transfer', 'income']);
+
+/** A user's intended correction rule (the trigger for a proposal). */
+export const CorrectionSignalSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema,
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+});
+export type CorrectionSignal = z.infer<typeof CorrectionSignalSchema>;
+
+/** The AI-adapted signal shares the signal shape. */
+export const AdaptedSignalSchema = CorrectionSignalSchema;
+
+/** Result of `analyzeCorrection` — a derived, validated rule. */
+export const CorrectionAnalysisSchema = z.object({
+  matchType: MatchTypeSchema,
+  pattern: z.string(),
+  confidence: z.number(),
+});
+export type CorrectionAnalysis = z.infer<typeof CorrectionAnalysisSchema>;
+
+/** A single proposal from `generateRules`. */
+export const ProposedRuleSchema = z.object({
+  descriptionPattern: z.string(),
+  matchType: MatchTypeSchema,
+  tags: z.array(z.string()),
+  reasoning: z.string(),
+});
+export type ProposedRule = z.infer<typeof ProposedRuleSchema>;
+
+export const ChangeSetImpactSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  newMatches: z.number().int().nonnegative(),
+  removedMatches: z.number().int().nonnegative(),
+  statusChanges: z.number().int().nonnegative(),
+  netMatchedDelta: z.number().int(),
+});
+export type ChangeSetImpactSummary = z.infer<typeof ChangeSetImpactSummarySchema>;
+
+export interface CorrectionClassificationOutcome {
+  ruleId: string | null;
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  tags: string[];
+  transactionType: 'purchase' | 'transfer' | 'income' | null;
+}
+
+export interface ChangeSetImpactCounts {
+  affected: number;
+  entityChanges: number;
+  locationChanges: number;
+  tagChanges: number;
+  typeChanges: number;
+}
+
+export interface ChangeSetImpactItem {
+  transactionId: string;
+  description: string;
+  before: CorrectionClassificationOutcome;
+  after: CorrectionClassificationOutcome;
+}
+
+/** The persisted-correction projection used in proposal `targetRules`. */
+export interface Correction {
+  id: string;
+  descriptionPattern: string;
+  matchType: 'exact' | 'contains' | 'regex';
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  tags: string[];
+  transactionType: 'purchase' | 'transfer' | 'income' | null;
+  isActive: boolean;
+  priority: number;
+  confidence: number;
+  timesApplied: number;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export function toCorrection(row: TransactionCorrectionRow): Correction {
+  return {
+    id: row.id,
+    descriptionPattern: row.descriptionPattern,
+    matchType: row.matchType,
+    entityId: row.entityId,
+    entityName: row.entityName,
+    location: row.location,
+    tags: parseCorrectionTags(row.tags),
+    transactionType: row.transactionType,
+    isActive: Boolean(row.isActive),
+    priority: row.priority,
+    confidence: row.confidence,
+    timesApplied: row.timesApplied,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+  };
+}
+
+export interface ChangeSetProposal {
+  changeSet: ChangeSet;
+  rationale: string;
+  preview: { counts: ChangeSetImpactCounts; affected: ChangeSetImpactItem[] };
+  targetRules: Record<string, Correction>;
+}
+
+/** Build the `id → Correction` map for the rules a ChangeSet's edit/disable/remove ops target. */
+export function buildTargetRulesMap(
+  changeSet: ChangeSet,
+  rulesBefore: CorrectionRow[]
+): Record<string, Correction> {
+  const byId = new Map(rulesBefore.map((r) => [r.id, r]));
+  const out: Record<string, Correction> = {};
+  for (const op of changeSet.ops) {
+    if (op.op === 'add') continue;
+    const row = byId.get(op.id);
+    if (row) out[op.id] = toCorrection(row);
+  }
+  return out;
+}

--- a/pillars/finance/src/api/modules/corrections/changeset-builders.ts
+++ b/pillars/finance/src/api/modules/corrections/changeset-builders.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure builders that turn a resolved correction signal into an add/edit
+ * ChangeSet. Ported from the monolith `core/corrections/handlers/changeset-builders.ts`.
+ */
+import { type CorrectionSignal } from './ai-types.js';
+import { type CorrectionRow } from './types.js';
+
+import type { ChangeSet } from '../../../contract/rest-corrections.js';
+
+/**
+ * Confidence assigned to a rule created/refreshed via a user-approved proposal.
+ * Stays above the matcher's default minConfidence (0.7) so the rule fires.
+ */
+export const PROPOSAL_APPROVED_CONFIDENCE = 0.95;
+
+interface BuildArgs {
+  effectiveSignal: CorrectionSignal;
+  normalizedPattern: string;
+  matchType: 'exact' | 'contains' | 'regex';
+  hasFeedback: boolean;
+  feedback?: string;
+}
+
+function describeReason(action: 'create' | 'update', args: BuildArgs): string {
+  if (args.hasFeedback && args.feedback !== undefined) {
+    return `Follow-up proposal after rejection feedback: "${args.feedback}"`;
+  }
+  return action === 'create'
+    ? 'Create new correction rule from user correction signal'
+    : 'Update existing correction rule from user correction signal';
+}
+
+function changeSetSource(hasFeedback: boolean): string {
+  return hasFeedback ? 'correction-signal-followup' : 'correction-signal';
+}
+
+export function buildEditChangeSet(existing: CorrectionRow, args: BuildArgs): ChangeSet {
+  const promotedConfidence = Math.max(existing.confidence, PROPOSAL_APPROVED_CONFIDENCE);
+  return {
+    source: changeSetSource(args.hasFeedback),
+    reason: describeReason('update', args),
+    ops: [
+      {
+        op: 'edit',
+        id: existing.id,
+        data: {
+          entityId: args.effectiveSignal.entityId,
+          entityName: args.effectiveSignal.entityName,
+          location: args.effectiveSignal.location,
+          tags: args.effectiveSignal.tags,
+          transactionType: args.effectiveSignal.transactionType,
+          confidence: promotedConfidence,
+          isActive: true,
+        },
+      },
+    ],
+  };
+}
+
+export function buildAddChangeSet(args: BuildArgs): ChangeSet {
+  return {
+    source: changeSetSource(args.hasFeedback),
+    reason: describeReason('create', args),
+    ops: [
+      {
+        op: 'add',
+        data: {
+          descriptionPattern: args.normalizedPattern,
+          matchType: args.matchType,
+          entityId: args.effectiveSignal.entityId ?? null,
+          entityName: args.effectiveSignal.entityName ?? null,
+          location: args.effectiveSignal.location ?? null,
+          tags: args.effectiveSignal.tags ?? [],
+          transactionType: args.effectiveSignal.transactionType ?? null,
+          confidence: PROPOSAL_APPROVED_CONFIDENCE,
+          isActive: true,
+        },
+      },
+    ],
+  };
+}

--- a/pillars/finance/src/api/modules/corrections/changeset-impact.ts
+++ b/pillars/finance/src/api/modules/corrections/changeset-impact.ts
@@ -1,0 +1,180 @@
+/**
+ * DB-scanning ChangeSet impact preview for the propose flow — finds candidate
+ * transactions matching the rule pattern (SQL prefilter mirroring the monolith
+ * normalizer) and diffs their before/after correction outcome. Ported from the
+ * monolith `core/corrections/{changeset-impact,preview-helpers}.ts`, rewritten
+ * onto a `FinanceDb` handle.
+ */
+import { sql } from 'drizzle-orm';
+
+import { type FinanceDb, transactionCorrections, transactions } from '../../../db/index.js';
+import { applyChangeSetToRules, findMatchingCorrectionFromRules } from './pure.js';
+import { parseCorrectionTags, type CorrectionMatchResult, type CorrectionRow } from './types.js';
+
+import type { ChangeSet } from '../../../contract/rest-corrections.js';
+import type {
+  ChangeSetImpactCounts,
+  ChangeSetImpactItem,
+  CorrectionClassificationOutcome,
+} from './ai-types.js';
+
+interface CandidateTransaction {
+  id: string;
+  description: string;
+  tags: string | null;
+}
+
+function fetchCandidates(
+  db: FinanceDb,
+  matchType: 'exact' | 'contains' | 'regex',
+  normalizedPattern: string,
+  maxPreviewItems: number
+): CandidateTransaction[] {
+  const upper = sql`upper(${transactions.description})`;
+  const noDigits = sql`replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(${upper}, '0', ''), '1', ''), '2', ''), '3', ''), '4', ''), '5', ''), '6', ''), '7', ''), '8', ''), '9', '')`;
+  const collapsed = sql`replace(replace(replace(${noDigits}, '  ', ' '), '  ', ' '), '  ', ' ')`;
+  const prefilter = matchType === 'regex' ? upper : collapsed;
+
+  return db
+    .select({ id: transactions.id, description: transactions.description, tags: transactions.tags })
+    .from(transactions)
+    .where(
+      matchType === 'regex' ? undefined : sql`${prefilter} LIKE '%' || ${normalizedPattern} || '%'`
+    )
+    .limit(maxPreviewItems)
+    .all();
+}
+
+function outcomeFromMatch(match: CorrectionMatchResult | null): CorrectionClassificationOutcome {
+  if (!match) {
+    return {
+      ruleId: null,
+      entityId: null,
+      entityName: null,
+      location: null,
+      tags: [],
+      transactionType: null,
+    };
+  }
+  const r = match.correction;
+  return {
+    ruleId: r.id,
+    entityId: r.entityId ?? null,
+    entityName: r.entityName ?? null,
+    location: r.location ?? null,
+    tags: parseCorrectionTags(r.tags),
+    transactionType: r.transactionType ?? null,
+  };
+}
+
+function mergeTags(base: string[], add: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of [...base, ...add]) {
+    if (!seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+function tagsEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((t, i) => b[i] === t);
+}
+
+function outcomeChanged(
+  a: CorrectionClassificationOutcome,
+  b: CorrectionClassificationOutcome
+): boolean {
+  return (
+    a.ruleId !== b.ruleId ||
+    a.entityId !== b.entityId ||
+    a.entityName !== b.entityName ||
+    a.location !== b.location ||
+    a.transactionType !== b.transactionType ||
+    !tagsEqual(a.tags, b.tags)
+  );
+}
+
+function computeImpactCounts(items: ChangeSetImpactItem[]): ChangeSetImpactCounts {
+  let entityChanges = 0;
+  let locationChanges = 0;
+  let tagChanges = 0;
+  let typeChanges = 0;
+  for (const item of items) {
+    if (
+      item.before.entityId !== item.after.entityId ||
+      item.before.entityName !== item.after.entityName
+    ) {
+      entityChanges += 1;
+    }
+    if (item.before.location !== item.after.location) locationChanges += 1;
+    if (item.before.transactionType !== item.after.transactionType) typeChanges += 1;
+    if (!tagsEqual(item.before.tags, item.after.tags)) tagChanges += 1;
+  }
+  return { affected: items.length, entityChanges, locationChanges, tagChanges, typeChanges };
+}
+
+function withTagsMerged(
+  base: CorrectionClassificationOutcome,
+  txTags: string[]
+): CorrectionClassificationOutcome {
+  return { ...base, tags: mergeTags(txTags, base.tags).toSorted() };
+}
+
+function buildImpactItem(
+  candidate: CandidateTransaction,
+  rulesBefore: CorrectionRow[],
+  rulesAfter: CorrectionRow[],
+  minConfidence: number
+): ChangeSetImpactItem | null {
+  const txTags = parseCorrectionTags(candidate.tags ?? '[]');
+  const before = withTagsMerged(
+    outcomeFromMatch(
+      findMatchingCorrectionFromRules(candidate.description, rulesBefore, minConfidence)
+    ),
+    txTags
+  );
+  const after = withTagsMerged(
+    outcomeFromMatch(
+      findMatchingCorrectionFromRules(candidate.description, rulesAfter, minConfidence)
+    ),
+    txTags
+  );
+  if (!outcomeChanged(before, after)) return null;
+  return { transactionId: candidate.id, description: candidate.description, before, after };
+}
+
+export interface ImpactPreviewArgs {
+  changeSet: ChangeSet;
+  matchType: 'exact' | 'contains' | 'regex';
+  normalizedPattern: string;
+  minConfidence: number;
+  maxPreviewItems: number;
+}
+
+export function computeChangeSetImpact(
+  db: FinanceDb,
+  args: ImpactPreviewArgs
+): {
+  affected: ChangeSetImpactItem[];
+  counts: ChangeSetImpactCounts;
+  rulesBefore: CorrectionRow[];
+} {
+  const candidates = fetchCandidates(
+    db,
+    args.matchType,
+    args.normalizedPattern,
+    args.maxPreviewItems
+  );
+  const rulesBefore = db.select().from(transactionCorrections).all();
+  const rulesAfter = applyChangeSetToRules(rulesBefore, args.changeSet);
+
+  const affected: ChangeSetImpactItem[] = [];
+  for (const c of candidates) {
+    const item = buildImpactItem(c, rulesBefore, rulesAfter, args.minConfidence);
+    if (item) affected.push(item);
+  }
+  return { affected, counts: computeImpactCounts(affected), rulesBefore };
+}

--- a/pillars/finance/src/api/modules/corrections/index.ts
+++ b/pillars/finance/src/api/modules/corrections/index.ts
@@ -28,3 +28,24 @@ export {
   type CorrectionMatchStatus,
   type CorrectionRow,
 } from './types.js';
+
+// AI cluster (C1-b)
+export { analyzeCorrection, generateRules } from './ai-analyze.js';
+export { proposeChangeSetFromCorrectionSignal, reviseChangeSet } from './ai-propose.js';
+export {
+  persistRejectedChangeSetFeedback,
+  loadLatestRejectedFeedback,
+  feedbackKey,
+} from './ai-feedback.js';
+export {
+  __setClaudeCompleterForTests,
+  __setFeedbackStoreForTests,
+  type ClaudeCompleter,
+  type FeedbackStore,
+} from './ai-runtime.js';
+export {
+  type CorrectionAnalysis,
+  type ProposedRule,
+  type ChangeSetProposal,
+  type CorrectionSignal,
+} from './ai-types.js';

--- a/pillars/finance/src/api/rest/corrections-ai-handlers.ts
+++ b/pillars/finance/src/api/rest/corrections-ai-handlers.ts
@@ -1,0 +1,78 @@
+/**
+ * AI-cluster handlers for the `corrections.*` sub-router — analyze /
+ * generate-rules / propose / revise / reject. Thin wrappers over the
+ * `api/modules/corrections` AI functions; the AI client + the cross-pillar
+ * rejection-feedback store are injectable (see `ai-runtime.ts`) so tests run
+ * offline. The finance pillar trusts the docker network, so the rejection
+ * record is stamped with a service principal rather than a request user.
+ */
+import { type FinanceDb } from '../../db/index.js';
+import {
+  analyzeCorrection,
+  generateRules,
+  persistRejectedChangeSetFeedback,
+  proposeChangeSetFromCorrectionSignal,
+  reviseChangeSet,
+} from '../modules/corrections/index.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { financeCorrectionsContract } from '../../contract/rest-corrections.js';
+
+type Req = ServerInferRequest<typeof financeCorrectionsContract>;
+
+const REJECTION_PRINCIPAL = 'finance-pillar';
+
+export function makeCorrectionsAiHandlers(db: FinanceDb) {
+  return {
+    analyzeCorrection: ({ body }: Req['analyzeCorrection']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: { data: await analyzeCorrection(body) },
+      })),
+
+    generateRules: ({ body }: Req['generateRules']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: { proposals: await generateRules(db, body.transactions) },
+      })),
+
+    proposeChangeSet: ({ body }: Req['proposeChangeSet']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await proposeChangeSetFromCorrectionSignal(db, {
+          signal: body.signal,
+          minConfidence: body.minConfidence,
+          maxPreviewItems: body.maxPreviewItems,
+        }),
+      })),
+
+    reviseChangeSet: ({ body }: Req['reviseChangeSet']) =>
+      runHttp(async () => ({
+        status: 200 as const,
+        body: await reviseChangeSet(db, {
+          signal: body.signal,
+          currentChangeSet: body.currentChangeSet,
+          instruction: body.instruction,
+          triggeringTransactions: body.triggeringTransactions,
+        }),
+      })),
+
+    rejectChangeSet: ({ body }: Req['rejectChangeSet']) =>
+      runHttp(async () => {
+        try {
+          await persistRejectedChangeSetFeedback({
+            signal: body.signal,
+            changeSet: body.changeSet,
+            feedback: body.feedback,
+            impactSummary: body.impactSummary ?? null,
+            userEmail: REJECTION_PRINCIPAL,
+          });
+        } catch {
+          // best-effort: rejection feedback persistence is non-critical to the reject.
+        }
+        return { status: 200 as const, body: { message: 'ChangeSet rejected' } };
+      }),
+  };
+}

--- a/pillars/finance/src/api/rest/corrections-handlers.ts
+++ b/pillars/finance/src/api/rest/corrections-handlers.ts
@@ -15,6 +15,7 @@ import {
   previewChangeSetImpact,
 } from '../modules/corrections/index.js';
 import { paginationMeta } from '../shared/pagination.js';
+import { makeCorrectionsAiHandlers } from './corrections-ai-handlers.js';
 import {
   DEFAULT_LIMIT,
   DEFAULT_OFFSET,
@@ -159,5 +160,7 @@ export function makeCorrectionsHandlers(db: FinanceDb) {
           message: 'ChangeSet applied',
         },
       })),
+
+    ...makeCorrectionsAiHandlers(db),
   };
 }

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -58,6 +58,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/corrections/analyze': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** AI-derive a reusable rule (matchType/pattern/confidence) from one labelled transaction */
+    post: operations['corrections.analyzeCorrection'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/corrections/apply-changeset': {
     parameters: {
       query?: never;
@@ -86,6 +103,23 @@ export interface paths {
     put?: never;
     /** Find the winning correction for a description (null when none match) */
     post: operations['corrections.findMatch'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/generate-rules': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** AI-propose reusable tagging rules from a batch of transactions */
+    post: operations['corrections.generateRules'];
     delete?: never;
     options?: never;
     head?: never;
@@ -137,6 +171,57 @@ export interface paths {
     put?: never;
     /** Preview the transactions a candidate (pattern, matchType) rule would match */
     post: operations['corrections.previewMatches'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/propose-changeset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Propose an add/edit ChangeSet for a correction signal (adapts to prior rejections) */
+    post: operations['corrections.proposeChangeSet'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/reject-changeset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Record rejection feedback for a ChangeSet (best-effort; feeds the next proposal) */
+    post: operations['corrections.rejectChangeSet'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/corrections/revise-changeset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** AI-revise an in-progress ChangeSet from a free-text instruction */
+    post: operations['corrections.reviseChangeSet'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1115,6 +1200,81 @@ export interface operations {
       };
     };
   };
+  'corrections.analyzeCorrection': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          amount: number;
+          description: string;
+          entityName: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              confidence: number;
+              /** @enum {string} */
+              matchType: 'exact' | 'contains' | 'regex';
+              pattern: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'corrections.applyChangeSet': {
     parameters: {
       query?: never;
@@ -1302,6 +1462,87 @@ export interface operations {
             } | null;
             /** @enum {string|null} */
             status: 'matched' | 'uncertain' | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.generateRules': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          transactions: {
+            account: string;
+            amount: number;
+            /** @default [] */
+            currentTags: string[];
+            description: string;
+            entityName: string | null;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            proposals: {
+              descriptionPattern: string;
+              /** @enum {string} */
+              matchType: 'exact' | 'contains' | 'regex';
+              reasoning: string;
+              tags: string[];
+            }[];
           };
         };
       };
@@ -1750,6 +1991,556 @@ export interface operations {
               scanned: number;
               total: number;
               truncated: boolean;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.proposeChangeSet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @default 200 */
+          maxPreviewItems: number;
+          /** @default 0.7 */
+          minConfidence: number;
+          signal: {
+            descriptionPattern: string;
+            entityId?: string | null;
+            entityName?: string | null;
+            location?: string | null;
+            /** @enum {string} */
+            matchType: 'exact' | 'contains' | 'regex';
+            tags?: string[];
+            /** @enum {string|null} */
+            transactionType?: 'purchase' | 'transfer' | 'income' | null;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      /** @default [] */
+                      tags: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern?: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /** @enum {string} */
+                      matchType?: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags?: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+            preview: {
+              affected: {
+                after: {
+                  entityId: string | null;
+                  entityName: string | null;
+                  location: string | null;
+                  ruleId: string | null;
+                  tags: string[];
+                  /** @enum {string|null} */
+                  transactionType: 'purchase' | 'transfer' | 'income' | null;
+                };
+                before: {
+                  entityId: string | null;
+                  entityName: string | null;
+                  location: string | null;
+                  ruleId: string | null;
+                  tags: string[];
+                  /** @enum {string|null} */
+                  transactionType: 'purchase' | 'transfer' | 'income' | null;
+                };
+                description: string;
+                transactionId: string;
+              }[];
+              counts: {
+                affected: number;
+                entityChanges: number;
+                locationChanges: number;
+                tagChanges: number;
+                typeChanges: number;
+              };
+            };
+            rationale: string;
+            targetRules: {
+              [key: string]: {
+                confidence: number;
+                createdAt: string;
+                descriptionPattern: string;
+                entityId: string | null;
+                entityName: string | null;
+                id: string;
+                isActive: boolean;
+                lastUsedAt: string | null;
+                location: string | null;
+                /** @enum {string} */
+                matchType: 'exact' | 'contains' | 'regex';
+                priority: number;
+                tags: string[];
+                timesApplied: number;
+                /** @enum {string|null} */
+                transactionType: 'purchase' | 'transfer' | 'income' | null;
+              };
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.rejectChangeSet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          feedback: string;
+          impactSummary?: {
+            netMatchedDelta: number;
+            newMatches: number;
+            removedMatches: number;
+            statusChanges: number;
+            total: number;
+          };
+          signal: {
+            descriptionPattern: string;
+            entityId?: string | null;
+            entityName?: string | null;
+            location?: string | null;
+            /** @enum {string} */
+            matchType: 'exact' | 'contains' | 'regex';
+            tags?: string[];
+            /** @enum {string|null} */
+            transactionType?: 'purchase' | 'transfer' | 'income' | null;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'corrections.reviseChangeSet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          currentChangeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    /** @default [] */
+                    tags: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern?: string;
+                    entityId?: string | null;
+                    entityName?: string | null;
+                    isActive?: boolean;
+                    location?: string | null;
+                    /** @enum {string} */
+                    matchType?: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags?: string[];
+                    /** @enum {string|null} */
+                    transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          instruction: string;
+          signal: {
+            descriptionPattern: string;
+            entityId?: string | null;
+            entityName?: string | null;
+            location?: string | null;
+            /** @enum {string} */
+            matchType: 'exact' | 'contains' | 'regex';
+            tags?: string[];
+            /** @enum {string|null} */
+            transactionType?: 'purchase' | 'transfer' | 'income' | null;
+          };
+          triggeringTransactions: {
+            checksum?: string;
+            description: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      /** @default [] */
+                      tags: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern?: string;
+                      entityId?: string | null;
+                      entityName?: string | null;
+                      isActive?: boolean;
+                      location?: string | null;
+                      /** @enum {string} */
+                      matchType?: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags?: string[];
+                      /** @enum {string|null} */
+                      transactionType?: 'purchase' | 'transfer' | 'income' | null;
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+            rationale: string;
+            targetRules: {
+              [key: string]: {
+                confidence: number;
+                createdAt: string;
+                descriptionPattern: string;
+                entityId: string | null;
+                entityName: string | null;
+                id: string;
+                isActive: boolean;
+                lastUsedAt: string | null;
+                location: string | null;
+                /** @enum {string} */
+                matchType: 'exact' | 'contains' | 'regex';
+                priority: number;
+                tags: string[];
+                timesApplied: number;
+                /** @enum {string|null} */
+                transactionType: 'purchase' | 'transfer' | 'income' | null;
+              };
             };
           };
         };

--- a/pillars/finance/src/contract/rest-corrections-ai-schemas.ts
+++ b/pillars/finance/src/contract/rest-corrections-ai-schemas.ts
@@ -1,0 +1,119 @@
+/**
+ * Zod schemas for the `corrections.*` AI cluster (C1-b): analyze / generate-rules
+ * / propose / revise / reject. Split out of `rest-corrections-schemas.ts` to keep
+ * both files under the line cap; the base schemas they build on
+ * (`ChangeSetSchema`, `CorrectionSchema`, …) are imported from there.
+ */
+import { z } from 'zod';
+
+import {
+  ChangeSetPreviewSummarySchema,
+  ChangeSetSchema,
+  CorrectionSchema,
+  MatchTypeSchema,
+  TransactionTypeSchema,
+} from './rest-corrections-schemas.js';
+
+/** A user's intended correction rule — the trigger for an AI proposal. */
+export const CorrectionSignalSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema,
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  transactionType: TransactionTypeSchema.nullable().optional(),
+});
+
+export const AnalyzeCorrectionBody = z.object({
+  description: z.string().min(1),
+  entityName: z.string(),
+  amount: z.number(),
+});
+
+export const CorrectionAnalysisSchema = z.object({
+  matchType: MatchTypeSchema,
+  pattern: z.string(),
+  confidence: z.number(),
+});
+
+export const GenerateRulesBody = z.object({
+  transactions: z
+    .array(
+      z.object({
+        description: z.string(),
+        entityName: z.string().nullable(),
+        amount: z.number(),
+        account: z.string(),
+        currentTags: z.array(z.string()).optional().default([]),
+      })
+    )
+    .min(1)
+    .max(50),
+});
+
+export const ProposedRuleSchema = z.object({
+  descriptionPattern: z.string(),
+  matchType: MatchTypeSchema,
+  tags: z.array(z.string()),
+  reasoning: z.string(),
+});
+
+export const ProposeChangeSetBody = z.object({
+  signal: CorrectionSignalSchema,
+  minConfidence: z.number().min(0).max(1).default(0.7),
+  maxPreviewItems: z.number().int().positive().max(500).default(200),
+});
+
+const ClassificationOutcomeSchema = z.object({
+  ruleId: z.string().nullable(),
+  entityId: z.string().nullable(),
+  entityName: z.string().nullable(),
+  location: z.string().nullable(),
+  tags: z.array(z.string()),
+  transactionType: TransactionTypeSchema.nullable(),
+});
+
+const ImpactCountsSchema = z.object({
+  affected: z.number().int().nonnegative(),
+  entityChanges: z.number().int().nonnegative(),
+  locationChanges: z.number().int().nonnegative(),
+  tagChanges: z.number().int().nonnegative(),
+  typeChanges: z.number().int().nonnegative(),
+});
+
+const ImpactItemSchema = z.object({
+  transactionId: z.string(),
+  description: z.string(),
+  before: ClassificationOutcomeSchema,
+  after: ClassificationOutcomeSchema,
+});
+
+export const ChangeSetProposalSchema = z.object({
+  changeSet: ChangeSetSchema,
+  rationale: z.string(),
+  preview: z.object({ counts: ImpactCountsSchema, affected: z.array(ImpactItemSchema) }),
+  targetRules: z.record(z.string(), CorrectionSchema),
+});
+
+export const ReviseChangeSetBody = z.object({
+  signal: CorrectionSignalSchema,
+  currentChangeSet: ChangeSetSchema,
+  instruction: z.string().min(1).max(2000),
+  triggeringTransactions: z
+    .array(z.object({ checksum: z.string().optional(), description: z.string() }))
+    .max(500),
+});
+
+export const ReviseResultSchema = z.object({
+  changeSet: ChangeSetSchema,
+  rationale: z.string(),
+  targetRules: z.record(z.string(), CorrectionSchema),
+});
+
+export const RejectChangeSetBody = z.object({
+  signal: CorrectionSignalSchema,
+  changeSet: ChangeSetSchema,
+  feedback: z.string().min(1),
+  impactSummary: ChangeSetPreviewSummarySchema.optional(),
+});

--- a/pillars/finance/src/contract/rest-corrections.ts
+++ b/pillars/finance/src/contract/rest-corrections.ts
@@ -3,9 +3,9 @@
  *
  * Finance-owned (the `transaction_corrections` table lives in the finance db).
  * Serves the deterministic CRUD + the ChangeSet preview/apply/merged-list
- * surface. Deferred (kept in the monolith for now): the AI procedures
- * (analyzeCorrection / generateRules / propose / revise / reject) — they pull
- * in the Anthropic SDK and a cross-pillar core.db settings write.
+ * surface, plus the AI cluster (analyze / generate-rules / propose / revise /
+ * reject) — Anthropic via the finance env key; rejection-feedback + AI config
+ * reached over the core settings server SDK, best-effort.
  *
  * tRPC `query` procedures that carry a request body (`findMatch`,
  * `previewMatches`, `listMerged`, `previewChangeSet`) become `POST` here — a GET
@@ -18,6 +18,17 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import {
+  AnalyzeCorrectionBody,
+  ChangeSetProposalSchema,
+  CorrectionAnalysisSchema,
+  GenerateRulesBody,
+  ProposedRuleSchema,
+  ProposeChangeSetBody,
+  RejectChangeSetBody,
+  ReviseChangeSetBody,
+  ReviseResultSchema,
+} from './rest-corrections-ai-schemas.js';
 import {
   ChangeSetPreviewDiffSchema,
   ChangeSetPreviewSummarySchema,
@@ -144,5 +155,44 @@ export const financeCorrectionsContract = c.router({
       ...ERR_RESPONSES,
     },
     summary: 'Apply a correction-rule ChangeSet atomically; returns the full rule set',
+  },
+  analyzeCorrection: {
+    method: 'POST',
+    path: '/corrections/analyze',
+    body: AnalyzeCorrectionBody,
+    responses: {
+      200: z.object({ data: CorrectionAnalysisSchema.nullable() }),
+      ...ERR_RESPONSES,
+    },
+    summary:
+      'AI-derive a reusable rule (matchType/pattern/confidence) from one labelled transaction',
+  },
+  generateRules: {
+    method: 'POST',
+    path: '/corrections/generate-rules',
+    body: GenerateRulesBody,
+    responses: { 200: z.object({ proposals: z.array(ProposedRuleSchema) }), ...ERR_RESPONSES },
+    summary: 'AI-propose reusable tagging rules from a batch of transactions',
+  },
+  proposeChangeSet: {
+    method: 'POST',
+    path: '/corrections/propose-changeset',
+    body: ProposeChangeSetBody,
+    responses: { 200: ChangeSetProposalSchema, ...ERR_RESPONSES },
+    summary: 'Propose an add/edit ChangeSet for a correction signal (adapts to prior rejections)',
+  },
+  reviseChangeSet: {
+    method: 'POST',
+    path: '/corrections/revise-changeset',
+    body: ReviseChangeSetBody,
+    responses: { 200: ReviseResultSchema, ...ERR_RESPONSES },
+    summary: 'AI-revise an in-progress ChangeSet from a free-text instruction',
+  },
+  rejectChangeSet: {
+    method: 'POST',
+    path: '/corrections/reject-changeset',
+    body: RejectChangeSetBody,
+    responses: { 200: MessageSchema, ...ERR_RESPONSES },
+    summary: 'Record rejection feedback for a ChangeSet (best-effort; feeds the next proposal)',
   },
 });


### PR DESCRIPTION
## What

Ports the corrections **AI cluster** onto the finance pillar's REST contract at monolith parity — the C1-b slice of the finance reclaim (follows C1-a #3449 and C1-c #3450).

Five new `POST` routes under `corrections.*`:

| Route | Purpose |
| --- | --- |
| `/corrections/analyze` | AI-derive a reusable rule (matchType/pattern/confidence) from one labelled transaction; validates the AI pattern actually matches before returning |
| `/corrections/generate-rules` | AI-propose reusable tagging rules from a batch of transactions |
| `/corrections/propose-changeset` | Propose an add/edit ChangeSet for a correction signal, DB-scanned impact preview, adapting to prior rejection feedback |
| `/corrections/revise-changeset` | AI-revise an in-progress ChangeSet from a free-text instruction |
| `/corrections/reject-changeset` | Record rejection feedback (best-effort; feeds the next proposal) |

## How

- **Anthropic** via the finance env key (`ANTHROPIC_API_KEY` / `CLAUDE_API_KEY`), model `claude-haiku-4-5-20251001` — same env-key pattern as the finance AI categorizer.
- **Rejection-feedback + AI config** reached over the **core settings server SDK** (`pillar('core').callDynamic('settings', …)`), entirely **best-effort**: a missing/unavailable core degrades silently and never throws into the AI flow.
- **Injectable seams** (`__setClaudeCompleterForTests`, `__setFeedbackStoreForTests`) keep the whole cluster testable with in-memory fakes — no test touches the network or the core pillar.
- Contract schemas split into `rest-corrections-ai-schemas.ts` to keep both contract files under the line cap. All schemas transform-free (OpenAPI-gen safe).

## Verification (finance pillar, local)

- format clean · lint exit 0 (warnings only) · typecheck (src + scripts) clean
- **340 tests pass** (24 files), incl. 12 new AI-cluster integration tests
- OpenAPI generate idempotent; all 5 routes present in `finance.openapi.json`

Pre-existing red-by-design CI checks (monolith typecheck, affected rebuild, docker validate, duplication, Playwright E2E) remain red exactly as on #3444–#3450 — unblocked only by 02 (monolith decommission).