### PR TITLE
feat(finance): relocate Up Bank webhook ingest to the finance pillar (02 R1)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -88,4 +88,9 @@ jobs:
       # (`pillars/core`) is the single source of truth; the surviving monolith
       # `modules/core` + `routes/pillars.ts` copies (retired in Phase E, gated on
       # epic 09) are excluded so the lifted platform code isn't double-penalised.
-      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/db/schema.ts,**/db/seeder.ts,apps/pops-api/src/modules/food/**,apps/pops-api/src/routes/food/**,apps/pops-api/src/modules/cerebrum/**,packages/cerebrum-db/**,packages/cerebrum-contract/**,apps/pops-api/src/modules/media/**,apps/pops-api/src/routes/media/**,apps/pops-api/src/modules/core/**,apps/pops-api/src/routes/pillars.ts" --reporters "console" --exitCode 0 .
+      #
+      # The 02 monolith-decommission relocation tombstones follow the same rule:
+      # the Up Bank webhook (`routes/webhooks`, lifted into `pillars/finance`,
+      # relocation R1) is excluded so the in-flight relocation isn't
+      # double-penalised before the 02 barrier delete removes the monolith copy.
+      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/db/schema.ts,**/db/seeder.ts,apps/pops-api/src/modules/food/**,apps/pops-api/src/routes/food/**,apps/pops-api/src/modules/cerebrum/**,packages/cerebrum-db/**,packages/cerebrum-contract/**,apps/pops-api/src/modules/media/**,apps/pops-api/src/routes/media/**,apps/pops-api/src/modules/core/**,apps/pops-api/src/routes/pillars.ts,apps/pops-api/src/routes/webhooks/**" --reporters "console" --exitCode 0 .

--- a/pillars/finance/src/api/app.ts
+++ b/pillars/finance/src/api/app.ts
@@ -20,6 +20,7 @@ import express, { type Express, type Request, type Response } from 'express';
 import { financeContract } from '../contract/rest.js';
 import { type FinanceApiDeps, makeRequestHandler } from './handlers.js';
 import { makeFinanceRestHandlers } from './rest/handlers.js';
+import { createUpBankWebhookRouter } from './webhooks/up-bank.js';
 
 /**
  * JSON body cap. Statement-import uploads will arrive as base64 strings in
@@ -52,6 +53,11 @@ const openapiDocument: unknown = JSON.parse(
 export function createFinanceApiApp(deps: FinanceApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
+
+  // Up Bank signs the raw request bytes, so the webhook body must reach the
+  // handler unparsed. The path-scoped raw parser MUST precede the global JSON
+  // parser, which would otherwise consume the stream first.
+  app.use('/webhooks/up', express.raw({ type: 'application/json' }));
   app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
   const handlers = makeRequestHandler(deps);
@@ -73,6 +79,11 @@ export function createFinanceApiApp(deps: FinanceApiDeps): Express {
   });
 
   createExpressEndpoints(financeContract, makeFinanceRestHandlers(deps), app);
+
+  // Raw (non-ts-rest) webhook route. Mounted after the contract endpoints; its
+  // `/webhooks/up` paths don't collide with any contract path, so it adds no
+  // OpenAPI surface.
+  app.use(createUpBankWebhookRouter());
 
   return app;
 }

--- a/pillars/finance/src/api/webhooks/up-bank.test.ts
+++ b/pillars/finance/src/api/webhooks/up-bank.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Up Bank webhook route tests.
+ *
+ * Exercises the signature-verification contract end-to-end through Express:
+ * missing header → 401, bad signature → 403, valid signature → 200, the
+ * `UP_WEBHOOK_SECRET_FILE` secret source, the missing-secret → 500 path, and
+ * the liveness ping. The app under test wires the same path-scoped raw parser
+ * the real factory uses, so the Buffer-body assumption is covered too.
+ */
+import { createHmac } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import express, { type Express } from 'express';
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createUpBankWebhookRouter } from './up-bank.js';
+
+const SECRET = 'test-up-webhook-secret';
+
+function buildApp(): Express {
+  const app = express();
+  app.use('/webhooks/up', express.raw({ type: 'application/json' }));
+  app.use(express.json());
+  app.use(createUpBankWebhookRouter());
+  return app;
+}
+
+function sign(body: string, secret: string = SECRET): string {
+  return createHmac('sha256', secret).update(Buffer.from(body, 'utf-8')).digest('hex');
+}
+
+const EVENT_BODY = JSON.stringify({
+  data: {
+    attributes: { eventType: 'TRANSACTION_CREATED' },
+    relationships: { transaction: { data: { id: 'txn-123' } } },
+  },
+});
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'up-bank-webhook-test-'));
+  process.env['UP_WEBHOOK_SECRET'] = SECRET;
+  delete process.env['UP_WEBHOOK_SECRET_FILE'];
+});
+
+afterEach(() => {
+  delete process.env['UP_WEBHOOK_SECRET'];
+  delete process.env['UP_WEBHOOK_SECRET_FILE'];
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('POST /webhooks/up', () => {
+  it('rejects a request with no signature header (401)', async () => {
+    const res = await supertest(buildApp())
+      .post('/webhooks/up')
+      .set('content-type', 'application/json')
+      .send(EVENT_BODY);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Missing signature header' });
+  });
+
+  it('rejects a request with an invalid signature (403)', async () => {
+    const res = await supertest(buildApp())
+      .post('/webhooks/up')
+      .set('content-type', 'application/json')
+      .set('x-up-authenticity-signature', 'not-the-real-hmac')
+      .send(EVENT_BODY);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Invalid signature' });
+  });
+
+  it('accepts a correctly signed webhook (200)', async () => {
+    const res = await supertest(buildApp())
+      .post('/webhooks/up')
+      .set('content-type', 'application/json')
+      .set('x-up-authenticity-signature', sign(EVENT_BODY))
+      .send(EVENT_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  });
+
+  it('verifies against a secret read from UP_WEBHOOK_SECRET_FILE', async () => {
+    const fileSecret = 'secret-from-file';
+    const secretPath = join(tmpDir, 'up-secret');
+    writeFileSync(secretPath, `${fileSecret}\n`, 'utf-8');
+    delete process.env['UP_WEBHOOK_SECRET'];
+    process.env['UP_WEBHOOK_SECRET_FILE'] = secretPath;
+
+    const res = await supertest(buildApp())
+      .post('/webhooks/up')
+      .set('content-type', 'application/json')
+      .set('x-up-authenticity-signature', sign(EVENT_BODY, fileSecret))
+      .send(EVENT_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  });
+
+  it('fails closed (500) when no webhook secret is configured', async () => {
+    delete process.env['UP_WEBHOOK_SECRET'];
+    delete process.env['UP_WEBHOOK_SECRET_FILE'];
+
+    const res = await supertest(buildApp())
+      .post('/webhooks/up')
+      .set('content-type', 'application/json')
+      .set('x-up-authenticity-signature', sign(EVENT_BODY))
+      .send(EVENT_BODY);
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /webhooks/up/ping', () => {
+  it('answers the liveness ping (200)', async () => {
+    const res = await supertest(buildApp()).post('/webhooks/up/ping').send();
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/pillars/finance/src/api/webhooks/up-bank.ts
+++ b/pillars/finance/src/api/webhooks/up-bank.ts
@@ -1,0 +1,75 @@
+/**
+ * Up Bank webhook ingest route for the finance pillar.
+ *
+ * Raw Express route — deliberately NOT a ts-rest contract route — because Up
+ * signs the exact request bytes (`X-Up-Authenticity-Signature` is the
+ * HMAC-SHA256 of the raw body), so the handler must read the unparsed Buffer.
+ * The app factory registers a path-scoped `express.raw()` ahead of the global
+ * `express.json()` for this reason (see `app.ts`).
+ *
+ * The endpoint bypasses gateway auth by design (Cloudflare Access excludes the
+ * Up webhook path); authenticity is established by the signature check alone.
+ */
+import { createHmac } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import { type Router as ExpressRouter, Router } from 'express';
+
+function getWebhookSecret(): string {
+  const filePath = process.env['UP_WEBHOOK_SECRET_FILE'];
+  if (filePath) {
+    return readFileSync(filePath, 'utf-8').trim();
+  }
+  const envVal = process.env['UP_WEBHOOK_SECRET'];
+  if (envVal) return envVal;
+  throw new Error('Missing UP_WEBHOOK_SECRET_FILE or UP_WEBHOOK_SECRET');
+}
+
+function verifySignature(body: Buffer, signature: string): boolean {
+  const secret = getWebhookSecret();
+  const expected = createHmac('sha256', secret).update(body).digest('hex');
+  return expected === signature;
+}
+
+/**
+ * Build the Up Bank webhook router. Two POST routes:
+ * - `/webhooks/up` — signature-verified transaction event receiver.
+ * - `/webhooks/up/ping` — endpoint liveness probe Up calls on setup.
+ */
+export function createUpBankWebhookRouter(): ExpressRouter {
+  const router = Router();
+
+  router.post('/webhooks/up', (req, res) => {
+    const signature = req.headers['x-up-authenticity-signature'];
+    if (typeof signature !== 'string') {
+      res.status(401).json({ error: 'Missing signature header' });
+      return;
+    }
+
+    const rawBody = req.body as Buffer;
+    if (!verifySignature(rawBody, signature)) {
+      res.status(403).json({ error: 'Invalid signature' });
+      return;
+    }
+
+    const payload = JSON.parse(rawBody.toString('utf-8')) as {
+      data?: {
+        attributes?: { eventType?: string };
+        relationships?: { transaction?: { data?: { id?: string } } };
+      };
+    };
+
+    const eventType = payload.data?.attributes?.eventType;
+    const transactionId = payload.data?.relationships?.transaction?.data?.id;
+
+    console.warn(`[webhook/up] Event: ${eventType}, Transaction: ${transactionId}`);
+
+    res.status(200).json({ received: true });
+  });
+
+  router.post('/webhooks/up/ping', (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## What

Runbook **02 monolith-decommission — relocation R1**. Moves the Up Bank webhook ingest route out of the monolith (`apps/pops-api/src/routes/webhooks/up-bank.ts`) into the finance pillar, so the surface survives the upcoming barrier delete.

- New `pillars/finance/src/api/webhooks/up-bank.ts` exporting `createUpBankWebhookRouter()` — a raw Express router (deliberately **not** a ts-rest contract route, so it adds no OpenAPI surface).
- `pillars/finance/src/api/app.ts` mounts it behind a **path-scoped `express.raw()`** registered ahead of the global `express.json()`, so Up's `X-Up-Authenticity-Signature` (HMAC-SHA256 of the raw body) is verified over the exact bytes. Mirrors the media pillar's `/media/images` raw-route pattern.
- Behaviour preserved verbatim: signature verification (`UP_WEBHOOK_SECRET_FILE` / `UP_WEBHOOK_SECRET`), the `/webhooks/up` event receiver, and the `/webhooks/up/ping` liveness probe.

## Tests

`up-bank.test.ts` (supertest): missing-header → 401, bad-signature → 403, valid → 200, `UP_WEBHOOK_SECRET_FILE` source, missing-secret fail-closed → 500, ping → 200. Full finance suite green (346 tests), oxlint/oxfmt/typecheck clean, no OpenAPI drift.

## Notes / Gaps (tracked)

- The transaction **ingest** (Up API re-fetch → entity match → persist) was never implemented in the monolith — it shipped as TODO stubs. This relocation preserves that stub faithfully; implementing ingest is out of scope. A follow-up gap issue tracks it.
- Webhook **ingress routing** (gateway `/webhooks/up` → `finance-api:3004`) lands with the nginx/compose changes in the 02 barrier-delete PR.
- The monolith copy is removed by the 02 barrier delete.

Base: `lake-migration` (per the migration's squash-merge process).