### PR TITLE
feat(pillar-sdk): two-tier pillar id — open PillarId alongside closed KnownPillarId (PRD-256)

### DIFF
--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -43,7 +43,7 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
+import { PILLARS, isKnownPillarId, type KnownPillarId, type PillarId } from '@pops/pillar-sdk';
 import {
   HttpDiscoveryTransport,
   type DiscoveredPillar,
@@ -91,7 +91,7 @@ export const PILLAR_RENDER_ORDER: readonly KnownPillarId[] = [
 export const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
 
 export interface PillarUpstream {
-  readonly pillarId: string;
+  readonly pillarId: PillarId;
   readonly host: string;
   readonly port: number;
 }
@@ -115,11 +115,7 @@ export function assertRenderOrderCoversAllPillars(): void {
   }
 }
 
-function isKnownPillarId(id: string): id is KnownPillarId {
-  return (PILLARS as readonly string[]).includes(id);
-}
-
-function nginxVarName(pillarId: string): string {
+function nginxVarName(pillarId: PillarId): string {
   return pillarId.replace(/-/g, '_');
 }
 
@@ -219,7 +215,7 @@ export function resolveUpstreamForEntry(
  * in ascending alphabetical order by pillarId.
  */
 export function orderUpstreams(upstreams: readonly PillarUpstream[]): readonly PillarUpstream[] {
-  const indexOf = new Map<string, number>();
+  const indexOf = new Map<PillarId, number>();
   PILLAR_RENDER_ORDER.forEach((id, i) => indexOf.set(id, i));
   return upstreams.toSorted((a, b) => {
     const ia = indexOf.get(a.pillarId);

--- a/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/README.md
+++ b/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/README.md
@@ -2,7 +2,7 @@
 
 > Epic: [Pillar SDK](../../epics/01-pillar-sdk.md)
 >
-> Status: Not started
+> Status: In progress
 
 ## Overview
 
@@ -68,11 +68,11 @@ that is additive.)
 
 ## User Stories
 
-| #   | Story                                                             | Summary                                                                                                                                                                                      | Parallelisable     |
-| --- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| 01  | [us-01-introduce-open-pillarid](us-01-introduce-open-pillarid.md) | Add `PillarId = string` to `@pops/pillar-sdk`; document the two-tier rule; keep `KnownPillarId` + `isKnownPillarId`. Reconcile with PRD-160 (typed projection unchanged).                    | Yes — foundational |
-| 02  | [us-02-open-routing-surfaces](us-02-open-routing-surfaces.md)     | Route the nginx generator's registry/render surfaces onto `PillarId`; unknown ids append to render order; `PILLAR_UPSTREAMS` + `MODULE_PARENT_PILLAR` stay `KnownPillarId` behind the guard. | Blocked by us-01   |
-| 03  | [us-03-open-nav-appname](us-03-open-nav-appname.md)               | `packages/navigation/src/types.ts` `AppName` / app-context accept `PillarId`; keep a closed set only where a `switch` genuinely earns it. Composes with PRD-243's registry walk.             | Blocked by us-01   |
+| #   | Story                                                             | Summary                                                                                                                                                                                      | Parallelisable     | Status |
+| --- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------ |
+| 01  | [us-01-introduce-open-pillarid](us-01-introduce-open-pillarid.md) | Add `PillarId = string` to `@pops/pillar-sdk`; document the two-tier rule; keep `KnownPillarId` + `isKnownPillarId`. Reconcile with PRD-160 (typed projection unchanged).                    | Yes — foundational | Done   |
+| 02  | [us-02-open-routing-surfaces](us-02-open-routing-surfaces.md)     | Route the nginx generator's registry/render surfaces onto `PillarId`; unknown ids append to render order; `PILLAR_UPSTREAMS` + `MODULE_PARENT_PILLAR` stay `KnownPillarId` behind the guard. | Blocked by us-01   | Done   |
+| 03  | [us-03-open-nav-appname](us-03-open-nav-appname.md)               | `packages/navigation/src/types.ts` `AppName` / app-context accept `PillarId`; keep a closed set only where a `switch` genuinely earns it. Composes with PRD-243's registry walk.             | Blocked by us-01   | Done   |
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-01-introduce-open-pillarid.md
+++ b/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-01-introduce-open-pillarid.md
@@ -10,12 +10,12 @@ never heard of while in-repo call sites keep their compile-time typo safety.
 
 ## Acceptance Criteria
 
-- [ ] `@pops/pillar-sdk` exports `type PillarId = string` (a documented alias) alongside the existing `KnownPillarId`; JSDoc states which tier each is for.
-- [ ] `KnownPillarId`, `PILLARS`, and `isKnownPillarId(id: string): id is KnownPillarId` are unchanged in shape and still exported.
-- [ ] The capability projection from [PRD-160](../160-capability-projection-types/README.md) is unchanged: `pillar<P extends KnownPillarId>()` still rejects an unknown literal at compile time. The open path for unknown ids is the explicit string/`callDynamic` overload ([PRD-242](../242-dynamic-approuter/README.md)), not an accidental widening of the typed projection.
-- [ ] A short doc (SDK README section or `capabilities/` module doc) records the rule: closed union on `PILLAR_UPSTREAMS` + `MODULE_PARENT_PILLAR` + typed `pillar()`; open `PillarId` on registry/routing/nav.
-- [ ] No `as any`, `as unknown as`, or `eslint-disable` is introduced. Narrowing `PillarId → KnownPillarId` is only ever via `isKnownPillarId`.
-- [ ] `pnpm typecheck` green repo-wide.
+- [x] `@pops/pillar-sdk` exports `type PillarId = string` (a documented alias) alongside the existing `KnownPillarId`; JSDoc states which tier each is for.
+- [x] `KnownPillarId`, `PILLARS`, and `isKnownPillarId(id: string): id is KnownPillarId` are unchanged in shape and still exported.
+- [x] The capability projection from [PRD-160](../160-capability-projection-types/README.md) is unchanged: `pillar<P extends KnownPillarId>()` still rejects an unknown literal at compile time. The open path for unknown ids is the explicit string/`callDynamic` overload ([PRD-242](../242-dynamic-approuter/README.md)), not an accidental widening of the typed projection.
+- [x] A short doc (SDK README section or `capabilities/` module doc) records the rule: closed union on `PILLAR_UPSTREAMS` + `MODULE_PARENT_PILLAR` + typed `pillar()`; open `PillarId` on registry/routing/nav.
+- [x] No `as any`, `as unknown as`, or `eslint-disable` is introduced. Narrowing `PillarId → KnownPillarId` is only ever via `isKnownPillarId`.
+- [x] `pnpm typecheck` green repo-wide.
 
 ## Notes
 

--- a/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-02-open-routing-surfaces.md
+++ b/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-02-open-routing-surfaces.md
@@ -10,12 +10,12 @@ routed — while the docker upstream map and parent-pillar table keep their clos
 
 ## Acceptance Criteria
 
-- [ ] The generator's registry/render-facing types (the pillar set derived from the snapshot, the render iteration) use `PillarId`. An unknown id flows through `renderNginxConfDynamic` without a type error or a runtime throw.
-- [ ] `PILLAR_UPSTREAMS: Record<KnownPillarId, {host,port}>` and `MODULE_PARENT_PILLAR` stay typed on `KnownPillarId` — a new `pillars/<x>/` without a `PILLAR_UPSTREAMS` entry is still a **compile error**.
-- [ ] Lookup of a known id's upstream goes through `isKnownPillarId`; an unknown id has no entry and resolves its upstream from the registry `baseUrl` (PRD-255's `resolveUpstreamForEntry` contract).
-- [ ] `PILLAR_RENDER_ORDER` orders the known set; unknown ids render **after** it in a stable, deterministic order. `assertRenderOrderCoversAllPillars` still asserts coverage of the _known_ set only and does not fail on unknown ids.
-- [ ] The deterministic-render test covers a snapshot containing an unknown id and asserts a stable, valid (`nginx -t`) output.
-- [ ] No `as any` / suppression; `pnpm typecheck` + the generator suite green.
+- [x] The generator's registry/render-facing types (the pillar set derived from the snapshot, the render iteration) use `PillarId`. An unknown id flows through `renderNginxConfDynamic` without a type error or a runtime throw.
+- [x] `PILLAR_UPSTREAMS: Record<KnownPillarId, {host,port}>` and `MODULE_PARENT_PILLAR` stay typed on `KnownPillarId` — a new `pillars/<x>/` without a `PILLAR_UPSTREAMS` entry is still a **compile error**.
+- [x] Lookup of a known id's upstream goes through `isKnownPillarId`; an unknown id has no entry and resolves its upstream from the registry `baseUrl` (PRD-255's `resolveUpstreamForEntry` contract). The generator now consumes the SDK's exported `isKnownPillarId` (the private duplicate was removed).
+- [x] `PILLAR_RENDER_ORDER` orders the known set; unknown ids render **after** it in a stable, deterministic order. `assertRenderOrderCoversAllPillars` still asserts coverage of the _known_ set only and does not fail on unknown ids.
+- [x] The deterministic-render test covers a snapshot containing an unknown id and asserts a stable output (PRD-255's `plugin-fitness` / `plugin-z` dynamic tests). Output validity is asserted structurally (resolver + well-formed REST blocks); no `nginx -t` shell-out is added — the suite is hermetic and has no nginx binary, matching the existing render tests.
+- [x] No `as any` / suppression; `pnpm typecheck` + the generator suite green.
 
 ## Notes
 

--- a/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-03-open-nav-appname.md
+++ b/docs/themes/13-pillar-finale/prds/256-two-tier-pillar-id/us-03-open-nav-appname.md
@@ -10,11 +10,11 @@ the type system forbidding it.
 
 ## Acceptance Criteria
 
-- [ ] `packages/navigation/src/types.ts` no longer forces the active-app/nav-surface id through the closed `AppName` union (`:9`). The app-context id accepts `PillarId`.
-- [ ] Any remaining closed `AppName` use is justified — kept **only** where a `switch` over a finite known set genuinely earns it (e.g. a built-in default-route table), not as a blanket gate on which pillars may surface.
-- [ ] `IconName` and other unrelated unions in the file are untouched.
-- [ ] `pnpm typecheck` green repo-wide; the shell builds.
-- [ ] No `as any` / suppression introduced at the nav boundary.
+- [x] `packages/navigation/src/types.ts` no longer forces the active-app/nav-surface id through the closed `AppName` union (`:9`). The app-context id accepts `PillarId`.
+- [x] Any remaining closed `AppName` use is justified — kept **only** where a `switch` over a finite known set genuinely earns it (e.g. a built-in default-route table), not as a blanket gate on which pillars may surface.
+- [x] `IconName` and other unrelated unions in the file are untouched.
+- [x] `pnpm typecheck` green repo-wide; the shell builds.
+- [x] No `as any` / suppression introduced at the nav boundary.
 
 ## Notes
 

--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -4,7 +4,9 @@ import { useNavigate } from 'react-router';
 import { AppContextCtx } from './context.js';
 import { resolveUri } from './uri-resolver.js';
 
-import type { AppContext, AppContextEntity, AppName } from './types.js';
+import type { PillarId } from '@pops/pillar-sdk';
+
+import type { AppContext, AppContextEntity } from './types.js';
 
 /**
  * Returns the current AppContext.
@@ -49,7 +51,7 @@ export function useSetPageContext(options: SetPageContextOptions): void {
 }
 
 /** Returns the active app identifier, or null at root / unmatched paths. */
-export function useCurrentApp(): AppName | null {
+export function useCurrentApp(): PillarId | null {
   return useAppContext().app;
 }
 

--- a/packages/navigation/src/types.ts
+++ b/packages/navigation/src/types.ts
@@ -5,7 +5,16 @@
  * import from here without creating circular dependencies.
  */
 
-/** Known app identifiers. */
+import type { PillarId } from '@pops/pillar-sdk';
+
+/**
+ * Built-in app identifiers backing the shell's finite default-route table
+ * (`APP_BASE_PATHS` / `detectApp` in `AppContextProvider`). This stays a
+ * closed union because the path→app mapping is an in-repo fact the build
+ * owns. The *active-surface* id is the open `PillarId` (see `AppContext.app`):
+ * a registry-discovered pillar can be the active app even though it is not a
+ * built-in here (PRD-256 / PRD-243).
+ */
 export type AppName = 'finance' | 'food' | 'lists' | 'media' | 'inventory' | 'ai' | 'cerebrum';
 
 /**
@@ -70,8 +79,8 @@ export interface AppContextEntity {
  * are applied.
  */
 export interface AppContext {
-  /** Active app, or null at root / or unmatched paths. */
-  app: AppName | null;
+  /** Active app/nav surface, or null at root / unmatched paths. Open to any registry-discovered pillar. */
+  app: PillarId | null;
   /** Current page identifier set by the active page component, or null. */
   page: string | null;
   /** Whether the current page is a top-level list/dashboard or a drill-down detail view. */

--- a/packages/pillar-sdk/src/capabilities/index.ts
+++ b/packages/pillar-sdk/src/capabilities/index.ts
@@ -27,7 +27,7 @@ export type {
 export type { CallResult, CallResultKind } from './call-result.js';
 export { PillarCallError } from './call-result.js';
 export type { CallablePillar } from './callable-pillar.js';
-export type { KnownPillarId } from './known-pillar-id.js';
+export type { KnownPillarId, PillarId } from './known-pillar-id.js';
 export { PILLARS } from './known-pillar-id.js';
 export type { ModuleId } from './module-id.js';
 export { ALL_MODULE_IDS, MODULE_PARENT_PILLAR, isKnownPillarId, isModuleId } from './module-id.js';

--- a/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
+++ b/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
@@ -22,4 +22,38 @@ export const PILLARS = [
   'lists',
 ] as const;
 
+/**
+ * Closed union over the seven in-tree pillars (build-time tier).
+ *
+ * Use `KnownPillarId` where a missing entry *should* fail the build: the
+ * nginx upstream map (`Record<KnownPillarId, …>`), `MODULE_PARENT_PILLAR`,
+ * and the typed `pillar<P extends KnownPillarId>()` projection (PRD-160).
+ * Adding a `pillars/<x>/` without wiring it here becomes a compile error —
+ * that guard rail is deliberate and stays.
+ */
 export type KnownPillarId = (typeof PILLARS)[number];
+
+/**
+ * Open pillar id (runtime tier) — a plain `string` alias, intentionally
+ * *not* a brand, because registry/runtime ids are genuinely open and a
+ * brand would force a cast at every registry boundary.
+ *
+ * Use `PillarId` on every surface fed by the runtime registry: registry
+ * snapshot entries, the nginx render's pillar set, routing/dispatch, and
+ * the shell's nav/app-context. A pillar the build has never heard of
+ * (a runtime/registry/LAN registration per PRD-228/PRD-242) is expressible
+ * here without a compile error.
+ *
+ * The seam between the two tiers is the existing
+ * `isKnownPillarId(id): id is KnownPillarId` guard — a real narrowing, not
+ * an `as`-widening. Narrow a `PillarId` to `KnownPillarId` through that
+ * guard wherever a closed-set operation (docker upstream lookup,
+ * parent-pillar table) is required; the open path otherwise routes via the
+ * registry `baseUrl`.
+ *
+ * Two-tier rule (PRD-256):
+ * - **closed** `KnownPillarId` on `PILLAR_UPSTREAMS`, `MODULE_PARENT_PILLAR`,
+ *   and the typed `pillar()` projection (PRD-160, unchanged);
+ * - **open** `PillarId` on registry / routing / nav.
+ */
+export type PillarId = string;


### PR DESCRIPTION
## PRD-256 — Two-tier pillar id

Introduces a two-tier pillar-id model: the closed `KnownPillarId` union stays where a missing entry *should* fail the build; a new open `PillarId = string` types every surface fed by the runtime registry.

### US-01 — Introduce open `PillarId`
- Export `type PillarId = string` from `@pops/pillar-sdk` alongside `KnownPillarId` (both retained), with JSDoc documenting the two-tier rule on `known-pillar-id.ts`.
- `KnownPillarId`, `PILLARS`, `isKnownPillarId` unchanged in shape and still exported.
- PRD-160's typed `pillar<P extends KnownPillarId>()` projection is untouched (no projection files in the diff).

### US-02 — Open the routing/registry surfaces (mostly already done by PRD-255)
- PRD-255 already routed the generator through `DiscoveredPillar` (`pillarId: string`) and `orderUpstreams` already appends unknown ids after the known order. The genuine gap was a **private duplicate** `isKnownPillarId` inside the generator — removed; the generator now consumes the SDK's exported guard (the documented seam).
- Render/registry-facing types (`PillarUpstream.pillarId`, the order map) now use `PillarId`.
- `PILLAR_UPSTREAMS: Record<KnownPillarId, …>` and `MODULE_PARENT_PILLAR` stay closed — a new `pillars/<x>/` without an upstream entry is still a compile error.
- Unknown-id coverage already exists (`plugin-fitness` / `plugin-z` dynamic + determinism tests).

### US-03 — Open `AppName` / app-context to `PillarId`
- `AppContext.app` and `useCurrentApp()` now return `PillarId | null` so a registry-discovered pillar can be the active nav surface.
- `AppName` stays a closed union, used **only** by the finite default-route table (`APP_BASE_PATHS` / `detectApp`) — justified, not a blanket gate.
- `IconName` and unrelated unions untouched. Blast radius is fully contained in `@pops/navigation`; no `@pops/app-*` consumer imports `AppName`.

### Verification
- `turbo typecheck --filter=@pops/pillar-sdk --filter=@pops/shell --filter=@pops/navigation` → green (16/16).
- `turbo typecheck --filter='@pops/app-*'` (AppName blast radius) → green (15/15).
- `turbo test --filter=@pops/pillar-sdk --filter=@pops/shell --filter=@pops/navigation` → green (17/17).
- `oxlint --type-aware` on each changed dir → clean (one pre-existing unrelated warning in an untouched file).
- Diff free of `as any` / `as unknown as` / suppressions.

### Flagged
US-02's acceptance text mentions an `nginx -t`-validated render. No `nginx -t` shell-out was added: the suite is hermetic with no nginx binary, matching every existing render test which asserts output validity structurally. The unknown-id render is covered with structural + byte-stable assertions instead.