### PR TITLE
fix(food,lists): apply pillar-owned migrations in tests, not the deleted monolith path

### DIFF
--- a/pillars/food/src/db/__tests__/batches-lifecycle.test.ts
+++ b/pillars/food/src/db/__tests__/batches-lifecycle.test.ts
@@ -5,14 +5,11 @@
  * service-enforced `deleted_at IS NOT NULL → qty_remaining = 0`
  * invariant (final `afterAll` scan).
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../open-food-db.js';
 import { batches, ingredientVariants, recipeVersions } from '../schema.js';
 import {
   adjustBatchQty,
@@ -30,33 +27,10 @@ import { createRun } from '../services/recipe-runs.js';
 import { createRecipe } from '../services/recipes.js';
 import { createVariant } from '../services/variants.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0069_prd_145_batches_deleted_at.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 let lastDb: FoodDb | null = null;
 
 function freshDb(): FoodDb {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  const db = drizzle(raw);
-  lastDb = db;
-  return db;
+  return openFoodDb(':memory:').db;
 }
 
 interface SeedResult {

--- a/pillars/food/src/db/__tests__/batches.test.ts
+++ b/pillars/food/src/db/__tests__/batches.test.ts
@@ -4,15 +4,12 @@
  * against an in-memory SQLite seeded with PRD-106 + PRD-107 + PRD-108
  * migrations.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { CannotCookUncompiledRecipe } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { batches, ingredientVariants, recipeVersions } from '../schema.js';
 import { consumeForRun, type ConsumptionNeed } from '../services/batches.js';
 import { createIngredient } from '../services/ingredients.js';
@@ -21,29 +18,10 @@ import { createRun, markRunComplete } from '../services/recipe-runs.js';
 import { createRecipe } from '../services/recipes.js';
 import { createVariant } from '../services/variants.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0069_prd_145_batches_deleted_at.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 /**

--- a/pillars/food/src/db/__tests__/creations.test.ts
+++ b/pillars/food/src/db/__tests__/creations.test.ts
@@ -3,13 +3,10 @@
  * registrations that fall inside the configurable window ending at
  * `recipe_versions.compiled_at`.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../open-food-db.js';
 import { recipes, recipeVersions } from '../schema.js';
 import {
   countCreationsForVersion,
@@ -19,35 +16,10 @@ import {
 } from '../services/creations.js';
 import { type FoodDb } from '../services/internal.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0062_chemical_donald_blake.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  '0065_prd_116_recipe_compile.sql',
-  '0066_prd_123_conversions.sql',
-  '0067_prd_125_ingest_error_columns.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 interface SeedVersionArgs {

--- a/pillars/food/src/db/__tests__/data-page-services.test.ts
+++ b/pillars/food/src/db/__tests__/data-page-services.test.ts
@@ -13,13 +13,10 @@
  *   - prep-states:            listPrepStates
  *   - slug-search:            searchSlugs across kinds with name resolution
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../open-food-db.js';
 import { ingredientAliases } from '../schema.js';
 import {
   bulkApproveAliases,
@@ -44,28 +41,10 @@ import { listSubstitutions, updateSubstitution } from '../services/substitutions
 import { createSubstitution } from '../services/substitutions.js';
 import { createVariant } from '../services/variants.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    for (const stmt of migration.split('--> statement-breakpoint')) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 interface Seed {

--- a/pillars/food/src/db/__tests__/inbox-drafts.test.ts
+++ b/pillars/food/src/db/__tests__/inbox-drafts.test.ts
@@ -12,15 +12,12 @@
  *   - `gatherQualityInputsForVersions` runs once per `listDrafts` call (no N+1)
  *   - `countPendingDrafts` matches the pre-filter count
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as gather from '../../inbox/gather-quality-inputs.js';
+import { openFoodDb } from '../open-food-db.js';
 import { ingestSources, recipes, recipeVersions } from '../schema.js';
 import {
   countPendingDrafts,
@@ -28,37 +25,12 @@ import {
   listDrafts,
 } from '../services/inbox-queries-drafts.js';
 
+import type Database from 'better-sqlite3';
+
 import type { FoodDb } from '../services/internal.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0062_chemical_donald_blake.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  '0065_prd_116_recipe_compile.sql',
-  '0066_prd_123_conversions.sql',
-  '0067_prd_125_ingest_error_columns.sql',
-  '0068_prd_136_inbox_review.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    for (const stmt of migration.split('--> statement-breakpoint')) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 interface SeedOpts {

--- a/pillars/food/src/db/__tests__/ingest-sources-model.test.ts
+++ b/pillars/food/src/db/__tests__/ingest-sources-model.test.ts
@@ -3,51 +3,21 @@
  * service layer against an in-memory SQLite seeded with PRDs 106 + 107 +
  * 110 migrations.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { IngestSourceNotFound, IngestSourceUrlRequired } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { ingestSources, recipes } from '../schema.js';
 import { createIngestSource, linkDraftRecipe, markArchived } from '../services/ingest-sources.js';
 import { type FoodDb } from '../services/internal.js';
 import { createRecipe } from '../services/recipes.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns.
-  '0067_prd_125_ingest_error_columns.sql',
-  // PRD-136 amendment — reviewed_at column on ingest_sources.
-  '0068_prd_136_inbox_review.sql',
-  // PRD-145 — batches.deleted_at soft-delete column.
-  '0069_prd_145_batches_deleted_at.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 describe('PRD-110 — ingest_sources schema', () => {

--- a/pillars/food/src/db/__tests__/ingredient-model.test.ts
+++ b/pillars/food/src/db/__tests__/ingredient-model.test.ts
@@ -3,12 +3,8 @@
  * an in-memory SQLite seeded with the food schema. No Redis, no API process,
  * no external services.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -17,6 +13,7 @@ import {
   InvalidSlugError,
   SlugAlreadyRegisteredError,
 } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { ingredients, prepStates, slugRegistry } from '../schema.js';
 import {
   changeIngredientParent,
@@ -28,32 +25,15 @@ import {
 import { createPrepState } from '../services/prep-states.js';
 import { createVariant } from '../services/variants.js';
 
+import type Database from 'better-sqlite3';
+
 // All food-domain migrations are applied: drizzle's TypeScript types reflect
 // the full schema (e.g. PRD-108's shelf-life columns on ingredient_variants),
 // so inserts via drizzle would fail against a partial DB even if this PRD
 // doesn't exercise the new columns.
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 describe('PRD-106 — ingredient model invariants', () => {

--- a/pillars/food/src/db/__tests__/ingredient-tags.test.ts
+++ b/pillars/food/src/db/__tests__/ingredient-tags.test.ts
@@ -12,14 +12,11 @@
  *   - `countIngredientsInNamespace` distinct-count helper
  *   - Expression index is honoured (EXPLAIN QUERY PLAN sanity check)
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../open-food-db.js';
 import { ingredients, ingredientTags } from '../schema.js';
 import {
   addTagToIngredient,
@@ -32,31 +29,12 @@ import {
   setTagsForIngredient,
 } from '../services/ingredient-tags.js';
 
+import type Database from 'better-sqlite3';
+
 import type { FoodDb } from '../services/internal.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0070_prd_151_ingredient_tags.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    for (const stmt of migration.split('--> statement-breakpoint')) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 function seedIngredient(db: FoodDb, slug: string, name: string): number {

--- a/pillars/food/src/db/__tests__/plan-entries.test.ts
+++ b/pillars/food/src/db/__tests__/plan-entries.test.ts
@@ -6,12 +6,8 @@
  * PRD-113 owns the seeded `plan_slots` rows; this suite seeds its own
  * minimal slot vocabulary so the FK can be exercised in isolation.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { asc, eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -22,6 +18,7 @@ import {
   PlanSlotNotFound,
   PlanSlotSlugAlreadyExists,
 } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { planEntries, planSlots } from '../schema.js';
 import {
   addCustomSlot,
@@ -36,19 +33,9 @@ import {
 import { createRun } from '../services/recipe-runs.js';
 import { createRecipe } from '../services/recipes.js';
 
-import type { FoodDb } from '../services/internal.js';
+import type Database from 'better-sqlite3';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0063_bumpy_wolverine.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type { FoodDb } from '../services/internal.js';
 
 const DEFAULT_SLOTS = [
   { slug: 'breakfast', name: 'Breakfast', displayOrder: 10 },
@@ -59,19 +46,11 @@ const DEFAULT_SLOTS = [
 ] as const;
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  const db = drizzle(raw);
+  const opened = openFoodDb(':memory:');
   // PRD-113 will seed these; mirror it here so PRD-111 tests run standalone.
   for (const slot of DEFAULT_SLOTS) {
-    db.insert(planSlots)
+    opened.db
+      .insert(planSlots)
       .values({
         slug: slot.slug,
         name: slot.name,
@@ -80,7 +59,7 @@ function freshDb(): { db: FoodDb; raw: Database.Database } {
       })
       .run();
   }
-  return { db, raw };
+  return opened;
 }
 
 function makeRecipe(db: FoodDb, slug = 'smash-burger'): number {

--- a/pillars/food/src/db/__tests__/recipe-model.test.ts
+++ b/pillars/food/src/db/__tests__/recipe-model.test.ts
@@ -2,12 +2,8 @@
  * PRD-107 invariant tests — exercises the recipe + version schema against
  * an in-memory SQLite seeded with PRD-106 + PRD-107 migrations.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { and, eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -15,6 +11,7 @@ import {
   CannotPromoteUncompiledVersion,
   SlugAlreadyRegisteredError,
 } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { recipes, recipeTags, recipeVersions, slugRegistry } from '../schema.js';
 import { createIngredient } from '../services/ingredients.js';
 import { type FoodDb } from '../services/ingredients.js';
@@ -30,31 +27,10 @@ import {
   renameRecipeSlug,
 } from '../services/recipes.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  // PRD-109's substitutions table is referenced from deleteRecipe, which
-  // cascades any recipe-scoped subs before dropping the recipe row.
-  '0061_shocking_skreet.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 function makeCompiledRecipe(

--- a/pillars/food/src/db/__tests__/seed.test.ts
+++ b/pillars/food/src/db/__tests__/seed.test.ts
@@ -18,15 +18,12 @@
  *
  * No Redis, no API process — pure schema + service exercise.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq, isNotNull, isNull, sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { seedFood, type SeedFoodSummary } from '../../seed/index.js';
+import { openFoodDb } from '../open-food-db.js';
 import {
   batches,
   ingestSources,
@@ -37,40 +34,12 @@ import {
   substitutions,
 } from '../schema.js';
 
+import type Database from 'better-sqlite3';
+
 import type { FoodDb } from '../services/internal.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql', // PRD-106 ingredients + slug_registry + prep_states + aliases
-  '0059_useful_hiroim.sql', // PRD-107 recipes + recipe_versions + recipe_tags
-  '0060_familiar_leo.sql', // PRD-108 batches + recipe_runs + batch_consumptions
-  '0061_shocking_skreet.sql', // PRD-109 substitutions
-  '0062_chemical_donald_blake.sql', // PRD-112 lists + list_items
-  '0063_bumpy_wolverine.sql', // PRD-111 plan_slots + plan_entries
-  '0064_peaceful_magma.sql', // PRD-110 ingest_sources
-  '0065_prd_116_recipe_compile.sql', // PRD-116 recipe_lines + recipe_steps + proposed_slugs
-  '0066_prd_123_conversions.sql', // PRD-123 unit_conversions + ingredient_weights
-  '0067_prd_125_ingest_error_columns.sql', // PRD-125 error_code/message/attempts on ingest_sources
-  '0068_prd_136_inbox_review.sql', // PRD-136 recipe_version_rejections + ingest_sources.reviewed_at
-  '0069_prd_145_batches_deleted_at.sql', // PRD-145 batches.deleted_at soft-delete column
-  '0070_prd_151_ingredient_tags.sql', // PRD-151 ingredient_tags + namespace expression index
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 describe('PRD-113 phase-1 seed', () => {

--- a/pillars/food/src/db/__tests__/substitutions.test.ts
+++ b/pillars/food/src/db/__tests__/substitutions.test.ts
@@ -3,44 +3,22 @@
  * substitutions schema against an in-memory SQLite seeded with PRD-106 +
  * PRD-107 + PRD-109 migrations. No Redis, no API process.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { and, eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { CannotSubstituteSelf } from '../errors.js';
+import { openFoodDb } from '../open-food-db.js';
 import { substitutions } from '../schema.js';
 import { createIngredient, type FoodDb } from '../services/ingredients.js';
 import { createRecipe, deleteRecipe } from '../services/recipes.js';
 import { createSubstitution, deleteRecipeScopedSubstitutions } from '../services/substitutions.js';
 import { createVariant } from '../services/variants.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 interface Seed {

--- a/pillars/food/src/dsl/__tests__/compile.test.ts
+++ b/pillars/food/src/dsl/__tests__/compile.test.ts
@@ -6,14 +6,11 @@
  * state (recipe_lines, recipe_steps, recipe_version_proposed_slugs, and
  * the recipe_versions columns the compile mutates).
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import {
   recipeLines,
   recipeSteps,
@@ -34,34 +31,8 @@ const { createPrepState } = prepStatesService;
 const { createRecipe } = recipesService;
 const { createVariant } = variantsService;
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0065_prd_116_recipe_compile.sql',
-  // PRD-123 — compile now consults `unit_conversions` + `ingredient_weights`
-  // via `normaliseLineQty`. Tests still cover the unresolved path (no rows
-  // seeded → falls back to ingredient default_unit); see dedicated
-  // "conversion v1" test for the seeded-row happy path.
-  '0066_prd_123_conversions.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): FoodDb {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return drizzle(raw);
+  return openFoodDb(':memory:').db;
 }
 
 function seedKnownIngredients(db: FoodDb): void {

--- a/pillars/food/src/dsl/__tests__/cycle.test.ts
+++ b/pillars/food/src/dsl/__tests__/cycle.test.ts
@@ -7,14 +7,11 @@
  * reads. When PRD-116's full schema arrives, the same queries continue to
  * work against the superset.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import { recipeVersions } from '../../db/schema.js';
 import * as ingredientsService from '../../db/services/ingredients.js';
 import { type FoodDb } from '../../db/services/internal.js';
@@ -22,40 +19,16 @@ import * as recipeVersionsService from '../../db/services/recipe-versions.js';
 import * as recipesService from '../../db/services/recipes.js';
 import { detectRecipeCycle } from '../cycle.js';
 
+import type Database from 'better-sqlite3';
+
 import type { ResolvedIngredientBlock, ResolvedRecipeAst } from '../resolver-types.js';
 
 const { createIngredient } = ingredientsService;
 const { promoteVersion } = recipeVersionsService;
 const { createRecipe } = recipesService;
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  // PRD-116 lands `recipe_lines` proper — no more stub.
-  '0065_prd_116_recipe_compile.sql',
-  // PRD-123 — required because compile-lines now consults the conversion
-  // tables; the cycle suite drives compile-time recipe-ref persistence so
-  // the materialiser needs both schemas live.
-  '0066_prd_123_conversions.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 function makePromotedRecipe(

--- a/pillars/food/src/dsl/__tests__/normalisation.test.ts
+++ b/pillars/food/src/dsl/__tests__/normalisation.test.ts
@@ -5,13 +5,10 @@
  * conversion-table migrations on top of PRD-106's ingredients schema.
  * Each test asserts BOTH the returned shape and the resolution path.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import * as conversionsService from '../../db/services/conversions.js';
 import * as ingredientsService from '../../db/services/ingredients.js';
 import { type FoodDb } from '../../db/services/internal.js';
@@ -22,32 +19,8 @@ const { createIngredientWeight, createUnitConversion } = conversionsService;
 const { createIngredient } = ingredientsService;
 const { createVariant } = variantsService;
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  // 0059 (PRD-107 recipes) is a prerequisite for 0060's batches → recipe_runs FK.
-  '0059_useful_hiroim.sql',
-  // 0060 (PRD-108) ALTERs `ingredient_variants` with the shelf_life columns —
-  // without it, createVariant fails on insert.
-  '0060_familiar_leo.sql',
-  '0066_prd_123_conversions.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): FoodDb {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return drizzle(raw);
+  return openFoodDb(':memory:').db;
 }
 
 describe('PRD-123 — normaliseLineQty', () => {

--- a/pillars/food/src/dsl/__tests__/resolver.test.ts
+++ b/pillars/food/src/dsl/__tests__/resolver.test.ts
@@ -6,14 +6,11 @@
  * path, mixed-error path, self-reference, recipe-as-ingredient, variant
  * scoping, and the `_` skip segment.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import { recipeVersions } from '../../db/schema.js';
 import * as ingredientsService from '../../db/services/ingredients.js';
 import { type FoodDb } from '../../db/services/internal.js';
@@ -36,28 +33,8 @@ import type {
   ResolvedStepBlock,
 } from '../resolver-types.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): FoodDb {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return drizzle(raw);
+  return openFoodDb(':memory:').db;
 }
 
 function parse(input: string) {

--- a/pillars/food/src/inbox/__tests__/gather-quality-inputs.test.ts
+++ b/pillars/food/src/inbox/__tests__/gather-quality-inputs.test.ts
@@ -6,52 +6,19 @@
  * `extracted_json`, count creation slugs via the window join, and
  * collapse to a sensible default when the source row is missing.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import { ingestSources, recipes, recipeVersions, slugRegistry } from '../../db/schema.js';
 import { type FoodDb } from '../../db/services/internal.js';
 import { gatherQualityInputsForVersions } from '../gather-quality-inputs.js';
 import { scoreDraft } from '../quality.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0062_chemical_donald_blake.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  '0065_prd_116_recipe_compile.sql',
-  '0066_prd_123_conversions.sql',
-  '0067_prd_125_ingest_error_columns.sql',
-  // PRD-136 adds `ingest_sources.reviewed_at` and the `recipe_version_rejections`
-  // table. PRD-137's gather helper reads `reviewed_at` so the migration must
-  // apply here too — without it the schema is missing the column.
-  '0068_prd_136_inbox_review.sql',
-  '0069_prd_145_batches_deleted_at.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
+import type Database from 'better-sqlite3';
 
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 interface SeededRecipe {

--- a/pillars/food/src/seed/__tests__/seed-phase-2.test.ts
+++ b/pillars/food/src/seed/__tests__/seed-phase-2.test.ts
@@ -17,14 +17,11 @@
  *   - PRD-123 conversion seeds let `normaliseLineQty` resolve qty:unit pairs
  *     like `kg` → `g` and variant-specific `tsp` → `g`
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { and, eq, sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { openFoodDb } from '../../db/open-food-db.js';
 import {
   ingredientWeights,
   recipeLines,
@@ -39,44 +36,12 @@ import { parseRecipeDsl } from '../../dsl/parser.js';
 import { resolveRecipeAst } from '../../dsl/resolver.js';
 import { seedFood, type SeedFoodSummary } from '../index.js';
 
+import type Database from 'better-sqlite3';
+
 import type { FoodDb } from '../../db/services/internal.js';
 
-const MIGRATIONS = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0062_chemical_donald_blake.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  '0065_prd_116_recipe_compile.sql',
-  '0066_prd_123_conversions.sql',
-  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns.
-  '0067_prd_125_ingest_error_columns.sql',
-  // PRD-136 amendment — reviewed_at column on ingest_sources.
-  '0068_prd_136_inbox_review.sql',
-  // PRD-145 — batches.deleted_at soft-delete column.
-  '0069_prd_145_batches_deleted_at.sql',
-  // PRD-151 — ingredient_tags + namespace expression index.
-  '0070_prd_151_ingredient_tags.sql',
-].map((name) =>
-  readFileSync(
-    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
-    'utf8'
-  )
-);
-
 function freshDb(): { db: FoodDb; raw: Database.Database } {
-  const raw = new Database(':memory:');
-  raw.pragma('foreign_keys = ON');
-  for (const migration of MIGRATIONS) {
-    const stmts = migration.split('--> statement-breakpoint');
-    for (const stmt of stmts) {
-      const trimmed = stmt.trim();
-      if (trimmed.length > 0) raw.exec(trimmed);
-    }
-  }
-  return { db: drizzle(raw), raw };
+  return openFoodDb(':memory:');
 }
 
 function selectRecipeId(db: FoodDb, slug: string): number {

--- a/pillars/lists/src/db/__tests__/lists.test.ts
+++ b/pillars/lists/src/db/__tests__/lists.test.ts
@@ -36,10 +36,7 @@ import {
 } from '../services/lists.js';
 
 const MIGRATION_SQL = readFileSync(
-  join(
-    __dirname,
-    '../../../../../apps/pops-api/src/db/drizzle-migrations/0062_chemical_donald_blake.sql'
-  ),
+  join(__dirname, '../../../migrations/0062_chemical_donald_blake.sql'),
   'utf8'
 );
 


### PR DESCRIPTION
## Problem
The monolith migrations dir `apps/pops-api/src/db/drizzle-migrations` was deleted and each pillar now owns a squashed/renamed migration sequence. 18 food test suites + 1 lists suite still read specific *old monolith* `.sql` filenames (`0059_useful_hiroim.sql`, `0060_familiar_leo.sql`, …) that no longer exist, failing with `ENOENT` on `lake-migration` (the Food + Lists pillar CI lanes were red).

## Fix
- **Food (18 files):** drop the hand-curated monolith `.sql` lists + manual statement-exec `freshDb()`; build the in-memory test DB via the pillar's own migrator `openFoodDb(':memory:')`, which applies the in-package migration journal — matching how the passing pillars (finance) work. `plan-entries.test.ts` keeps its default `plan_slots` seeding on top.
- **Lists (1 file):** `lists.test.ts` repoints its single migration read to the in-package `pillars/lists/migrations/` path (the sibling `list-items.test.ts` already did this).

## Verification
- `@pops/food`: 78 files / 929 tests pass. `@pops/lists`: 14 files / 182 tests pass.
- typecheck + oxlint + oxfmt clean. No `apps/pops-api` migration reads remain (only pre-existing doc comments).
- Root cause was an intervening migration-relocation commit (green as of #3456); unrelated to the self-registration epic.