### PR TITLE
ci(publish): build + publish cerebrum, orchestrator, and docs images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -24,6 +24,8 @@ jobs:
         app:
           - { image: pops-shell, file: apps/pops-shell/Dockerfile }
           - { image: pops-mcp, file: apps/pops-mcp/Dockerfile }
+          - { image: pops-orchestrator, file: apps/pops-orchestrator/Dockerfile }
+          - { image: pops-docs, file: apps/pops-docs/Dockerfile }
     steps:
       - uses: actions/checkout@v6
 
@@ -75,8 +77,10 @@ jobs:
         # `pillars/<x>/Dockerfile` exists to build it from. This keeps the
         # publish set in lockstep with compose's `image:` refs — adding a
         # pillar image to compose makes it publish here with no workflow
-        # edit, and pillars that build-from-source in compose (cerebrum,
-        # orchestrator: no `image:` ref) are excluded by construction.
+        # edit. Services whose Dockerfile lives under `apps/` rather than
+        # `pillars/<x>/` (orchestrator, docs) are published by the `apps`
+        # job above instead, so they're excluded here by the Dockerfile
+        # existence check even though they pin an `image:` ref.
         run: |
           set -euo pipefail
           mapfile -t pillars < <(

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -358,6 +358,7 @@ services:
       dockerfile: pillars/cerebrum/Dockerfile
       args:
         BUILD_VERSION: ${BUILD_VERSION:-dev}
+    image: ghcr.io/knoxio/pops-cerebrum:${POPS_IMAGE_TAG:-main}
     container_name: pops-cerebrum-api
     restart: unless-stopped
     networks:
@@ -410,6 +411,7 @@ services:
       dockerfile: pillars/cerebrum/Dockerfile
       args:
         BUILD_VERSION: ${BUILD_VERSION:-dev}
+    image: ghcr.io/knoxio/pops-cerebrum:${POPS_IMAGE_TAG:-main}
     container_name: pops-cerebrum-worker
     restart: unless-stopped
     command: ['node', 'dist/worker/index.js']
@@ -446,6 +448,7 @@ services:
       dockerfile: apps/pops-orchestrator/Dockerfile
       args:
         BUILD_VERSION: ${BUILD_VERSION:-dev}
+    image: ghcr.io/knoxio/pops-orchestrator:${POPS_IMAGE_TAG:-main}
     container_name: pops-orchestrator
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Why

The v1.0.0 image-publish run produced 8 images (shell, mcp + 6 pillars). The three remaining v1.0 services were **build-only** in `infra/docker-compose.yml` and never published, so capivara — which deploys by `docker compose --pull`, never builds — cannot run the full v1.0 topology.

## What

- **cerebrum** — pin `image: ghcr.io/knoxio/pops-cerebrum` on `cerebrum-api` + `cerebrum-worker`. The `discover` job now picks it up via the image ref + the existing `pillars/cerebrum/Dockerfile`.
- **orchestrator** — pin `image: ghcr.io/knoxio/pops-orchestrator` + add to the `apps` publish matrix (its Dockerfile lives under `apps/`, not `pillars/`).
- **docs** — add to the `apps` publish matrix (Dockerfile under `apps/`).

Worker services reuse their pillar image (`cerebrum-worker` → `pops-cerebrum`, `pops-worker-food` → `pops-food`), so no separate publish.

## Verification

- All three (`apps/pops-orchestrator/Dockerfile`, `apps/pops-docs/Dockerfile`, `pillars/cerebrum/Dockerfile`) full-build clean locally.
- `docker compose -f infra/docker-compose.yml config --quiet` passes; all 11 `ghcr.io/knoxio/pops-*` images resolve.
- Discover grep now yields 7 pillars (incl. cerebrum); orchestrator/docs route to the apps job.

Brings the publishable set to the full **11-image** v1.0 topology so the prod stack deploys without source on the host.