### PR TITLE
fix(shell): order set before rewrite in pillar nginx blocks (500 on all FE→pillar calls)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -43,50 +43,50 @@ server {
     # upstream is in place.
 
     location /core-api/ {
-        rewrite ^/core-api/(.*)$ /$1 break;
         set $core_api_upstream http://core-api:3001;
+        rewrite ^/core-api/(.*)$ /$1 break;
         proxy_pass $core_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /inventory-api/ {
-        rewrite ^/inventory-api/(.*)$ /$1 break;
         set $inventory_api_upstream http://inventory-api:3002;
+        rewrite ^/inventory-api/(.*)$ /$1 break;
         proxy_pass $inventory_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /media-api/ {
-        rewrite ^/media-api/(.*)$ /$1 break;
         set $media_api_upstream http://media-api:3003;
+        rewrite ^/media-api/(.*)$ /$1 break;
         proxy_pass $media_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /finance-api/ {
-        rewrite ^/finance-api/(.*)$ /$1 break;
         set $finance_api_upstream http://finance-api:3004;
+        rewrite ^/finance-api/(.*)$ /$1 break;
         proxy_pass $finance_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /food-api/ {
-        rewrite ^/food-api/(.*)$ /$1 break;
         set $food_api_upstream http://food-api:3005;
+        rewrite ^/food-api/(.*)$ /$1 break;
         proxy_pass $food_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /lists-api/ {
-        rewrite ^/lists-api/(.*)$ /$1 break;
         set $lists_api_upstream http://lists-api:3006;
+        rewrite ^/lists-api/(.*)$ /$1 break;
         proxy_pass $lists_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }
 
     location /cerebrum-api/ {
-        rewrite ^/cerebrum-api/(.*)$ /$1 break;
         set $cerebrum_api_upstream http://cerebrum-api:3007;
+        rewrite ^/cerebrum-api/(.*)$ /$1 break;
         proxy_pass $cerebrum_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }

--- a/apps/pops-shell/scripts/generate-nginx-conf.test.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.test.ts
@@ -178,6 +178,24 @@ describe('generate-nginx-conf', () => {
       expect(rendered).toContain('set $core_api_upstream http://core-api:3001;');
     });
 
+    it('emits `set $<pillar>_api_upstream` BEFORE `rewrite ... break` in every pillar block', () => {
+      // `rewrite ... break` halts the ngx_http_rewrite_module phase, so a `set`
+      // placed after it never runs — the upstream variable stays uninitialised
+      // and `proxy_pass $var` 500s with "invalid URL prefix". The `set` must
+      // precede the `rewrite` in each `/<pillar>-api/` block.
+      for (const id of Object.keys(PILLAR_UPSTREAMS)) {
+        const block = rendered.match(
+          new RegExp(`location /${id}-api/ \\{([\\s\\S]*?)\\n    \\}`)
+        )?.[1];
+        expect(block, `missing /${id}-api/ block`).toBeDefined();
+        const setIdx = block!.indexOf(`set $`);
+        const rewriteIdx = block!.indexOf('rewrite ');
+        expect(setIdx).toBeGreaterThanOrEqual(0);
+        expect(rewriteIdx).toBeGreaterThanOrEqual(0);
+        expect(setIdx, `set must precede rewrite in /${id}-api/`).toBeLessThan(rewriteIdx);
+      }
+    });
+
     it('routes the core /registry/subscribe SSE stream to the core pillar with buffering off', () => {
       expect(rendered).toContain('location ~ ^/registry/subscribe/?$ {');
       expect(rendered).toContain('set $registry_subscribe_upstream http://core-api:3001;');

--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -134,8 +134,8 @@ function renderPillarRestBlockFromUpstream(upstream: PillarUpstream): string {
   const varName = nginxVarName(upstream.pillarId);
   return [
     `    location /${upstream.pillarId}-api/ {`,
-    `        rewrite ^/${upstream.pillarId}-api/(.*)$ /$1 break;`,
     `        set $${varName}_api_upstream http://${upstream.host}:${upstream.port};`,
+    `        rewrite ^/${upstream.pillarId}-api/(.*)$ /$1 break;`,
     `        proxy_pass $${varName}_api_upstream;`,
     `        include /etc/nginx/snippets/_pillar-proxy.conf;`,
     `    }`,


### PR DESCRIPTION
## Bug

Every `/<pillar>-api/` location block in the generated `nginx.conf` emitted:

```nginx
location /core-api/ {
    rewrite ^/core-api/(.*)$ /$1 break;
    set $core_api_upstream http://core-api:3001;   # never runs
    proxy_pass $core_api_upstream;                  # → "" → 500
}
```

`rewrite ... break` halts the `ngx_http_rewrite_module` phase, so the `set` directive after it is skipped. The upstream variable stays uninitialised → `proxy_pass $var` fails with `invalid URL prefix in ""` → **HTTP 500 on every FE→pillar request**. Discovered on the capivara v1.0 deploy: pillars healthy + reachable directly, but the shell's proxy 500'd for all `/<pillar>-api/` routes.

## Fix

Emit `set` **before** `rewrite ... break` (matching every other proxy block in the file, which already do `set` first). Regenerated `nginx.conf` (all 7 pillar blocks).

## Regression guard

Added a test asserting `set $<pillar>_api_upstream` precedes `rewrite` in each block. The existing drift test pins exact output but not ordering semantics, so it passed with the bug present.