### PR TITLE
fix(shell): order set before rewrite in the orchestrator nginx block

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -100,8 +100,8 @@ server {
     # variable-form upstream (boots even when the orchestrator is absent).
 
     location /orchestrator-api/ {
-        rewrite ^/orchestrator-api/(.*)$ /$1 break;
         set $orchestrator_api_upstream http://pops-orchestrator:3009;
+        rewrite ^/orchestrator-api/(.*)$ /$1 break;
         proxy_pass $orchestrator_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }

--- a/apps/pops-shell/scripts/generate-nginx-conf.test.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.test.ts
@@ -196,6 +196,16 @@ describe('generate-nginx-conf', () => {
       }
     });
 
+    it('emits `set` before `rewrite ... break` in the orchestrator block too', () => {
+      const block = rendered.match(/location \/orchestrator-api\/ \{([\s\S]*?)\n    \}/)?.[1];
+      expect(block, 'missing /orchestrator-api/ block').toBeDefined();
+      const setIdx = block!.indexOf('set $');
+      const rewriteIdx = block!.indexOf('rewrite ');
+      expect(setIdx).toBeGreaterThanOrEqual(0);
+      expect(rewriteIdx).toBeGreaterThanOrEqual(0);
+      expect(setIdx, 'set must precede rewrite in /orchestrator-api/').toBeLessThan(rewriteIdx);
+    });
+
     it('routes the core /registry/subscribe SSE stream to the core pillar with buffering off', () => {
       expect(rendered).toContain('location ~ ^/registry/subscribe/?$ {');
       expect(rendered).toContain('set $registry_subscribe_upstream http://core-api:3001;');

--- a/apps/pops-shell/scripts/nginx-conf-orchestrator.ts
+++ b/apps/pops-shell/scripts/nginx-conf-orchestrator.ts
@@ -23,8 +23,8 @@ export const NGINX_CONF_ORCHESTRATOR = `    # ── Federated-search orchestrat
     # variable-form upstream (boots even when the orchestrator is absent).
 
     location /orchestrator-api/ {
-        rewrite ^/orchestrator-api/(.*)$ /$1 break;
         set $orchestrator_api_upstream http://pops-orchestrator:3009;
+        rewrite ^/orchestrator-api/(.*)$ /$1 break;
         proxy_pass $orchestrator_api_upstream;
         include /etc/nginx/snippets/_pillar-proxy.conf;
     }


### PR DESCRIPTION
Follow-up to #3468 — the orchestrator location block (separate generator, `nginx-conf-orchestrator.ts`) had the same `rewrite`-before-`set` ordering, 500ing every `/orchestrator-api/*` call. Fixed identically; regenerated `nginx.conf`; extended the regression test to the orchestrator block. Verified live on capivara: the 7 pillar proxies already return 200 (the #3468 fix landed via watchtower); orchestrator was the last 500.