### PR TITLE
refactor(registry): DB registry as source of truth for /pillars + URI dispatch (env demoted to seed/fallback)

### DIFF
--- a/apps/pops-orchestrator/src/__tests__/app.test.ts
+++ b/apps/pops-orchestrator/src/__tests__/app.test.ts
@@ -2,12 +2,52 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createOrchestratorApp } from '../app.js';
-import { __resetPillarRegistryCache } from '../pillars/registry.js';
+import { __resetPillarRegistryCache, type RegistrySnapshotReader } from '../pillars/registry.js';
+
+import type { PillarSnapshot } from '@pops/pillar-sdk/discovery';
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 const SELF_BASE_URL = 'http://localhost:3009';
 
-function makeApp() {
-  return createOrchestratorApp({ version: '1.2.3', selfBaseUrl: SELF_BASE_URL });
+function manifestFor(pillarId: string): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '0.1.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '0.1.0',
+      tag: `contract-${pillarId}@v0.1.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+function snapshotEntry(pillarId: string, baseUrl: string): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl,
+    manifest: manifestFor(pillarId),
+    registered: true,
+    lastSeenAt: new Date(),
+    status: 'healthy',
+  };
+}
+
+/** Snapshot reader that yields the given live entries. */
+function reader(...entries: PillarSnapshot[]): RegistrySnapshotReader {
+  return async () => entries;
+}
+
+/** Snapshot reader that yields an empty registry (cold-start / seed-only). */
+const emptyReader: RegistrySnapshotReader = async () => [];
+
+function makeApp(snapshotReader: RegistrySnapshotReader) {
+  return createOrchestratorApp({ version: '1.2.3', selfBaseUrl: SELF_BASE_URL, snapshotReader });
 }
 
 describe('orchestrator app', () => {
@@ -29,7 +69,7 @@ describe('orchestrator app', () => {
 
   describe('GET /health', () => {
     it('returns ok with the orchestrator service identity and build version', async () => {
-      const res = await request(makeApp()).get('/health');
+      const res = await request(makeApp(emptyReader)).get('/health');
 
       expect(res.status).toBe(200);
       expect(res.body).toMatchObject({
@@ -43,19 +83,19 @@ describe('orchestrator app', () => {
     });
   });
 
-  describe('GET /pillars', () => {
+  describe('GET /pillars — seed fallback (empty registry)', () => {
     it('lists the synthetic orchestrator self-entry first when POPS_PILLARS is unset', async () => {
-      const res = await request(makeApp()).get('/pillars');
+      const res = await request(makeApp(emptyReader)).get('/pillars');
 
       expect(res.status).toBe(200);
       expect(res.body.pillars).toEqual([{ id: 'orchestrator', baseUrl: SELF_BASE_URL }]);
     });
 
-    it('federates the parsed POPS_PILLARS entries behind the self-entry', async () => {
+    it('federates the parsed POPS_PILLARS seed behind the self-entry', async () => {
       process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004,food:http://food-api:3005';
       __resetPillarRegistryCache();
 
-      const res = await request(makeApp()).get('/pillars');
+      const res = await request(makeApp(emptyReader)).get('/pillars');
 
       expect(res.status).toBe(200);
       expect(res.body.pillars).toEqual([
@@ -65,18 +105,61 @@ describe('orchestrator app', () => {
       ]);
     });
 
-    it('drops a stale orchestrator entry from POPS_PILLARS in favour of the live self-entry', async () => {
+    it('drops a stale orchestrator seed entry in favour of the live self-entry', async () => {
       process.env['POPS_PILLARS'] =
         'orchestrator:http://stale:9999,finance:http://finance-api:3004';
       __resetPillarRegistryCache();
 
-      const res = await request(makeApp()).get('/pillars');
+      const res = await request(makeApp(emptyReader)).get('/pillars');
 
       expect(res.status).toBe(200);
       expect(res.body.pillars).toEqual([
         { id: 'orchestrator', baseUrl: SELF_BASE_URL },
         { id: 'finance', baseUrl: 'http://finance-api:3004' },
       ]);
+    });
+  });
+
+  describe('GET /pillars — registry-as-truth', () => {
+    it('surfaces a registry-registered pillar even when POPS_PILLARS is unset', async () => {
+      const res = await request(
+        makeApp(reader(snapshotEntry('media', 'http://media-api:3005')))
+      ).get('/pillars');
+
+      expect(res.status).toBe(200);
+      expect(res.body.pillars).toEqual([
+        { id: 'orchestrator', baseUrl: SELF_BASE_URL },
+        { id: 'media', baseUrl: 'http://media-api:3005' },
+      ]);
+    });
+
+    it('backfills a seeded id the registry has no live entry for, registry first', async () => {
+      process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004';
+      __resetPillarRegistryCache();
+
+      const res = await request(
+        makeApp(reader(snapshotEntry('media', 'http://media-api:3005')))
+      ).get('/pillars');
+
+      expect(res.status).toBe(200);
+      expect(res.body.pillars).toEqual([
+        { id: 'orchestrator', baseUrl: SELF_BASE_URL },
+        { id: 'media', baseUrl: 'http://media-api:3005' },
+        { id: 'finance', baseUrl: 'http://finance-api:3004' },
+      ]);
+    });
+
+    it('lets a live registration win over a stale seed entry for the same id', async () => {
+      process.env['POPS_PILLARS'] = 'media:http://stale-media:9999';
+      __resetPillarRegistryCache();
+
+      const res = await request(
+        makeApp(reader(snapshotEntry('media', 'http://media-api:3005')))
+      ).get('/pillars');
+
+      expect(res.status).toBe(200);
+      const mediaEntries = res.body.pillars.filter((p: { id: string }) => p.id === 'media');
+      expect(mediaEntries).toEqual([{ id: 'media', baseUrl: 'http://media-api:3005' }]);
     });
   });
 });

--- a/apps/pops-orchestrator/src/app.ts
+++ b/apps/pops-orchestrator/src/app.ts
@@ -3,14 +3,15 @@
  *
  * Precursor C2 (ADR-029, epics 06+07) stands up the foundation: the
  * minimal `/health` liveness probe plus the federated `/pillars` view
- * derived from `POPS_PILLARS`. The cross-pillar aggregators — federated
- * search (epic 06), the AI-tool registry (epic 07), and possibly the
- * cross-pillar embeddings pipeline — mount here in follow-up increments.
+ * (registry-first via the SDK discovery client, `POPS_PILLARS` seed
+ * fallback). The cross-pillar aggregators — federated search (epic 06), the
+ * AI-tool registry (epic 07), and possibly the cross-pillar embeddings
+ * pipeline — mount here in follow-up increments.
  *
  * Kept as a factory so the test suite can spin up an in-process
  * `supertest` instance without binding a real port.
  */
-import express, { type Express, type Request, type Response } from 'express';
+import express, { type Express, type NextFunction, type Request, type Response } from 'express';
 import { z } from 'zod';
 
 import { type BuildToolList, createAiToolsHandler } from './ai-tools/index.js';
@@ -76,8 +77,11 @@ export function createOrchestratorApp(
     res.json(handlers.health());
   });
 
-  app.get('/pillars', (_req: Request, res: Response) => {
-    res.json(handlers.pillars());
+  app.get('/pillars', (_req: Request, res: Response, next: NextFunction) => {
+    void handlers
+      .pillars()
+      .then((payload) => res.json(payload))
+      .catch(next);
   });
 
   app.post('/search', (req: Request, res: Response) => {

--- a/apps/pops-orchestrator/src/handlers.ts
+++ b/apps/pops-orchestrator/src/handlers.ts
@@ -6,7 +6,11 @@
  * DB, so `health` is a pure liveness shape rather than a DB round-trip
  * (contrast the pillars, which touch SQLite to surface a dead handle).
  */
-import { getPillarRegistry, ORCHESTRATOR_PILLAR_ID } from './pillars/registry.js';
+import {
+  ORCHESTRATOR_PILLAR_ID,
+  resolvePillarRegistry,
+  type RegistrySnapshotReader,
+} from './pillars/registry.js';
 
 import type { PillarRegistryEntry } from '@pops/types';
 
@@ -19,6 +23,13 @@ export interface OrchestratorDeps {
    * have to special-case the federating service.
    */
   selfBaseUrl: string;
+  /**
+   * Live registry snapshot reader for `GET /pillars`. Production omits this so
+   * the handler reads the DB registry via the SDK discovery client; tests
+   * inject a stub to assert the registry-first / seed-fallback projection
+   * without a network round-trip.
+   */
+  snapshotReader?: RegistrySnapshotReader;
 }
 
 export interface HealthResponse {
@@ -35,7 +46,7 @@ export interface PillarsResponse {
 
 export function makeRequestHandler(deps: OrchestratorDeps): {
   health(): HealthResponse;
-  pillars(): PillarsResponse;
+  pillars(): Promise<PillarsResponse>;
 } {
   return {
     health(): HealthResponse {
@@ -47,8 +58,12 @@ export function makeRequestHandler(deps: OrchestratorDeps): {
         ts: new Date().toISOString(),
       };
     },
-    pillars(): PillarsResponse {
-      return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };
+    async pillars(): Promise<PillarsResponse> {
+      const pillars = await resolvePillarRegistry(
+        { selfBaseUrl: deps.selfBaseUrl },
+        deps.snapshotReader
+      );
+      return { pillars };
     },
   };
 }

--- a/apps/pops-orchestrator/src/pillars/__tests__/registry.test.ts
+++ b/apps/pops-orchestrator/src/pillars/__tests__/registry.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { RegistryUnreachableError, type PillarSnapshot } from '@pops/pillar-sdk/discovery';
+
+import {
+  __resetPillarRegistryCache,
+  getPillarRegistry,
+  resolvePillarRegistry,
+  type RegistrySnapshotReader,
+} from '../registry.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+const SELF = 'http://localhost:3009';
+
+function manifestFor(pillarId: string): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '0.1.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '0.1.0',
+      tag: `contract-${pillarId}@v0.1.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+function snapshotEntry(pillarId: string, baseUrl: string): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl,
+    manifest: manifestFor(pillarId),
+    registered: true,
+    lastSeenAt: new Date(),
+    status: 'healthy',
+  };
+}
+
+const originalPillars = process.env['POPS_PILLARS'];
+
+beforeEach(() => {
+  __resetPillarRegistryCache();
+  delete process.env['POPS_PILLARS'];
+});
+
+afterEach(() => {
+  __resetPillarRegistryCache();
+  if (originalPillars === undefined) delete process.env['POPS_PILLARS'];
+  else process.env['POPS_PILLARS'] = originalPillars;
+});
+
+describe('resolvePillarRegistry — registry-first', () => {
+  it('projects live snapshot entries behind the synthetic self entry', async () => {
+    const reader: RegistrySnapshotReader = async () => [
+      snapshotEntry('media', 'http://media-api:3005'),
+    ];
+    const entries = await resolvePillarRegistry({ selfBaseUrl: SELF }, reader);
+    expect(entries).toEqual([
+      { id: 'orchestrator', baseUrl: SELF },
+      { id: 'media', baseUrl: 'http://media-api:3005' },
+    ]);
+  });
+
+  it('lets a live registration win over a stale seed for the same id', async () => {
+    process.env['POPS_PILLARS'] = 'media:http://stale-media:9999';
+    __resetPillarRegistryCache();
+    const reader: RegistrySnapshotReader = async () => [
+      snapshotEntry('media', 'http://media-api:3005'),
+    ];
+    const entries = await resolvePillarRegistry({ selfBaseUrl: SELF }, reader);
+    expect(entries.filter((e) => e.id === 'media')).toEqual([
+      { id: 'media', baseUrl: 'http://media-api:3005' },
+    ]);
+  });
+
+  it('backfills seed-only ids the registry has no entry for, registry first', async () => {
+    process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004';
+    __resetPillarRegistryCache();
+    const reader: RegistrySnapshotReader = async () => [
+      snapshotEntry('media', 'http://media-api:3005'),
+    ];
+    const entries = await resolvePillarRegistry({ selfBaseUrl: SELF }, reader);
+    expect(entries).toEqual([
+      { id: 'orchestrator', baseUrl: SELF },
+      { id: 'media', baseUrl: 'http://media-api:3005' },
+      { id: 'finance', baseUrl: 'http://finance-api:3004' },
+    ]);
+  });
+
+  it('drops a snapshot self-entry — the live self entry always leads', async () => {
+    const reader: RegistrySnapshotReader = async () => [
+      snapshotEntry('orchestrator', 'http://stale-orch:1234'),
+      snapshotEntry('media', 'http://media-api:3005'),
+    ];
+    const entries = await resolvePillarRegistry({ selfBaseUrl: SELF }, reader);
+    expect(entries.filter((e) => e.id === 'orchestrator')).toEqual([
+      { id: 'orchestrator', baseUrl: SELF },
+    ]);
+  });
+});
+
+describe('resolvePillarRegistry — registry unreachable', () => {
+  it('falls back to the env-only seed view when the registry is unreachable', async () => {
+    process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004';
+    __resetPillarRegistryCache();
+    const reader: RegistrySnapshotReader = async () => {
+      throw new RegistryUnreachableError('down', { attempts: 1 });
+    };
+    const entries = await resolvePillarRegistry({ selfBaseUrl: SELF }, reader);
+    expect(entries).toEqual(getPillarRegistry({ selfBaseUrl: SELF }));
+    expect(entries).toEqual([
+      { id: 'orchestrator', baseUrl: SELF },
+      { id: 'finance', baseUrl: 'http://finance-api:3004' },
+    ]);
+  });
+
+  it('rethrows non-RegistryUnreachable errors', async () => {
+    const reader: RegistrySnapshotReader = async () => {
+      throw new Error('schema validation boom');
+    };
+    await expect(resolvePillarRegistry({ selfBaseUrl: SELF }, reader)).rejects.toThrow(
+      'schema validation boom'
+    );
+  });
+});

--- a/apps/pops-orchestrator/src/pillars/registry.ts
+++ b/apps/pops-orchestrator/src/pillars/registry.ts
@@ -1,18 +1,32 @@
 /**
  * Pillar registry view served by the orchestrator.
  *
- * Wraps the local copy of `parsePillarsEnv` with a process-level cache
- * (same pattern the pillars use). Adds the synthetic `orchestrator` entry
- * so a consumer sees the federating service alongside the pillars it
- * aggregates over without having to special-case the call site.
+ * Registry-as-truth: `resolvePillarRegistry` reads the live DB-backed registry
+ * snapshot (via the pillar SDK's discovery client) as the primary source and
+ * falls back to the `POPS_PILLARS` boot seed. A registered pillar (snapshot
+ * entry) wins over its seed entry, so a redeployed pillar's fresh `baseUrl`
+ * supersedes a stale env value. When the registry is unreachable and nothing is
+ * cached, the seed alone keeps the federation view working (cold-start / outage
+ * resilience).
+ *
+ * The synthetic `orchestrator` self-entry is always prepended so a consumer
+ * sees the federating service alongside the pillars it aggregates over.
  */
+import { pillarRegistry, RegistryUnreachableError } from '@pops/pillar-sdk/discovery';
+
 import { parseBareOrigin, parsePillarsEnv } from './env.js';
 
+import type { PillarSnapshot } from '@pops/pillar-sdk/discovery';
 import type { PillarRegistryEntry } from '@pops/types';
 
 export const ORCHESTRATOR_PILLAR_ID = 'orchestrator' as const;
 
-let cached: readonly PillarRegistryEntry[] | undefined;
+let cachedSeed: readonly PillarRegistryEntry[] | undefined;
+
+function seedEntries(): readonly PillarRegistryEntry[] {
+  cachedSeed ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  return cachedSeed;
+}
 
 export interface PillarRegistryOptions {
   /**
@@ -25,14 +39,73 @@ export interface PillarRegistryOptions {
   readonly selfBaseUrl: string;
 }
 
-export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
-  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
-  const normalisedSelf = parseBareOrigin("orchestrator's selfBaseUrl", options.selfBaseUrl);
-  const withoutSelf = cached.filter((p) => p.id !== ORCHESTRATOR_PILLAR_ID);
-  return [{ id: ORCHESTRATOR_PILLAR_ID, baseUrl: normalisedSelf }, ...withoutSelf];
+/**
+ * Reads the live registry snapshot. Defaults to the SDK discovery client; tests
+ * inject a stub so they neither hit the network nor depend on the process-wide
+ * discovery cache.
+ */
+export type RegistrySnapshotReader = () => Promise<readonly PillarSnapshot[]>;
+
+const defaultSnapshotReader: RegistrySnapshotReader = async () => {
+  const snapshot = await pillarRegistry();
+  return snapshot.pillars;
+};
+
+function selfEntry(selfBaseUrl: string): PillarRegistryEntry {
+  return {
+    id: ORCHESTRATOR_PILLAR_ID,
+    baseUrl: parseBareOrigin("orchestrator's selfBaseUrl", selfBaseUrl),
+  };
 }
 
-/** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */
+/**
+ * Env-seed projection (synchronous). The `POPS_PILLARS` fallback view used when
+ * the registry is unreachable and nothing is cached. Drops a stale
+ * `orchestrator` seed entry in favour of the live self entry.
+ */
+export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
+  const withoutSelf = seedEntries().filter((p) => p.id !== ORCHESTRATOR_PILLAR_ID);
+  return [selfEntry(options.selfBaseUrl), ...withoutSelf];
+}
+
+/**
+ * Registry-first pillar view (async). Live snapshot entries lead; `POPS_PILLARS`
+ * seed entries backfill ids the snapshot has no entry for. Falls back to the
+ * env-only {@link getPillarRegistry} when the registry is unreachable.
+ */
+export async function resolvePillarRegistry(
+  options: PillarRegistryOptions,
+  reader: RegistrySnapshotReader = defaultSnapshotReader
+): Promise<readonly PillarRegistryEntry[]> {
+  let live: readonly PillarSnapshot[];
+  try {
+    live = await reader();
+  } catch (err) {
+    // Registry unreachable with an empty cache: the seed is the only signal we
+    // have, so degrade to the env-only view rather than serving nothing.
+    if (err instanceof RegistryUnreachableError) return getPillarRegistry(options);
+    throw err;
+  }
+
+  const liveById = new Map<string, PillarRegistryEntry>();
+  for (const pillar of live) {
+    if (pillar.pillarId === ORCHESTRATOR_PILLAR_ID) continue;
+    liveById.set(pillar.pillarId, { id: pillar.pillarId, baseUrl: pillar.baseUrl });
+  }
+
+  // Registry-first ordering: live entries lead, seed-only ids follow. The seed
+  // is the fallback, so it MUST NOT shadow a registered pillar.
+  const merged: PillarRegistryEntry[] = [...liveById.values()];
+  for (const seed of seedEntries()) {
+    if (seed.id === ORCHESTRATOR_PILLAR_ID) continue;
+    if (liveById.has(seed.id)) continue;
+    merged.push(seed);
+  }
+
+  return [selfEntry(options.selfBaseUrl), ...merged];
+}
+
+/** Test-only: forget the cached `POPS_PILLARS` seed so a new value is re-read. */
 export function __resetPillarRegistryCache(): void {
-  cached = undefined;
+  cachedSeed = undefined;
 }

--- a/apps/pops-orchestrator/src/server.ts
+++ b/apps/pops-orchestrator/src/server.ts
@@ -20,6 +20,7 @@
  * registry sees an explicit deregister before the HTTP server shuts down.
  */
 import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
+import { setRegistryUrl } from '@pops/pillar-sdk/discovery';
 
 import { createOrchestratorApp } from './app.js';
 import { buildOrchestratorManifest } from './manifest.js';
@@ -55,6 +56,13 @@ function resolveSelfBaseUrl(): string {
   }
 }
 const selfBaseUrl = resolveSelfBaseUrl();
+
+// Point the SDK discovery client (the `GET /pillars` registry-first source) at
+// core's registry. When unset, the SDK keeps its `http://core-api:3001` default.
+const registryUrl = process.env['POPS_REGISTRY_URL'];
+if (registryUrl !== undefined && registryUrl !== '') {
+  setRegistryUrl(registryUrl);
+}
 
 const app = createOrchestratorApp({ version, selfBaseUrl });
 

--- a/apps/pops-orchestrator/src/server.ts
+++ b/apps/pops-orchestrator/src/server.ts
@@ -59,9 +59,19 @@ const selfBaseUrl = resolveSelfBaseUrl();
 
 // Point the SDK discovery client (the `GET /pillars` registry-first source) at
 // core's registry. When unset, the SDK keeps its `http://core-api:3001` default.
+// Normalise through the same bare-origin parser as the self URL so a stray
+// path/query/trailing-slash crashes boot loudly instead of silently breaking
+// discovery.
 const registryUrl = process.env['POPS_REGISTRY_URL'];
 if (registryUrl !== undefined && registryUrl !== '') {
-  setRegistryUrl(registryUrl);
+  try {
+    setRegistryUrl(parseBareOrigin('POPS_REGISTRY_URL', registryUrl));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[orchestrator] POPS_REGISTRY_URL ${registryUrl} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
 }
 
 const app = createOrchestratorApp({ version, selfBaseUrl });

--- a/pillars/core/src/api/__tests__/pillars.test.ts
+++ b/pillars/core/src/api/__tests__/pillars.test.ts
@@ -1,9 +1,15 @@
 /**
- * Smoke tests for the `GET /pillars` registry endpoint.
+ * Tests for the `GET /pillars` registry endpoint.
  *
- * Covers the synthetic-`core`-entry contract, deduplication when the
- * env already lists `core`, and a malformed POPS_PILLARS returning 500
- * (since the parser is strict by design).
+ * `GET /pillars` is registry-as-truth: the live DB-backed `pillar_registry`
+ * table is the primary source, `POPS_PILLARS` is a boot seed / fallback. The
+ * suite covers:
+ *   - the synthetic-`core`-entry contract and the seed-only path (empty
+ *     registry ⇒ behaves exactly like the old static env view);
+ *   - a registered pillar surfacing in `/pillars` from the DB;
+ *   - the seed backfilling a known id the registry has no live entry for;
+ *   - a live registration WINNING over a stale seed entry for the same id;
+ *   - a malformed POPS_PILLARS seed still returning 500 (strict parser).
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,13 +18,42 @@ import { join } from 'node:path';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { openCoreDb, type OpenedCoreDb } from '../../db/index.js';
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '../../db/index.js';
 import { createCoreApiApp } from '../app.js';
 import { __resetPillarRegistryCache } from '../pillars/registry.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
 
 let tmpDir: string;
 let coreDb: OpenedCoreDb;
 const originalPillars = process.env['POPS_PILLARS'];
+
+/** Minimal-but-schema-valid manifest for a registered pillar. */
+function manifestFor(pillarId: string): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '0.1.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '0.1.0',
+      tag: `contract-${pillarId}@v0.1.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+/** Register a pillar in the live DB registry. */
+function register(pillarId: string, baseUrl: string): void {
+  pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+    baseUrl,
+    manifest: manifestFor(pillarId),
+  });
+}
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'core-api-pillars-test-'));
@@ -43,7 +78,7 @@ function makeApp(): ReturnType<typeof createCoreApiApp> {
   });
 }
 
-describe('GET /pillars', () => {
+describe('GET /pillars — seed-only fallback (empty registry)', () => {
   it('returns the synthetic core entry when POPS_PILLARS is unset', async () => {
     const res = await request(makeApp()).get('/pillars');
     expect(res.status).toBe(200);
@@ -76,19 +111,19 @@ describe('GET /pillars', () => {
     });
   });
 
-  it('returns 500 on a malformed POPS_PILLARS', async () => {
+  it('returns 500 on a malformed POPS_PILLARS seed', async () => {
     process.env['POPS_PILLARS'] = 'no-colon-here';
     const res = await request(makeApp()).get('/pillars');
     expect(res.status).toBe(500);
   });
 
-  it('rejects a POPS_PILLARS entry with a path/query/fragment', async () => {
+  it('rejects a POPS_PILLARS seed entry with a path/query/fragment', async () => {
     process.env['POPS_PILLARS'] = 'food:http://food-api:3000/api';
     const res = await request(makeApp()).get('/pillars');
     expect(res.status).toBe(500);
   });
 
-  it('strips a trailing slash from a clean origin', async () => {
+  it('strips a trailing slash from a clean seed origin', async () => {
     process.env['POPS_PILLARS'] = 'food:http://food-api:3000/';
     const res = await request(makeApp()).get('/pillars');
     expect(res.status).toBe(200);
@@ -96,5 +131,52 @@ describe('GET /pillars', () => {
       id: 'food',
       baseUrl: 'http://food-api:3000',
     });
+  });
+});
+
+describe('GET /pillars — registry-as-truth', () => {
+  it('surfaces a DB-registered pillar even when POPS_PILLARS is unset', async () => {
+    register('media', 'http://media-api:3005');
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body.pillars).toContainEqual({ id: 'core', baseUrl: 'http://core-api:3001' });
+    expect(res.body.pillars).toContainEqual({ id: 'media', baseUrl: 'http://media-api:3005' });
+  });
+
+  it('falls back to a seeded id the registry has no live entry for', async () => {
+    process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004';
+    register('media', 'http://media-api:3005');
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    // media comes from the live registry; finance is seed-only fallback.
+    expect(res.body.pillars).toContainEqual({ id: 'media', baseUrl: 'http://media-api:3005' });
+    expect(res.body.pillars).toContainEqual({ id: 'finance', baseUrl: 'http://finance-api:3004' });
+  });
+
+  it('lets a live registration win over a stale seed entry for the same id', async () => {
+    process.env['POPS_PILLARS'] = 'media:http://stale-media:9999';
+    register('media', 'http://media-api:3005');
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    const mediaEntries = res.body.pillars.filter((p: { id: string }) => p.id === 'media');
+    expect(mediaEntries).toEqual([{ id: 'media', baseUrl: 'http://media-api:3005' }]);
+  });
+
+  it('orders live registry entries ahead of seed-only fallback entries', async () => {
+    process.env['POPS_PILLARS'] = 'finance:http://finance-api:3004';
+    register('media', 'http://media-api:3005');
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.body.pillars).toEqual([
+      { id: 'core', baseUrl: 'http://core-api:3001' },
+      { id: 'media', baseUrl: 'http://media-api:3005' },
+      { id: 'finance', baseUrl: 'http://finance-api:3004' },
+    ]);
+  });
+
+  it('never proxies the synthetic core self-entry to a DB-registered core row', async () => {
+    register('core', 'http://stale-core-row:9000');
+    const res = await request(makeApp()).get('/pillars');
+    const coreEntries = res.body.pillars.filter((p: { id: string }) => p.id === 'core');
+    expect(coreEntries).toEqual([{ id: 'core', baseUrl: 'http://core-api:3001' }]);
   });
 });

--- a/pillars/core/src/api/__tests__/uri-dispatch.test.ts
+++ b/pillars/core/src/api/__tests__/uri-dispatch.test.ts
@@ -17,10 +17,30 @@ import { join } from 'node:path';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { openCoreDb, type OpenedCoreDb } from '../../db/index.js';
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '../../db/index.js';
 import { createCoreApiApp } from '../app.js';
 import { __resetInstalledModulesCache } from '../env-modules.js';
 import { __resetPillarRegistryCache } from '../pillars/registry.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+function manifestFor(pillarId: string): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '0.1.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '0.1.0',
+      tag: `contract-${pillarId}@v0.1.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
 
 let tmpDir: string;
 let coreDb: OpenedCoreDb;
@@ -117,6 +137,96 @@ describe('POST /uri/resolve', () => {
         .post('/uri/resolve')
         .send({ uri: 'pops:food/recipe/rec-1' });
       expect(res.status).toBe(200);
+      expect(res.body).toEqual(remoteBody);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://food-api:3000/uri/resolve',
+        expect.objectContaining({ method: 'POST' })
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('POST /uri/resolve — registry-as-truth routing', () => {
+  it('routes the remote leg off a DB-registered pillar when POPS_PILLARS is unset', async () => {
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://food-api:3000',
+      manifest: manifestFor('food'),
+    });
+    const remoteBody = {
+      kind: 'object',
+      moduleId: 'food',
+      type: 'recipe',
+      id: 'rec-1',
+      data: { title: 'Soup' },
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(remoteBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    try {
+      const res = await request(makeApp())
+        .post('/uri/resolve')
+        .send({ uri: 'pops:food/recipe/rec-1' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(remoteBody);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://food-api:3000/uri/resolve',
+        expect.objectContaining({ method: 'POST' })
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('prefers the live registry baseUrl over a stale POPS_PILLARS seed', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://stale-food:9999';
+    __resetPillarRegistryCache();
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://food-api:3000',
+      manifest: manifestFor('food'),
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ kind: 'not-found', moduleId: 'food', type: 'recipe', id: 'x' }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    );
+    try {
+      await request(makeApp()).post('/uri/resolve').send({ uri: 'pops:food/recipe/x' });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://food-api:3000/uri/resolve',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(fetchSpy).not.toHaveBeenCalledWith(
+        'http://stale-food:9999/uri/resolve',
+        expect.anything()
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('falls back to the POPS_PILLARS seed when the registry has no live entry', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000';
+    __resetPillarRegistryCache();
+    const remoteBody = { kind: 'not-found', moduleId: 'food', type: 'recipe', id: 'rec-2' };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(remoteBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    try {
+      const res = await request(makeApp())
+        .post('/uri/resolve')
+        .send({ uri: 'pops:food/recipe/rec-2' });
       expect(res.body).toEqual(remoteBody);
       expect(fetchSpy).toHaveBeenCalledWith(
         'http://food-api:3000/uri/resolve',

--- a/pillars/core/src/api/app.ts
+++ b/pillars/core/src/api/app.ts
@@ -75,7 +75,8 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
 
   // Cross-pillar URI dispatcher (ADR-026 P2). Raw HTTP: pillars POST
   // `{ uri }` here and core resolves in-process or proxies to the owning
-  // pillar via `POPS_PILLARS`. Never throws — every error path is a typed
+  // pillar. The remote leg routes off the live DB registry, falling back to
+  // the `POPS_PILLARS` seed. Never throws — every error path is a typed
   // `UriResolverResult`.
   app.post('/uri/resolve', (req: Request, res: Response, next: NextFunction) => {
     const body: unknown = req.body;
@@ -109,8 +110,9 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
 
   // DB-backed registry snapshot — the discovery surface the pillar SDK's
   // `HttpDiscoveryTransport` reads. Raw HTTP (not ts-rest / not tRPC); returns
-  // the bare `{ pillars, fetchedAt }` shape. Distinct from `GET /pillars`,
-  // which reflects the static `POPS_PILLARS` env, not the DB registry table.
+  // the bare `{ pillars, fetchedAt }` shape. `GET /pillars` is the same DB
+  // registry projected onto the `{ id, baseUrl }` shape (registry-first, with
+  // the `POPS_PILLARS` env as a boot seed / fallback).
   app.get('/core.registry.list', createRegistrySnapshotHandler(deps.coreDb.db));
 
   app.post('/core.registry.register', createExternalRegisterHandler({ coreDb: deps.coreDb.db }));

--- a/pillars/core/src/api/handlers.ts
+++ b/pillars/core/src/api/handlers.ts
@@ -10,11 +10,11 @@ import { readInstalledModules } from './env-modules.js';
 import { getUriRegistry } from './modules/uri/registry.js';
 import { dispatchUri, type DispatchUriOptions } from './pillars/dispatcher.js';
 import { type PillarHealthMap, probeAllPillars } from './pillars/health-probe.js';
-import { getPillarRegistry } from './pillars/registry.js';
+import { getPillarRegistry, getRemotePillarEntry } from './pillars/registry.js';
 
 import type { PillarRegistryEntry, UriResolverResult } from '@pops/types';
 
-import type { OpenedCoreDb } from '../db/index.js';
+import type { CoreDb, OpenedCoreDb } from '../db/index.js';
 
 export interface CoreApiDeps {
   /** Open handle to the core pillar's SQLite. */
@@ -51,13 +51,17 @@ export interface PillarsHealthResponse {
  * Factored out so tests can call `dispatchUri` directly with stub registries
  * while the HTTP route uses the live in-process module registry + install
  * set. Mirrors `apps/pops-api/src/routes/pillars.ts:buildResolveOptions`.
+ *
+ * `lookupPillar` is registry-first: it routes the remote leg off the live DB
+ * registry and falls back to the `POPS_PILLARS` seed (`getRemotePillarEntry`).
  */
-function buildResolveOptions(): DispatchUriOptions {
+function buildResolveOptions(db: CoreDb): DispatchUriOptions {
   const installed = readInstalledModules();
   const installedSet = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
   return {
     registry: getUriRegistry(),
     isInstalled: (moduleId: string) => installedSet.has(moduleId),
+    lookupPillar: (id: string) => getRemotePillarEntry(db, id),
   };
 }
 
@@ -68,7 +72,7 @@ export function makeRequestHandler(deps: CoreApiDeps): {
   pillarsHealth(): Promise<PillarsHealthResponse>;
 } {
   function listPillars(): readonly PillarRegistryEntry[] {
-    return getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl });
+    return getPillarRegistry({ db: deps.coreDb.db, selfBaseUrl: deps.selfBaseUrl });
   }
 
   return {
@@ -89,7 +93,7 @@ export function makeRequestHandler(deps: CoreApiDeps): {
       return { pillars: listPillars() };
     },
     resolveUri(uri: string): Promise<UriResolverResult> {
-      return dispatchUri(uri, buildResolveOptions());
+      return dispatchUri(uri, buildResolveOptions(deps.coreDb.db));
     },
     async pillarsHealth(): Promise<PillarsHealthResponse> {
       return { health: await probeAllPillars(listPillars()) };

--- a/pillars/core/src/api/pillars/__tests__/dispatcher.test.ts
+++ b/pillars/core/src/api/pillars/__tests__/dispatcher.test.ts
@@ -72,6 +72,37 @@ describe('dispatchUri — in-process fallback', () => {
       data: { id: 'tx-1' },
     });
   });
+
+  it('treats a throwing lookupPillar (e.g. DB error) as a cache miss and resolves in-process', async () => {
+    const manifest: ModuleManifest = {
+      id: 'finance',
+      name: 'Finance',
+      surfaces: ['app'],
+      uriHandler: {
+        types: ['transaction'],
+        resolve: async (_type, id) => ({ kind: 'object', data: { id } }),
+      },
+    };
+    const remote = vi.fn();
+    const result = await dispatchUri('pops:finance/transaction/tx-1', {
+      registry: [manifest],
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+      lookupPillar: () => {
+        throw new Error('registry DB unavailable');
+      },
+    });
+    // Must NOT bubble the throw (no 500) and must NOT hit the remote leg —
+    // it falls through to in-process resolution.
+    expect(remote).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: 'object',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'tx-1',
+      data: { id: 'tx-1' },
+    });
+  });
 });
 
 describe('dispatchUri — remote leg', () => {

--- a/pillars/core/src/api/pillars/dispatcher.ts
+++ b/pillars/core/src/api/pillars/dispatcher.ts
@@ -8,13 +8,14 @@
  * remote pillar can't be reached, return `pillar-unavailable` so the caller
  * renders a placeholder rather than surfacing a network error.
  *
- * With no `POPS_PILLARS` set, every dispatch falls through to the in-process
- * resolver. As pillars split off, deployers add entries to `POPS_PILLARS`
- * and the dispatcher routes accordingly.
+ * The owning-pillar lookup is registry-first: the production wiring routes off
+ * the live DB registry and falls back to the `POPS_PILLARS` seed. When neither
+ * knows the owning pillar, the dispatch falls through to the in-process
+ * resolver.
  */
 import { parseUri } from '../modules/uri/parse.js';
 import { resolveUri, type ResolveUriOptions } from '../modules/uri/resolver.js';
-import { getRemotePillarEntry } from './registry.js';
+import { seedPillarEntry } from './registry.js';
 
 import type { PillarRegistryEntry, UriResolverResult } from '@pops/types';
 
@@ -43,8 +44,10 @@ export interface DispatchUriOptions extends ResolveUriOptions {
    */
   readonly selfPillarId?: string;
   /**
-   * Remote-pillar lookup. Defaults to the live `getRemotePillarEntry`; tests
-   * inject a stub so they don't depend on `process.env.POPS_PILLARS`.
+   * Remote-pillar lookup. The production wiring (`handlers.ts`) injects a
+   * registry-first resolver (live DB registry, `POPS_PILLARS` seed fallback).
+   * When omitted, the dispatcher defaults to the env-seed-only `seedPillarEntry`
+   * so a DB-less caller (or a unit test) still routes off `POPS_PILLARS`.
    */
   readonly lookupPillar?: (id: string) => PillarRegistryEntry | undefined;
 }
@@ -77,8 +80,9 @@ function isKnownKind(kind: string): kind is UriResolverResult['kind'] {
  *   1. Parse the URI — malformed input returns `malformed` without touching
  *      the registry.
  *   2. If the URI is owned by `selfPillarId`, ALWAYS resolve in-process.
- *   3. Look up the owning pillar in `POPS_PILLARS`. Hit ⇒ remote leg.
- *      Miss ⇒ fall through to in-process `resolveUri`.
+ *   3. Look up the owning pillar via `lookupPillar` (registry-first; seed
+ *      fallback). Hit ⇒ remote leg. Miss ⇒ fall through to in-process
+ *      `resolveUri`.
  *   4. Remote leg: POST to `${baseUrl}/uri/resolve` with `{uri}`. Bound by
  *      `remoteTimeoutMs`. Any throw becomes `pillar-unavailable`.
  */
@@ -96,7 +100,7 @@ export async function dispatchUri(
     return resolveUri(uri, options);
   }
 
-  const lookup = options.lookupPillar ?? getRemotePillarEntry;
+  const lookup = options.lookupPillar ?? seedPillarEntry;
   const entry = lookup(parsed.parsed.moduleId);
   if (!entry) {
     return resolveUri(uri, options);

--- a/pillars/core/src/api/pillars/dispatcher.ts
+++ b/pillars/core/src/api/pillars/dispatcher.ts
@@ -101,7 +101,15 @@ export async function dispatchUri(
   }
 
   const lookup = options.lookupPillar ?? seedPillarEntry;
-  const entry = lookup(parsed.parsed.moduleId);
+  // A registry-first lookup reads the DB; a DB error must NOT turn /uri/resolve
+  // into a 500. Treat any lookup failure as a cache miss and fall through to
+  // in-process resolution, preserving the "never throws" dispatch contract.
+  let entry: PillarRegistryEntry | undefined;
+  try {
+    entry = lookup(parsed.parsed.moduleId);
+  } catch {
+    return resolveUri(uri, options);
+  }
   if (!entry) {
     return resolveUri(uri, options);
   }

--- a/pillars/core/src/api/pillars/registry.ts
+++ b/pillars/core/src/api/pillars/registry.ts
@@ -11,7 +11,7 @@
  * Adds the synthetic `core` entry so the shell sees the host pillar in the
  * `/pillars` listing without having to special-case the call site.
  */
-import { buildRegistrySnapshot } from '../modules/registry/snapshot.js';
+import { pillarRegistryService } from '../../db/index.js';
 import { parseBareOrigin, parsePillarsEnv } from './env.js';
 
 import type { PillarRegistryEntry } from '@pops/types';
@@ -32,12 +32,18 @@ function seedEntries(): readonly PillarRegistryEntry[] {
  * keyed by id. The synthetic `core` self-entry is dropped — the caller re-adds
  * it from the live `selfBaseUrl` so the host pillar's advertised origin is
  * never stale.
+ *
+ * Reads the raw `pillar_registry` rows via the DB service rather than the full
+ * `buildRegistrySnapshot`: `{ id, baseUrl }` needs neither the per-row manifest
+ * Zod parse nor status computation, and avoiding them keeps `/pillars` + the
+ * dispatcher's registry-first lookup serving baseUrls even if a single
+ * persisted manifest row is corrupt/legacy.
  */
 function liveEntries(db: CoreDb): Map<string, PillarRegistryEntry> {
   const byId = new Map<string, PillarRegistryEntry>();
-  for (const pillar of buildRegistrySnapshot(db).pillars) {
-    if (pillar.pillarId === SELF_PILLAR_ID) continue;
-    byId.set(pillar.pillarId, { id: pillar.pillarId, baseUrl: pillar.baseUrl });
+  for (const reg of pillarRegistryService.listPillarRegistrations(db)) {
+    if (reg.pillarId === SELF_PILLAR_ID) continue;
+    byId.set(reg.pillarId, { id: reg.pillarId, baseUrl: reg.baseUrl });
   }
   return byId;
 }

--- a/pillars/core/src/api/pillars/registry.ts
+++ b/pillars/core/src/api/pillars/registry.ts
@@ -1,18 +1,70 @@
 /**
  * Pillar registry view served by core-api.
  *
- * Wraps the local copy of `parsePillarsEnv` with a process-level cache
- * (same pattern pops-api uses). Adds the synthetic `core` entry so the
- * shell sees the host pillar in the `/pillars` listing without having
- * to special-case the call site.
+ * Registry-as-truth: the live DB-backed `pillar_registry` table (served by
+ * `buildRegistrySnapshot`) is the primary source. `POPS_PILLARS` is demoted to
+ * a BOOT SEED / FALLBACK — it pre-populates the mesh during cold-start before
+ * pillars have registered, and backfills any known id the registry has no live
+ * entry for. A pillar that has registered (DB row) always wins over its seed
+ * entry, so a redeployed pillar's fresh `baseUrl` supersedes a stale env value.
+ *
+ * Adds the synthetic `core` entry so the shell sees the host pillar in the
+ * `/pillars` listing without having to special-case the call site.
  */
+import { buildRegistrySnapshot } from '../modules/registry/snapshot.js';
 import { parseBareOrigin, parsePillarsEnv } from './env.js';
 
 import type { PillarRegistryEntry } from '@pops/types';
 
-let cached: readonly PillarRegistryEntry[] | undefined;
+import type { CoreDb } from '../../db/index.js';
+
+const SELF_PILLAR_ID = 'core';
+
+let cachedSeed: readonly PillarRegistryEntry[] | undefined;
+
+function seedEntries(): readonly PillarRegistryEntry[] {
+  cachedSeed ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  return cachedSeed;
+}
+
+/**
+ * Live registry entries projected onto the `{ id, baseUrl }` registry shape,
+ * keyed by id. The synthetic `core` self-entry is dropped — the caller re-adds
+ * it from the live `selfBaseUrl` so the host pillar's advertised origin is
+ * never stale.
+ */
+function liveEntries(db: CoreDb): Map<string, PillarRegistryEntry> {
+  const byId = new Map<string, PillarRegistryEntry>();
+  for (const pillar of buildRegistrySnapshot(db).pillars) {
+    if (pillar.pillarId === SELF_PILLAR_ID) continue;
+    byId.set(pillar.pillarId, { id: pillar.pillarId, baseUrl: pillar.baseUrl });
+  }
+  return byId;
+}
+
+/**
+ * Merge the live DB registry (primary) with the `POPS_PILLARS` seed (fallback).
+ * Registry rows win per-id; the seed only backfills ids the registry has no
+ * live entry for. The `core` self-entry is excluded from both — the caller
+ * prepends it from `selfBaseUrl`.
+ */
+function mergedRegistry(db: CoreDb): PillarRegistryEntry[] {
+  const live = liveEntries(db);
+  // Registry-first ordering: live entries lead, seed-only ids follow. The seed
+  // is the fallback, so it MUST NOT shadow a registered pillar — a stale env
+  // baseUrl on a redeployed pillar would otherwise misroute cross-pillar calls.
+  const merged: PillarRegistryEntry[] = [...live.values()];
+  for (const seed of seedEntries()) {
+    if (seed.id === SELF_PILLAR_ID) continue;
+    if (live.has(seed.id)) continue;
+    merged.push(seed);
+  }
+  return merged;
+}
 
 export interface PillarRegistryOptions {
+  /** Open handle to the core pillar's SQLite — the live registry source. */
+  readonly db: CoreDb;
   /**
    * HTTP origin core-api is reachable at. Required — `server.ts` derives
    * it from `CORE_SELF_BASE_URL` (or falls back to `http://localhost:PORT`)
@@ -25,26 +77,37 @@ export interface PillarRegistryOptions {
 }
 
 export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
-  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
   const normalisedSelf = parseBareOrigin("core's selfBaseUrl", options.selfBaseUrl);
-  const withoutSelf = cached.filter((p) => p.id !== 'core');
-  return [{ id: 'core', baseUrl: normalisedSelf }, ...withoutSelf];
+  return [{ id: SELF_PILLAR_ID, baseUrl: normalisedSelf }, ...mergedRegistry(options.db)];
 }
 
 /**
- * Look up a *remote* pillar entry from `POPS_PILLARS` by id, or `undefined`
- * if it is not registered. Used by the URI dispatcher's remote leg to route
- * a cross-pillar URI to its owning process. The synthetic `core` self-entry
- * is intentionally excluded — self-owned URIs always resolve in-process, so
- * the dispatcher never proxies to itself.
+ * Look up a *remote* pillar entry by id, or `undefined` if it is not
+ * registered. Prefers the live DB registry and falls back to the
+ * `POPS_PILLARS` seed when the registry has no live entry. Used by the URI
+ * dispatcher's remote leg to route a cross-pillar URI to its owning process.
+ * The synthetic `core` self-entry is intentionally excluded — self-owned URIs
+ * always resolve in-process, so the dispatcher never proxies to itself.
  */
-export function getRemotePillarEntry(id: string): PillarRegistryEntry | undefined {
-  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
-  if (id === 'core') return undefined;
-  return cached.find((p) => p.id === id);
+export function getRemotePillarEntry(db: CoreDb, id: string): PillarRegistryEntry | undefined {
+  if (id === SELF_PILLAR_ID) return undefined;
+  const live = liveEntries(db).get(id);
+  if (live) return live;
+  return seedPillarEntry(id);
 }
 
-/** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */
+/**
+ * Env-seed-only remote lookup — the DB-less fallback the dispatcher uses when
+ * no DB-backed `lookupPillar` is injected. Routes solely off the `POPS_PILLARS`
+ * seed (cold-start / DB-unavailable resilience). The `core` self-entry is
+ * excluded so the dispatcher never proxies to itself.
+ */
+export function seedPillarEntry(id: string): PillarRegistryEntry | undefined {
+  if (id === SELF_PILLAR_ID) return undefined;
+  return seedEntries().find((p) => p.id === id);
+}
+
+/** Test-only: forget the cached `POPS_PILLARS` seed so a new value is re-read. */
 export function __resetPillarRegistryCache(): void {
-  cached = undefined;
+  cachedSeed = undefined;
 }


### PR DESCRIPTION
## What

Make the **dynamic DB-backed pillar registry** the source of truth for the user-facing pillar-resolution paths, demoting the static `POPS_PILLARS` env to a **boot seed / fallback**.

The live `pillar_registry` table (served by `buildRegistrySnapshot` / `GET /core.registry.list`) is now primary. `POPS_PILLARS` only:
- pre-populates the mesh during **cold-start**, before pillars have registered, and
- **backfills** any known id the registry has no live entry for (registry outage / brief emptiness).

A registered pillar (DB row) always wins over its seed entry, so a redeployed pillar's fresh `baseUrl` supersedes a stale env value.

## Changes

### `core`
- **`GET /pillars`** now projects the DB registry snapshot onto the `{ id, baseUrl }` shape, merged **registry-first** with the `POPS_PILLARS` seed. The synthetic `core` self-entry is always prepended from the live `selfBaseUrl`.
- The **cross-pillar URI dispatcher**'s remote leg routes off `getRemotePillarEntry(db, id)` — **DB registry primary, seed fallback** — threaded through `buildResolveOptions(db)`.
- The dispatcher keeps a DB-less default lookup (`seedPillarEntry`, env-only) so a caller/test that injects no DB still routes off `POPS_PILLARS`. The production wiring injects the registry-first resolver.

### `orchestrator`
- **`GET /pillars`** resolves **registry-first** via the SDK discovery client (`resolvePillarRegistry`), with the `POPS_PILLARS` seed as fallback and a `RegistryUnreachableError → env-only` degrade path (cold-start / outage resilience).
- `server.ts` points the SDK discovery client at `POPS_REGISTRY_URL` when set (the SDK keeps its `http://core-api:3001` default otherwise).
- The snapshot reader is dependency-injected so tests assert the projection without a network round-trip.

### `mcp`
- **No change.** The MCP already resolves pillars registry-first through the pillar SDK (`pillar()` → `HttpDiscoveryTransport` → `core.registry.list`); its only env reads are internal base-URL overrides + `POPS_REGISTRY_URL`, both fed straight into the SDK config. The original audit's "MCP reads the static env" claim does not hold.

## Bootstrap ordering / resilience

The fallback ordering is deliberate and load-bearing: when the registry is empty (cold-start) or unreachable, both core and the orchestrator degrade to the env seed so the mesh still boots. The existing register/heartbeat flow is untouched. Registry-empty behaviour is **byte-for-byte** the old env-only view (the existing `/pillars` and dispatcher tests pass unchanged).

## Tests

New tests prove:
- a **DB-registered pillar appears** in `/pillars` (core + orchestrator), even with `POPS_PILLARS` unset;
- the **seed backfills** an unregistered-but-seeded id;
- a **live registration wins** over a stale seed entry for the same id;
- the **env-fallback path** works when the registry is empty / unreachable;
- the URI dispatcher routes the remote leg off the live registry baseUrl, preferring it over a stale seed.

## Verification (all green)

- `pnpm --filter @pops/core typecheck && test` — 643 tests
- `pnpm --filter @pops/pillar-sdk test` — 591; orchestrator typecheck/test — 57; mcp typecheck/test — 170
- repo-wide `pnpm typecheck` — 40/40
- `pnpm lint` / `pnpm lint:boundaries:verify` — clean
- `pnpm --filter @pops/core generate:openapi` → `git diff --exit-code` — idempotent (OpenAPI + api-types)
- `pnpm format:check` — clean

## Deferred (intentionally out of scope)

To keep the cross-pillar mesh change conservative and fully testable, these still read the `POPS_PILLARS` seed and are **not** touched here:

- **Non-core pillars' `GET /pillars`** (`media`, `inventory`, `finance`, `food`, `cerebrum`, `lists`): these have no local DB registry, so registry-first would mean a new HTTP fetch to core in the hot path with cold-start ordering risk. Their `/pillars` is a secondary listing surface. Follow-up: route them through the SDK discovery client (same pattern as the orchestrator here).
- **Orchestrator federated-search presence intersection** (`resolveSearchPillars`): a sync construction-time presence check; making it registry-first ripples async into the search hot path. The federated calls themselves already resolve baseUrls via the SDK registry, so this is presence-only. Follow-up.
- **Direct peer-resolution sites** `food/.../lists-client.ts` and `cerebrum/.../peer-clients.ts`: resolve a single peer baseUrl from the seed env; registry-first there is an async HTTP dependency on the call path — deferred for the same conservatism.

No changes to `POPS_PILLARS` definitions in `infra/docker-compose*.yml` or CI workflows (owned by a separate task).
