### PR TITLE
refactor(orchestrator): drive federated search membership from the live registry

### DIFF
--- a/apps/pops-orchestrator/src/pillars/registry.ts
+++ b/apps/pops-orchestrator/src/pillars/registry.ts
@@ -46,7 +46,12 @@ export interface PillarRegistryOptions {
  */
 export type RegistrySnapshotReader = () => Promise<readonly PillarSnapshot[]>;
 
-const defaultSnapshotReader: RegistrySnapshotReader = async () => {
+/**
+ * Production snapshot reader: the SDK discovery client (TTL-cached). Shared by
+ * the `GET /pillars` view and the federated-search membership projection so
+ * both read the same live registry through one path.
+ */
+export const defaultSnapshotReader: RegistrySnapshotReader = async () => {
   const snapshot = await pillarRegistry();
   return snapshot.pillars;
 };

--- a/apps/pops-orchestrator/src/search/__tests__/federation.test.ts
+++ b/apps/pops-orchestrator/src/search/__tests__/federation.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { __resetPillarRegistryCache } from '../../pillars/registry.js';
+import { RegistryUnreachableError, type PillarSnapshot } from '@pops/pillar-sdk/discovery';
+
 import {
   createFederationSource,
-  resolveSearchPillars,
-  SEARCH_PILLARS,
-  type PillarSearchMeta,
+  sectionMetaFor,
+  selectSearchPillars,
+  SEARCH_SECTION_META,
   type SearchInvoker,
 } from '../federation.js';
 
 import type { CallResult } from '@pops/pillar-sdk/client';
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import type { SearchContext, SearchHit } from '../types.js';
 
@@ -23,27 +25,177 @@ function ok(hits: SearchHit[]): CallResult<{ hits: SearchHit[] }> {
   return { kind: 'ok', value: { hits } };
 }
 
-const ALL_PILLARS: { id: string; meta: PillarSearchMeta }[] = Object.entries(SEARCH_PILLARS).map(
-  ([id, meta]) => ({ id, meta })
-);
+/**
+ * A search adapter descriptor passing manifest validation. The federation
+ * source only inspects `manifest.search.adapters.length`, so the exact
+ * adapter shape is incidental — but we keep it schema-valid so the fixtures
+ * cannot lie about what a real pillar advertises.
+ */
+function searchAdapter(name: string): ManifestPayload['search']['adapters'][number] {
+  return {
+    name,
+    entityType: `${name}-entity`,
+    queryShape: {
+      supportsText: true,
+      supportsTags: false,
+      supportsDateRange: false,
+      supportsScope: [],
+    },
+    procedurePath: `${name}.search.search`,
+  };
+}
+
+function manifestFor(
+  pillarId: string,
+  opts: { searchCapable: boolean } = { searchCapable: true }
+): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '0.1.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '0.1.0',
+      tag: `contract-${pillarId}@v0.1.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: opts.searchCapable ? [searchAdapter('entities')] : [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+function snapshot(
+  pillarId: string,
+  opts: {
+    searchCapable?: boolean;
+    registered?: boolean;
+    status?: PillarSnapshot['status'];
+  } = {}
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}:3000`,
+    manifest: manifestFor(pillarId, { searchCapable: opts.searchCapable ?? true }),
+    registered: opts.registered ?? true,
+    lastSeenAt: new Date(),
+    ...(opts.status !== undefined ? { status: opts.status } : { status: 'healthy' }),
+  };
+}
+
+describe('selectSearchPillars — registry-driven membership', () => {
+  it('selects only registered, healthy pillars that declare search.adapters', () => {
+    const onWarn = vi.fn();
+    const resolved = selectSearchPillars(
+      [
+        snapshot('core'),
+        snapshot('finance'),
+        snapshot('food', { searchCapable: false }),
+        snapshot('inventory'),
+      ],
+      onWarn
+    );
+
+    expect(resolved.map((p) => p.id).toSorted()).toEqual(['core', 'finance', 'inventory']);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('drops an unregistered pillar even if it advertises search', () => {
+    const resolved = selectSearchPillars([snapshot('finance', { registered: false })], vi.fn());
+    expect(resolved).toEqual([]);
+  });
+
+  it('drops an unavailable or unknown pillar', () => {
+    const resolved = selectSearchPillars(
+      [
+        snapshot('finance', { status: 'unavailable' }),
+        snapshot('inventory', { status: 'unknown' }),
+      ],
+      vi.fn()
+    );
+    expect(resolved).toEqual([]);
+  });
+
+  it('treats a registered pillar with no explicit status as healthy (legacy snapshot)', () => {
+    const legacy: PillarSnapshot = {
+      pillarId: 'core',
+      baseUrl: 'http://core:3000',
+      manifest: manifestFor('core'),
+      registered: true,
+      lastSeenAt: new Date(),
+    };
+    const resolved = selectSearchPillars([legacy], vi.fn());
+    expect(resolved.map((p) => p.id)).toEqual(['core']);
+  });
+
+  it('decorates a known pillar with its ported section chrome', () => {
+    const resolved = selectSearchPillars([snapshot('finance')], vi.fn());
+    expect(resolved[0]?.meta).toEqual(SEARCH_SECTION_META['finance']);
+  });
+
+  it('federates a search-capable pillar with no static chrome, defaulting its decoration', () => {
+    const resolved = selectSearchPillars([snapshot('media')], vi.fn());
+    expect(resolved.map((p) => p.id)).toEqual(['media']);
+    expect(resolved[0]?.meta).toEqual({ domain: 'media', icon: 'Circle', color: 'gray' });
+  });
+});
+
+describe('sectionMetaFor', () => {
+  it('returns the static entry for a mapped pillar', () => {
+    expect(sectionMetaFor('core')).toEqual({ domain: 'core', icon: 'Building2', color: 'green' });
+  });
+
+  it('keys the default domain to the pillar id for an unmapped pillar', () => {
+    expect(sectionMetaFor('photos')).toEqual({ domain: 'photos', icon: 'Circle', color: 'gray' });
+  });
+});
 
 describe('createFederationSource', () => {
-  it('fans the query out to every resolved pillar with the same envelope', async () => {
+  function sourceFor(
+    snapshots: readonly PillarSnapshot[],
+    invoke: SearchInvoker,
+    onWarn = vi.fn()
+  ) {
+    return createFederationSource({ invoke, snapshotReader: async () => snapshots, onWarn });
+  }
+
+  it('fans the query out to every registry-resolved search-capable pillar', async () => {
     const invoke = vi.fn<SearchInvoker>(async () => ok([]));
-    const source = createFederationSource({ invoke, pillars: ALL_PILLARS });
+    const source = sourceFor(
+      [snapshot('core'), snapshot('finance'), snapshot('inventory')],
+      invoke
+    );
     const query = { text: 'rent' };
 
     await source(query, ROOT);
 
     expect(invoke).toHaveBeenCalledTimes(3);
-    for (const { id } of ALL_PILLARS) {
+    for (const id of ['core', 'finance', 'inventory']) {
       expect(invoke).toHaveBeenCalledWith(id, { query, context: ROOT });
     }
   });
 
+  it('does NOT federate a registered pillar that lacks the search capability', async () => {
+    const invoke = vi.fn<SearchInvoker>(async () => ok([hit('pops:x/1')]));
+    const source = sourceFor(
+      [snapshot('finance'), snapshot('food', { searchCapable: false })],
+      invoke
+    );
+
+    const groups = await source({ text: 'x' }, ROOT);
+
+    expect(groups.map((g) => g.moduleId)).toEqual(['finance']);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('finance', expect.anything());
+  });
+
   it('decorates each pillar group with its ported domain/icon/color', async () => {
     const invoke: SearchInvoker = async (pillarId) => ok([hit(`pops:${pillarId}/1`)]);
-    const source = createFederationSource({ invoke, pillars: ALL_PILLARS });
+    const source = sourceFor(
+      [snapshot('core'), snapshot('finance'), snapshot('inventory')],
+      invoke
+    );
 
     const groups = await source({ text: 'x' }, ROOT);
 
@@ -64,7 +216,7 @@ describe('createFederationSource', () => {
   it('collects every pillar hit unchanged into its group', async () => {
     const invoke: SearchInvoker = async (pillarId) =>
       ok([hit(`pops:${pillarId}/1`, 0.9), hit(`pops:${pillarId}/2`, 0.4)]);
-    const source = createFederationSource({ invoke, pillars: ALL_PILLARS });
+    const source = sourceFor([snapshot('finance')], invoke);
 
     const groups = await source({ text: 'x' }, ROOT);
 
@@ -73,13 +225,15 @@ describe('createFederationSource', () => {
   });
 
   describe('best-effort failure isolation', () => {
+    const ALL = [snapshot('core'), snapshot('finance'), snapshot('inventory')];
+
     it('skips an unavailable pillar but keeps the others', async () => {
       const onWarn = vi.fn();
       const invoke: SearchInvoker = async (pillarId) => {
         if (pillarId === 'finance') return { kind: 'unavailable', pillar: 'finance' };
         return ok([hit(`pops:${pillarId}/1`)]);
       };
-      const source = createFederationSource({ invoke, pillars: ALL_PILLARS, onWarn });
+      const source = sourceFor(ALL, invoke, onWarn);
 
       const groups = await source({ text: 'x' }, ROOT);
 
@@ -96,7 +250,7 @@ describe('createFederationSource', () => {
         if (pillarId === 'inventory') throw new Error('network down');
         return ok([hit(`pops:${pillarId}/1`)]);
       };
-      const source = createFederationSource({ invoke, pillars: ALL_PILLARS, onWarn });
+      const source = sourceFor(ALL, invoke, onWarn);
 
       const groups = await source({ text: 'x' }, ROOT);
 
@@ -112,44 +266,66 @@ describe('createFederationSource', () => {
       const invoke: SearchInvoker = async () => {
         throw new Error('all down');
       };
-      const source = createFederationSource({ invoke, pillars: ALL_PILLARS, onWarn });
+      const source = sourceFor(ALL, invoke, onWarn);
 
       await expect(source({ text: 'x' }, ROOT)).resolves.toEqual([]);
       expect(onWarn).toHaveBeenCalledTimes(3);
     });
   });
-});
 
-describe('resolveSearchPillars', () => {
-  const SELF = 'http://localhost:3009';
-  const original = process.env['POPS_PILLARS'];
+  describe('registry resilience', () => {
+    it('degrades to an empty federation when the registry is unreachable', async () => {
+      const onWarn = vi.fn();
+      const invoke = vi.fn<SearchInvoker>(async () => ok([hit('pops:x/1')]));
+      const source = createFederationSource({
+        invoke,
+        snapshotReader: async () => {
+          throw new RegistryUnreachableError('down', { attempts: 1 });
+        },
+        onWarn,
+      });
 
-  beforeEach(() => {
-    __resetPillarRegistryCache();
-    delete process.env['POPS_PILLARS'];
-  });
+      await expect(source({ text: 'x' }, ROOT)).resolves.toEqual([]);
+      expect(invoke).not.toHaveBeenCalled();
+      expect(onWarn).toHaveBeenCalledWith(
+        '[orchestrator] registry unreachable; serving empty federated-search set',
+        expect.any(RegistryUnreachableError)
+      );
+    });
 
-  afterEach(() => {
-    __resetPillarRegistryCache();
-    if (original === undefined) delete process.env['POPS_PILLARS'];
-    else process.env['POPS_PILLARS'] = original;
-  });
+    it('degrades to an empty federation when the registry read throws any error', async () => {
+      const onWarn = vi.fn();
+      const invoke = vi.fn<SearchInvoker>(async () => ok([hit('pops:x/1')]));
+      const source = createFederationSource({
+        invoke,
+        snapshotReader: async () => {
+          throw new Error('schema validation boom');
+        },
+        onWarn,
+      });
 
-  it('intersects the search-capable constant with the registered pillars', () => {
-    process.env['POPS_PILLARS'] =
-      'finance:http://finance:3004,food:http://food:3005,inventory:http://inv:3002';
-    __resetPillarRegistryCache();
+      await expect(source({ text: 'x' }, ROOT)).resolves.toEqual([]);
+      expect(invoke).not.toHaveBeenCalled();
+      expect(onWarn).toHaveBeenCalledWith(
+        '[orchestrator] registry read failed; serving empty federated-search set',
+        expect.any(Error)
+      );
+    });
 
-    const resolved = resolveSearchPillars(SELF);
+    it('re-resolves membership per search so a newly registered pillar appears', async () => {
+      const invoke = vi.fn<SearchInvoker>(async () => ok([hit('pops:x/1')]));
+      let snapshots: PillarSnapshot[] = [snapshot('finance')];
+      const source = createFederationSource({
+        invoke,
+        snapshotReader: async () => snapshots,
+      });
 
-    // food is registered but not search-capable; core is search-capable but not registered.
-    expect(resolved.map((p) => p.id).toSorted()).toEqual(['finance', 'inventory']);
-  });
+      const first = await source({ text: 'x' }, ROOT);
+      expect(first.map((g) => g.moduleId)).toEqual(['finance']);
 
-  it('returns no pillars when none of the registered pillars are search-capable', () => {
-    process.env['POPS_PILLARS'] = 'food:http://food:3005';
-    __resetPillarRegistryCache();
-
-    expect(resolveSearchPillars(SELF)).toEqual([]);
+      snapshots = [snapshot('finance'), snapshot('inventory')];
+      const second = await source({ text: 'x' }, ROOT);
+      expect(second.map((g) => g.moduleId).toSorted()).toEqual(['finance', 'inventory']);
+    });
   });
 });

--- a/apps/pops-orchestrator/src/search/federation.ts
+++ b/apps/pops-orchestrator/src/search/federation.ts
@@ -19,19 +19,29 @@
  * SDK result is LOGGED and SKIPPED — federation never fails the whole search
  * because one pillar is down (epic 06).
  *
- * Pillar discovery: the search-capable set is a typed constant
- * ({@link SEARCH_PILLARS}) intersected with the pillars actually present in
- * `POPS_PILLARS`. The registry/manifest does advertise search capability
- * (`manifest.search.adapters`), but the orchestrator's `POPS_PILLARS` registry
- * view (`pillars/registry.ts`) carries only `{ id, baseUrl }` — not manifests
- * — so capability cannot be read from it cleanly. The constant list is the
- * deliberate, typed alternative; see the increment report.
+ * Pillar discovery (registry-as-truth): the search-capable set is derived from
+ * the LIVE registry snapshot — every registered, healthy pillar whose manifest
+ * declares a non-empty `search.adapters` slot is federated, mirroring the
+ * AI-tools handler's `manifest.ai.tools` projection. Adding a search-capable
+ * pillar needs no orchestrator edit: it registers, advertises `search.adapters`,
+ * and appears in federated search on the next discovery refresh.
+ *
+ * Presentation metadata (the section `icon`/`color`/`domain`) is NOT carried by
+ * the manifest's `search` slot — that slot describes adapter mechanics
+ * (`name`/`entityType`/`queryShape`/`procedurePath`), not section chrome. The
+ * monolith's per-section icon/color descriptors have no manifest equivalent, so
+ * they stay in the small static {@link SEARCH_SECTION_META} table keyed by
+ * pillar id. A search-capable pillar with no entry there is still federated,
+ * decorated with {@link DEFAULT_SECTION_META} — membership is registry-driven,
+ * only the chrome falls back.
  */
+import { RegistryUnreachableError } from '@pops/pillar-sdk/discovery';
 import { pillar } from '@pops/pillar-sdk/server';
 
-import { getPillarRegistry } from '../pillars/registry.js';
+import { defaultSnapshotReader, type RegistrySnapshotReader } from '../pillars/registry.js';
 
 import type { CallResult } from '@pops/pillar-sdk/client';
+import type { PillarSnapshot, PillarStatus } from '@pops/pillar-sdk/discovery';
 
 import type { PillarSearchGroup, SearchSource } from './engine.js';
 import type { Query, SearchContext, SearchHit } from './types.js';
@@ -47,8 +57,11 @@ export interface PillarSearchMeta {
 }
 
 /**
- * The pillars that serve `POST /search` and the section metadata the
- * federator decorates their hits with. Ported from the monolith:
+ * Section presentation metadata, ported from the monolith adapter descriptors.
+ * This table does NOT decide membership — that is the live registry's job (a
+ * pillar whose manifest declares `search.adapters`). It only supplies the
+ * section chrome (icon/color/domain) the manifest's `search` slot does not
+ * express:
  *   - core  → `entities` adapter (`Building2`, green)
  *   - finance → transactions/budgets/wishlist adapters, aggregated under one
  *     `/search`; decorated with the transactions descriptor (`ArrowRightLeft`,
@@ -56,14 +69,35 @@ export interface PillarSearchMeta {
  *   - inventory → items adapter; pillar manifest icon `package` / color
  *     `amber`.
  *
- * Media also serves `/search` but is out of scope for this increment (core /
- * finance / inventory only).
+ * A search-capable pillar absent from this table (e.g. media, or a brand-new
+ * pillar) is still federated, decorated with {@link DEFAULT_SECTION_META}.
  */
-export const SEARCH_PILLARS: Readonly<Record<string, PillarSearchMeta>> = {
+export const SEARCH_SECTION_META: Readonly<Record<string, PillarSearchMeta>> = {
   core: { domain: 'core', icon: 'Building2', color: 'green' },
   finance: { domain: 'finance', icon: 'ArrowRightLeft', color: 'green' },
   inventory: { domain: 'inventory', icon: 'Package', color: 'amber' },
 };
+
+/**
+ * Chrome for a search-capable pillar with no {@link SEARCH_SECTION_META} entry.
+ * `domain` is overridden with the pillar id by {@link sectionMetaFor} so
+ * context-section detection still works for an unmapped pillar.
+ */
+const DEFAULT_SECTION_META: PillarSearchMeta = {
+  domain: '',
+  icon: 'Circle',
+  color: 'gray',
+};
+
+/**
+ * Resolve a pillar's section chrome: its static entry, or a default keyed to
+ * the pillar id so an unmapped-but-search-capable pillar still federates.
+ */
+export function sectionMetaFor(pillarId: string): PillarSearchMeta {
+  const mapped = SEARCH_SECTION_META[pillarId];
+  if (mapped !== undefined) return mapped;
+  return { ...DEFAULT_SECTION_META, domain: pillarId };
+}
 
 /** Wire shape returned by a pillar's `search.search` procedure. */
 export interface PillarSearchResponse {
@@ -102,50 +136,108 @@ export interface FederationSourceOptions {
   /** Search dispatcher. Defaults to {@link sdkSearchInvoker}. */
   readonly invoke?: SearchInvoker;
   /**
-   * Search-capable pillars present in this deploy. Defaults to the constant
-   * {@link SEARCH_PILLARS} intersected with `POPS_PILLARS` via
-   * {@link resolveSearchPillars}.
+   * Live registry snapshot reader. Defaults to the SDK discovery client (the
+   * same `defaultSnapshotReader` the `GET /pillars` view uses). Injectable so
+   * tests drive membership off a fixed snapshot with no network.
    */
-  readonly pillars?: readonly { id: string; meta: PillarSearchMeta }[];
+  readonly snapshotReader?: RegistrySnapshotReader;
   /** Warning sink. Defaults to `console.warn` so a down pillar is observable. */
   readonly onWarn?: (message: string, detail?: unknown) => void;
-  /** Self base URL for the registry view. Defaults to the unused localhost placeholder. */
-  readonly selfBaseUrl?: string;
+}
+
+/** One resolved, search-capable pillar plus the chrome to decorate its hits. */
+export interface ResolvedSearchPillar {
+  readonly id: string;
+  readonly meta: PillarSearchMeta;
 }
 
 /**
- * Intersect the search-capable constant with the pillars actually present in
- * `POPS_PILLARS`. A search-capable pillar absent from the registry is silently
- * skipped (it is not deployed); a registry pillar with no search capability
- * (e.g. `food`) is ignored.
+ * Effective availability for federation. Mirrors the AI-tools handler's
+ * `resolveStatus`: `registered=false` is authoritative (the SDK client refuses
+ * to route an unregistered pillar regardless of `status`), and a missing
+ * `status` on a registered pillar is treated as healthy for legacy snapshots.
  */
-export function resolveSearchPillars(
-  selfBaseUrl: string
-): readonly { id: string; meta: PillarSearchMeta }[] {
-  const registered = new Set(getPillarRegistry({ selfBaseUrl }).map((p) => p.id));
-  const resolved: { id: string; meta: PillarSearchMeta }[] = [];
-  for (const [id, meta] of Object.entries(SEARCH_PILLARS)) {
-    if (registered.has(id)) resolved.push({ id, meta });
+function resolveStatus(snapshot: PillarSnapshot): PillarStatus {
+  if (!snapshot.registered) return 'unavailable';
+  if (snapshot.status !== undefined) return snapshot.status;
+  return 'healthy';
+}
+
+/** True iff the pillar advertises at least one search adapter in its manifest. */
+function isSearchCapable(snapshot: PillarSnapshot): boolean {
+  return snapshot.manifest.search.adapters.length > 0;
+}
+
+/**
+ * Project the live registry snapshot to the set of search-capable pillars,
+ * each decorated with its section chrome. Selection mirrors the AI-tools
+ * `buildToolList` projection: registered, healthy, and advertising the
+ * capability (here `search.adapters`; there `ai.tools`).
+ *
+ * Defensive: a single malformed snapshot row is skipped (logged), never
+ * allowed to sink the whole projection — one bad manifest must not break
+ * search for every other pillar.
+ */
+export function selectSearchPillars(
+  snapshots: readonly PillarSnapshot[],
+  onWarn: (message: string, detail?: unknown) => void
+): readonly ResolvedSearchPillar[] {
+  const resolved: ResolvedSearchPillar[] = [];
+
+  for (const snapshot of snapshots) {
+    try {
+      if (resolveStatus(snapshot) !== 'healthy') continue;
+      if (!isSearchCapable(snapshot)) continue;
+      resolved.push({ id: snapshot.pillarId, meta: sectionMetaFor(snapshot.pillarId) });
+    } catch (err) {
+      onWarn('[orchestrator] skipped malformed registry entry during search projection', err);
+    }
   }
+
   return resolved;
 }
 
-/** Localhost placeholder — the registry view requires a self base URL but the federator never calls itself. */
-const REGISTRY_SELF_PLACEHOLDER = 'http://localhost';
+/**
+ * Resolve the search-capable pillar set from the live registry, degrading to an
+ * empty set when the registry read fails. An empty set is the correct degraded
+ * result — federation returns no sections rather than throwing, matching the
+ * AI-tools handler's "empty list, never a 500" stance.
+ */
+async function resolveSearchPillars(
+  reader: RegistrySnapshotReader,
+  onWarn: (message: string, detail?: unknown) => void
+): Promise<readonly ResolvedSearchPillar[]> {
+  let snapshots: readonly PillarSnapshot[];
+  try {
+    snapshots = await reader();
+  } catch (err) {
+    if (err instanceof RegistryUnreachableError) {
+      onWarn('[orchestrator] registry unreachable; serving empty federated-search set', err);
+    } else {
+      onWarn('[orchestrator] registry read failed; serving empty federated-search set', err);
+    }
+    return [];
+  }
+  return selectSearchPillars(snapshots, onWarn);
+}
 
 /**
- * Build the federation {@link SearchSource}. Fans the query out to every
- * resolved search-capable pillar in parallel; collects each pillar's hits and
- * decorates them; skips (logs) any pillar that is unavailable, errors, or
- * returns a non-ok result.
+ * Build the federation {@link SearchSource}. On every search it re-reads the
+ * live registry, projects the search-capable pillars, fans the query out to
+ * each in parallel, collects + decorates their hits, and skips (logs) any
+ * pillar that is unavailable, errors, or returns a non-ok result. Membership is
+ * resolved per-search so a newly registered search-capable pillar is picked up
+ * without restarting the orchestrator (the SDK discovery cache rate-limits the
+ * actual registry traffic).
  */
 export function createFederationSource(options: FederationSourceOptions = {}): SearchSource {
   const invoke = options.invoke ?? sdkSearchInvoker;
   const onWarn = options.onWarn ?? defaultWarn;
-  const selfBaseUrl = options.selfBaseUrl ?? REGISTRY_SELF_PLACEHOLDER;
-  const pillars = options.pillars ?? resolveSearchPillars(selfBaseUrl);
+  const reader = options.snapshotReader ?? defaultSnapshotReader;
 
   return async (query: Query, context: SearchContext): Promise<PillarSearchGroup[]> => {
+    const pillars = await resolveSearchPillars(reader, onWarn);
+
     const settled = await Promise.allSettled(
       pillars.map(async ({ id, meta }) => {
         const result = await invoke(id, { query, context });

--- a/apps/pops-orchestrator/src/search/index.ts
+++ b/apps/pops-orchestrator/src/search/index.ts
@@ -16,14 +16,16 @@ export { searchAll, HITS_PER_SECTION } from './engine.js';
 export type { PillarSearchGroup, SearchSource, SearchAllResult } from './engine.js';
 export {
   createFederationSource,
-  resolveSearchPillars,
+  selectSearchPillars,
+  sectionMetaFor,
   sdkSearchInvoker,
-  SEARCH_PILLARS,
+  SEARCH_SECTION_META,
 } from './federation.js';
 export type {
   FederationSourceOptions,
   PillarSearchMeta,
   PillarSearchResponse,
+  ResolvedSearchPillar,
   SearchInvoker,
 } from './federation.js';
 export { parseQuery } from './query-parser.js';


### PR DESCRIPTION
## What

Make the orchestrator's federated search discover its search-capable pillars from the **live registry + their manifests**, instead of a hardcoded static list.

Previously `federation.ts` carried a hardcoded `SEARCH_PILLARS` constant (`core`, `finance`, `inventory`) intersected with the `POPS_PILLARS` env seed. Adding a search-capable pillar required editing the orchestrator.

## How

Mirror the AI-tools handler's manifest projection (`buildToolList` projects `manifest.ai.tools`; this projects `manifest.search.adapters`):

- **Membership is registry-driven.** `createFederationSource` now reads the live registry snapshot (the SDK discovery client — the same `defaultSnapshotReader` the `GET /pillars` view uses, now exported for reuse) and federates every pillar that is **registered, healthy, and declares a non-empty `search.adapters` slot**. Membership is resolved per search, so a newly registered search-capable pillar shows up with **no orchestrator edit** (the SDK discovery cache rate-limits the actual registry traffic). The orchestrator does not federate to itself — its own manifest declares `search: { adapters: [] }`.
- **Availability** mirrors the AI-tools `resolveStatus`: `registered=false` is authoritative; a missing `status` on a registered pillar is treated as healthy (legacy snapshots).
- **Behavior preserved.** `core` / `finance` / `inventory` still federate with the same section decoration when registered.

## Static fallback (design note)

The per-section **presentation metadata** (`icon` / `color` / `domain`) stays in a small static `SEARCH_SECTION_META` table keyed by pillar id. The manifest's `search` slot describes adapter *mechanics* (`name` / `entityType` / `queryShape` / `procedurePath`), not section chrome — there is no manifest field to source icon/color from (the `nav` slot's kebab-case icon/`NAV_COLOR` is for the app rail, a different concern from the ported monolith search-section descriptors). A search-capable pillar with **no** static entry is still federated, decorated with a neutral default (`Circle` / `gray`, domain keyed to the pillar id). So: **membership is registry-driven; only the chrome falls back.**

## Resilience

- A registry read failure (`RegistryUnreachableError` or any other error) degrades to an **empty federation** rather than throwing — matching the AI-tools handler's "empty, never a 500" stance.
- A single malformed snapshot row is skipped (logged), never allowed to sink the whole projection.

## Tests

`apps/pops-orchestrator/src/search/__tests__/federation.test.ts` proves:

- a pillar with a `search.adapters` manifest capability **is** federated; one without **is not**;
- unregistered / unavailable / unknown pillars are dropped; a registered pillar with no explicit status is treated as healthy;
- a search-capable pillar with no static chrome is federated with a defaulted decoration;
- the registry-unreachable (and generic-error) path degrades to an empty result, never throwing;
- membership re-resolves per search, so a newly registered pillar appears on the next call;
- best-effort isolation is preserved (a down/throwing pillar is skipped, the rest still federate).

## Verification

- `pnpm --filter @pops/orchestrator typecheck` — clean
- `pnpm --filter @pops/orchestrator test` — 67 passing
- repo-wide `pnpm typecheck` (38/38), `pnpm lint:boundaries:verify`, `pnpm format:check` — clean
- CI-equivalent scoped checks (`oxfmt --check apps/pops-orchestrator/`, `oxlint apps/pops-orchestrator/src`, build) — clean
