### PR TITLE
feat(shell): load external-pillar UI bundles at runtime (PRD-243 US-05)

### DIFF
--- a/apps/pops-shell/src/app/bundle-map.tsx
+++ b/apps/pops-shell/src/app/bundle-map.tsx
@@ -6,10 +6,11 @@ import { useEffect } from 'react';
  *
  * The shell discovers each in-repo pillar's UI surface (nav + pages +
  * capture overlay) by walking this map. For external pillars (PRD-228)
- * the registry will advertise an `assetsBaseUrl`; the lazy-load mechanism
- * is gated on US-05 landing — until then any external-only pillar id
- * falls through the `external UI loading not implemented` skip path in
- * `installed-modules.ts`.
+ * the registry advertises an `assetsBaseUrl` and the wire-shaped `nav` /
+ * `pages` descriptors; those never appear in this map (ADR-002 keeps the
+ * in-repo FE a single static SPA). They reach the shell through the
+ * runtime loader in `external-ui.tsx`, which lazy-`import()`s the remote
+ * bundle (PRD-243 US-05, Option A).
  *
  * Each entry carries:
  *
@@ -40,12 +41,14 @@ import { useEffect } from 'react';
  *                               component to mount. Cerebrum binds
  *                               `'ingest-form'` to its `IngestForm` +
  *                               `useIngestPageModel`.
- *   - `assetsBaseUrl?`        — reserved for external pillars (US-05).
- *                               Always `undefined` for in-repo entries.
+ *   - `assetsBaseUrl?`        — set only for synthesized external-pillar
+ *                               entries (`external-ui.tsx`); echoed for
+ *                               diagnostics. Always `undefined` for the
+ *                               in-repo entries declared in this file.
  *
  * Adding a new in-repo pillar = adding one entry here. External pillars
  * never appear in this map; they reach the shell via the registry walk and
- * (once US-05 lands) the asset-URL loading path.
+ * the asset-URL loading path in `external-ui.tsx` (PRD-243 US-05).
  */
 import { manifest as aiManifest } from '@pops/app-ai';
 import { IngestForm, manifest as cerebrumManifest, useIngestPageModel } from '@pops/app-cerebrum';

--- a/apps/pops-shell/src/app/external-ui.test.tsx
+++ b/apps/pops-shell/src/app/external-ui.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * PRD-243 US-05 — external-pillar UI loading (Option A) unit tests.
+ *
+ * Exercises the runtime loader end to end against a fake remote bundle so
+ * no network round-trip is needed:
+ *
+ *   - A registered external pillar (absent from the static bundle map)
+ *     whose manifest advertises an `assetsBaseUrl` + `pages` has its remote
+ *     component lazily imported and rendered under its route.
+ *   - A failed remote load (rejected import, missing slot, bad bundle
+ *     shape) degrades to the error-boundary placeholder — the shell does
+ *     not crash.
+ *   - In-repo pillars never reach this path: the synthesizer only consumes
+ *     the wire descriptor, leaving the static bundle map untouched.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  synthesizeExternalBundleEntry,
+  type RemoteModuleImporter,
+  type RemoteUiDescriptor,
+} from './external-ui';
+import { hasRoutes } from './installed-modules';
+import { buildRegisteredAppsFromBundleMap } from './nav/registry';
+
+import type { RouteObject } from 'react-router';
+
+import type { BundleEntry } from './bundle-map';
+
+/**
+ * Pull the synthesized routes out of a bundle entry through the shared
+ * `hasRoutes` guard so the test never asserts against the `unknown`-typed
+ * `frontend.routes` slot directly.
+ */
+function routesOf(entry: BundleEntry): RouteObject[] {
+  if (!hasRoutes(entry.manifest)) throw new Error('synthesized entry is missing frontend.routes');
+  return entry.manifest.frontend.routes;
+}
+
+/** Nav config the app-rail walk derives from a single synthesized entry. */
+function navOf(id: string, entry: BundleEntry) {
+  return buildRegisteredAppsFromBundleMap({ [id]: entry }).find((app) => app.id === id);
+}
+
+function RemoteHome() {
+  return <div data-testid="remote-home">remote home page</div>;
+}
+
+const VALID_BUNDLE = { bundles: { home: RemoteHome } };
+
+function descriptor(overrides: Partial<RemoteUiDescriptor> = {}): RemoteUiDescriptor {
+  return {
+    pillarId: 'acme',
+    assetsBaseUrl: 'https://cdn.example.com/acme/index.js',
+    nav: {
+      id: 'acme',
+      label: 'Acme',
+      labelKey: 'acme',
+      icon: 'Compass',
+      basePath: '/acme',
+      order: 42,
+      items: [{ path: '', label: 'Home', labelKey: 'acme.home', icon: 'Compass' }],
+    },
+    pages: [{ path: '', index: true, bundleSlot: 'home' }],
+    ...overrides,
+  };
+}
+
+function mountSynthesizedRoutes(routes: readonly RouteObject[], at: string): void {
+  render(
+    <MemoryRouter initialEntries={[at]}>
+      <Routes>
+        <Route path="acme" element={<Outlet />}>
+          {routes.map((route, i) => (
+            <Route
+              key={route.path ?? (route.index ? '__index__' : String(i))}
+              index={route.index}
+              path={route.path}
+              element={route.element}
+            />
+          ))}
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('synthesizeExternalBundleEntry — descriptor → bundle entry', () => {
+  it('derives navConfig + navOrder from the wire nav descriptor', () => {
+    const entry = synthesizeExternalBundleEntry(descriptor());
+    expect(entry).not.toBeNull();
+    if (entry === null) return;
+    expect(entry.navOrder).toBe(42);
+    expect(navOf('acme', entry)?.id).toBe('acme');
+    expect(entry.manifest.surfaces).toContain('app');
+    expect(entry.assetsBaseUrl).toBe('https://cdn.example.com/acme/index.js');
+  });
+
+  it('falls back to a neutral icon when the wire nav icon is unknown', () => {
+    const entry = synthesizeExternalBundleEntry(
+      descriptor({
+        nav: {
+          id: 'acme',
+          label: 'Acme',
+          labelKey: 'acme',
+          icon: 'not-a-real-icon',
+          basePath: '/acme',
+          order: 1,
+          items: [{ path: '', label: 'Home', labelKey: 'acme.home', icon: 'also-fake' }],
+        },
+      })
+    );
+    expect(entry).not.toBeNull();
+    if (entry === null) return;
+    const nav = navOf('acme', entry);
+    expect(nav?.icon).toBe('Compass');
+    expect(nav?.items[0]?.icon).toBe('Compass');
+  });
+
+  it('returns null when the pillar advertises an asset URL but no nav/pages', () => {
+    const entry = synthesizeExternalBundleEntry(descriptor({ nav: undefined, pages: undefined }));
+    expect(entry).toBeNull();
+  });
+
+  it('does not import the remote bundle during synthesis (lazy on first render)', () => {
+    const importer = vi.fn<RemoteModuleImporter>(() => Promise.resolve(VALID_BUNDLE));
+    synthesizeExternalBundleEntry(descriptor(), importer);
+    expect(importer).not.toHaveBeenCalled();
+  });
+});
+
+describe('external pillar UI — runtime mount (US-05 Option A)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lazily imports the remote bundle and renders its component under the route', async () => {
+    const importer = vi.fn<RemoteModuleImporter>(() => Promise.resolve(VALID_BUNDLE));
+    const entry = synthesizeExternalBundleEntry(descriptor(), importer);
+    if (entry === null) throw new Error('expected a synthesized entry');
+
+    mountSynthesizedRoutes(routesOf(entry), '/acme');
+
+    await waitFor(() => expect(screen.getByTestId('remote-home')).toBeInTheDocument());
+    expect(importer).toHaveBeenCalledTimes(1);
+    expect(importer).toHaveBeenCalledWith('https://cdn.example.com/acme/index.js');
+  });
+
+  it('degrades to the error-boundary placeholder when the remote import rejects (no crash)', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const importer = vi.fn<RemoteModuleImporter>(() => Promise.reject(new Error('network down')));
+    const entry = synthesizeExternalBundleEntry(descriptor(), importer);
+    if (entry === null) throw new Error('expected a synthesized entry');
+
+    mountSynthesizedRoutes(routesOf(entry), '/acme');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-pillar-load-error')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('remote-home')).not.toBeInTheDocument();
+  });
+
+  it('degrades gracefully when the remote bundle is missing the declared slot', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const importer = vi.fn<RemoteModuleImporter>(() =>
+      Promise.resolve({ bundles: { somethingElse: RemoteHome } })
+    );
+    const entry = synthesizeExternalBundleEntry(descriptor(), importer);
+    if (entry === null) throw new Error('expected a synthesized entry');
+
+    mountSynthesizedRoutes(routesOf(entry), '/acme');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-pillar-load-error')).toBeInTheDocument()
+    );
+  });
+
+  it('degrades gracefully when the remote bundle has the wrong shape', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const importer = vi.fn<RemoteModuleImporter>(() => Promise.resolve({ notBundles: 1 }));
+    const entry = synthesizeExternalBundleEntry(descriptor(), importer);
+    if (entry === null) throw new Error('expected a synthesized entry');
+
+    mountSynthesizedRoutes(routesOf(entry), '/acme');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-pillar-load-error')).toBeInTheDocument()
+    );
+  });
+});

--- a/apps/pops-shell/src/app/external-ui.tsx
+++ b/apps/pops-shell/src/app/external-ui.tsx
@@ -1,0 +1,238 @@
+/**
+ * External-pillar UI loading (PRD-243 US-05, Option A).
+ *
+ * In-repo pillars reach the shell through the static `WORKSPACE_BUNDLE_MAP`
+ * (`./bundle-map.tsx`) — a build-time import graph that ADR-002 keeps as a
+ * single static Vite SPA. This module covers the orthogonal case: a pillar
+ * the build does not know about, registered at runtime (PRD-228), whose
+ * manifest advertises an `assetsBaseUrl`.
+ *
+ * The mechanism is the one US-05 recommends (Option A, not Module
+ * Federation): the shell `import()`s the pillar's single ESM entry from the
+ * URL it advertises and resolves each `PageDescriptor.bundleSlot` to a React
+ * component the remote bundle exports. The nav rail comes off the wire
+ * (`NavConfigDescriptor`) so it renders synchronously at boot; the remote
+ * bundle is fetched lazily on first navigation, behind `React.lazy` +
+ * `<Suspense>`, and wrapped in an `<ErrorBoundary>` so a failed load
+ * (network error, missing slot, invalid bundle) degrades to a placeholder
+ * instead of crashing the shell.
+ *
+ * This adds no bundler coupling and does not change how in-repo pillars are
+ * bundled: it is a runtime dynamic `import()` of a URL, native to ES modules
+ * and Vite. ADR-002 stands — the in-repo FE is still one static SPA.
+ */
+import { lazy, Suspense, type ComponentType } from 'react';
+
+import { ErrorBoundary } from '@pops/ui';
+
+import { iconMap } from './nav/icon-map';
+
+import type { RouteObject } from 'react-router';
+
+import type { NavConfigDescriptor, PageDescriptor } from '@pops/pillar-sdk';
+import type { ModuleManifest } from '@pops/types';
+
+import type { BundleEntry } from './bundle-map';
+import type { AppNavConfig, AppNavItem, IconName } from './nav/types';
+
+/**
+ * The contract an external pillar's remote ESM bundle must satisfy.
+ *
+ * The bundle is fetched via `import(assetsBaseUrl)`; its module namespace is
+ * expected to expose a `bundles` record keyed by the kebab-case
+ * `PageDescriptor.bundleSlot` ids the pillar declares in its manifest. Each
+ * value is a zero-prop-required React component the shell mounts under the
+ * matching route. Keeping the contract to "a record of components" avoids
+ * leaking the shell's router/React types across the wire boundary while
+ * still being fully typed on the shell side.
+ */
+export interface RemotePillarUiModule {
+  readonly bundles: Readonly<Record<string, ComponentType>>;
+}
+
+/**
+ * Wire-shaped description of an external pillar's UI surface, projected from
+ * its registry manifest. Unlike the in-repo `BundleEntry`, none of this
+ * carries React references — the components live in the remote bundle and
+ * are resolved lazily through `assetsBaseUrl`.
+ */
+export interface RemoteUiDescriptor {
+  readonly pillarId: string;
+  readonly assetsBaseUrl: string;
+  readonly nav?: NavConfigDescriptor;
+  readonly pages?: readonly PageDescriptor[];
+}
+
+/**
+ * Default for `RemotePillarUiModule.import` — the production loader. A thin
+ * indirection so tests can inject a fake remote module without a real
+ * network fetch. `/* @vite-ignore *\/` keeps Vite from trying to resolve the
+ * runtime URL at build time; the import is genuinely dynamic.
+ */
+export type RemoteModuleImporter = (assetsBaseUrl: string) => Promise<unknown>;
+
+const defaultRemoteModuleImporter: RemoteModuleImporter = (assetsBaseUrl) =>
+  import(/* @vite-ignore */ assetsBaseUrl);
+
+/**
+ * Narrow an unknown dynamic-import result to `RemotePillarUiModule`. Throws a
+ * descriptive `Error` (never returns a partial) so the lazy-import promise
+ * rejects and the surrounding `<ErrorBoundary>` renders the fallback.
+ */
+function assertRemoteUiModule(value: unknown, pillarId: string): RemotePillarUiModule {
+  if (typeof value !== 'object' || value === null || !('bundles' in value)) {
+    throw new Error(`external pillar '${pillarId}' bundle does not export a 'bundles' record`);
+  }
+  const bundles = (value as { bundles: unknown }).bundles;
+  if (typeof bundles !== 'object' || bundles === null) {
+    throw new Error(`external pillar '${pillarId}' bundle 'bundles' export is not an object`);
+  }
+  return { bundles: bundles as Readonly<Record<string, ComponentType>> };
+}
+
+/**
+ * Resolve a single `bundleSlot` from a freshly imported remote module to a
+ * `{ default }` shape `React.lazy` expects. Rejects (so the boundary fires)
+ * when the slot is absent — a manifest that names a slot the bundle does not
+ * ship is a remote-side contract break, not a shell crash.
+ */
+async function loadRemoteComponent(
+  descriptor: RemoteUiDescriptor,
+  bundleSlot: string,
+  importer: RemoteModuleImporter
+): Promise<{ default: ComponentType }> {
+  const imported = await importer(descriptor.assetsBaseUrl);
+  const module = assertRemoteUiModule(imported, descriptor.pillarId);
+  const component = module.bundles[bundleSlot];
+  if (component === undefined) {
+    throw new Error(
+      `external pillar '${descriptor.pillarId}' bundle has no component for slot '${bundleSlot}'`
+    );
+  }
+  return { default: component };
+}
+
+const RemoteLoadFallback = (
+  <div className="p-6 text-muted-foreground" data-testid="external-pillar-load-error">
+    This pillar&rsquo;s interface could not be loaded.
+  </div>
+);
+
+const RemoteSuspenseFallback = (
+  <div className="flex items-center justify-center h-64 text-muted-foreground">Loading…</div>
+);
+
+/**
+ * Build the lazy, guarded element the shell mounts for one external page.
+ * The remote bundle is imported on first render of this element (so an
+ * unvisited external pillar costs nothing); a rejected import is contained
+ * by the `<ErrorBoundary>` and never propagates to the shell's router error
+ * element.
+ */
+function remotePageElement(
+  descriptor: RemoteUiDescriptor,
+  page: PageDescriptor,
+  importer: RemoteModuleImporter
+): RouteObject {
+  const LazyComponent = lazy(() => loadRemoteComponent(descriptor, page.bundleSlot, importer));
+  return {
+    path: page.index === true ? undefined : page.path,
+    index: page.index === true ? true : undefined,
+    element: (
+      <ErrorBoundary fallback={() => RemoteLoadFallback}>
+        <Suspense fallback={RemoteSuspenseFallback}>
+          <LazyComponent />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+  };
+}
+
+const FALLBACK_NAV_ICON: IconName = 'Compass';
+
+/**
+ * Resolve a wire-format kebab-case-or-PascalCase icon id to a shell
+ * `IconName`. External pillars travel icons as identifiers; an unknown id
+ * degrades to a neutral fallback rather than failing the nav build.
+ */
+function resolveNavIcon(icon: string): IconName {
+  return icon in iconMap ? (icon as IconName) : FALLBACK_NAV_ICON;
+}
+
+function navItemFromDescriptor(item: NavConfigDescriptor['items'][number]): AppNavItem {
+  return {
+    path: item.path,
+    label: item.label,
+    labelKey: item.labelKey,
+    icon: resolveNavIcon(item.icon),
+  };
+}
+
+/**
+ * Project a wire `NavConfigDescriptor` onto the runtime `AppNavConfig` the
+ * app rail consumes. Icons resolve to `IconName` with a fallback; everything
+ * else is a structural copy.
+ */
+function navConfigFromDescriptor(nav: NavConfigDescriptor): AppNavConfig {
+  return {
+    id: nav.id,
+    label: nav.label,
+    labelKey: nav.labelKey,
+    icon: resolveNavIcon(nav.icon),
+    color: nav.color,
+    basePath: nav.basePath,
+    items: nav.items.map(navItemFromDescriptor),
+  };
+}
+
+/**
+ * Synthesize the `BundleEntry` an external pillar contributes, mirroring the
+ * shape in-repo pillars get from the static bundle map. The resulting entry
+ * carries:
+ *
+ *   - `manifest.frontend.navConfig` derived from the wire `nav` descriptor
+ *     (so the app rail renders synchronously, no remote fetch needed),
+ *   - `manifest.frontend.routes` whose elements lazy-load the remote bundle
+ *     per `PageDescriptor.bundleSlot`, each wrapped in an error boundary,
+ *   - `navOrder` from the wire `nav.order` (app-rail ordering parity with
+ *     in-repo pillars),
+ *   - `assetsBaseUrl` echoed back for diagnostics.
+ *
+ * Returns `null` when the descriptor advertises an asset URL but no UI
+ * surface (`nav` and `pages` both absent) — there is nothing to mount, so
+ * the caller treats it like a backend-only pillar and skips it.
+ *
+ * `importer` is injectable so tests exercise the synthesis + resilience
+ * without a network round-trip; production omits it and uses the dynamic
+ * `import()` loader.
+ */
+export function synthesizeExternalBundleEntry(
+  descriptor: RemoteUiDescriptor,
+  importer: RemoteModuleImporter = defaultRemoteModuleImporter
+): BundleEntry | null {
+  const hasNav = descriptor.nav !== undefined;
+  const hasPages = descriptor.pages !== undefined && descriptor.pages.length > 0;
+  if (!hasNav && !hasPages) return null;
+
+  const routes: RouteObject[] = (descriptor.pages ?? []).map((page) =>
+    remotePageElement(descriptor, page, importer)
+  );
+
+  const frontend: NonNullable<ModuleManifest['frontend']> = { routes };
+  if (descriptor.nav !== undefined) {
+    frontend.navConfig = navConfigFromDescriptor(descriptor.nav);
+  }
+
+  const manifest: ModuleManifest = {
+    id: descriptor.pillarId,
+    name: descriptor.nav?.label ?? descriptor.pillarId,
+    surfaces: ['app'],
+    frontend,
+  };
+
+  return {
+    manifest,
+    navOrder: descriptor.nav?.order ?? Number.MAX_SAFE_INTEGER,
+    assetsBaseUrl: descriptor.assetsBaseUrl,
+  };
+}

--- a/apps/pops-shell/src/app/installed-modules.ts
+++ b/apps/pops-shell/src/app/installed-modules.ts
@@ -8,19 +8,31 @@
  * manifest by name and reduced the registry intersection through the
  * `KNOWN_FRONTEND_MANIFESTS` literal. The registry walk replaces both:
  * every installed pillar id resolves through `lookupBundleEntry()`,
- * which fronts the workspace bundle map. External pillars (PRD-228)
- * that the registry advertises via `assetsBaseUrl` but the bundle map
- * has not bound to a workspace bundle fall through the "external UI
- * loading not implemented" branch — gated on PRD-243 US-05.
+ * which fronts the workspace bundle map.
  *
- * See `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-03-shell-registry-walk.md`.
+ * External pillars (PRD-228) that the registry advertises via
+ * `assetsBaseUrl` are absent from the workspace bundle map by design
+ * (ADR-002 keeps the in-repo FE a single static SPA). For those the walk
+ * takes the runtime path (PRD-243 US-05, Option A): it lazily `import()`s
+ * the pillar's ESM bundle from the advertised URL and mounts it like an
+ * in-repo module. A failed remote load degrades to skipping the pillar's
+ * UI, never crashing the shell.
+ *
+ * See `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-03-shell-registry-walk.md`
+ * and `us-05-external-pillar-ui-loading.md`.
  */
 import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
 
 import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from './bundle-map';
+import {
+  synthesizeExternalBundleEntry,
+  type RemoteModuleImporter,
+  type RemoteUiDescriptor,
+} from './external-ui';
 
 import type { RouteObject } from 'react-router';
 
+import type { NavConfigDescriptor, PageDescriptor } from '@pops/pillar-sdk';
 import type { ModuleManifest } from '@pops/types';
 
 /**
@@ -41,21 +53,25 @@ export function hasRoutes(
 }
 
 /**
- * Thrown when the registry advertises a pillar via `assetsBaseUrl` (i.e.
- * the pillar expects to be UI-mounted via the external loading
- * mechanism) but PRD-243 US-05 has not yet landed the resolver. Caught
- * in `walkRegistry()` so the shell logs once and skips the pillar
- * instead of crashing the boot.
+ * Raised when synthesizing the UI surface for an external pillar fails at
+ * walk time (e.g. the registry advertised an `assetsBaseUrl` but the
+ * descriptor is structurally unusable). Caught in `walkRegistry()` so the
+ * shell logs once and skips that pillar's UI instead of crashing the boot.
+ *
+ * Failures that happen *later* — when the remote bundle is actually
+ * imported on first navigation — are contained by the per-route
+ * `<ErrorBoundary>` the external loader wraps each page in, not by this
+ * error. This type covers only the synchronous synthesis step.
  */
-export class ExternalUiLoadingNotImplementedError extends Error {
-  override readonly name = 'ExternalUiLoadingNotImplementedError';
+export class ExternalUiLoadError extends Error {
+  override readonly name = 'ExternalUiLoadError';
   readonly pillarId: string;
   readonly assetsBaseUrl: string;
 
-  constructor(pillarId: string, assetsBaseUrl: string) {
-    super(
-      `external UI loading not implemented (pillarId=${pillarId}, assetsBaseUrl=${assetsBaseUrl})`
-    );
+  constructor(pillarId: string, assetsBaseUrl: string, cause?: unknown) {
+    super(`external UI load failed (pillarId=${pillarId}, assetsBaseUrl=${assetsBaseUrl})`, {
+      cause,
+    });
     this.pillarId = pillarId;
     this.assetsBaseUrl = assetsBaseUrl;
   }
@@ -64,17 +80,21 @@ export class ExternalUiLoadingNotImplementedError extends Error {
 /**
  * Minimal "registry entry" shape the shell walks. Mirrors the
  * `PillarSnapshot` projection `discoverSettings()` reads (PRD-240) but
- * carries only the fields PRD-243 US-03 needs to decide which UI surface
- * to mount: the pillar id and (for external pillars) the `assetsBaseUrl`
- * the US-05 follow-up will consume.
+ * carries only the fields PRD-243 needs to decide which UI surface to
+ * mount: the pillar id, and — for external pillars (PRD-228) absent from
+ * the workspace bundle map — the `assetsBaseUrl` plus the wire-shaped
+ * `nav` / `pages` descriptors the runtime loader (US-05) consumes.
  *
- * Backed by `MODULES` + `INSTALLED_MODULES` today; PRD-228 wires the
- * runtime registry behind the same shape so external pillars flow
- * through the same walk.
+ * In-repo pillars carry only `pillarId`: their UI surface comes from the
+ * static bundle map, never the wire. Backed by `MODULES` +
+ * `INSTALLED_MODULES` today; PRD-228 wires the runtime registry behind
+ * the same shape so external pillars flow through the same walk.
  */
 export interface RegistryEntry {
   readonly pillarId: string;
   readonly assetsBaseUrl?: string;
+  readonly nav?: NavConfigDescriptor;
+  readonly pages?: readonly PageDescriptor[];
 }
 
 /**
@@ -92,20 +112,61 @@ function defaultRegistryEntries(): readonly RegistryEntry[] {
 }
 
 /**
+ * Resolve an external pillar's UI surface into a frontend manifest, or
+ * `null` to skip it. Wraps `synthesizeExternalBundleEntry` so any
+ * synchronous failure is logged once and contained — the shell never
+ * crashes because an external pillar shipped a bad descriptor.
+ *
+ * `importer` defaults (inside the synthesizer) to a dynamic `import()` of
+ * the advertised URL; tests inject a fake to exercise the path offline.
+ */
+function resolveExternalManifest(
+  entry: RegistryEntry & { assetsBaseUrl: string },
+  importer?: RemoteModuleImporter
+): FrontendManifest | null {
+  const descriptor: RemoteUiDescriptor = {
+    pillarId: entry.pillarId,
+    assetsBaseUrl: entry.assetsBaseUrl,
+    nav: entry.nav,
+    pages: entry.pages,
+  };
+  try {
+    const synthesized = synthesizeExternalBundleEntry(descriptor, importer);
+    if (synthesized === null) {
+      // Advertised an asset URL but no `nav` / `pages` — nothing to mount.
+      // Treated like a backend-only pillar.
+      return null;
+    }
+    return synthesized.manifest;
+  } catch (cause) {
+    const err = new ExternalUiLoadError(entry.pillarId, entry.assetsBaseUrl, cause);
+    console.warn(`[installed-modules] ${err.message}`, cause);
+    return null;
+  }
+}
+
+/**
  * Walk a registry entry list against a workspace bundle map, returning
  * the frontend manifests the shell should mount. Resolution per id:
  *
- *   - Bundle map hit → emit the workspace manifest.
- *   - Bundle map miss + `assetsBaseUrl` set → log the structured
- *     `ExternalUiLoadingNotImplementedError` message (PRD-243 US-05
- *     deferred) and skip.
+ *   - Bundle map hit → emit the in-repo workspace manifest (ADR-002:
+ *     statically bundled, unchanged).
+ *   - Bundle map miss + `assetsBaseUrl` set → external pillar (PRD-228).
+ *     Synthesize a manifest whose routes lazy-`import()` the remote bundle
+ *     (PRD-243 US-05, Option A). A bad descriptor is logged and skipped;
+ *     a remote bundle that fails to load later is contained by the
+ *     per-route error boundary, not here.
  *   - Bundle map miss + no `assetsBaseUrl` → backend-only pillar, drop
  *     silently. Mirrors the pre-PRD-243 behaviour where backend-only
  *     ids simply weren't in `KNOWN_FRONTEND_MANIFESTS`.
+ *
+ * `importer` is injectable for tests; production omits it so the external
+ * loader uses the real dynamic `import()`.
  */
 export function walkRegistry(
   entries: readonly RegistryEntry[],
-  bundleMap: Readonly<Record<string, BundleEntry>>
+  bundleMap: Readonly<Record<string, BundleEntry>>,
+  importer?: RemoteModuleImporter
 ): readonly FrontendManifest[] {
   const out: FrontendManifest[] = [];
   for (const entry of entries) {
@@ -115,8 +176,11 @@ export function walkRegistry(
       continue;
     }
     if (entry.assetsBaseUrl !== undefined) {
-      const err = new ExternalUiLoadingNotImplementedError(entry.pillarId, entry.assetsBaseUrl);
-      console.warn(`[installed-modules] ${err.message}`);
+      const manifest = resolveExternalManifest(
+        { ...entry, assetsBaseUrl: entry.assetsBaseUrl },
+        importer
+      );
+      if (manifest !== null) out.push(manifest);
       continue;
     }
     // Backend-only pillars (e.g. `core`) sit in `MODULES` but contribute

--- a/apps/pops-shell/src/app/registry-walk.test.ts
+++ b/apps/pops-shell/src/app/registry-walk.test.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-243 US-03 — registry-walk unit tests.
+ * PRD-243 US-03 + US-05 — registry-walk unit tests.
  *
  * Exercises the bundle-map-driven discovery path with synthetic data
  * instead of the live `WORKSPACE_BUNDLE_MAP` / `MODULES` constants. The
@@ -9,20 +9,25 @@
  *   - Two synthetic pillars produce two nav configs.
  *   - Frontend manifests joined through the walk preserve `frontend.routes`.
  *   - Pillars omitting both `nav` and `pages` are skipped from the rail.
- *   - Pillars advertising an `assetsBaseUrl` without a bundle entry log
- *     once and are skipped (the US-05 stub branch).
+ *   - An external pillar (absent from the bundle map) that advertises an
+ *     `assetsBaseUrl` plus `nav` / `pages` is loaded via the runtime path
+ *     (US-05, Option A) and contributes a mounted manifest.
+ *   - A structurally broken external descriptor is logged once and skipped
+ *     (no crash).
  *   - Sort order respects `navOrder` ascending with a lexicographic
  *     tiebreak on the nav id.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  ExternalUiLoadingNotImplementedError,
+  hasRoutes,
   walkRegistry,
   type FrontendManifest,
   type RegistryEntry,
 } from './installed-modules';
 import { buildRegisteredAppsFromBundleMap } from './nav/registry';
+
+import type { NavConfigDescriptor, PageDescriptor } from '@pops/pillar-sdk';
 
 import type { BundleEntry } from './bundle-map';
 import type { AppNavConfig } from './nav/types';
@@ -119,29 +124,59 @@ describe('walkRegistry', () => {
     expect(apps.map((a) => a.id)).toEqual(['finance']);
   });
 
-  it('logs and skips a registry entry that advertises assetsBaseUrl without a bundle map entry (US-05 stub branch)', () => {
-    const bundleMap: Record<string, BundleEntry> = {};
+  it('mounts an external pillar (no bundle map entry) via the runtime loader (US-05 Option A)', () => {
+    const externalNav: NavConfigDescriptor = {
+      id: 'external-pillar',
+      label: 'External Pillar',
+      labelKey: 'externalPillar',
+      icon: 'Compass',
+      basePath: '/external-pillar',
+      order: 35,
+      items: [{ path: '', label: 'Home', labelKey: 'externalPillar.home', icon: 'Compass' }],
+    };
+    const externalPages: PageDescriptor[] = [{ path: '', index: true, bundleSlot: 'home' }];
     const entries: RegistryEntry[] = [
-      { pillarId: 'external-pillar', assetsBaseUrl: 'https://cdn.example.com/external/' },
+      {
+        pillarId: 'external-pillar',
+        assetsBaseUrl: 'https://cdn.example.com/external/index.js',
+        nav: externalNav,
+        pages: externalPages,
+      },
     ];
 
-    const out = walkRegistry(entries, bundleMap);
+    // Importer is never invoked here: synthesis is synchronous; the remote
+    // bundle is fetched lazily only when the route actually renders.
+    const out = walkRegistry(entries, {}, () =>
+      Promise.reject(new Error('importer must not run during synthesis'))
+    );
 
-    expect(out).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
-    expect(message).toContain('external UI loading not implemented');
-    expect(message).toContain('external-pillar');
-    expect(message).toContain('https://cdn.example.com/external/');
+    expect(out).toHaveLength(1);
+    const manifest = out[0];
+    expect(manifest?.id).toBe('external-pillar');
+    expect(manifest?.surfaces).toContain('app');
+    expect(manifest !== undefined && hasRoutes(manifest)).toBe(true);
+    if (manifest !== undefined && hasRoutes(manifest)) {
+      expect(manifest.frontend.routes).toHaveLength(1);
+    }
+    const navIds = buildRegisteredAppsFromBundleMap({
+      'external-pillar': {
+        manifest: manifest as FrontendManifest,
+        navOrder: externalNav.order,
+      },
+    }).map((app) => app.id);
+    expect(navIds).toContain('external-pillar');
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('exposes the US-05 stub failure as a structured error type callers can detect', () => {
-    const err = new ExternalUiLoadingNotImplementedError('foo', 'https://x/');
+  it('skips an external pillar that advertises an asset URL but no nav/pages (nothing to mount)', () => {
+    const entries: RegistryEntry[] = [
+      { pillarId: 'external-headless', assetsBaseUrl: 'https://cdn.example.com/headless.js' },
+    ];
 
-    expect(err).toBeInstanceOf(Error);
-    expect(err.name).toBe('ExternalUiLoadingNotImplementedError');
-    expect(err.pillarId).toBe('foo');
-    expect(err.assetsBaseUrl).toBe('https://x/');
+    const out = walkRegistry(entries, {});
+
+    expect(out).toHaveLength(0);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('sorts registeredApps by navOrder ascending with a lexicographic tiebreak on id', () => {

--- a/apps/pops-shell/src/tests/synthetic-pillar.integration.test.tsx
+++ b/apps/pops-shell/src/tests/synthetic-pillar.integration.test.tsx
@@ -160,23 +160,38 @@ describe('PRD-243 US-04 — synthetic pillar mounts via registry (audit M7)', ()
     expect(manifests.map((m) => m.id)).not.toContain(SYNTHETIC_ID);
   });
 
-  it('synthetic registry entry without a bundle slot logs the US-05 stub and skips (no crash)', () => {
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message: unknown) => {
-      warnings.push(String(message));
-    };
-    try {
-      const entries: RegistryEntry[] = [
-        { pillarId: SYNTHETIC_ID, assetsBaseUrl: 'https://cdn.example.com/synthetic-foo/' },
-      ];
-      const manifests = walkRegistry(entries, {});
+  it('an external registry entry (no bundle map entry) mounts via the runtime loader (US-05)', () => {
+    const entries: RegistryEntry[] = [
+      {
+        pillarId: SYNTHETIC_ID,
+        assetsBaseUrl: 'https://cdn.example.com/synthetic-foo/index.js',
+        nav: {
+          id: SYNTHETIC_ID,
+          label: 'Synthetic Foo',
+          labelKey: SYNTHETIC_ID,
+          icon: 'Compass',
+          basePath: SYNTHETIC_BASE_PATH,
+          order: SYNTHETIC_NAV_ORDER,
+          items: [{ path: '', label: 'Home', labelKey: `${SYNTHETIC_ID}.home`, icon: 'Compass' }],
+        },
+        pages: [{ path: '', index: true, bundleSlot: 'home' }],
+      },
+    ];
 
-      expect(manifests).toHaveLength(0);
-      expect(warnings.some((m) => m.includes('external UI loading not implemented'))).toBe(true);
-      expect(warnings.some((m) => m.includes(SYNTHETIC_ID))).toBe(true);
-    } finally {
-      console.warn = originalWarn;
-    }
+    // No bundle map entry at all — the synthetic pillar is external. The
+    // importer never runs during the walk (lazy on first route render).
+    const manifests = walkRegistry(entries, {}, () =>
+      Promise.reject(new Error('importer must not run during synthesis'))
+    );
+
+    expect(manifests).toHaveLength(1);
+    const mounted = manifests[0];
+    expect(mounted?.id).toBe(SYNTHETIC_ID);
+    expect(mounted !== undefined && hasRoutes(mounted)).toBe(true);
+
+    const navIds = buildRegisteredAppsFromBundleMap({
+      [SYNTHETIC_ID]: { manifest: mounted as FrontendManifest, navOrder: SYNTHETIC_NAV_ORDER },
+    }).map((app) => app.id);
+    expect(navIds).toContain(SYNTHETIC_ID);
   });
 });


### PR DESCRIPTION
## What

Implements the external-pillar UI loading path (PRD-243 US-05, **Option A**) at the existing bundle-map seam in `apps/pops-shell`. A pillar the build does not know about — registered at runtime (PRD-228) and absent from the static `WORKSPACE_BUNDLE_MAP` — can now load its UI into the shell by advertising an `assetsBaseUrl` on its manifest.

Previously the shell threw `ExternalUiLoadingNotImplementedError` for any such pillar. The FE was closed to anything the build didn't statically bundle. This opens it for external pillars only.

## How

- **`external-ui.tsx` (new)** — synthesizes a `BundleEntry` from the pillar's wire-format manifest descriptors:
  - the app-rail nav is built **synchronously** from the `NavConfigDescriptor` (so the rail renders at boot, no fetch); icons resolve kebab/PascalCase → `IconName` with a neutral fallback.
  - each `PageDescriptor` becomes a route whose element lazy-`import()`s the pillar's ESM bundle and resolves the component named by its `bundleSlot`.
  - the remote module contract (`RemotePillarUiModule = { bundles: Record<string, ComponentType> }`) is fully typed and structurally validated after import — **no `as any` / `as unknown as`, no `ts-ignore`**.
- **`installed-modules.ts`** — `walkRegistry` replaces the throw with the real loader. In-repo pillars (bundle-map hits) keep loading **statically and unchanged**; only ids absent from the map take the remote path. `RegistryEntry` now carries the wire `nav` / `pages` descriptors the loader consumes.

## Resilience

A failed remote load never crashes the shell:
- a structurally bad descriptor is logged once and the pillar is skipped at walk time (`ExternalUiLoadError`);
- a remote bundle that fails to import, ships the wrong shape, or is missing the declared `bundleSlot` is contained by a per-route `ErrorBoundary` that degrades to a placeholder.

Exactly as robust as the rest of the registry-driven walk.

## ADR-002 is preserved

The in-repo FE is still **one static Vite SPA**. This is a native runtime dynamic `import()` of a URL (US-05 Option A) — **not** Module Federation (Option B, explicitly rejected for Epic 10) and **not** per-pillar FE builds. The `@vite-ignore`'d import is left as a runtime import and never enters the build graph; `pnpm --filter @pops/shell build` still bundles every in-repo pillar.

## Tests

`apps/pops-shell/src/app/external-ui.test.tsx` (new) plus updates to `registry-walk.test.ts` and the US-04 integration test:
- an external (not-in-static-map) registered pillar with a UI-asset URL is loaded and its remote component renders under its route;
- every remote failure mode (rejected import, wrong shape, missing slot, bad descriptor) degrades gracefully — no crash;
- in-repo pillars still load statically through the bundle map.

## Verification

- `pnpm --filter @pops/shell typecheck` ✅
- `pnpm --filter @pops/shell test` ✅ (47 files, 542 tests)
- `pnpm --filter @pops/shell build` ✅ (SPA still bundles)
- repo-wide `pnpm typecheck` ✅ (38/38), `pnpm format:check` ✅, `pnpm lint` ✅ (0 errors)
- No manifest-schema change (US-01 already landed `assetsBaseUrl` / `nav` / `pages`), so codegen stays idempotent.

Closes PRD-243 US-05.
