### PR TITLE
fix(pillars): exclude colocated app/ from pillar vitest discovery

### DIFF
--- a/pillars/cerebrum/vitest.config.ts
+++ b/pillars/cerebrum/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],

--- a/pillars/core/vitest.config.ts
+++ b/pillars/core/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     // Auto-restore vi.stubGlobal'd globals (e.g. `fetch`) after every test so a
     // stub from one file can't leak into another file running in parallel —
     // the source of intermittent ai-providers/ai-alerts health-check failures.

--- a/pillars/finance/vitest.config.ts
+++ b/pillars/finance/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],

--- a/pillars/food/vitest.config.ts
+++ b/pillars/food/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],

--- a/pillars/inventory/vitest.config.ts
+++ b/pillars/inventory/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],

--- a/pillars/lists/vitest.config.ts
+++ b/pillars/lists/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],

--- a/pillars/media/vitest.config.ts
+++ b/pillars/media/vitest.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: [...configDefaults.exclude, 'app/**', 'overlay-ego/**'],
     // Reliability: the many client suites stub `globalThis.fetch` via
     // `vi.stubGlobal`. Auto-restore stubbed globals/mocks after every test,
     // and run test files sequentially, so a fetch stub from one suite can


### PR DESCRIPTION
PRD-253 (#3474) moved each pillar's FE into `pillars/<id>/app`. The pillars' bare `vitest run` then picked up those app `*.test.tsx` files, which need FE devDeps not present under the pillar's `--filter @pops/<id>...` install scope — failing the **Pillar Quality matrix** for all 7 pillars on main (it runs on push to main, so main was red). Scope each pillar's vitest to exclude `app/`/`overlay-ego/` (preserving default node_modules/dist excludes via `configDefaults.exclude`). Apps keep their own vitest config + test script, so app coverage is unchanged. Verified: inventory 253 / cerebrum 613 / media 418 / core 644 pillar tests pass.