### PR TITLE
feat(ai-telemetry): shared @pops/ai-telemetry wrapper + record schema

### DIFF
--- a/.github/workflows/ai-telemetry-quality.yml
+++ b/.github/workflows/ai-telemetry-quality.yml
@@ -1,0 +1,42 @@
+name: AI Telemetry Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/ai-telemetry/**"
+      - ".github/workflows/ai-telemetry-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+    paths:
+      - "packages/ai-telemetry/**"
+      - ".github/workflows/ai-telemetry-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/ai-telemetry/**'
+              - '.github/workflows/ai-telemetry-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/ai-telemetry
+      has-test: true
+      needs-db-build: false
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/ai-telemetry/package.json
+++ b/packages/ai-telemetry/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@pops/ai-telemetry",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    },
+    "./record-schema": {
+      "types": "./dist/record-schema.d.ts",
+      "default": "./dist/record-schema.js"
+    },
+    "./call-with-logging": {
+      "types": "./dist/call-with-logging.d.ts",
+      "default": "./dist/call-with-logging.js"
+    },
+    "./call-with-logging-stream": {
+      "types": "./dist/call-with-logging-stream.d.ts",
+      "default": "./dist/call-with-logging-stream.js"
+    },
+    "./report-sink": {
+      "types": "./dist/report-sink.d.ts",
+      "default": "./dist/report-sink.js"
+    },
+    "./pricing-http": {
+      "types": "./dist/pricing-http.d.ts",
+      "default": "./dist/pricing-http.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/ai-telemetry/src/__tests__/call-with-logging-stream.test.ts
+++ b/packages/ai-telemetry/src/__tests__/call-with-logging-stream.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { callWithLoggingStream } from '../call-with-logging-stream.js';
+
+import type { InferenceContext, LookupPricingFn, ReportInferenceFn } from '../types.js';
+
+interface StreamEvent {
+  type?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+}
+
+const ctx: InferenceContext = {
+  provider: 'anthropic',
+  model: 'claude-haiku-4-5',
+  operation: 'ego.stream',
+  domain: 'cerebrum',
+};
+
+const pricing: LookupPricingFn = () => Promise.resolve({ input: 3, output: 15 });
+
+const extractUsage = (event: StreamEvent | undefined) =>
+  event?.type === 'done'
+    ? { inputTokens: event.tokensIn ?? 0, outputTokens: event.tokensOut ?? 0 }
+    : null;
+
+async function* fromEvents(events: StreamEvent[]): AsyncGenerator<StreamEvent> {
+  for (const event of events) yield event;
+}
+
+async function* throwAfter(events: StreamEvent[], error: Error): AsyncGenerator<StreamEvent> {
+  for (const event of events) yield event;
+  throw error;
+}
+
+async function drain(gen: AsyncGenerator<StreamEvent>): Promise<StreamEvent[]> {
+  const out: StreamEvent[] = [];
+  for await (const event of gen) out.push(event);
+  return out;
+}
+
+describe('callWithLoggingStream', () => {
+  it('re-yields every event verbatim and reports usage after drain', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    const events: StreamEvent[] = [
+      { type: 'delta' },
+      { type: 'delta' },
+      { type: 'done', tokensIn: 10, tokensOut: 5 },
+    ];
+    const out = await drain(
+      callWithLoggingStream(
+        { ...ctx, stream: () => fromEvents(events), extractUsage },
+        { report, lookupPricing: pricing }
+      )
+    );
+    expect(out).toEqual(events);
+    await vi.waitFor(() => expect(report).toHaveBeenCalledTimes(1));
+    const record = report.mock.calls[0]?.[0];
+    expect(record).toMatchObject({ status: 'success', inputTokens: 10, outputTokens: 5 });
+    // (10/1e6)*3 + (5/1e6)*15 = 0.000105
+    expect(record?.costUsd).toBeCloseTo(0.000105, 9);
+  });
+
+  it('reports an error record and rethrows when the stream throws', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    await expect(
+      drain(
+        callWithLoggingStream(
+          {
+            ...ctx,
+            stream: () => throwAfter([{ type: 'delta' }], new Error('mid-stream')),
+            extractUsage,
+          },
+          { report, lookupPricing: pricing }
+        )
+      )
+    ).rejects.toThrow('mid-stream');
+    await vi.waitFor(() => expect(report).toHaveBeenCalledTimes(1));
+    expect(report.mock.calls[0]?.[0]).toMatchObject({
+      status: 'error',
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+  });
+
+  it('reports tokens 0 when usage is unavailable', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    await drain(
+      callWithLoggingStream(
+        { ...ctx, stream: () => fromEvents([{ type: 'delta' }]), extractUsage },
+        { report, lookupPricing: pricing }
+      )
+    );
+    await vi.waitFor(() => expect(report).toHaveBeenCalled());
+    expect(report.mock.calls[0]?.[0]).toMatchObject({
+      status: 'success',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+  });
+});

--- a/packages/ai-telemetry/src/__tests__/call-with-logging.test.ts
+++ b/packages/ai-telemetry/src/__tests__/call-with-logging.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { callWithLogging, computeCostUsd } from '../call-with-logging.js';
+
+import type { InferenceContext, LookupPricingFn, ReportInferenceFn } from '../types.js';
+
+const ctx: InferenceContext = {
+  provider: 'anthropic',
+  model: 'claude-haiku-4-5',
+  operation: 'categorize',
+  domain: 'finance',
+};
+
+const pricing: LookupPricingFn = () => Promise.resolve({ input: 3, output: 15 });
+
+describe('computeCostUsd', () => {
+  it('computes from per-million-token pricing', () => {
+    expect(computeCostUsd(1_000_000, 1_000_000, { input: 3, output: 15 })).toEqual({
+      costUsd: 18,
+      missing: false,
+    });
+  });
+
+  it('flags unknown pricing', () => {
+    expect(computeCostUsd(10, 10, null)).toEqual({ costUsd: 0, missing: true });
+  });
+});
+
+describe('callWithLogging', () => {
+  it('returns the response on the hot path', async () => {
+    const report: ReportInferenceFn = vi.fn(() => Promise.resolve());
+    const result = await callWithLogging(
+      {
+        ...ctx,
+        call: () =>
+          Promise.resolve({ response: 'RESP', usage: { inputTokens: 1, outputTokens: 1 } }),
+      },
+      { report, lookupPricing: pricing }
+    );
+    expect(result).toBe('RESP');
+  });
+
+  it('reports a success record with computed cost off the hot path', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    await callWithLogging(
+      {
+        ...ctx,
+        call: () =>
+          Promise.resolve({ response: 1, usage: { inputTokens: 1_000_000, outputTokens: 0 } }),
+      },
+      { report, lookupPricing: pricing }
+    );
+    await vi.waitFor(() => expect(report).toHaveBeenCalledTimes(1));
+    expect(report.mock.calls[0]?.[0]).toMatchObject({
+      status: 'success',
+      domain: 'finance',
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      costUsd: 3,
+      cached: false,
+    });
+  });
+
+  it('reports an error record and rethrows when the call throws', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    await expect(
+      callWithLogging(
+        { ...ctx, call: () => Promise.reject(new Error('boom')) },
+        { report, lookupPricing: pricing }
+      )
+    ).rejects.toThrow('boom');
+    await vi.waitFor(() => expect(report).toHaveBeenCalledTimes(1));
+    expect(report.mock.calls[0]?.[0]).toMatchObject({
+      status: 'error',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      errorMessage: 'boom',
+    });
+  });
+
+  it('swallows a failing sink via warn without throwing', async () => {
+    const warn = vi.fn();
+    const report: ReportInferenceFn = () => Promise.reject(new Error('sink down'));
+    const result = await callWithLogging(
+      {
+        ...ctx,
+        call: () => Promise.resolve({ response: 'ok', usage: { inputTokens: 1, outputTokens: 1 } }),
+      },
+      { report, lookupPricing: pricing, warn }
+    );
+    expect(result).toBe('ok');
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+  });
+
+  it('records costUsd 0 when pricing is unknown', async () => {
+    const report = vi.fn<ReportInferenceFn>(() => Promise.resolve());
+    await callWithLogging(
+      {
+        ...ctx,
+        call: () =>
+          Promise.resolve({ response: 1, usage: { inputTokens: 100, outputTokens: 100 } }),
+      },
+      { report, lookupPricing: () => Promise.resolve(null) }
+    );
+    await vi.waitFor(() => expect(report).toHaveBeenCalled());
+    expect(report.mock.calls[0]?.[0]).toMatchObject({ status: 'success', costUsd: 0 });
+  });
+});

--- a/packages/ai-telemetry/src/__tests__/pricing-http.test.ts
+++ b/packages/ai-telemetry/src/__tests__/pricing-http.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { httpLookupPricing } from '../pricing-http.js';
+
+type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+describe('httpLookupPricing', () => {
+  it('uses the dedicated /ai-pricing route when present', async () => {
+    const fetchImpl = vi.fn<FetchImpl>((input) =>
+      Promise.resolve(
+        String(input).includes('/ai-pricing/')
+          ? json({ input: 3, output: 15 })
+          : new Response(null, { status: 404 })
+      )
+    );
+    const lookup = httpLookupPricing('http://ai-api:3008', fetchImpl);
+    expect(await lookup('anthropic', 'claude-haiku-4-5')).toEqual({ input: 3, output: 15 });
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain(
+      '/ai-pricing/anthropic/claude-haiku-4-5'
+    );
+  });
+
+  it('falls back to /ai-providers mapping when the dedicated route 404s', async () => {
+    const fetchImpl = vi.fn<FetchImpl>((input) => {
+      if (String(input).includes('/ai-pricing/'))
+        return Promise.resolve(new Response(null, { status: 404 }));
+      if (String(input).endsWith('/ai-providers')) {
+        return Promise.resolve(
+          json([
+            {
+              id: 'anthropic',
+              models: [{ model: 'claude-haiku-4-5', inputCostPerMtok: 0.8, outputCostPerMtok: 4 }],
+            },
+          ])
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    // trailing slash is trimmed
+    const lookup = httpLookupPricing('http://ai-api:3008/', fetchImpl);
+    expect(await lookup('anthropic', 'claude-haiku-4-5')).toEqual({ input: 0.8, output: 4 });
+  });
+
+  it('returns null when neither route resolves', async () => {
+    const fetchImpl = vi.fn<FetchImpl>(() => Promise.resolve(new Response(null, { status: 404 })));
+    expect(await httpLookupPricing('http://ai-api:3008', fetchImpl)('x', 'y')).toBeNull();
+  });
+
+  it('returns null and never throws on a network error', async () => {
+    const fetchImpl = vi.fn<FetchImpl>(() => Promise.reject(new Error('ECONNREFUSED')));
+    expect(await httpLookupPricing('http://ai-api:3008', fetchImpl)('x', 'y')).toBeNull();
+  });
+});

--- a/packages/ai-telemetry/src/__tests__/record-schema.test.ts
+++ b/packages/ai-telemetry/src/__tests__/record-schema.test.ts
@@ -49,6 +49,11 @@ describe('InferenceRecordSchema', () => {
     expect(InferenceRecordSchema.safeParse({ ...valid, status: 'weird' }).success).toBe(false);
   });
 
+  it('rejects a non-finite costUsd', () => {
+    expect(InferenceRecordSchema.safeParse({ ...valid, costUsd: Infinity }).success).toBe(false);
+    expect(InferenceRecordSchema.safeParse({ ...valid, costUsd: Number.NaN }).success).toBe(false);
+  });
+
   it('accepts every widened status value', () => {
     for (const status of ['success', 'error', 'timeout', 'budget-blocked'] as const) {
       expect(InferenceRecordSchema.safeParse({ ...valid, status }).success).toBe(true);

--- a/packages/ai-telemetry/src/__tests__/record-schema.test.ts
+++ b/packages/ai-telemetry/src/__tests__/record-schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { InferenceRecordSchema, type InferenceRecord } from '../record-schema.js';
+
+const valid: InferenceRecord = {
+  provider: 'anthropic',
+  model: 'claude-haiku-4-5',
+  operation: 'categorize',
+  domain: 'finance',
+  inputTokens: 10,
+  outputTokens: 5,
+  costUsd: 0.001,
+  latencyMs: 120,
+  status: 'success',
+  cached: false,
+};
+
+describe('InferenceRecordSchema', () => {
+  it('accepts a minimal valid record', () => {
+    expect(InferenceRecordSchema.parse(valid)).toMatchObject(valid);
+  });
+
+  it('accepts optional contextId/promptVersion/metadata', () => {
+    const parsed = InferenceRecordSchema.safeParse({
+      ...valid,
+      contextId: 'ingest_source:42',
+      promptVersion: 'v3',
+      metadata: { prompt_version: 'v3' },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an empty provider', () => {
+    expect(InferenceRecordSchema.safeParse({ ...valid, provider: '' }).success).toBe(false);
+  });
+
+  it('rejects negative or non-integer token counts', () => {
+    expect(InferenceRecordSchema.safeParse({ ...valid, inputTokens: -1 }).success).toBe(false);
+    expect(InferenceRecordSchema.safeParse({ ...valid, outputTokens: 1.5 }).success).toBe(false);
+  });
+
+  it('rejects a contextId containing whitespace (PII guard)', () => {
+    expect(InferenceRecordSchema.safeParse({ ...valid, contextId: 'has space' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects an unknown status', () => {
+    expect(InferenceRecordSchema.safeParse({ ...valid, status: 'weird' }).success).toBe(false);
+  });
+
+  it('accepts every widened status value', () => {
+    for (const status of ['success', 'error', 'timeout', 'budget-blocked'] as const) {
+      expect(InferenceRecordSchema.safeParse({ ...valid, status }).success).toBe(true);
+    }
+  });
+});

--- a/packages/ai-telemetry/src/__tests__/report-sink.test.ts
+++ b/packages/ai-telemetry/src/__tests__/report-sink.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type InferenceRecord } from '../record-schema.js';
+import { createEnvReportSink } from '../report-sink.js';
+
+const record: InferenceRecord = {
+  provider: 'anthropic',
+  model: 'claude-haiku-4-5',
+  operation: 'categorize',
+  domain: 'finance',
+  inputTokens: 10,
+  outputTokens: 5,
+  costUsd: 0.001,
+  latencyMs: 120,
+  status: 'success',
+  cached: false,
+};
+
+const okFetch = (): ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) =>
+  vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+    Promise.resolve(new Response(null, { status: 200 }))
+  );
+
+afterEach(() => {
+  delete process.env['AI_API_URL'];
+  delete process.env['POPS_API_URL'];
+  delete process.env['POPS_API_INTERNAL_TOKEN'];
+});
+
+describe('createEnvReportSink', () => {
+  it('POSTs the record to /ai-usage/record with the internal token header', async () => {
+    const fetchImpl = okFetch();
+    await createEnvReportSink({ baseUrl: 'http://ai-api:3008', token: 'secret', fetchImpl })(
+      record
+    );
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(url)).toBe('http://ai-api:3008/ai-usage/record');
+    expect(init?.method).toBe('POST');
+    expect(new Headers(init?.headers).get('x-pops-internal-token')).toBe('secret');
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      provider: 'anthropic',
+      domain: 'finance',
+    });
+  });
+
+  it('is a no-op when no base URL resolves', async () => {
+    const fetchImpl = okFetch();
+    await createEnvReportSink({ fetchImpl })(record);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('prefers AI_API_URL over a self-pointing POPS_API_URL', async () => {
+    process.env['AI_API_URL'] = 'http://ai-api:3008';
+    process.env['POPS_API_URL'] = 'http://food-api:3005';
+    const fetchImpl = okFetch();
+    await createEnvReportSink({ fetchImpl })(record);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('http://ai-api:3008/ai-usage/record');
+  });
+
+  it('falls back to POPS_API_URL when AI_API_URL is unset', async () => {
+    process.env['POPS_API_URL'] = 'http://self:3005';
+    const fetchImpl = okFetch();
+    await createEnvReportSink({ fetchImpl })(record);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('http://self:3005/ai-usage/record');
+  });
+
+  it('omits the token header when none is configured', async () => {
+    const fetchImpl = okFetch();
+    await createEnvReportSink({ baseUrl: 'http://ai-api:3008/', fetchImpl })(record);
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(new Headers(init?.headers).get('x-pops-internal-token')).toBeNull();
+    // trailing slash on the base URL is trimmed, not doubled
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('http://ai-api:3008/ai-usage/record');
+  });
+});

--- a/packages/ai-telemetry/src/__tests__/report-sink.test.ts
+++ b/packages/ai-telemetry/src/__tests__/report-sink.test.ts
@@ -51,6 +51,17 @@ describe('createEnvReportSink', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('never throws when the transport rejects (best-effort contract)', async () => {
+    const onError = vi.fn();
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.reject(new Error('ECONNREFUSED'))
+    );
+    await expect(
+      createEnvReportSink({ baseUrl: 'http://ai-api:3008', fetchImpl, onError })(record)
+    ).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
   it('prefers AI_API_URL over a self-pointing POPS_API_URL', async () => {
     process.env['AI_API_URL'] = 'http://ai-api:3008';
     process.env['POPS_API_URL'] = 'http://food-api:3005';

--- a/packages/ai-telemetry/src/call-with-logging-stream.ts
+++ b/packages/ai-telemetry/src/call-with-logging-stream.ts
@@ -1,0 +1,63 @@
+import { computeCostUsd } from './call-with-logging.js';
+import { buildBaseRecord, errorMessageOf, makeFire, noopWarn } from './internal.js';
+import { createEnvReportSink } from './report-sink.js';
+
+import type { CallWithLoggingDeps, CallWithLoggingStreamOpts } from './types.js';
+
+/**
+ * Wraps a Claude stream generator: re-yields every event verbatim with zero
+ * added latency, tracking only the last event. After the stream drains it
+ * extracts usage (`extractUsage(last)`), looks up pricing, and reports a
+ * `status: 'success'` record — all off the hot path. If the underlying
+ * generator throws, it reports `status: 'error'` (tokens 0) BEFORE rethrowing.
+ * It never buffers the stream and never delays a yield.
+ */
+export async function* callWithLoggingStream<E>(
+  opts: CallWithLoggingStreamOpts<E>,
+  deps: CallWithLoggingDeps
+): AsyncGenerator<E> {
+  const warn = deps.warn ?? noopWarn;
+  const fire = makeFire(deps.report ?? createEnvReportSink(), warn);
+  const base = buildBaseRecord(opts);
+  const start = Date.now();
+  let last: E | undefined;
+
+  try {
+    for await (const event of opts.stream()) {
+      last = event;
+      yield event;
+    }
+  } catch (error) {
+    fire({
+      ...base,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs: Date.now() - start,
+      status: 'error',
+      cached: false,
+      errorMessage: errorMessageOf(error),
+    });
+    throw error;
+  }
+
+  const latencyMs = Date.now() - start;
+  const usage = opts.extractUsage(last);
+  const inputTokens = usage?.inputTokens ?? 0;
+  const outputTokens = usage?.outputTokens ?? 0;
+  void (async (): Promise<void> => {
+    const pricing = usage
+      ? await deps.lookupPricing(opts.provider, opts.model).catch(() => null)
+      : null;
+    const { costUsd } = computeCostUsd(inputTokens, outputTokens, pricing);
+    fire({
+      ...base,
+      inputTokens,
+      outputTokens,
+      costUsd,
+      latencyMs,
+      status: 'success',
+      cached: false,
+    });
+  })().catch((error: unknown) => warn('ai-telemetry: cost/report failed', error));
+}

--- a/packages/ai-telemetry/src/call-with-logging.ts
+++ b/packages/ai-telemetry/src/call-with-logging.ts
@@ -1,0 +1,69 @@
+import { buildBaseRecord, errorMessageOf, makeFire, noopWarn } from './internal.js';
+import { createEnvReportSink } from './report-sink.js';
+
+import type { CallWithLoggingDeps, CallWithLoggingOpts, PricingEntry } from './types.js';
+
+/**
+ * Computes the USD cost of a call from per-million-token pricing. Returns
+ * `missing: true` (and `costUsd: 0`) when pricing is unknown so the caller can
+ * distinguish "free" from "unpriced".
+ */
+export function computeCostUsd(
+  inputTokens: number,
+  outputTokens: number,
+  pricing: PricingEntry | null
+): { costUsd: number; missing: boolean } {
+  if (!pricing) return { costUsd: 0, missing: true };
+  const costUsd =
+    (inputTokens / 1_000_000) * pricing.input + (outputTokens / 1_000_000) * pricing.output;
+  return { costUsd, missing: false };
+}
+
+/**
+ * Wraps a non-streaming Claude call: returns the response on the hot path
+ * unchanged, then — fire-and-forget, off the hot path — looks up pricing,
+ * computes cost, and reports the inference record. On throw it reports a
+ * `status: 'error'` record (tokens 0) BEFORE rethrowing. Reporting failures are
+ * swallowed via `deps.warn`; telemetry never alters control flow.
+ */
+export async function callWithLogging<T>(
+  opts: CallWithLoggingOpts<T>,
+  deps: CallWithLoggingDeps
+): Promise<T> {
+  const warn = deps.warn ?? noopWarn;
+  const fire = makeFire(deps.report ?? createEnvReportSink(), warn);
+  const base = buildBaseRecord(opts);
+  const start = Date.now();
+
+  try {
+    const { response, usage } = await opts.call();
+    const latencyMs = Date.now() - start;
+    void (async (): Promise<void> => {
+      const pricing = await deps.lookupPricing(opts.provider, opts.model).catch(() => null);
+      const { costUsd } = computeCostUsd(usage.inputTokens, usage.outputTokens, pricing);
+      fire({
+        ...base,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        costUsd,
+        latencyMs,
+        status: 'success',
+        cached: false,
+      });
+    })().catch((error: unknown) => warn('ai-telemetry: cost/report failed', error));
+    return response;
+  } catch (error) {
+    const latencyMs = Date.now() - start;
+    fire({
+      ...base,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs,
+      status: 'error',
+      cached: false,
+      errorMessage: errorMessageOf(error),
+    });
+    throw error;
+  }
+}

--- a/packages/ai-telemetry/src/index.ts
+++ b/packages/ai-telemetry/src/index.ts
@@ -1,0 +1,15 @@
+export { InferenceRecordSchema, type InferenceRecord } from './record-schema.js';
+export type {
+  CallResult,
+  CallWithLoggingDeps,
+  CallWithLoggingOpts,
+  CallWithLoggingStreamOpts,
+  InferenceContext,
+  LookupPricingFn,
+  PricingEntry,
+  ReportInferenceFn,
+} from './types.js';
+export { callWithLogging, computeCostUsd } from './call-with-logging.js';
+export { callWithLoggingStream } from './call-with-logging-stream.js';
+export { createEnvReportSink, reportInference, type ReportSinkConfig } from './report-sink.js';
+export { httpLookupPricing } from './pricing-http.js';

--- a/packages/ai-telemetry/src/internal.ts
+++ b/packages/ai-telemetry/src/internal.ts
@@ -1,0 +1,35 @@
+import type { InferenceRecord } from './record-schema.js';
+import type { InferenceContext, ReportInferenceFn } from './types.js';
+
+/** The provenance fields shared by every emitted record (no measurements). */
+export type BaseRecord = Pick<InferenceRecord, 'provider' | 'model' | 'operation' | 'domain'> &
+  Partial<Pick<InferenceRecord, 'contextId' | 'promptVersion' | 'metadata'>>;
+
+/** Projects an {@link InferenceContext} onto the provenance subset of a record. */
+export function buildBaseRecord(ctx: InferenceContext): BaseRecord {
+  return {
+    provider: ctx.provider,
+    model: ctx.model,
+    operation: ctx.operation,
+    domain: ctx.domain,
+    ...(ctx.contextId !== undefined ? { contextId: ctx.contextId } : {}),
+    ...(ctx.promptVersion !== undefined ? { promptVersion: ctx.promptVersion } : {}),
+    ...(ctx.metadata !== undefined ? { metadata: ctx.metadata } : {}),
+  };
+}
+
+export function noopWarn(): void {}
+
+/** A fire-and-forget reporter that funnels sink failures to `warn`. */
+export function makeFire(
+  report: ReportInferenceFn,
+  warn: (message: string, error: unknown) => void
+): (record: InferenceRecord) => void {
+  return (record) => {
+    void report(record).catch((error: unknown) => warn('ai-telemetry: report failed', error));
+  };
+}
+
+export function errorMessageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ai-telemetry/src/pricing-http.ts
+++ b/packages/ai-telemetry/src/pricing-http.ts
@@ -1,0 +1,82 @@
+import type { LookupPricingFn, PricingEntry } from './types.js';
+
+/**
+ * Cross-pillar HTTP pricing adapter. Prefers the dedicated
+ * `GET /ai-pricing/:provider/:model` route (already shaped as a
+ * {@link PricingEntry}); falls back to `GET /ai-providers` and maps
+ * `models[].{inputCostPerMtok,outputCostPerMtok}` → `{ input, output }` when the
+ * dedicated route is absent (e.g. an older ai pillar). Returns null on any miss;
+ * never throws (telemetry must not break callers).
+ */
+export function httpLookupPricing(
+  aiApiBaseUrl: string,
+  fetchImpl: typeof fetch = fetch
+): LookupPricingFn {
+  const base = aiApiBaseUrl.endsWith('/') ? aiApiBaseUrl.slice(0, -1) : aiApiBaseUrl;
+
+  return async (provider, model) => {
+    const direct = await fetchPricingEntry(
+      fetchImpl,
+      `${base}/ai-pricing/${encodeURIComponent(provider)}/${encodeURIComponent(model)}`
+    );
+    if (direct) return direct;
+    return fetchProviderFallback(fetchImpl, `${base}/ai-providers`, provider, model);
+  };
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+async function readJson(fetchImpl: typeof fetch, url: string): Promise<unknown> {
+  try {
+    const response = await fetchImpl(url);
+    if (!response.ok) return null;
+    return (await response.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPricingEntry(
+  fetchImpl: typeof fetch,
+  url: string
+): Promise<PricingEntry | null> {
+  const body = await readJson(fetchImpl, url);
+  if (typeof body !== 'object' || body === null) return null;
+  const input = asNumber(Reflect.get(body, 'input'));
+  const output = asNumber(Reflect.get(body, 'output'));
+  return input !== null && output !== null ? { input, output } : null;
+}
+
+async function fetchProviderFallback(
+  fetchImpl: typeof fetch,
+  url: string,
+  provider: string,
+  model: string
+): Promise<PricingEntry | null> {
+  const body = await readJson(fetchImpl, url);
+  const providers = Array.isArray(body) ? body : toArray(getField(body, 'providers'));
+  const providerEntry = providers.find((entry) => fieldEquals(entry, ['id', 'provider'], provider));
+  const models = toArray(getField(providerEntry, 'models'));
+  const modelEntry = models.find((entry) => fieldEquals(entry, ['model', 'id'], model));
+  return pricingFromModel(modelEntry);
+}
+
+function pricingFromModel(model: unknown): PricingEntry | null {
+  const input = asNumber(getField(model, 'inputCostPerMtok'));
+  const output = asNumber(getField(model, 'outputCostPerMtok'));
+  return input !== null && output !== null ? { input, output } : null;
+}
+
+function getField(obj: unknown, key: string): unknown {
+  return typeof obj === 'object' && obj !== null ? Reflect.get(obj, key) : undefined;
+}
+
+function fieldEquals(obj: unknown, keys: string[], value: string): boolean {
+  return keys.some((key) => getField(obj, key) === value);
+}
+
+function toArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/packages/ai-telemetry/src/record-schema.ts
+++ b/packages/ai-telemetry/src/record-schema.ts
@@ -18,7 +18,7 @@ export const InferenceRecordSchema = z.object({
   domain: z.string().min(1),
   inputTokens: z.number().int().nonnegative(),
   outputTokens: z.number().int().nonnegative(),
-  costUsd: z.number().nonnegative(),
+  costUsd: z.number().nonnegative().finite(),
   latencyMs: z.number().int().nonnegative(),
   status: z.enum(['success', 'error', 'timeout', 'budget-blocked']),
   /** Stored as 0|1 server-side. */

--- a/packages/ai-telemetry/src/record-schema.ts
+++ b/packages/ai-telemetry/src/record-schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Canonical wire shape for a single AI inference event — the SINGLE SOURCE OF
+ * TRUTH for the `POST /ai-usage/record` ingest. The ai pillar's ingest route
+ * imports this exact schema so the wrapper and the sink can never drift.
+ *
+ * One row per Claude call. PII discipline: `contextId` is an opaque,
+ * low-cardinality key (no whitespace), `metadata` is caller-supplied and must
+ * be PII-free; the server caps its serialized length defensively.
+ */
+export const InferenceRecordSchema = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  /** Free-form; each pillar owns its operation vocabulary. */
+  operation: z.string().min(1),
+  /** The caller's pillar id (validated against KNOWN_MODULES server-side). */
+  domain: z.string().min(1),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  latencyMs: z.number().int().nonnegative(),
+  status: z.enum(['success', 'error', 'timeout', 'budget-blocked']),
+  /** Stored as 0|1 server-side. */
+  cached: z.boolean(),
+  /** Opaque low-cardinality FK to the originating row; no whitespace (PII guard). */
+  contextId: z.string().max(128).regex(/^\S+$/).optional(),
+  /** Merged into `metadata.prompt_version` server-side. */
+  promptVersion: z.string().max(64).optional(),
+  errorMessage: z.string().max(1000).optional(),
+  /** Caller-supplied, PII-free; server caps the serialized JSON length. */
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type InferenceRecord = z.infer<typeof InferenceRecordSchema>;

--- a/packages/ai-telemetry/src/report-sink.ts
+++ b/packages/ai-telemetry/src/report-sink.ts
@@ -13,6 +13,8 @@ export interface ReportSinkConfig {
   token?: string;
   /** Injectable for tests. Defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
+  /** Opt-in diagnostics for a swallowed transport failure. */
+  onError?: (error: unknown) => void;
 }
 
 const RECORD_PATH = '/ai-usage/record';
@@ -36,11 +38,17 @@ export function createEnvReportSink(config: ReportSinkConfig = {}): ReportInfere
     const headers: Record<string, string> = { 'content-type': 'application/json' };
     if (token) headers['x-pops-internal-token'] = token;
     const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    await fetchImpl(`${base}${RECORD_PATH}`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(record),
-    });
+    try {
+      await fetchImpl(`${base}${RECORD_PATH}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(record),
+      });
+    } catch (error) {
+      // Best-effort by contract: a transport failure must never propagate into
+      // a caller. Surfaced only through the opt-in diagnostics hook.
+      config.onError?.(error);
+    }
   };
 }
 

--- a/packages/ai-telemetry/src/report-sink.ts
+++ b/packages/ai-telemetry/src/report-sink.ts
@@ -1,0 +1,48 @@
+import { type InferenceRecord } from './record-schema.js';
+
+import type { ReportInferenceFn } from './types.js';
+
+export interface ReportSinkConfig {
+  /**
+   * Base URL of the ai pillar. Defaults to `AI_API_URL` (checked FIRST so it
+   * never collides with a service's self-pointing `POPS_API_URL`), then
+   * `POPS_API_URL`. When neither resolves, reporting is a silent no-op.
+   */
+  baseUrl?: string;
+  /** Internal token; defaults to `POPS_API_INTERNAL_TOKEN`. */
+  token?: string;
+  /** Injectable for tests. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+const RECORD_PATH = '/ai-usage/record';
+
+function resolveBaseUrl(explicit?: string): string | undefined {
+  return explicit ?? process.env['AI_API_URL'] ?? process.env['POPS_API_URL'] ?? undefined;
+}
+
+/**
+ * Builds an env-driven {@link ReportInferenceFn} that POSTs an
+ * {@link InferenceRecord} to the ai pillar's internal `/ai-usage/record`
+ * ingest. Best-effort by contract: a missing sink, a non-2xx response, or a
+ * thrown fetch are all swallowed so telemetry can never break a caller.
+ */
+export function createEnvReportSink(config: ReportSinkConfig = {}): ReportInferenceFn {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  return async (record: InferenceRecord): Promise<void> => {
+    const baseUrl = resolveBaseUrl(config.baseUrl);
+    if (!baseUrl) return;
+    const token = config.token ?? process.env['POPS_API_INTERNAL_TOKEN'];
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (token) headers['x-pops-internal-token'] = token;
+    const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    await fetchImpl(`${base}${RECORD_PATH}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(record),
+    });
+  };
+}
+
+/** The default env-driven sink, resolved lazily from `process.env` per call. */
+export const reportInference: ReportInferenceFn = (record) => createEnvReportSink()(record);

--- a/packages/ai-telemetry/src/types.ts
+++ b/packages/ai-telemetry/src/types.ts
@@ -1,0 +1,61 @@
+import type { InferenceRecord } from './record-schema.js';
+
+export type { InferenceRecord } from './record-schema.js';
+
+/** Fire-and-forget sink for a finished inference record. Must never throw. */
+export type ReportInferenceFn = (record: InferenceRecord) => Promise<void>;
+
+/** Per-million-token USD pricing for a given provider/model. */
+export interface PricingEntry {
+  input: number;
+  output: number;
+}
+
+/** Resolves pricing for a provider/model, or null when unknown. */
+export type LookupPricingFn = (provider: string, model: string) => Promise<PricingEntry | null>;
+
+/** What a wrapped non-streaming Claude call must hand back. */
+export interface CallResult<T> {
+  response: T;
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+/** Dependencies shared by both the request and streaming entrypoints. */
+export interface CallWithLoggingDeps {
+  /** Defaults to the env-driven {@link ReportInferenceFn} from `report-sink`. */
+  report?: ReportInferenceFn;
+  lookupPricing: LookupPricingFn;
+  /** Diagnostic channel for swallowed telemetry failures. */
+  warn?: (message: string, error: unknown) => void;
+}
+
+/** Identity + provenance carried onto every emitted {@link InferenceRecord}. */
+export interface InferenceContext {
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string;
+  contextId?: string;
+  promptVersion?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Reserved for the future `GET /ai-budgets/check` pre-call gate (Open
+   * Decision 2 ratified telemetry-only for v1). Carried through but not
+   * enforced — present so callers can wire budgets without an interface break.
+   */
+  costCapUsd?: number;
+}
+
+export interface CallWithLoggingOpts<T> extends InferenceContext {
+  call: () => Promise<CallResult<T>>;
+}
+
+export interface CallWithLoggingStreamOpts<E> extends InferenceContext {
+  /** The underlying Claude stream generator. */
+  stream: () => AsyncGenerator<E>;
+  /**
+   * Extracts token usage from the last observed event. Returns null when usage
+   * is unavailable (e.g. the stream errored before the terminal event).
+   */
+  extractUsage: (lastEvent: E | undefined) => { inputTokens: number; outputTokens: number } | null;
+}

--- a/packages/ai-telemetry/tsconfig.json
+++ b/packages/ai-telemetry/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/ai-telemetry/vitest.config.ts
+++ b/packages/ai-telemetry/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts', '**/index.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,25 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
 
+  packages/ai-telemetry:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/db-types:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

First foundation track of the AI-ops extraction program (`docs/plans/04-ai-ops-pillar.md`, Stage 1b). A new, additive package — **nothing is wired through it yet**, so it changes no running behavior. It generalizes food's battle-tested inference wrapper into a provider-agnostic, de-React-coupled shape so every Claude-calling pillar can later report usage to the AI pillar's ingest.

## What's here

| Module | Responsibility |
|---|---|
| `record-schema.ts` | `InferenceRecordSchema` — **single source of truth** for `POST /ai-usage/record`; the ai pillar's ingest will import this verbatim |
| `call-with-logging.ts` | `callWithLogging<T>` — returns the response on the hot path, reports cost/usage/latency fire-and-forget; error path reports `status:'error'` then rethrows. `computeCostUsd` (per-Mtok, flags unknown pricing) |
| `call-with-logging-stream.ts` | `callWithLoggingStream<E>` — generator-aware variant for cerebrum's streaming callers; re-yields verbatim with zero added latency, reports after drain |
| `report-sink.ts` | `createEnvReportSink` — best-effort POST (`AI_API_URL` first so it never collides with a service's self-pointing `POPS_API_URL`; `x-pops-internal-token`); no-op when unconfigured; never throws |
| `pricing-http.ts` | `httpLookupPricing` — dedicated `/ai-pricing/:p/:m` with `/ai-providers` mapping fallback |

## Verification

- `pnpm typecheck` clean
- `pnpm test` — **26/26 pass** (schema validation incl. PII/whitespace guards, both entrypoints, env sink precedence + token header, pricing route + fallback + network-error safety)
- `pnpm lint` (oxlint type-aware) clean, `oxfmt --check` clean
- Per-package CI gate added (`ai-telemetry-quality.yml` → `_pkg-check.yml`)

## Notes / decisions baked in

- `status` enum widened to `success|error|timeout|budget-blocked` (plan Open Decision 3).
- `costCapUsd` is carried on the context but **not enforced** — telemetry-only for v1 (plan Open Decision 2); reserved for a future `GET /ai-budgets/check` gate.
- `cached` is always `false` from the wrapper (a cache hit never reaches it).

Part of the program tracked in #3481. Next foundations: `@pops/pillar-settings`, registry-cleanup Phase 0, contacts Rust scaffold.