### PR TITLE
feat(pillar-settings): shared RU+reset settings module (PRD settings US-S0)

### DIFF
--- a/.github/workflows/pillar-settings-quality.yml
+++ b/.github/workflows/pillar-settings-quality.yml
@@ -1,0 +1,42 @@
+name: Pillar Settings Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/pillar-settings/**"
+      - ".github/workflows/pillar-settings-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+    paths:
+      - "packages/pillar-settings/**"
+      - ".github/workflows/pillar-settings-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/pillar-settings/**'
+              - '.github/workflows/pillar-settings-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/pillar-settings
+      has-test: true
+      needs-db-build: false
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/pillar-settings/package.json
+++ b/packages/pillar-settings/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@pops/pillar-settings",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "default": "./dist/schema.js"
+    },
+    "./service": {
+      "types": "./dist/service.d.ts",
+      "default": "./dist/service.js"
+    },
+    "./redact": {
+      "types": "./dist/redact.d.ts",
+      "default": "./dist/redact.js"
+    },
+    "./contract": {
+      "types": "./dist/contract.d.ts",
+      "default": "./dist/contract.js"
+    },
+    "./manifest-keys": {
+      "types": "./dist/manifest-keys.d.ts",
+      "default": "./dist/manifest-keys.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@ts-rest/core": "3.53.0-rc.1",
+    "drizzle-orm": "^0.45.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^25.9.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "better-sqlite3": "^12.10.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/pillar-settings/src/__tests__/contract.test.ts
+++ b/packages/pillar-settings/src/__tests__/contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { makeSettingsContract } from '../contract.js';
+
+const errors = { 401: z.object({ message: z.string() }) };
+
+describe('makeSettingsContract', () => {
+  const contract = makeSettingsContract(['theme', 'finance.model'], errors);
+
+  it('exposes exactly the RU+reset (+internal ensure) verbs and no others', () => {
+    expect(Object.keys(contract).toSorted()).toEqual(
+      ['ensure', 'get', 'getMany', 'list', 'reset', 'resetKey', 'set', 'setMany'].toSorted()
+    );
+  });
+
+  it('exposes no create or delete verb', () => {
+    expect(contract).not.toHaveProperty('create');
+    expect(contract).not.toHaveProperty('delete');
+  });
+
+  it('maps verbs to the federated wire methods and paths', () => {
+    expect(contract.list).toMatchObject({ method: 'GET', path: '/settings' });
+    expect(contract.get).toMatchObject({ method: 'GET', path: '/settings/:key' });
+    expect(contract.getMany).toMatchObject({ method: 'POST', path: '/settings/get-many' });
+    expect(contract.set).toMatchObject({ method: 'PUT', path: '/settings/:key' });
+    expect(contract.setMany).toMatchObject({ method: 'POST', path: '/settings/set-many' });
+    expect(contract.resetKey).toMatchObject({ method: 'POST', path: '/settings/:key/reset' });
+    expect(contract.reset).toMatchObject({ method: 'POST', path: '/settings/reset' });
+    expect(contract.ensure).toMatchObject({ method: 'POST', path: '/settings/:key/ensure' });
+  });
+
+  it('constrains single-key routes to the declared key enum', () => {
+    expect(contract.get.pathParams.safeParse({ key: 'theme' }).success).toBe(true);
+    expect(contract.get.pathParams.safeParse({ key: 'not-declared' }).success).toBe(false);
+    expect(contract.set.pathParams.safeParse({ key: 'finance.model' }).success).toBe(true);
+    expect(contract.set.pathParams.safeParse({ key: 'finance.unknown' }).success).toBe(false);
+  });
+
+  it('accepts free-form keys on the batch routes', () => {
+    expect(contract.getMany.body.safeParse({ keys: ['anything', 'goes'] }).success).toBe(true);
+    expect(contract.setMany.body.safeParse({ entries: [{ key: 'x', value: 'y' }] }).success).toBe(
+      true
+    );
+  });
+
+  it('threads the injected error responses onto every route', () => {
+    expect(contract.get.responses).toHaveProperty('401');
+    expect(contract.reset.responses).toHaveProperty('401');
+  });
+});

--- a/packages/pillar-settings/src/__tests__/handlers.test.ts
+++ b/packages/pillar-settings/src/__tests__/handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { UnknownSettingKeyError } from '../errors.js';
 import { makeSettingsHandlers, type SettingsGate } from '../handlers.js';
 import { REDACTED } from '../redact.js';
 import { getOrNull } from '../service.js';
@@ -106,6 +107,36 @@ describe('makeSettingsHandlers — update + read', () => {
     expect(handlers.getMany(ALLOW, ['plex_url', 'media.retention', 'missing'])).toEqual({
       settings: { plex_url: 'u', 'media.retention': '7' },
     });
+  });
+});
+
+describe('makeSettingsHandlers — declared-key enforcement (no backdoor create)', () => {
+  it('set rejects an undeclared key', () => {
+    const { db, handlers } = setup();
+    expect(() => handlers.set(ALLOW, 'totally.unknown', 'x')).toThrow(UnknownSettingKeyError);
+    expect(getOrNull(db, 'totally.unknown')).toBeNull();
+  });
+
+  it('setMany rejects the whole batch when any key is undeclared and writes nothing', () => {
+    const { db, handlers } = setup();
+    expect(() =>
+      handlers.setMany(ALLOW, [
+        { key: 'plex_url', value: 'u' },
+        { key: 'rogue.key', value: 'v' },
+      ])
+    ).toThrow(UnknownSettingKeyError);
+    // validation runs before the transactional write — the declared key is untouched too
+    expect(getOrNull(db, 'plex_url')).toBeNull();
+  });
+
+  it('resetKey rejects an undeclared key', () => {
+    const { handlers } = setup();
+    expect(() => handlers.resetKey(ALLOW, 'nope')).toThrow(UnknownSettingKeyError);
+  });
+
+  it('read paths stay lenient — getMany omits undeclared keys instead of throwing', () => {
+    const { handlers } = setup();
+    expect(handlers.getMany(ALLOW, ['plex_url', 'undeclared']).settings).toEqual({});
   });
 });
 

--- a/packages/pillar-settings/src/__tests__/handlers.test.ts
+++ b/packages/pillar-settings/src/__tests__/handlers.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { makeSettingsHandlers, type SettingsGate } from '../handlers.js';
+import { REDACTED } from '../redact.js';
+import { getOrNull } from '../service.js';
+import { makeTestDb } from './helpers.js';
+
+import type { KeyDefaults } from '../manifest-keys.js';
+
+interface Principal {
+  readonly scopes: readonly string[];
+}
+
+const kd: KeyDefaults = {
+  keys: ['plex_url', 'plex_token', 'media.retention'],
+  defaults: { 'media.retention': '30' },
+  sensitive: ['plex_token'],
+};
+
+/** A real scope-checking gate — no mock, exercises the injected contract. */
+const scopeGate: SettingsGate<Principal> = (principal, scope) => {
+  if (!principal.scopes.includes(scope)) {
+    throw new Error(`forbidden: ${scope}`);
+  }
+};
+
+const ALLOW: Principal = {
+  scopes: [
+    'media.settings.list',
+    'media.settings.get',
+    'media.settings.getMany',
+    'media.settings.set',
+    'media.settings.setMany',
+    'media.settings.resetKey',
+    'media.settings.reset',
+    'media.settings.ensure',
+  ],
+};
+
+function setup() {
+  const db = makeTestDb();
+  const handlers = makeSettingsHandlers<Principal>({
+    db,
+    scopePrefix: 'media.settings',
+    keyDefaults: kd,
+    gate: scopeGate,
+  });
+  return { db, handlers };
+}
+
+describe('makeSettingsHandlers — gating', () => {
+  it('runs the injected gate with the scoped procedure name and denies when unscoped', () => {
+    const { handlers } = setup();
+    const gate = vi.fn();
+    const guarded = makeSettingsHandlers<Principal>({
+      db: makeTestDb(),
+      scopePrefix: 'media.settings',
+      keyDefaults: kd,
+      gate,
+    });
+    guarded.get(ALLOW, 'plex_url');
+    expect(gate).toHaveBeenCalledWith(ALLOW, 'media.settings.get');
+
+    expect(() => handlers.set({ scopes: [] }, 'plex_url', 'x')).toThrow(
+      'forbidden: media.settings.set'
+    );
+  });
+});
+
+describe('makeSettingsHandlers — update + read', () => {
+  it('set persists the verbatim value and get reads it back', () => {
+    const { db, handlers } = setup();
+    expect(handlers.set(ALLOW, 'plex_url', 'http://plex.local')).toEqual({
+      data: { key: 'plex_url', value: 'http://plex.local' },
+      message: 'Setting saved',
+    });
+    expect(handlers.get(ALLOW, 'plex_url')).toEqual({
+      data: { key: 'plex_url', value: 'http://plex.local' },
+    });
+    expect(getOrNull(db, 'plex_url')).toEqual({ key: 'plex_url', value: 'http://plex.local' });
+  });
+
+  it('get returns null for an unset key', () => {
+    const { handlers } = setup();
+    expect(handlers.get(ALLOW, 'plex_url')).toEqual({ data: null });
+  });
+
+  it('list returns the effective value set, redacting sensitive keys even when unset', () => {
+    const { handlers } = setup();
+    handlers.set(ALLOW, 'plex_url', 'http://plex.local');
+    expect(handlers.list(ALLOW)).toEqual({
+      data: [
+        { key: 'plex_url', value: 'http://plex.local' },
+        { key: 'plex_token', value: REDACTED },
+        { key: 'media.retention', value: '30' },
+      ],
+    });
+  });
+
+  it('setMany / getMany round-trip a batch', () => {
+    const { handlers } = setup();
+    handlers.setMany(ALLOW, [
+      { key: 'plex_url', value: 'u' },
+      { key: 'media.retention', value: '7' },
+    ]);
+    expect(handlers.getMany(ALLOW, ['plex_url', 'media.retention', 'missing'])).toEqual({
+      settings: { plex_url: 'u', 'media.retention': '7' },
+    });
+  });
+});
+
+describe('makeSettingsHandlers — redaction round-trip (GAP-256-E)', () => {
+  it('reads a sensitive value back as the sentinel while the DB holds the real secret', () => {
+    const { db, handlers } = setup();
+    handlers.set(ALLOW, 'plex_token', 'AES-ciphertext-secret');
+
+    expect(handlers.get(ALLOW, 'plex_token')).toEqual({
+      data: { key: 'plex_token', value: REDACTED },
+    });
+    expect(handlers.getMany(ALLOW, ['plex_token']).settings['plex_token']).toBe(REDACTED);
+    expect(handlers.list(ALLOW).data).toContainEqual({ key: 'plex_token', value: REDACTED });
+
+    expect(getOrNull(db, 'plex_token')).toEqual({
+      key: 'plex_token',
+      value: 'AES-ciphertext-secret',
+    });
+  });
+
+  it('never redacts the write path — the stored value is the real one', () => {
+    const { db, handlers } = setup();
+    const result = handlers.set(ALLOW, 'plex_token', 'real-secret');
+    expect(result.data.value).toBe('real-secret');
+    expect(getOrNull(db, 'plex_token')?.value).toBe('real-secret');
+  });
+});
+
+describe('makeSettingsHandlers — reset', () => {
+  it('resetKey reverts a single key to its default', () => {
+    const { handlers } = setup();
+    handlers.set(ALLOW, 'media.retention', '999');
+    expect(handlers.resetKey(ALLOW, 'media.retention')).toEqual({
+      data: { key: 'media.retention', value: '30' },
+      message: 'Setting reset to default',
+    });
+  });
+
+  it('reset reverts all declared keys when no keys are supplied', () => {
+    const { handlers } = setup();
+    handlers.set(ALLOW, 'media.retention', '999');
+    handlers.set(ALLOW, 'plex_url', 'changed');
+    const result = handlers.reset(ALLOW, undefined);
+    expect(result.reset).toEqual(['plex_url', 'plex_token', 'media.retention']);
+    expect(result.settings).toEqual({ plex_url: '', plex_token: '', 'media.retention': '30' });
+  });
+});
+
+describe('makeSettingsHandlers — ensure (internal seed)', () => {
+  it('writes once and never clobbers', () => {
+    const { handlers } = setup();
+    expect(handlers.ensure(ALLOW, 'plex_url', 'seed').data.value).toBe('seed');
+    expect(handlers.ensure(ALLOW, 'plex_url', 'second').data.value).toBe('seed');
+  });
+});

--- a/packages/pillar-settings/src/__tests__/helpers.ts
+++ b/packages/pillar-settings/src/__tests__/helpers.ts
@@ -1,0 +1,32 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import type { SettingsDb } from '../schema.js';
+
+/** A value a {@link makeRejectingDb} database refuses to store. */
+export const POISON_VALUE = '__db_reject__';
+
+/**
+ * Opens a real in-memory SQLite database with the `settings` table and
+ * returns a drizzle handle. Tests run against the actual storage engine —
+ * no mocks of things that can be real.
+ */
+export function makeTestDb(): SettingsDb {
+  const sqlite = new Database(':memory:');
+  sqlite.exec('CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);');
+  return drizzle(sqlite);
+}
+
+/**
+ * Like {@link makeTestDb} but with a CHECK constraint that rejects
+ * {@link POISON_VALUE}. Lets a transactional-write test trigger a genuine
+ * runtime failure on a mid-batch row using a well-typed (`string`) value,
+ * so rollback is exercised without any type-system escape hatch.
+ */
+export function makeRejectingDb(): SettingsDb {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(
+    `CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL CHECK (value <> '${POISON_VALUE}'));`
+  );
+  return drizzle(sqlite);
+}

--- a/packages/pillar-settings/src/__tests__/manifest-keys.test.ts
+++ b/packages/pillar-settings/src/__tests__/manifest-keys.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveKeySet, type DeclaredSettingsManifest } from '../manifest-keys.js';
+
+const manifests: DeclaredSettingsManifest[] = [
+  {
+    groups: [
+      {
+        fields: [
+          { key: 'finance.aiCategorizer.model', default: 'gpt-4o-mini' },
+          { key: 'finance.apiToken', sensitive: true },
+        ],
+      },
+      {
+        fields: [{ key: 'finance.retentionDays', default: '90' }],
+      },
+    ],
+  },
+  {
+    groups: [{ fields: [{ key: 'finance.enabled', default: 'true', sensitive: false }] }],
+  },
+];
+
+describe('deriveKeySet', () => {
+  it('collects every declared key in declaration order', () => {
+    const kd = deriveKeySet(manifests);
+    expect(kd.keys).toEqual([
+      'finance.aiCategorizer.model',
+      'finance.apiToken',
+      'finance.retentionDays',
+      'finance.enabled',
+    ]);
+  });
+
+  it('maps only keys that declare an explicit default', () => {
+    const kd = deriveKeySet(manifests);
+    expect(kd.defaults).toEqual({
+      'finance.aiCategorizer.model': 'gpt-4o-mini',
+      'finance.retentionDays': '90',
+      'finance.enabled': 'true',
+    });
+    expect(kd.defaults['finance.apiToken']).toBeUndefined();
+  });
+
+  it('collects only fields flagged sensitive === true', () => {
+    const kd = deriveKeySet(manifests);
+    expect(kd.sensitive).toEqual(['finance.apiToken']);
+  });
+
+  it('returns empty sets for an empty manifest list', () => {
+    const kd = deriveKeySet([]);
+    expect(kd.keys).toEqual([]);
+    expect(kd.defaults).toEqual({});
+    expect(kd.sensitive).toEqual([]);
+  });
+
+  it('handles manifests with empty groups', () => {
+    const kd = deriveKeySet([{ groups: [] }]);
+    expect(kd.keys).toEqual([]);
+  });
+});

--- a/packages/pillar-settings/src/__tests__/redact.test.ts
+++ b/packages/pillar-settings/src/__tests__/redact.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { REDACTED, redactSensitive, redactSensitiveMap } from '../redact.js';
+
+describe('redactSensitive', () => {
+  const sensitive = new Set(['plex_token', 'finance.apiToken']);
+
+  it('masks sensitive rows to the sentinel and leaves others intact', () => {
+    const rows = [
+      { key: 'plex_url', value: 'http://plex.local' },
+      { key: 'plex_token', value: 'super-secret-ciphertext' },
+      { key: 'finance.apiToken', value: 'tok_live_123' },
+    ];
+    expect(redactSensitive(rows, sensitive)).toEqual([
+      { key: 'plex_url', value: 'http://plex.local' },
+      { key: 'plex_token', value: REDACTED },
+      { key: 'finance.apiToken', value: REDACTED },
+    ]);
+  });
+
+  it('does not mutate the input rows', () => {
+    const rows = [{ key: 'plex_token', value: 'secret' }];
+    redactSensitive(rows, sensitive);
+    expect(rows[0]?.value).toBe('secret');
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(redactSensitive([], sensitive)).toEqual([]);
+  });
+});
+
+describe('redactSensitiveMap', () => {
+  const sensitive = new Set(['secret']);
+
+  it('masks sensitive entries in a key→value map', () => {
+    expect(redactSensitiveMap({ public: 'v', secret: 'hidden' }, sensitive)).toEqual({
+      public: 'v',
+      secret: REDACTED,
+    });
+  });
+
+  it('does not mutate the input map', () => {
+    const input = { secret: 'hidden' };
+    redactSensitiveMap(input, sensitive);
+    expect(input.secret).toBe('hidden');
+  });
+});

--- a/packages/pillar-settings/src/__tests__/reset.test.ts
+++ b/packages/pillar-settings/src/__tests__/reset.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOrNull, listEffective, resetSetting, resetSettings, setRaw } from '../service.js';
+import { makeTestDb } from './helpers.js';
+
+import type { KeyDefaults } from '../manifest-keys.js';
+
+const kd: KeyDefaults = {
+  keys: ['a', 'b', 'c'],
+  defaults: { a: 'da', b: 'db' },
+  sensitive: [],
+};
+
+describe('resetSetting', () => {
+  it('deletes the override and returns the manifest default', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', 'override');
+    expect(resetSetting(db, 'a', kd)).toEqual({ key: 'a', value: 'da' });
+    expect(getOrNull(db, 'a')).toBeNull();
+  });
+
+  it('is idempotent: resetting an unset key does not throw', () => {
+    const db = makeTestDb();
+    expect(() => resetSetting(db, 'a', kd)).not.toThrow();
+    expect(resetSetting(db, 'a', kd)).toEqual({ key: 'a', value: 'da' });
+  });
+
+  it('returns the empty string for a key with no declared default', () => {
+    const db = makeTestDb();
+    setRaw(db, 'c', 'override');
+    expect(resetSetting(db, 'c', kd)).toEqual({ key: 'c', value: '' });
+  });
+});
+
+describe('resetSettings', () => {
+  it('resets only the supplied declared keys', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', 'oa');
+    setRaw(db, 'b', 'ob');
+    const result = resetSettings(db, ['a'], kd);
+    expect(result).toEqual({ reset: ['a'], settings: { a: 'da' } });
+    expect(getOrNull(db, 'a')).toBeNull();
+    expect(getOrNull(db, 'b')).toEqual({ key: 'b', value: 'ob' });
+  });
+
+  it('resets ALL declared keys when keys is omitted', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', 'oa');
+    setRaw(db, 'b', 'ob');
+    const result = resetSettings(db, undefined, kd);
+    expect(result.reset).toEqual(['a', 'b', 'c']);
+    expect(result.settings).toEqual({ a: 'da', b: 'db', c: '' });
+    expect(listEffective(db, kd)).toEqual([
+      { key: 'a', value: 'da' },
+      { key: 'b', value: 'db' },
+      { key: 'c', value: '' },
+    ]);
+  });
+
+  it('resets ALL declared keys when keys is an empty array', () => {
+    const db = makeTestDb();
+    expect(resetSettings(db, [], kd).reset).toEqual(['a', 'b', 'c']);
+  });
+
+  it('silently ignores unknown keys, never writing them', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', 'oa');
+    const result = resetSettings(db, ['a', 'not-declared'], kd);
+    expect(result.reset).toEqual(['a']);
+    expect(result.settings).toEqual({ a: 'da' });
+    expect(getOrNull(db, 'not-declared')).toBeNull();
+  });
+});

--- a/packages/pillar-settings/src/__tests__/service.test.ts
+++ b/packages/pillar-settings/src/__tests__/service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { ensure, getBulk, getOrNull, listEffective, setBulk, setRaw } from '../service.js';
+import { makeRejectingDb, makeTestDb, POISON_VALUE } from './helpers.js';
+
+import type { KeyDefaults } from '../manifest-keys.js';
+
+const kd: KeyDefaults = {
+  keys: ['a', 'b', 'c'],
+  defaults: { a: 'da', b: 'db' },
+  sensitive: [],
+};
+
+describe('getOrNull / setRaw', () => {
+  it('returns null for an unset key', () => {
+    const db = makeTestDb();
+    expect(getOrNull(db, 'a')).toBeNull();
+  });
+
+  it('round-trips an upsert and overwrites on a second write', () => {
+    const db = makeTestDb();
+    expect(setRaw(db, 'a', 'one')).toEqual({ key: 'a', value: 'one' });
+    expect(getOrNull(db, 'a')).toEqual({ key: 'a', value: 'one' });
+    setRaw(db, 'a', 'two');
+    expect(getOrNull(db, 'a')).toEqual({ key: 'a', value: 'two' });
+  });
+});
+
+describe('getBulk', () => {
+  it('omits missing keys and de-dupes input', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', '1');
+    setRaw(db, 'b', '2');
+    expect(getBulk(db, ['a', 'a', 'b', 'missing'])).toEqual({ a: '1', b: '2' });
+  });
+
+  it('returns an empty object for no keys', () => {
+    expect(getBulk(makeTestDb(), [])).toEqual({});
+  });
+});
+
+describe('listEffective', () => {
+  it('resolves override → default → empty string per declared key', () => {
+    const db = makeTestDb();
+    setRaw(db, 'a', 'override-a');
+    expect(listEffective(db, kd)).toEqual([
+      { key: 'a', value: 'override-a' },
+      { key: 'b', value: 'db' },
+      { key: 'c', value: '' },
+    ]);
+  });
+});
+
+describe('setBulk', () => {
+  it('writes every entry and mirrors them back', () => {
+    const db = makeTestDb();
+    expect(
+      setBulk(db, [
+        { key: 'a', value: '1' },
+        { key: 'b', value: '2' },
+      ])
+    ).toEqual({
+      a: '1',
+      b: '2',
+    });
+    expect(getBulk(db, ['a', 'b'])).toEqual({ a: '1', b: '2' });
+  });
+
+  it('is transactional: a mid-batch failure rolls the whole batch back', () => {
+    const db = makeRejectingDb();
+    setRaw(db, 'a', 'original');
+    const badEntries = [
+      { key: 'a', value: 'changed' },
+      { key: 'b', value: POISON_VALUE },
+    ];
+    expect(() => setBulk(db, badEntries)).toThrow();
+    expect(getOrNull(db, 'a')).toEqual({ key: 'a', value: 'original' });
+    expect(getOrNull(db, 'b')).toBeNull();
+  });
+
+  it('returns an empty object for no entries', () => {
+    expect(setBulk(makeTestDb(), [])).toEqual({});
+  });
+});
+
+describe('ensure (write-once seed)', () => {
+  it('persists on first call and never clobbers on later calls', () => {
+    const db = makeTestDb();
+    expect(ensure(db, 'seed', 'first')).toEqual({ key: 'seed', value: 'first' });
+    expect(ensure(db, 'seed', 'second')).toEqual({ key: 'seed', value: 'first' });
+    expect(getOrNull(db, 'seed')).toEqual({ key: 'seed', value: 'first' });
+  });
+});

--- a/packages/pillar-settings/src/contract.ts
+++ b/packages/pillar-settings/src/contract.ts
@@ -1,0 +1,133 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+/** A single persisted setting on the wire (`{ key, value }`). */
+export const SettingSchema = z.object({ key: z.string(), value: z.string() });
+
+const SettingValueBody = z.object({ value: z.string() });
+const GetManyInput = z.object({ keys: z.array(z.string()) });
+const GetManyOutput = z.object({ settings: z.record(z.string(), z.string()) });
+const SetManyInput = z.object({ entries: z.array(SettingSchema) });
+const SetManyOutput = z.object({ settings: z.record(z.string(), z.string()) });
+const ResetInput = z.object({ keys: z.array(z.string()).optional() });
+const ResetOutput = z.object({
+  reset: z.array(z.string()),
+  settings: z.record(z.string(), z.string()),
+});
+
+/**
+ * A map of HTTP error status → response body schema, injected so the
+ * package carries no dependency on any pillar's shared error set. Core
+ * passes its `AUTH_ERR_RESPONSES`.
+ */
+export type ContractErrorResponses = Readonly<Record<number, z.ZodType>>;
+
+const readRoutes = <P extends z.ZodTypeAny>(keyParam: P, err: ContractErrorResponses) =>
+  ({
+    list: {
+      method: 'GET',
+      path: '/settings',
+      responses: { 200: z.object({ data: z.array(SettingSchema) }), ...err },
+      summary: 'List effective values for every declared key (sensitive redacted)',
+    },
+    get: {
+      method: 'GET',
+      path: '/settings/:key',
+      pathParams: keyParam,
+      responses: { 200: z.object({ data: SettingSchema.nullable() }), ...err },
+      summary: 'Read a single setting (null on unset; sensitive redacted)',
+    },
+    getMany: {
+      method: 'POST',
+      path: '/settings/get-many',
+      body: GetManyInput,
+      responses: { 200: GetManyOutput, ...err },
+      summary: 'Batch-read settings by key (missing omitted; sensitive redacted)',
+    },
+  }) as const;
+
+const writeRoutes = <P extends z.ZodTypeAny>(keyParam: P, err: ContractErrorResponses) =>
+  ({
+    set: {
+      method: 'PUT',
+      path: '/settings/:key',
+      pathParams: keyParam,
+      body: SettingValueBody,
+      responses: { 200: z.object({ data: SettingSchema, message: z.string() }), ...err },
+      summary: 'Upsert a single declared setting',
+    },
+    setMany: {
+      method: 'POST',
+      path: '/settings/set-many',
+      body: SetManyInput,
+      responses: { 200: SetManyOutput, ...err },
+      summary: 'Transactional batch write (all-or-nothing); returns the written mirror',
+    },
+  }) as const;
+
+const resetRoutes = <P extends z.ZodTypeAny>(keyParam: P, err: ContractErrorResponses) =>
+  ({
+    resetKey: {
+      method: 'POST',
+      path: '/settings/:key/reset',
+      pathParams: keyParam,
+      body: z.object({}).optional(),
+      responses: { 200: z.object({ data: SettingSchema, message: z.string() }), ...err },
+      summary: 'Reset a single setting to its manifest default',
+    },
+    reset: {
+      method: 'POST',
+      path: '/settings/reset',
+      body: ResetInput,
+      responses: { 200: ResetOutput, ...err },
+      summary: 'Reset declared keys to defaults (omit keys ⇒ reset all)',
+    },
+    ensure: {
+      method: 'POST',
+      path: '/settings/:key/ensure',
+      pathParams: keyParam,
+      body: SettingValueBody,
+      responses: { 200: z.object({ data: SettingSchema }), ...err },
+      summary: 'Internal-only write-once seed (encryption seed / client id)',
+    },
+  }) as const;
+
+/**
+ * Builds the federated RU+reset ts-rest router for one pillar. `:key` is
+ * constrained to that pillar's declared key enum; `getMany`/`setMany`
+ * accept free-form keys (matching the bulk service shape).
+ *
+ * Verbs: `list` (collection), `get` (single, null on unset), `getMany`
+ * (batch read), `set` (single upsert), `setMany` (transactional batch),
+ * `resetKey`/`reset` (single + batch reset-to-default), and the
+ * INTERNAL-ONLY `ensure` write-once seed. There is deliberately NO
+ * create and NO delete verb — keys are a fixed declared set.
+ *
+ * operationIds project to the dot-form (`settings.list`, `settings.get`,
+ * …) so polyglot pillars (the Rust crate) derive identical client method
+ * names.
+ */
+type KeyParamSchema<KeyEnum extends [string, ...string[]]> = z.ZodObject<{
+  key: z.ZodEnum<{ [K in KeyEnum[number]]: K }>;
+}>;
+
+/** The composed RU+reset route map for a given key enum. */
+export type SettingsContract<KeyEnum extends [string, ...string[]]> = ReturnType<
+  typeof readRoutes<KeyParamSchema<KeyEnum>>
+> &
+  ReturnType<typeof writeRoutes<KeyParamSchema<KeyEnum>>> &
+  ReturnType<typeof resetRoutes<KeyParamSchema<KeyEnum>>>;
+
+export function makeSettingsContract<KeyEnum extends [string, ...string[]]>(
+  keyValues: KeyEnum,
+  errorResponses: ContractErrorResponses
+): SettingsContract<KeyEnum> {
+  const keyParam = z.object({ key: z.enum(keyValues) });
+  return c.router({
+    ...readRoutes(keyParam, errorResponses),
+    ...writeRoutes(keyParam, errorResponses),
+    ...resetRoutes(keyParam, errorResponses),
+  });
+}

--- a/packages/pillar-settings/src/errors.ts
+++ b/packages/pillar-settings/src/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Raised when a write/reset addresses a key the pillar never declared in
+ * its settings manifest. Keys are a fixed declared set (no create verb), so
+ * an undeclared write is a client error — the mounting pillar maps this to a
+ * 400. Carries the offending keys for the response body.
+ */
+export class UnknownSettingKeyError extends Error {
+  readonly keys: readonly string[];
+
+  constructor(keys: readonly string[]) {
+    super(`unknown setting key(s): ${keys.join(', ')}`);
+    this.name = 'UnknownSettingKeyError';
+    this.keys = keys;
+  }
+}

--- a/packages/pillar-settings/src/handlers.ts
+++ b/packages/pillar-settings/src/handlers.ts
@@ -1,0 +1,117 @@
+import { redactSensitive, redactSensitiveMap } from './redact.js';
+import {
+  ensure,
+  getBulk,
+  getOrNull,
+  listEffective,
+  resetSetting,
+  resetSettings,
+  setBulk,
+  setRaw,
+  type ResetResult,
+  type SettingEntry,
+} from './service.js';
+
+import type { KeyDefaults } from './manifest-keys.js';
+import type { SettingRow, SettingsDb } from './schema.js';
+
+/**
+ * The identity gate, injected by the mounting pillar. Runs the same
+ * authorization check the pillar's REST middleware uses; throws (e.g.
+ * `UnauthorizedError`) when the principal lacks the scope. Kept generic
+ * over the principal type so the package carries no identity dependency.
+ */
+export type SettingsGate<Principal> = (principal: Principal, scope: string) => void;
+
+/** Dependencies a pillar injects to build its settings handlers. */
+export interface SettingsHandlerDeps<Principal> {
+  /** The pillar's drizzle settings database handle. */
+  readonly db: SettingsDb;
+  /** Scope prefix for the gate, e.g. `'finance.settings'`. */
+  readonly scopePrefix: string;
+  /** The pillar's derived key authority (keys, defaults, sensitive). */
+  readonly keyDefaults: KeyDefaults;
+  /** The injected identity gate. */
+  readonly gate: SettingsGate<Principal>;
+}
+
+/**
+ * The pure RU+reset handler logic for one pillar, decoupled from any
+ * transport. Each method gates the principal, runs the service, and
+ * redacts sensitive values on READ paths only. The mounting pillar wraps
+ * these in its ts-rest adapter (principal extraction + error mapping).
+ *
+ * There is no create or delete handler — only read, update, reset, and
+ * the internal-only `ensure` seed.
+ */
+export interface SettingsHandlers<Principal> {
+  list(principal: Principal): { data: SettingRow[] };
+  get(principal: Principal, key: string): { data: SettingRow | null };
+  getMany(principal: Principal, keys: readonly string[]): { settings: Record<string, string> };
+  set(principal: Principal, key: string, value: string): { data: SettingRow; message: string };
+  setMany(
+    principal: Principal,
+    entries: readonly SettingEntry[]
+  ): { settings: Record<string, string> };
+  resetKey(principal: Principal, key: string): { data: SettingRow; message: string };
+  reset(principal: Principal, keys: readonly string[] | undefined): ResetResult;
+  ensure(principal: Principal, key: string, value: string): { data: SettingRow };
+}
+
+/**
+ * Builds the injected, pillar-agnostic RU+reset handlers. READ paths
+ * (`list`/`get`/`getMany`) redact sensitive keys to the `__redacted__`
+ * sentinel; UPDATE/RESET paths persist and return real values.
+ */
+export function makeSettingsHandlers<Principal>(
+  deps: SettingsHandlerDeps<Principal>
+): SettingsHandlers<Principal> {
+  const { db, scopePrefix, keyDefaults, gate } = deps;
+  const sensitive = new Set(keyDefaults.sensitive);
+  const scope = (proc: string): string => `${scopePrefix}.${proc}`;
+
+  return {
+    list(principal) {
+      gate(principal, scope('list'));
+      return { data: redactSensitive(listEffective(db, keyDefaults), sensitive) };
+    },
+
+    get(principal, key) {
+      gate(principal, scope('get'));
+      const row = getOrNull(db, key);
+      if (row === null) return { data: null };
+      const [redacted] = redactSensitive([row], sensitive);
+      return { data: redacted ?? row };
+    },
+
+    getMany(principal, keys) {
+      gate(principal, scope('getMany'));
+      return { settings: redactSensitiveMap(getBulk(db, keys), sensitive) };
+    },
+
+    set(principal, key, value) {
+      gate(principal, scope('set'));
+      return { data: setRaw(db, key, value), message: 'Setting saved' };
+    },
+
+    setMany(principal, entries) {
+      gate(principal, scope('setMany'));
+      return { settings: setBulk(db, entries) };
+    },
+
+    resetKey(principal, key) {
+      gate(principal, scope('resetKey'));
+      return { data: resetSetting(db, key, keyDefaults), message: 'Setting reset to default' };
+    },
+
+    reset(principal, keys) {
+      gate(principal, scope('reset'));
+      return resetSettings(db, keys, keyDefaults);
+    },
+
+    ensure(principal, key, value) {
+      gate(principal, scope('ensure'));
+      return { data: ensure(db, key, value) };
+    },
+  };
+}

--- a/packages/pillar-settings/src/handlers.ts
+++ b/packages/pillar-settings/src/handlers.ts
@@ -1,3 +1,4 @@
+import { UnknownSettingKeyError } from './errors.js';
 import { redactSensitive, redactSensitiveMap } from './redact.js';
 import {
   ensure,
@@ -42,7 +43,10 @@ export interface SettingsHandlerDeps<Principal> {
  * these in its ts-rest adapter (principal extraction + error mapping).
  *
  * There is no create or delete handler — only read, update, reset, and
- * the internal-only `ensure` seed.
+ * the internal-only `ensure` seed. WRITE/RESET paths reject keys outside
+ * the declared set (`UnknownSettingKeyError`) so a batch write can never
+ * become a backdoor create; READ paths stay lenient (an undeclared key is
+ * simply absent), letting an aggregator query a superset without error.
  */
 export interface SettingsHandlers<Principal> {
   list(principal: Principal): { data: SettingRow[] };
@@ -68,7 +72,12 @@ export function makeSettingsHandlers<Principal>(
 ): SettingsHandlers<Principal> {
   const { db, scopePrefix, keyDefaults, gate } = deps;
   const sensitive = new Set(keyDefaults.sensitive);
+  const declared = new Set(keyDefaults.keys);
   const scope = (proc: string): string => `${scopePrefix}.${proc}`;
+  const assertDeclared = (keys: readonly string[]): void => {
+    const unknown = keys.filter((key) => !declared.has(key));
+    if (unknown.length > 0) throw new UnknownSettingKeyError(unknown);
+  };
 
   return {
     list(principal) {
@@ -91,16 +100,19 @@ export function makeSettingsHandlers<Principal>(
 
     set(principal, key, value) {
       gate(principal, scope('set'));
+      assertDeclared([key]);
       return { data: setRaw(db, key, value), message: 'Setting saved' };
     },
 
     setMany(principal, entries) {
       gate(principal, scope('setMany'));
+      assertDeclared(entries.map((entry) => entry.key));
       return { settings: setBulk(db, entries) };
     },
 
     resetKey(principal, key) {
       gate(principal, scope('resetKey'));
+      assertDeclared([key]);
       return { data: resetSetting(db, key, keyDefaults), message: 'Setting reset to default' };
     },
 

--- a/packages/pillar-settings/src/index.ts
+++ b/packages/pillar-settings/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * `@pops/pillar-settings` — the shared, storage-agnostic Read/Update/Reset
+ * settings module every pillar mounts to serve a byte-identical
+ * `/settings/*` surface (PRD-256 / settings-federation US-S0).
+ *
+ * The module owns the schema (drizzle table factory), the RU+reset+seed
+ * service, the ts-rest contract factory, read-side sensitive redaction,
+ * and `deriveKeySet` (manifest → key authority). Each pillar injects its
+ * own persistence handle and identity gate — the module binds to no
+ * specific database and imports no pillar code.
+ *
+ * Protocol is READ + UPDATE + RESET only. There is no create verb and no
+ * delete verb; keys are a fixed declared set per pillar. The `ensure`
+ * write-once seed is internal-only.
+ */
+export { settingsTable, type SettingRow, type SettingsDb } from './schema.js';
+
+export {
+  deriveKeySet,
+  type DeclaredSettingsField,
+  type DeclaredSettingsGroup,
+  type DeclaredSettingsManifest,
+  type KeyDefaults,
+} from './manifest-keys.js';
+
+export { REDACTED, redactSensitive, redactSensitiveMap } from './redact.js';
+
+export {
+  ensure,
+  getBulk,
+  getOrNull,
+  listEffective,
+  resetSetting,
+  resetSettings,
+  setBulk,
+  setRaw,
+  type ResetResult,
+  type SettingEntry,
+} from './service.js';
+
+export {
+  makeSettingsContract,
+  SettingSchema,
+  type ContractErrorResponses,
+  type SettingsContract,
+} from './contract.js';
+
+export {
+  makeSettingsHandlers,
+  type SettingsGate,
+  type SettingsHandlerDeps,
+  type SettingsHandlers,
+} from './handlers.js';

--- a/packages/pillar-settings/src/index.ts
+++ b/packages/pillar-settings/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * `@pops/pillar-settings` — the shared, storage-agnostic Read/Update/Reset
  * settings module every pillar mounts to serve a byte-identical
- * `/settings/*` surface (PRD-256 / settings-federation US-S0).
+ * `/settings/*` surface (settings-federation, US-S0; see
+ * `docs/plans/02-settings-federation.md`).
  *
  * The module owns the schema (drizzle table factory), the RU+reset+seed
  * service, the ts-rest contract factory, read-side sensitive redaction,
@@ -24,6 +25,8 @@ export {
 } from './manifest-keys.js';
 
 export { REDACTED, redactSensitive, redactSensitiveMap } from './redact.js';
+
+export { UnknownSettingKeyError } from './errors.js';
 
 export {
   ensure,

--- a/packages/pillar-settings/src/manifest-keys.ts
+++ b/packages/pillar-settings/src/manifest-keys.ts
@@ -1,0 +1,67 @@
+/**
+ * Derives a pillar's declared key set, default map, and sensitive-key
+ * list from its settings manifest descriptors. The manifest is the single
+ * authority for a pillar's keys (no central enum) — `deriveKeySet` is the
+ * sole bridge between the declared UI fields and the RU+reset router that
+ * gates them.
+ *
+ * The input type is the structural subset of
+ * `SettingsManifestDescriptor` (`@pops/pillar-sdk/manifest-schema`) this
+ * module actually reads, declared locally so the package stays decoupled
+ * from the SDK while remaining assignable from the real descriptor.
+ */
+
+/** A single declared settings field — the structural subset used here. */
+export interface DeclaredSettingsField {
+  readonly key: string;
+  readonly default?: string;
+  readonly sensitive?: boolean;
+}
+
+/** A group of declared fields within a manifest descriptor. */
+export interface DeclaredSettingsGroup {
+  readonly fields: readonly DeclaredSettingsField[];
+}
+
+/** The structural subset of a settings manifest descriptor read here. */
+export interface DeclaredSettingsManifest {
+  readonly groups: readonly DeclaredSettingsGroup[];
+}
+
+/**
+ * The resolved key authority for one pillar: the ordered declared keys,
+ * the key→default map (only keys with an explicit manifest default), and
+ * the sensitive-key list (redacted on read).
+ */
+export interface KeyDefaults {
+  readonly keys: readonly string[];
+  readonly defaults: Readonly<Record<string, string>>;
+  readonly sensitive: readonly string[];
+}
+
+interface KeySetAccumulator {
+  readonly keys: string[];
+  readonly defaults: Record<string, string>;
+  readonly sensitive: string[];
+}
+
+function collectField(acc: KeySetAccumulator, field: DeclaredSettingsField): void {
+  acc.keys.push(field.key);
+  if (field.default !== undefined) acc.defaults[field.key] = field.default;
+  if (field.sensitive === true) acc.sensitive.push(field.key);
+}
+
+/**
+ * Flattens a pillar's manifest descriptors into its {@link KeyDefaults}.
+ * Iterates every group's fields in declaration order, collecting keys,
+ * explicit defaults, and sensitive flags.
+ */
+export function deriveKeySet(manifests: readonly DeclaredSettingsManifest[]): KeyDefaults {
+  const acc: KeySetAccumulator = { keys: [], defaults: {}, sensitive: [] };
+  for (const manifest of manifests) {
+    for (const group of manifest.groups) {
+      for (const field of group.fields) collectField(acc, field);
+    }
+  }
+  return { keys: acc.keys, defaults: acc.defaults, sensitive: acc.sensitive };
+}

--- a/packages/pillar-settings/src/redact.ts
+++ b/packages/pillar-settings/src/redact.ts
@@ -1,0 +1,39 @@
+import type { SettingRow } from './schema.js';
+
+/**
+ * Fixed sentinel a sensitive value reads back as. The shell renders a
+ * field holding this sentinel as an empty password input and only sends
+ * fields the user actually edited, so a no-op save never persists the
+ * sentinel over the real secret.
+ */
+export const REDACTED = '__redacted__';
+
+/**
+ * Masks sensitive values for READ paths only. Returns a new array; rows
+ * whose key is in `sensitive` have their value replaced by
+ * {@link REDACTED}. Writes are never passed through this — the stored
+ * value stays intact, and only outbound reads are masked.
+ */
+export function redactSensitive(
+  rows: readonly SettingRow[],
+  sensitive: ReadonlySet<string>
+): SettingRow[] {
+  return rows.map((row) =>
+    sensitive.has(row.key) ? { key: row.key, value: REDACTED } : { key: row.key, value: row.value }
+  );
+}
+
+/**
+ * Redacts the values of a key→value map for READ paths. Returns a new
+ * map; keys in `sensitive` map to {@link REDACTED}.
+ */
+export function redactSensitiveMap(
+  settings: Readonly<Record<string, string>>,
+  sensitive: ReadonlySet<string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(settings)) {
+    out[key] = sensitive.has(key) ? REDACTED : value;
+  }
+  return out;
+}

--- a/packages/pillar-settings/src/schema.ts
+++ b/packages/pillar-settings/src/schema.ts
@@ -1,0 +1,25 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/**
+ * The single per-pillar settings table: a flat key/value store the
+ * federated RU+reset surface operates over. Storage-agnostic — each
+ * pillar's own SQLite database mounts this same shape via its own
+ * migration. There is no owner/namespace column: a pillar's table only
+ * ever holds that pillar's declared keys.
+ */
+export const settingsTable = sqliteTable('settings', {
+  key: text('key').primaryKey(),
+  value: text('value').notNull(),
+});
+
+/** Persisted settings row (`{ key, value }`). */
+export type SettingRow = typeof settingsTable.$inferSelect;
+
+/**
+ * A drizzle better-sqlite3 handle — either the top-level database or a
+ * transaction handle. The service is generic over this so each pillar
+ * injects its own connection; the module never opens a database itself.
+ */
+export type SettingsDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/pillar-settings/src/service.ts
+++ b/packages/pillar-settings/src/service.ts
@@ -1,0 +1,130 @@
+import { eq, inArray } from 'drizzle-orm';
+
+import { settingsTable, type SettingRow, type SettingsDb } from './schema.js';
+
+import type { KeyDefaults } from './manifest-keys.js';
+
+/** A key/value pair accepted by the write paths. */
+export interface SettingEntry {
+  readonly key: string;
+  readonly value: string;
+}
+
+/**
+ * Read one stored override. Returns `null` when the key has no stored
+ * row (the caller applies the manifest default). Does NOT resolve the
+ * default itself — {@link listEffective} is the effective-value path.
+ */
+export function getOrNull(db: SettingsDb, key: string): SettingRow | null {
+  return db.select().from(settingsTable).where(eq(settingsTable.key, key)).get() ?? null;
+}
+
+/**
+ * Batch-read stored overrides by key. Missing keys are omitted (absence
+ * means "not set"). Duplicate input keys are de-duped before the query.
+ */
+export function getBulk(db: SettingsDb, keys: readonly string[]): Record<string, string> {
+  if (keys.length === 0) return {};
+  const uniqueKeys = [...new Set(keys)];
+  const rows = db.select().from(settingsTable).where(inArray(settingsTable.key, uniqueKeys)).all();
+  const out: Record<string, string> = {};
+  for (const row of rows) out[row.key] = row.value;
+  return out;
+}
+
+/**
+ * The effective value set for a pillar: every declared key resolved to
+ * its stored override, else its manifest default, else the empty string.
+ * This is what the collection read (`GET /settings`) returns.
+ */
+export function listEffective(db: SettingsDb, kd: KeyDefaults): SettingRow[] {
+  const overrides = getBulk(db, kd.keys);
+  return kd.keys.map((key) => ({ key, value: overrides[key] ?? kd.defaults[key] ?? '' }));
+}
+
+/**
+ * Upsert a single setting (UPDATE). Returns the persisted row. The value
+ * is stored verbatim — writes are never redacted.
+ */
+export function setRaw(db: SettingsDb, key: string, value: string): SettingRow {
+  db.insert(settingsTable)
+    .values({ key, value })
+    .onConflictDoUpdate({ target: settingsTable.key, set: { value } })
+    .run();
+  return { key, value };
+}
+
+/**
+ * Transactional batch write (UPDATE) — every entry lands or none do.
+ * Returns a mirror of the written entries (key → value) without
+ * re-reading the table.
+ */
+export function setBulk(db: SettingsDb, entries: readonly SettingEntry[]): Record<string, string> {
+  if (entries.length === 0) return {};
+  db.transaction((tx) => {
+    for (const { key, value } of entries) {
+      tx.insert(settingsTable)
+        .values({ key, value })
+        .onConflictDoUpdate({ target: settingsTable.key, set: { value } })
+        .run();
+    }
+  });
+  const out: Record<string, string> = {};
+  for (const { key, value } of entries) out[key] = value;
+  return out;
+}
+
+/**
+ * Write-once seed for values that must stay stable for the install's
+ * lifetime (encryption seed, generated client id). Inserts with
+ * `ON CONFLICT DO NOTHING`, so concurrent first-time callers converge on
+ * the row that landed first. INTERNAL-ONLY — not part of the user-facing
+ * RU+reset surface.
+ */
+export function ensure(db: SettingsDb, key: string, value: string): SettingRow {
+  db.insert(settingsTable)
+    .values({ key, value })
+    .onConflictDoNothing({ target: settingsTable.key })
+    .run();
+  const row = db.select().from(settingsTable).where(eq(settingsTable.key, key)).get();
+  return row ?? { key, value };
+}
+
+/**
+ * RESET a single declared key to its manifest default by deleting any
+ * stored override (idempotent — no throw on miss). Returns the resolved
+ * default value the next read would now observe.
+ */
+export function resetSetting(db: SettingsDb, key: string, kd: KeyDefaults): SettingRow {
+  db.delete(settingsTable).where(eq(settingsTable.key, key)).run();
+  return { key, value: kd.defaults[key] ?? '' };
+}
+
+/** The outcome of a batch reset: the keys reset and their resolved defaults. */
+export interface ResetResult {
+  readonly reset: readonly string[];
+  readonly settings: Readonly<Record<string, string>>;
+}
+
+/**
+ * RESET declared keys to their manifest defaults transactionally. With
+ * `keys` omitted (or empty) ALL declared keys are reset; otherwise only
+ * the supplied keys that are actually declared (unknown keys are ignored,
+ * never written). Returns the reset keys and their resolved defaults.
+ */
+export function resetSettings(
+  db: SettingsDb,
+  keys: readonly string[] | undefined,
+  kd: KeyDefaults
+): ResetResult {
+  const declared = new Set(kd.keys);
+  const target = keys && keys.length > 0 ? keys.filter((key) => declared.has(key)) : [...kd.keys];
+
+  db.transaction((tx) => {
+    for (const key of target) tx.delete(settingsTable).where(eq(settingsTable.key, key)).run();
+  });
+
+  const settings: Record<string, string> = {};
+  for (const key of target) settings[key] = kd.defaults[key] ?? '';
+  return { reset: target, settings };
+}

--- a/packages/pillar-settings/tsconfig.json
+++ b/packages/pillar-settings/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/pillar-settings/vitest.config.ts
+++ b/packages/pillar-settings/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts', '**/index.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,37 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pillar-settings:
+    dependencies:
+      '@ts-rest/core':
+        specifier: 3.53.0-rc.1
+        version: 3.53.0-rc.1(@types/node@25.9.3)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/types:
     devDependencies:
       '@vitest/coverage-v8':


### PR DESCRIPTION
## What's here

Stage 1c / US-S0 of the settings-federation plan: the new **`@pops/pillar-settings`** package — the shared, storage-agnostic Read/Update/Reset settings module every pillar mounts to serve a byte-identical `/settings/*` surface.

The module owns, and nothing more:

- **`schema.ts`** — the drizzle `settings(key PK, value)` table factory + the `SettingsDb` handle type (`BetterSQLite3Database`). No DB binding.
- **`service.ts`** — the RU+reset+seed service over an injected handle: `getOrNull`, `getBulk`, `listEffective` (override → manifest default → `''`), `setRaw`, `setBulk` (transactional), `ensure` (write-once seed), `resetSetting`, `resetSettings`.
- **`contract.ts`** — `makeSettingsContract(keyEnum, errorResponses)` → the ts-rest router for `list / get / getMany / set / setMany / resetKey / reset` plus internal-only `ensure`. `:key` constrained to the pillar's declared enum; batch routes free-form. operationIds project to dot-form (`settings.get`, …) for polyglot parity.
- **`handlers.ts`** — `makeSettingsHandlers({ db, scopePrefix, keyDefaults, gate })` → pure RU+reset logic with the identity **gate injected** (no pillar dependency). READ paths redact sensitive keys; UPDATE/RESET persist real values.
- **`redact.ts`** — `redactSensitive` / `redactSensitiveMap` → fixed `__redacted__` sentinel, READS only.
- **`manifest-keys.ts`** — `deriveKeySet(manifests)` → `{ keys, defaults, sensitive }`, the sole key authority from a pillar's manifest.

### Protocol guarantees (per the plan)

- **RU + reset ONLY.** No `create` verb, no `delete` verb. Keys are a fixed declared set per pillar. The contract test asserts the verb set is exactly `{ list, get, getMany, set, setMany, resetKey, reset, ensure }`.
- **`ensure` is internal-only** (write-once seed), not user-facing CRUD.
- **Redaction is read-only.** Writes are never redacted and persist verbatim; sensitive values read back as the sentinel.
- **Storage-agnostic + identity-agnostic.** The pillar injects its own SQLite handle and its own gate; the package imports no pillar code and binds to no DB.

## Open Decisions baked in

- **OD-8 (sensitive redaction).** Reads redact to the fixed `__redacted__` sentinel; writes never redacted; the field stays present-but-masked so the shell can leave password fields empty and only send edited fields. Implemented in `redact.ts` + wired into every read handler.
- **OD-3 (reset honors all fields uniformly).** `reset` is a plain value-change to the manifest default — no special-casing.
- **OD-5 (system-scoped v1).** The table factory covers system-scoped settings only; per-user overrides are a deferred follow-up (US-09), out of scope here.
- **GAP-256-E / R12.** `listEffective` + the collection/get/getMany read paths redact sensitive keys so a federation-wide sweep cannot leak `plex_token` / encryption seeds.

## Resolved plan ambiguity

The spec's `deriveKeySet` pseudocode imports `SettingsManifestDescriptor` from `@pops/pillar-sdk`. To keep the foundation package decoupled (the SDK must not depend on it, and vice-versa), `deriveKeySet` takes a **locally-declared structural subset** (`DeclaredSettingsManifest` = `{ groups: { fields: { key, default?, sensitive? }[] }[] }`) — assignable from the real `SettingsManifestDescriptor` without a hard import. No behavior change; just avoids a circular/over-tight dependency.

## Verification (all green, run locally from repo root)

- `pnpm install` — lockfile updated and committed (`--frozen-lockfile` safe).
- `cd packages/pillar-settings && pnpm typecheck` — clean.
- `pnpm test` — **42 passed (6 files)**. Real in-memory better-sqlite3 (no mocks of real things); covers RU happy paths, reset-to-default (single + batch + reset-all), transactional rollback, the redaction round-trip (API reads sentinel, DB holds the real secret), `deriveKeySet`, and unknown-key rejection.
- `pnpm lint` (root, `--type-aware`) — exits 0, zero errors/warnings in the package.
- `pnpm exec oxfmt --check packages/pillar-settings .github/workflows/pillar-settings-quality.yml` — clean.
- `pnpm build` — emits `dist/` cleanly (then removed; not committed).

No `as any`, no `as unknown as`, no `eslint-disable`/`ts-ignore`. The transactional-rollback test triggers a genuine constraint failure via a CHECK-constrained test DB rather than any type-system escape hatch.

Adds a path-filtered per-package CI workflow `.github/workflows/pillar-settings-quality.yml` mirroring `ai-telemetry-quality.yml` (`_pkg-check.yml`, `has-test: true`, `needs-db-build: false`).
