### PR TITLE
refactor(pillar-sdk): registry path resolver with legacy fallback (PRD registry-cleanup Phase 0)

### DIFF
--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -11,8 +11,8 @@
  *
  *   - **Dynamic** (`--dynamic`) — PRD-232, Wave 6 BE-lego. Reads the
  *     live `pillar_registry` via the SDK's `HttpDiscoveryTransport`
- *     (`GET /core.registry.list`) and emits one `/<pillar>-api/` REST
- *     block per registered pillar.
+ *     (canonical `GET /registry/pillars`, legacy `GET /core.registry.list`)
+ *     and emits one `/<pillar>-api/` REST block per registered pillar.
  *     Used at boot-time inside the cluster: an init container (or a future
  *     subscription-bus watcher, PRD-163) runs the script with
  *     `--dynamic` so newly-registered external pillars (PRD-228) pick
@@ -37,8 +37,8 @@
  *   tsx generate-nginx-conf.ts --dynamic --out … --registry-url=http://core-api:3001
  *
  * The event-driven `nginx -s reload` wrapper that re-runs the dynamic
- * mode on each `core.registry` subscription event is intentionally NOT
- * shipped here; see PRD-163 follow-up.
+ * mode on each registry subscription event (`GET /registry/subscribe`) is
+ * intentionally NOT shipped here; see PRD-163 follow-up.
  */
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -10,9 +10,11 @@
  *     test guards this output.
  *
  *   - **Dynamic** (`--dynamic`) — PRD-232, Wave 6 BE-lego. Reads the
- *     live `pillar_registry` via the SDK's `HttpDiscoveryTransport`
- *     (canonical `GET /registry/pillars`, legacy `GET /core.registry.list`)
- *     and emits one `/<pillar>-api/` REST block per registered pillar.
+ *     live `pillar_registry` via the SDK's `HttpDiscoveryTransport`,
+ *     which currently fetches `GET /core.registry.list` (the route core
+ *     mounts today; the canonical `GET /registry/pillars` is introduced
+ *     in a later phase and is not live yet), and emits one
+ *     `/<pillar>-api/` REST block per registered pillar.
  *     Used at boot-time inside the cluster: an init container (or a future
  *     subscription-bus watcher, PRD-163) runs the script with
  *     `--dynamic` so newly-registered external pillars (PRD-228) pick

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -26,10 +26,10 @@ export interface BootstrapPillarOptions {
    * Must be a valid absolute URL (e.g. `http://finance-api:3004`). Persisted
    * server-side as the `PillarRegistryEntry.baseUrl` column; carried in the
    * register envelope this pillar POSTs to the registry's register route
-   * (canonical `/registry/register`, legacy `/core.registry.register` still
-   * accepted in-cluster until the dotted shape is removed). The manifest is
-   * PUSHED in that register envelope and re-served in the discovery snapshot —
-   * it is never pulled over HTTP from this base URL.
+   * (currently `/core.registry.register` — see `bootstrap/transport.ts`; the
+   * canonical `/registry/register` is introduced in a later phase and is not
+   * live yet). The manifest is PUSHED in that register envelope and re-served
+   * in the discovery snapshot — it is never pulled over HTTP from this base URL.
    */
   baseUrl: string;
   /**

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -22,11 +22,14 @@ export interface BootstrapPillarOptions {
   manifest: ManifestPayload;
   /**
    * Base URL the registry should record for this pillar — the address
-   * other pillars dial to reach its `/health`, `/manifest.json`, and
-   * `/uri/resolve` routes. Must be a valid absolute URL (e.g.
-   * `http://finance-api:3004`). Persisted server-side as the
-   * `PillarRegistryEntry.baseUrl` column; required by
-   * `POST /core.registry.register`.
+   * other pillars dial to reach its `/health` and `/uri/resolve` routes.
+   * Must be a valid absolute URL (e.g. `http://finance-api:3004`). Persisted
+   * server-side as the `PillarRegistryEntry.baseUrl` column; carried in the
+   * register envelope this pillar POSTs to the registry's register route
+   * (canonical `/registry/register`, legacy `/core.registry.register` still
+   * accepted in-cluster until the dotted shape is removed). The manifest is
+   * PUSHED in that register envelope and re-served in the discovery snapshot —
+   * it is never pulled over HTTP from this base URL.
    */
   baseUrl: string;
   /**

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -3,8 +3,9 @@ import { PillarSdkError } from './errors.js';
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
 /**
- * The shape returned by the registry discovery snapshot (PRD-161 / PRD-159) —
- * canonical `GET /registry/pillars`, legacy `GET /core.registry.list`.
+ * The shape returned by the registry discovery snapshot (PRD-161 / PRD-159).
+ * Currently served at `GET /core.registry.list`; the canonical slash form
+ * `GET /registry/pillars` is introduced in a later phase and is not live yet.
  * One entry per registered pillar.
  */
 export type DiscoveredPillar = {
@@ -18,11 +19,12 @@ export type DiscoveredPillar = {
 
 /**
  * The transport the client uses to fetch the registry snapshot. The
- * default HTTP impl reads the discovery snapshot (canonical
- * `/registry/pillars`, legacy `/core.registry.list`); tests inject a
- * fake. Decoupling the transport keeps the client unit-testable without
- * a live registry and lets future deployments swap to an SSE / file /
- * in-process variant without touching `pillar()`.
+ * default HTTP impl reads the discovery snapshot from `/core.registry.list`
+ * (the canonical slash form `/registry/pillars` is introduced in a later
+ * phase, not live yet); tests inject a fake. Decoupling the transport keeps
+ * the client unit-testable without a live registry and lets future
+ * deployments swap to an SSE / file / in-process variant without touching
+ * `pillar()`.
  */
 export interface DiscoveryTransport {
   fetchSnapshot(): Promise<readonly DiscoveredPillar[]>;
@@ -44,7 +46,8 @@ const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
  * the raw HTTP wire and reshapes the response into `DiscoveredPillar[]`.
  *
  * Wire shape (raw — no tRPC):
- *   GET /registry/pillars   (legacy alias: GET /core.registry.list)
+ *   GET /core.registry.list   (the route core mounts today; the canonical
+ *                              GET /registry/pillars lands in a later phase)
  *   → { pillars: [...], fetchedAt: ... }
  *
  * The body parser still tolerates a `{ result: { data } }` envelope so a

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -3,7 +3,8 @@ import { PillarSdkError } from './errors.js';
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
 /**
- * The shape returned by `core.registry.list` (PRD-161 / PRD-159).
+ * The shape returned by the registry discovery snapshot (PRD-161 / PRD-159) —
+ * canonical `GET /registry/pillars`, legacy `GET /core.registry.list`.
  * One entry per registered pillar.
  */
 export type DiscoveredPillar = {
@@ -17,7 +18,8 @@ export type DiscoveredPillar = {
 
 /**
  * The transport the client uses to fetch the registry snapshot. The
- * default HTTP impl talks to `core.registry.list`; tests inject a
+ * default HTTP impl reads the discovery snapshot (canonical
+ * `/registry/pillars`, legacy `/core.registry.list`); tests inject a
  * fake. Decoupling the transport keeps the client unit-testable without
  * a live registry and lets future deployments swap to an SSE / file /
  * in-process variant without touching `pillar()`.
@@ -42,7 +44,7 @@ const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
  * the raw HTTP wire and reshapes the response into `DiscoveredPillar[]`.
  *
  * Wire shape (raw — no tRPC):
- *   GET /core.registry.list
+ *   GET /registry/pillars   (legacy alias: GET /core.registry.list)
  *   → { pillars: [...], fetchedAt: ... }
  *
  * The body parser still tolerates a `{ result: { data } }` envelope so a

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -20,9 +20,11 @@ export type RegistryFetchResult = {
 export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * One-shot fetch of the registry discovery snapshot (PRD-161) — canonical
- * `GET /registry/pillars` (legacy `GET /core.registry.list` still served
- * in-cluster until the dotted shape is removed).
+ * One-shot fetch of the registry discovery snapshot (PRD-161). Currently hits
+ * `GET /core.registry.list` (see {@link buildRegistryListUrl}) — the only route
+ * core mounts today. The canonical slash form `GET /registry/pillars`
+ * (`REGISTRY_PATHS.snapshot`) is introduced in a later phase (dual-serve) and
+ * is not live yet.
  *
  * - 5s timeout via `AbortController` (configurable, but 5s is the default
  *   the PRD-159 contract calls out).

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -20,7 +20,9 @@ export type RegistryFetchResult = {
 export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * One-shot fetch of `core.registry.list` (PRD-161).
+ * One-shot fetch of the registry discovery snapshot (PRD-161) — canonical
+ * `GET /registry/pillars` (legacy `GET /core.registry.list` still served
+ * in-cluster until the dotted shape is removed).
  *
  * - 5s timeout via `AbortController` (configurable, but 5s is the default
  *   the PRD-159 contract calls out).

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -31,7 +31,9 @@ const RegistrySnapshotPayloadSchema = z
 
 /**
  * Validates the JSON body returned by the registry discovery snapshot
- * (PRD-161) — canonical `GET /registry/pillars`, legacy `GET /core.registry.list`.
+ * (PRD-161). The SDK currently fetches `GET /core.registry.list` — the only
+ * route core mounts today; the canonical `GET /registry/pillars` is introduced
+ * in a later phase and is not live yet.
  *
  * Accepts both the bare payload shape and the tRPC-wrapped
  * `{ result: { data: ... } }` envelope so the fetcher can talk to either

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -30,7 +30,8 @@ const RegistrySnapshotPayloadSchema = z
   .loose();
 
 /**
- * Validates the JSON body returned by `core.registry.list` (PRD-161).
+ * Validates the JSON body returned by the registry discovery snapshot
+ * (PRD-161) — canonical `GET /registry/pillars`, legacy `GET /core.registry.list`.
  *
  * Accepts both the bare payload shape and the tRPC-wrapped
  * `{ result: { data: ... } }` envelope so the fetcher can talk to either

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -1,4 +1,6 @@
 export * from './manifest-schema/index.js';
+export { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS, type RegistryPathKey } from './registry-paths.js';
+export { createPathResolver, type RegistryPathResolver } from './registry-path-resolver.js';
 export * from './bootstrap/index.js';
 export * from './discovery/index.js';
 export * from './capabilities/index.js';

--- a/packages/pillar-sdk/src/registry-path-resolver.test.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.test.ts
@@ -71,6 +71,39 @@ describe('createPathResolver', () => {
     expect(resolver.candidates()).toEqual([NEW, OLD]);
   });
 
+  it('orders the primary winner first after remembering the primary', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(NEW);
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('orders the fallback winner first but keeps the primary a candidate', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(OLD);
+    const ordered = resolver.candidates();
+    expect(ordered).toEqual([OLD, NEW]);
+    expect(ordered).toContain(NEW);
+  });
+
+  it('ignores remembering a path that is neither the primary nor the fallback', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    const before = resolver.candidates();
+
+    resolver.remember('/registry/not-a-real-route');
+
+    expect(resolver.candidates()).toEqual(before);
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('does not let an unknown path clobber a previously remembered winner', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(OLD);
+
+    resolver.remember('/core.registry.bogus');
+
+    expect(resolver.candidates()).toEqual([OLD, NEW]);
+  });
+
   it('resolves to the new path when core serves it (single request)', async () => {
     const resolver = createPathResolver(NEW, OLD);
     const result = await resolveOnce(resolver, serves(NEW), freshTracker());

--- a/packages/pillar-sdk/src/registry-path-resolver.test.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPathResolver, type RegistryPathResolver } from './registry-path-resolver.js';
+
+const NEW = '/registry/register';
+const OLD = '/core.registry.register';
+
+type WinTracker = { hadHint: boolean };
+
+/**
+ * A faithful miniature of the Phase-2a transport loop, exercising the resolver
+ * against an injected fetch: try each candidate in order, fall through on 404,
+ * cache the winner, and invalidate the hint on a 404 against the path that was
+ * the cached winner from a prior call. No mocks of real logic — the resolver is
+ * the real thing under test. `tracker` carries the "is a winner cached?" flag
+ * across calls exactly as a long-lived transport would.
+ */
+async function resolveOnce(
+  resolver: RegistryPathResolver,
+  status: (path: string) => number,
+  tracker: WinTracker
+): Promise<{ winner: string; attempts: string[] }> {
+  const attempts: string[] = [];
+  const candidates = resolver.candidates();
+  for (let i = 0; i < candidates.length; i += 1) {
+    const path = candidates[i]!;
+    attempts.push(path);
+    if (status(path) === 404) {
+      if (i === 0 && tracker.hadHint) {
+        resolver.invalidate();
+        tracker.hadHint = false;
+      }
+      continue;
+    }
+    resolver.remember(path);
+    tracker.hadHint = true;
+    return { winner: path, attempts };
+  }
+  throw new Error(`all candidates 404'd: ${attempts.join(', ')}`);
+}
+
+const serves =
+  (...live: string[]) =>
+  (path: string): number =>
+    live.includes(path) ? 200 : 404;
+
+const freshTracker = (): WinTracker => ({ hadHint: false });
+
+describe('createPathResolver', () => {
+  it('offers both candidates, primary first, before anything is resolved', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('keeps the fallback reachable after remembering the primary', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(NEW);
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('orders the legacy winner first but keeps the primary reachable', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(OLD);
+    expect(resolver.candidates()).toEqual([OLD, NEW]);
+  });
+
+  it('re-expands to both candidates after invalidate', () => {
+    const resolver = createPathResolver(NEW, OLD);
+    resolver.remember(OLD);
+    resolver.invalidate();
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('resolves to the new path when core serves it (single request)', async () => {
+    const resolver = createPathResolver(NEW, OLD);
+    const result = await resolveOnce(resolver, serves(NEW), freshTracker());
+    expect(result.winner).toBe(NEW);
+    expect(result.attempts).toEqual([NEW]);
+  });
+
+  it('falls back to the legacy path on a 404 against the new path', async () => {
+    const resolver = createPathResolver(NEW, OLD);
+    const result = await resolveOnce(resolver, serves(OLD), freshTracker());
+    expect(result.winner).toBe(OLD);
+    expect(result.attempts).toEqual([NEW, OLD]);
+  });
+
+  it('hits only the cached path once the winner is known (steady state)', async () => {
+    const resolver = createPathResolver(NEW, OLD);
+    const tracker = freshTracker();
+    await resolveOnce(resolver, serves(NEW), tracker);
+    const second = await resolveOnce(resolver, serves(NEW), tracker);
+    expect(second.attempts).toEqual([NEW]);
+    expect(second.winner).toBe(NEW);
+  });
+
+  it('self-heals when a cached new path later 404s (the rollback regression)', async () => {
+    const resolver = createPathResolver(NEW, OLD);
+    const tracker = freshTracker();
+
+    const first = await resolveOnce(resolver, serves(NEW), tracker);
+    expect(first.winner).toBe(NEW);
+
+    // Core rolled back: the cached new path now 404s. The call must fall
+    // through to the legacy path WITHOUT failing the heartbeat.
+    const rolledBack = await resolveOnce(resolver, serves(OLD), tracker);
+    expect(rolledBack.winner).toBe(OLD);
+    expect(rolledBack.attempts).toEqual([NEW, OLD]);
+
+    // The legacy path is now the live winner, but the new path stays reachable
+    // as a candidate — no permanent eviction onto one shape.
+    expect(resolver.candidates()).toEqual([OLD, NEW]);
+
+    // Roll forward again (new live, legacy gone, e.g. Phase 3): the cached
+    // legacy path 404s, the call falls through to the new path and re-caches it.
+    const rolledForward = await resolveOnce(resolver, serves(NEW), tracker);
+    expect(rolledForward.winner).toBe(NEW);
+    expect(rolledForward.attempts).toEqual([OLD, NEW]);
+    expect(resolver.candidates()).toEqual([NEW, OLD]);
+  });
+
+  it('throws when no candidate is served', async () => {
+    const resolver = createPathResolver(NEW, OLD);
+    await expect(resolveOnce(resolver, serves(), freshTracker())).rejects.toThrow(
+      /all candidates 404/
+    );
+  });
+});

--- a/packages/pillar-sdk/src/registry-path-resolver.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.ts
@@ -1,11 +1,18 @@
 /**
  * Self-healing path resolver for the registry handshake/discovery rollout.
  *
- * Two HTTP paths serve one logical registry operation during the rolling-deploy
- * window: the new slash form ({@link REGISTRY_PATHS}) and the legacy dotted form
- * ({@link LEGACY_REGISTRY_PATHS}). A caller tries {@link RegistryPathResolver.candidates}
- * in order, calls {@link RegistryPathResolver.remember} on the first 200, and
- * calls {@link RegistryPathResolver.invalidate} on a 404 against the cached path.
+ * PREPARATORY in Phase 0: this resolver is NOT yet wired into the transport or
+ * discovery. Core still serves ONLY the legacy dotted routes
+ * ({@link LEGACY_REGISTRY_PATHS}) and the SDK still calls them directly. The
+ * resolver lands here so Phase 1/2 can flip on dual-serve + fallback without a
+ * second logic change.
+ *
+ * Once that flip happens, two HTTP paths serve one logical registry operation
+ * during the rolling-deploy window: the new slash form ({@link REGISTRY_PATHS})
+ * and the legacy dotted form. A caller will try
+ * {@link RegistryPathResolver.candidates} in order, call
+ * {@link RegistryPathResolver.remember} on the first 200, and call
+ * {@link RegistryPathResolver.invalidate} on a 404 against the cached path.
  *
  * The cache is a HINT, not a lock. `candidates()` keeps BOTH paths reachable
  * even after a winner is cached, so a 404 on the cached path falls through to
@@ -22,7 +29,11 @@ export interface RegistryPathResolver {
    * (still reachable, so a single 404 self-heals in-call).
    */
   candidates(): readonly string[];
-  /** Cache the winning path so steady state issues a single request. */
+  /**
+   * Cache the winning path so steady state issues a single request. Only the
+   * primary or fallback this resolver was created with is a valid winner; any
+   * other path is ignored and leaves the cached hint untouched.
+   */
   remember(path: string): void;
   /** Drop the cached winner so the next call re-tries both candidates. */
   invalidate(): void;
@@ -42,6 +53,7 @@ export function createPathResolver(primary: string, fallback: string): RegistryP
       return resolved === primary ? [primary, fallback] : [fallback, primary];
     },
     remember(path: string): void {
+      if (path !== primary && path !== fallback) return;
       resolved = path;
     },
     invalidate(): void {

--- a/packages/pillar-sdk/src/registry-path-resolver.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.ts
@@ -1,0 +1,51 @@
+/**
+ * Self-healing path resolver for the registry handshake/discovery rollout.
+ *
+ * Two HTTP paths serve one logical registry operation during the rolling-deploy
+ * window: the new slash form ({@link REGISTRY_PATHS}) and the legacy dotted form
+ * ({@link LEGACY_REGISTRY_PATHS}). A caller tries {@link RegistryPathResolver.candidates}
+ * in order, calls {@link RegistryPathResolver.remember} on the first 200, and
+ * calls {@link RegistryPathResolver.invalidate} on a 404 against the cached path.
+ *
+ * The cache is a HINT, not a lock. `candidates()` keeps BOTH paths reachable
+ * even after a winner is cached, so a 404 on the cached path falls through to
+ * the other candidate within the SAME call — no failed heartbeat. `invalidate()`
+ * then drops the hint so the next call re-resolves from scratch. This is what
+ * makes the resolver survive a mid-rollout core rollback (a new-SDK pillar that
+ * cached the new path meeting a core instance that no longer serves it): a naive
+ * one-shot cache would 404 forever and the pillar would be evicted.
+ */
+export interface RegistryPathResolver {
+  /**
+   * Paths to try, in order. Before a winner is cached: `[primary, fallback]`.
+   * After {@link remember}: the cached winner first, then the other candidate
+   * (still reachable, so a single 404 self-heals in-call).
+   */
+  candidates(): readonly string[];
+  /** Cache the winning path so steady state issues a single request. */
+  remember(path: string): void;
+  /** Drop the cached winner so the next call re-tries both candidates. */
+  invalidate(): void;
+}
+
+/**
+ * Create a {@link RegistryPathResolver} for one logical operation.
+ *
+ * @param primary - the canonical (new, preferred) path
+ * @param fallback - the legacy path tried when the primary 404s
+ */
+export function createPathResolver(primary: string, fallback: string): RegistryPathResolver {
+  let resolved: string | undefined;
+  return {
+    candidates(): readonly string[] {
+      if (resolved === undefined) return [primary, fallback];
+      return resolved === primary ? [primary, fallback] : [fallback, primary];
+    },
+    remember(path: string): void {
+      resolved = path;
+    },
+    invalidate(): void {
+      resolved = undefined;
+    },
+  };
+}

--- a/packages/pillar-sdk/src/registry-paths.test.ts
+++ b/packages/pillar-sdk/src/registry-paths.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from './registry-paths.js';
+
+describe('registry path maps', () => {
+  it('exposes the same operation keys in both maps', () => {
+    expect(Object.keys(REGISTRY_PATHS).toSorted()).toEqual(
+      Object.keys(LEGACY_REGISTRY_PATHS).toSorted()
+    );
+  });
+
+  it('maps every operation to the canonical slash form', () => {
+    expect(REGISTRY_PATHS).toEqual({
+      register: '/registry/register',
+      heartbeat: '/registry/heartbeat',
+      deregister: '/registry/deregister',
+      snapshot: '/registry/pillars',
+    });
+  });
+
+  it('maps every operation to the legacy dotted form', () => {
+    expect(LEGACY_REGISTRY_PATHS).toEqual({
+      register: '/core.registry.register',
+      heartbeat: '/core.registry.heartbeat',
+      deregister: '/core.registry.deregister',
+      snapshot: '/core.registry.list',
+    });
+  });
+
+  it('starts every canonical path with the /registry/ namespace', () => {
+    for (const path of Object.values(REGISTRY_PATHS)) {
+      expect(path.startsWith('/registry/')).toBe(true);
+    }
+  });
+
+  it('uses dotted, non-/registry/ literals for every legacy path', () => {
+    for (const path of Object.values(LEGACY_REGISTRY_PATHS)) {
+      expect(path.startsWith('/core.registry.')).toBe(true);
+      expect(path.startsWith('/registry/')).toBe(false);
+    }
+  });
+
+  it('keeps the two maps disjoint so a candidate list never repeats a path', () => {
+    const canonical = new Set<string>(Object.values(REGISTRY_PATHS));
+    for (const legacy of Object.values(LEGACY_REGISTRY_PATHS)) {
+      expect(canonical.has(legacy)).toBe(false);
+    }
+  });
+});

--- a/packages/pillar-sdk/src/registry-paths.ts
+++ b/packages/pillar-sdk/src/registry-paths.ts
@@ -1,10 +1,12 @@
 /**
  * Canonical (new) registry handshake/discovery HTTP paths.
  *
- * Idiomatic slash routes that replace the tRPC-vestigial dotted shape
- * (`/core.registry.*`). The core pillar serves these alongside the legacy
- * dotted paths during the rolling-deploy window; the SDK transport/discovery
- * prefer these and fall back to {@link LEGACY_REGISTRY_PATHS} on a 404.
+ * Idiomatic slash routes that will replace the tRPC-vestigial dotted shape
+ * (`/core.registry.*`). PLANNED for a later phase, NOT yet wired: in Phase 0
+ * core mounts only the legacy dotted paths and the SDK calls them directly.
+ * Once Phase 1 dual-serves these alongside the legacy paths, the SDK transport/
+ * discovery will prefer them and fall back to {@link LEGACY_REGISTRY_PATHS} on a
+ * 404 during the rolling-deploy window.
  */
 export const REGISTRY_PATHS = {
   register: '/registry/register',

--- a/packages/pillar-sdk/src/registry-paths.ts
+++ b/packages/pillar-sdk/src/registry-paths.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical (new) registry handshake/discovery HTTP paths.
+ *
+ * Idiomatic slash routes that replace the tRPC-vestigial dotted shape
+ * (`/core.registry.*`). The core pillar serves these alongside the legacy
+ * dotted paths during the rolling-deploy window; the SDK transport/discovery
+ * prefer these and fall back to {@link LEGACY_REGISTRY_PATHS} on a 404.
+ */
+export const REGISTRY_PATHS = {
+  register: '/registry/register',
+  heartbeat: '/registry/heartbeat',
+  deregister: '/registry/deregister',
+  snapshot: '/registry/pillars',
+} as const;
+
+/**
+ * Legacy (dotted, tRPC-vestigial) registry paths kept alive across the
+ * rolling-deploy window so an old-SDK pillar can register against a new core
+ * and a new-SDK pillar can fall back against an old core. Removed once every
+ * pillar image is on the new SDK and the legacy-path metric reads zero.
+ */
+export const LEGACY_REGISTRY_PATHS = {
+  register: '/core.registry.register',
+  heartbeat: '/core.registry.heartbeat',
+  deregister: '/core.registry.deregister',
+  snapshot: '/core.registry.list',
+} as const;
+
+/** A registry operation key shared by the canonical and legacy path maps. */
+export type RegistryPathKey = keyof typeof REGISTRY_PATHS;

--- a/pillars/core/src/api/modules/external-registry/deregister.ts
+++ b/pillars/core/src/api/modules/external-registry/deregister.ts
@@ -1,10 +1,10 @@
 /**
  * HTTP-JSON deregister handler for external pillars (Theme 13 PRD-228 US-04).
  *
- * An external pillar shutting down cleanly POSTs to
- * `/core.registry.deregister` so the dispatcher can drop its route
- * immediately, rather than waiting for the missed-heartbeat → unavailable
- * → eviction chain to land.
+ * An external pillar shutting down cleanly POSTs the deregister route
+ * (canonical `/registry/deregister`, legacy `/core.registry.deregister` still
+ * served in-cluster) so the dispatcher can drop its route immediately, rather
+ * than waiting for the missed-heartbeat → unavailable → eviction chain to land.
  *
  * Behaviour:
  *   - Trust model (ADR-027): the docker network is the boundary.

--- a/pillars/core/src/api/modules/external-registry/deregister.ts
+++ b/pillars/core/src/api/modules/external-registry/deregister.ts
@@ -1,10 +1,11 @@
 /**
  * HTTP-JSON deregister handler for external pillars (Theme 13 PRD-228 US-04).
  *
- * An external pillar shutting down cleanly POSTs the deregister route
- * (canonical `/registry/deregister`, legacy `/core.registry.deregister` still
- * served in-cluster) so the dispatcher can drop its route immediately, rather
- * than waiting for the missed-heartbeat → unavailable → eviction chain to land.
+ * An external pillar shutting down cleanly POSTs the deregister route,
+ * currently `/core.registry.deregister` (the canonical `/registry/deregister`
+ * lands in a later phase and is not mounted yet), so the dispatcher can drop
+ * its route immediately, rather than waiting for the missed-heartbeat →
+ * unavailable → eviction chain to land.
  *
  * Behaviour:
  *   - Trust model (ADR-027): the docker network is the boundary.

--- a/pillars/core/src/api/modules/external-registry/heartbeat.ts
+++ b/pillars/core/src/api/modules/external-registry/heartbeat.ts
@@ -1,11 +1,11 @@
 /**
  * HTTP-JSON heartbeat handler for external pillars (Theme 13 PRD-228 US-02).
  *
- * External pillars POST the heartbeat route (canonical `/registry/heartbeat`,
- * legacy `/core.registry.heartbeat` still served in-cluster) with their
- * `pillarId`. Trust model (ADR-027): the docker network is the boundary;
- * anything able to reach this endpoint is already inside the compose
- * network.
+ * External pillars POST the heartbeat route, currently
+ * `/core.registry.heartbeat` (the canonical `/registry/heartbeat` lands in a
+ * later phase and is not mounted yet), with their `pillarId`. Trust model
+ * (ADR-027): the docker network is the boundary; anything able to reach this
+ * endpoint is already inside the compose network.
  *
  * Soft failure (rather than 404) on missing row: PRD-228 acceptance
  * criterion is `{ ok: false, reason: 'not-registered' }` with a 200,
@@ -65,8 +65,9 @@ function applyHeartbeat(
 }
 
 /**
- * Factory for the heartbeat handler (canonical `POST /registry/heartbeat`,
- * legacy `POST /core.registry.heartbeat`).
+ * Factory for the heartbeat handler, currently mounted at
+ * `POST /core.registry.heartbeat` (the canonical `POST /registry/heartbeat`
+ * lands in a later phase).
  */
 export function createExternalHeartbeatHandler(
   deps: ExternalHeartbeatDeps

--- a/pillars/core/src/api/modules/external-registry/heartbeat.ts
+++ b/pillars/core/src/api/modules/external-registry/heartbeat.ts
@@ -1,7 +1,8 @@
 /**
  * HTTP-JSON heartbeat handler for external pillars (Theme 13 PRD-228 US-02).
  *
- * External pillars POST to `/core.registry.heartbeat` with their
+ * External pillars POST the heartbeat route (canonical `/registry/heartbeat`,
+ * legacy `/core.registry.heartbeat` still served in-cluster) with their
  * `pillarId`. Trust model (ADR-027): the docker network is the boundary;
  * anything able to reach this endpoint is already inside the compose
  * network.
@@ -9,7 +10,7 @@
  * Soft failure (rather than 404) on missing row: PRD-228 acceptance
  * criterion is `{ ok: false, reason: 'not-registered' }` with a 200,
  * so the external SDK can re-register cleanly without parsing HTTP
- * status codes. This matches the in-network tRPC heartbeat (PRD-162).
+ * status codes. This matches the in-network heartbeat route (PRD-162).
  */
 import { pillarRegistryService, type CoreDb } from '../../../db/index.js';
 import { emitRegistryEvent } from '../registry/event-bus.js';
@@ -64,7 +65,8 @@ function applyHeartbeat(
 }
 
 /**
- * Factory for the `POST /core.registry.heartbeat` handler.
+ * Factory for the heartbeat handler (canonical `POST /registry/heartbeat`,
+ * legacy `POST /core.registry.heartbeat`).
  */
 export function createExternalHeartbeatHandler(
   deps: ExternalHeartbeatDeps

--- a/pillars/core/src/api/modules/external-registry/register.ts
+++ b/pillars/core/src/api/modules/external-registry/register.ts
@@ -5,13 +5,13 @@ import { validateManifestPayload } from '@pops/pillar-sdk';
  *
  * External pillars — those that ship from a different repository and run
  * outside the in-tree `bootstrapPillar` path — register themselves with the
- * core registry by POSTing the register route (canonical `/registry/register`,
- * legacy `/core.registry.register` still served in-cluster). The nginx edge
- * blocks the mutating registry paths from external traffic (PRD-161); PRD-228
- * carves a sibling allow-list — `^/core\.registry\.(register|heartbeat|deregister)$`
- * today, to be widened to the `^/registry/(register|heartbeat|deregister)$`
- * slash form before the dotted shape is removed — for this plain HTTP-JSON
- * surface.
+ * core registry by POSTing the register route, currently
+ * `/core.registry.register` (the canonical `/registry/register` lands in a
+ * later phase and is not mounted yet). The nginx edge blocks the mutating
+ * registry paths from external traffic (PRD-161); PRD-228 carves a sibling
+ * allow-list — `^/core\.registry\.(register|heartbeat|deregister)$` today, to
+ * be widened to the `^/registry/(register|heartbeat|deregister)$` slash form
+ * when those routes are introduced — for this plain HTTP-JSON surface.
  *
  * Trust model (ADR-027): the docker network is the boundary. Anything
  * able to POST here is already inside the compose network — the
@@ -110,8 +110,9 @@ function persistAndRespond(
 export type ExternalRegisterHandler = (req: Request, res: Response) => void;
 
 /**
- * Factory for the register handler (canonical `POST /registry/register`,
- * legacy `POST /core.registry.register`).
+ * Factory for the register handler, currently mounted at
+ * `POST /core.registry.register` (the canonical `POST /registry/register`
+ * lands in a later phase).
  */
 export function createExternalRegisterHandler(deps: ExternalRegisterDeps): ExternalRegisterHandler {
   return function externalRegisterHandler(req, res) {

--- a/pillars/core/src/api/modules/external-registry/register.ts
+++ b/pillars/core/src/api/modules/external-registry/register.ts
@@ -5,11 +5,13 @@ import { validateManifestPayload } from '@pops/pillar-sdk';
  *
  * External pillars — those that ship from a different repository and run
  * outside the in-tree `bootstrapPillar` path — register themselves with the
- * core registry by POSTing to `/core.registry.register`. The nginx edge
- * blocks the mutating `core.registry.*` paths from external traffic
- * (PRD-161); PRD-228 carves a sibling allow-list at
- * `^/core\.registry\.(register|heartbeat|deregister)$` for this plain
- * HTTP-JSON surface.
+ * core registry by POSTing the register route (canonical `/registry/register`,
+ * legacy `/core.registry.register` still served in-cluster). The nginx edge
+ * blocks the mutating registry paths from external traffic (PRD-161); PRD-228
+ * carves a sibling allow-list — `^/core\.registry\.(register|heartbeat|deregister)$`
+ * today, to be widened to the `^/registry/(register|heartbeat|deregister)$`
+ * slash form before the dotted shape is removed — for this plain HTTP-JSON
+ * surface.
  *
  * Trust model (ADR-027): the docker network is the boundary. Anything
  * able to POST here is already inside the compose network — the
@@ -108,7 +110,8 @@ function persistAndRespond(
 export type ExternalRegisterHandler = (req: Request, res: Response) => void;
 
 /**
- * Factory for the `POST /core.registry.register` handler.
+ * Factory for the register handler (canonical `POST /registry/register`,
+ * legacy `POST /core.registry.register`).
  */
 export function createExternalRegisterHandler(deps: ExternalRegisterDeps): ExternalRegisterHandler {
   return function externalRegisterHandler(req, res) {

--- a/pillars/core/src/api/modules/registry/eviction-ticker.ts
+++ b/pillars/core/src/api/modules/registry/eviction-ticker.ts
@@ -15,8 +15,8 @@
  *
  * `origin = 'internal'` rows are NEVER hard-evicted regardless of
  * status — internal pillars manage their own lifecycle via the
- * in-network deregister route (canonical `/registry/deregister`, legacy
- * `/core.registry.deregister`).
+ * in-network deregister route, currently `/core.registry.deregister` (the
+ * canonical `/registry/deregister` lands in a later phase).
  *
  * The router's lazy-status compute (`computeStatus` from
  * `./status.js`) flips `unavailable` after 30s of missed heartbeats;

--- a/pillars/core/src/api/modules/registry/eviction-ticker.ts
+++ b/pillars/core/src/api/modules/registry/eviction-ticker.ts
@@ -15,7 +15,8 @@
  *
  * `origin = 'internal'` rows are NEVER hard-evicted regardless of
  * status — internal pillars manage their own lifecycle via the
- * in-network `core.registry.deregister` tRPC procedure.
+ * in-network deregister route (canonical `/registry/deregister`, legacy
+ * `/core.registry.deregister`).
  *
  * The router's lazy-status compute (`computeStatus` from
  * `./status.js`) flips `unavailable` after 30s of missed heartbeats;

--- a/pillars/core/src/api/modules/registry/snapshot.ts
+++ b/pillars/core/src/api/modules/registry/snapshot.ts
@@ -1,9 +1,10 @@
 /**
  * DB-backed registry snapshot — the discovery surface every pillar reads.
  *
- * During the migration `core.registry.list` was a tRPC query; the collapsed
- * pillar serves the same snapshot as a raw `GET /core.registry.list` Express
- * route. The registry wire is raw HTTP/SSE, not a ts-rest shape — the response
+ * During the migration this snapshot was a tRPC query; the collapsed pillar
+ * serves it as a raw Express route — canonical `GET /registry/pillars`, legacy
+ * `GET /core.registry.list` still served in-cluster until the dotted shape is
+ * removed. The registry wire is raw HTTP/SSE, not a ts-rest shape — the response
  * body is the bare `{ pillars, fetchedAt }` object (no tRPC envelope), which
  * the pillar SDK's discovery transport reads directly.
  *
@@ -63,9 +64,9 @@ export function buildRegistrySnapshot(db: CoreDb, now: Date = registryNow()): Re
 }
 
 /**
- * Raw `GET /core.registry.list` handler. Returns the bare snapshot the pillar
- * SDK's `HttpDiscoveryTransport` consumes — discovery stays raw HTTP, never
- * tRPC.
+ * Raw registry-snapshot handler (canonical `GET /registry/pillars`, legacy
+ * `GET /core.registry.list`). Returns the bare snapshot the pillar SDK's
+ * `HttpDiscoveryTransport` consumes — discovery stays raw HTTP, never tRPC.
  */
 export function createRegistrySnapshotHandler(db: CoreDb): (req: Request, res: Response) => void {
   return function registrySnapshotHandler(_req: Request, res: Response): void {

--- a/pillars/core/src/api/modules/registry/snapshot.ts
+++ b/pillars/core/src/api/modules/registry/snapshot.ts
@@ -2,11 +2,12 @@
  * DB-backed registry snapshot — the discovery surface every pillar reads.
  *
  * During the migration this snapshot was a tRPC query; the collapsed pillar
- * serves it as a raw Express route — canonical `GET /registry/pillars`, legacy
- * `GET /core.registry.list` still served in-cluster until the dotted shape is
- * removed. The registry wire is raw HTTP/SSE, not a ts-rest shape — the response
- * body is the bare `{ pillars, fetchedAt }` object (no tRPC envelope), which
- * the pillar SDK's discovery transport reads directly.
+ * serves it as a raw Express route. Currently mounted only at
+ * `GET /core.registry.list` (see `pillars/core/src/api/app.ts`); the canonical
+ * slash form `GET /registry/pillars` is introduced in a later phase and is not
+ * mounted yet. The registry wire is raw HTTP/SSE, not a ts-rest shape — the
+ * response body is the bare `{ pillars, fetchedAt }` object (no tRPC envelope),
+ * which the pillar SDK's discovery transport reads directly.
  *
  * Status is computed live from `lastHeartbeatAt` on every read (`computeStatus`)
  * so consumers see the freshest state even if the background ticker lags. The
@@ -64,8 +65,9 @@ export function buildRegistrySnapshot(db: CoreDb, now: Date = registryNow()): Re
 }
 
 /**
- * Raw registry-snapshot handler (canonical `GET /registry/pillars`, legacy
- * `GET /core.registry.list`). Returns the bare snapshot the pillar SDK's
+ * Raw registry-snapshot handler, currently mounted only at
+ * `GET /core.registry.list` (the canonical `GET /registry/pillars` lands in a
+ * later phase). Returns the bare snapshot the pillar SDK's
  * `HttpDiscoveryTransport` consumes — discovery stays raw HTTP, never tRPC.
  */
 export function createRegistrySnapshotHandler(db: CoreDb): (req: Request, res: Response) => void {

--- a/pillars/core/src/api/modules/registry/types.ts
+++ b/pillars/core/src/api/modules/registry/types.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
 
 /**
- * Wire types for the registry handshake/discovery surface (PRD-161) — the raw
- * HTTP routes `/registry/{register,heartbeat,deregister,pillars}` (legacy
- * dotted aliases `/core.registry.*` still served in-cluster).
+ * Wire types for the registry handshake/discovery surface (PRD-161). Core
+ * currently mounts only the raw dotted routes
+ * `/core.registry.{register,heartbeat,deregister,list}` (see
+ * `pillars/core/src/api/app.ts`); the canonical slash form
+ * `/registry/{register,heartbeat,deregister,pillars}` is introduced in a later
+ * phase and is not mounted yet.
  *
  * The input/output zod schemas live here so the router stays focused on
  * the procedure plumbing and the tests can import the shapes directly.
@@ -92,9 +95,10 @@ export const ListOutputSchema = z.object({
 /**
  * Heartbeat wire shapes (Theme 13 PRD-162).
  *
- * Pillars POST the heartbeat route (canonical `/registry/heartbeat`, legacy
- * `/core.registry.heartbeat`) every `HEARTBEAT_INTERVAL_MS` (≈10s) with their
- * `pillarId`. The output is a discriminated union:
+ * Pillars POST the heartbeat route — currently `/core.registry.heartbeat` (the
+ * canonical `/registry/heartbeat` lands in a later phase) — every
+ * `HEARTBEAT_INTERVAL_MS` (≈10s) with their `pillarId`. The output is a
+ * discriminated union:
  *   - `ok: true`  — the heartbeat was recorded; status now `healthy`.
  *   - `ok: false` — the pillar is not registered; SDK should re-register.
  */

--- a/pillars/core/src/api/modules/registry/types.ts
+++ b/pillars/core/src/api/modules/registry/types.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 /**
- * Wire types for the `core.registry.*` tRPC surface (PRD-161).
+ * Wire types for the registry handshake/discovery surface (PRD-161) — the raw
+ * HTTP routes `/registry/{register,heartbeat,deregister,pillars}` (legacy
+ * dotted aliases `/core.registry.*` still served in-cluster).
  *
  * The input/output zod schemas live here so the router stays focused on
  * the procedure plumbing and the tests can import the shapes directly.
@@ -90,8 +92,9 @@ export const ListOutputSchema = z.object({
 /**
  * Heartbeat wire shapes (Theme 13 PRD-162).
  *
- * Pillars POST `core.registry.heartbeat({ pillar })` every
- * `HEARTBEAT_INTERVAL_MS` (≈10s). The output is a discriminated union:
+ * Pillars POST the heartbeat route (canonical `/registry/heartbeat`, legacy
+ * `/core.registry.heartbeat`) every `HEARTBEAT_INTERVAL_MS` (≈10s) with their
+ * `pillarId`. The output is a discriminated union:
  *   - `ok: true`  — the heartbeat was recorded; status now `healthy`.
  *   - `ok: false` — the pillar is not registered; SDK should re-register.
  */

--- a/pillars/core/src/api/server.ts
+++ b/pillars/core/src/api/server.ts
@@ -85,9 +85,9 @@ const stopAlertsScheduler = startAlertsScheduler(coreDb.db);
 
 // The bootstrap handshake registers core with its own registry once the
 // HTTP server is accepting traffic. Done after `app.listen` because the
-// SDK transport posts to `${registryUrl}/registry/...` and the registry
-// lives in this very process — registering before listen would race the
-// HTTP server up.
+// SDK transport posts the register/heartbeat handshake back to this very
+// process (the registry lives here) — registering before listen would race
+// the HTTP server up.
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({


### PR DESCRIPTION
## Scope — registry-cleanup **Phase 0 only** (additive prep, zero runtime behaviour change)

Stage 1a of the POPS extraction program. Introduces the shared path constants and the self-healing path resolver, and sweeps the documentation debt — **nothing is wired into routing yet**. No new routes are mounted on the core pillar, no path literals are swapped in the SDK transport/discovery, no manifest strings change. Those are Phase 1 / Phase 2.

The eventual goal (later phases, not this PR) is to de-tRPC-ify the registry handshake/discovery HTTP surface: rename the vestigial dotted routes `/core.registry.{register,heartbeat,deregister,list}` to idiomatic slash routes `/registry/{register,heartbeat,deregister,pillars}`, behind a rolling-deploy-safe dual-serve + SDK fallback window.

### What this PR adds

- **`packages/pillar-sdk/src/registry-paths.ts`** — `REGISTRY_PATHS` (canonical slash) and `LEGACY_REGISTRY_PATHS` (legacy dotted), plus `RegistryPathKey`. Exported from the SDK barrel as the single source of truth that core's route registration (Phase 1) and the SDK transport/discovery (Phase 2a) will both consume.
- **`packages/pillar-sdk/src/registry-path-resolver.ts`** — `createPathResolver(primary, fallback)` returning `candidates()` / `remember()` / `invalidate()`.
- **Barrel export** of `REGISTRY_PATHS`, `LEGACY_REGISTRY_PATHS`, `RegistryPathKey`, `createPathResolver`, `RegistryPathResolver`.
- **Doc-debt sweep** (prose only): removed the `/manifest.json` fiction from the SDK `baseUrl` JSDoc (manifests are PUSHED in the register envelope and re-served in the discovery snapshot — never pulled over HTTP) and the stale `POST /core.registry.register` reference; corrected dotted-route / tRPC prose across `bootstrap.ts`, `client/discovery.ts`, `discovery/fetcher.ts`, `discovery/snapshot-schema.ts`, the core registry `snapshot.ts` / `eviction-ticker.ts` / `types.ts`, the three `external-registry` handler docstrings, `server.ts`, and the nginx generator docstrings. Each now names the canonical slash route and notes the legacy dotted form is still accepted in-cluster until the dotted shape is removed.

Route-literal lines, the core route registrations, the manifest strings, the nginx template NOTE, and `register-with-registry.ts` are intentionally **left for later phases**.

## Self-healing fallback design

The resolver makes the cached winning path a **hint, not a lock**:

- Before resolution, `candidates()` returns `[primary, fallback]`.
- A caller tries candidates in order, `remember()`s the first 200, and `invalidate()`s on a 404 against the cached path.
- After `remember()`, `candidates()` still returns **both** paths (winner first), so a single 404 on the cached path falls through to the other candidate **within the same call** — no failed heartbeat — and `invalidate()` resets the hint so the next call re-resolves from scratch.

A naive one-shot cache would reproduce an eviction-on-rollback bug: a new-SDK pillar that cached the new path, then meets a core instance that no longer serves it (a rollback or a not-yet-rolled replica), would 404 forever and be evicted after the missed-heartbeat threshold. Keeping both candidates reachable plus invalidate-on-404 closes that gap while keeping the happy path a single request (the cached winner returns 200, the second candidate is never dialed).

## Rolling-deploy safety (the property later phases rely on)

The constants and resolver here are the foundation for the four live combinations during an independent (Watchtower) rollout, all of which must work with no atomic flip:

- **old pillar + new core** — core dual-serve (Phase 1) keeps old dotted paths live.
- **new pillar + old core** — SDK 404-fallback (Phase 2a) retries the legacy path.
- **new pillar that cached the new path, then meets a rolled-back core** — the self-healing resolver falls through in-call and re-resolves, no eviction.
- **new pillar + new core** — steady state, single request on the canonical path.

## Verification (run locally from the worktree)

- `pnpm --filter @pops/pillar-sdk build` — clean.
- `pnpm --filter @pops/pillar-sdk typecheck` — clean (exit 0).
- `pnpm --filter @pops/pillar-sdk test` — **606 passed (36 files)**, including the two new suites: `registry-paths.test.ts` (map invariants — same keys, disjoint values, canonical paths under `/registry/`) and `registry-path-resolver.test.ts` (new-path success, legacy fallback on 404, steady-state single request, and re-expansion after a cached-hint 404 — the rollback regression — driven against real resolver logic with an injected fetch, no mocks).
- Root `pnpm lint` (oxlint --type-aware) — exit 0, **zero errors**, zero warnings from the new code.
- `pnpm exec oxfmt --check packages/pillar-sdk` — clean; the other touched files format-clean too.
- Consumer typecheck: `turbo typecheck --filter=...@pops/pillar-sdk` — **32/32 tasks pass** (every pillar-sdk dependent, incl. `@pops/core` and the shell), confirming the barrel export and core docstring edits break no consumers.
- `grep '/manifest.json' packages/pillar-sdk/src` — no route-suggesting hit (GATE-0).

DO NOT MERGE without the program owner's go-ahead — this is the first node of a deploy-gated sequence.
