### PR TITLE
feat(contacts): entities domain CRUD + dotted operationIds (N1)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +203,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -454,6 +467,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +752,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +770,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -995,6 +1044,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1070,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1039,7 +1104,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1126,6 +1191,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1749,6 +1820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,10 +1903,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "whoami"
@@ -1910,6 +2095,100 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/pillars/contacts/Cargo.toml
+++ b/pillars/contacts/Cargo.toml
@@ -31,6 +31,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "test-util"] }

--- a/pillars/contacts/migrations/0002_entities.sql
+++ b/pillars/contacts/migrations/0002_entities.sql
@@ -1,0 +1,25 @@
+-- The contacts `entities` table — the authoritative contact store.
+--
+-- Column-for-column mirror of core's `entities` schema
+-- (`pillars/core/src/db/schema/entities.ts`): a contact is the superset of
+-- core's + finance's entity fields. `aliases` is opaque CSV text and
+-- `default_tags` opaque JSON text — both preserved byte-for-byte across the
+-- wire round-trip (split/join only at the serialization boundary). `notion_id`
+-- is the integration key and is UNIQUE; `owner_uri` carries the denormalized
+-- backfill pointer and is indexed for the owner_uri resolution path.
+CREATE TABLE entities (
+    id TEXT PRIMARY KEY,
+    notion_id TEXT UNIQUE,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'company',
+    abn TEXT,
+    aliases TEXT,
+    default_transaction_type TEXT,
+    default_tags TEXT,
+    notes TEXT,
+    last_edited_time TEXT NOT NULL,
+    owner_uri TEXT,
+    owner_uri_stale_at TEXT
+);
+
+CREATE INDEX idx_entities_owner_uri ON entities (owner_uri);

--- a/pillars/contacts/openapi/contacts.openapi.json
+++ b/pillars/contacts/openapi/contacts.openapi.json
@@ -1,6 +1,182 @@
 {
   "components": {
     "schemas": {
+      "CreateEntityBody": {
+        "description": "Body accepted by `POST /entities`. `type` defaults to `company`; the array\nfields default to empty.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Entity": {
+        "description": "The wire shape served by every entities route — the `toEntity` projection.\n`notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed\n(internal/integration columns), matching core's `EntitySchema`.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastEditedTime": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "aliases",
+          "defaultTags",
+          "lastEditedTime"
+        ],
+        "type": "object"
+      },
+      "EntityListResponse": {
+        "description": "`GET /entities` response body.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Entity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "EntityLookup": {
+        "description": "Wire shape of one bulk-lookup entry.",
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "aliases"
+        ],
+        "type": "object"
+      },
+      "EntityMutation": {
+        "description": "Create/update response body — the entity plus a human-readable message.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Entity"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "message"
+        ],
+        "type": "object"
+      },
+      "EntityResponse": {
+        "description": "`GET /entities/:id` response body.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Entity"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ErrorBody": {
+        "description": "Error envelope returned by every fallible route. `code` carries the\noriginating error class name (e.g. `NotFoundError`) so clients can branch\nwithout parsing `message`.",
+        "properties": {
+          "code": {
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "HealthResponse": {
         "description": "`GET /health` response body. Field-for-field identical to the TS pillar\nhealth envelope: `ok`, `status`, `pillar`, `version`, `ts` (an RFC 3339 /\nISO 8601 UTC timestamp, matching the TS `new Date().toISOString()`). The\nregistry health probe parses this shape across every pillar.",
         "properties": {
@@ -27,6 +203,215 @@
           "version",
           "ts"
         ],
+        "type": "object"
+      },
+      "LookupBody": {
+        "description": "`POST /entities/lookup` body — reserved for a future field selector; an\nempty body fetches the default match columns.",
+        "properties": {
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LookupResponse": {
+        "description": "`POST /entities/lookup` response — the whole contact set's match columns in\none round-trip, plus the fetch instant for the caller's in-run cache.",
+        "properties": {
+          "entities": {
+            "items": {
+              "$ref": "#/components/schemas/EntityLookup"
+            },
+            "type": "array"
+          },
+          "fetchedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entities",
+          "fetchedAt"
+        ],
+        "type": "object"
+      },
+      "MatchType": {
+        "enum": [
+          "exact",
+          "prefix",
+          "contains"
+        ],
+        "type": "string"
+      },
+      "MessageResponse": {
+        "description": "Bare `{ message }` body returned by delete.",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "PaginationMeta": {
+        "description": "Pagination envelope returned by every list endpoint. Mirrors core's\n`PaginationMetaSchema`.",
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "offset": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "SearchHit": {
+        "description": "One ranked search hit. `uri` is the canonical `pops:contacts/contact/<id>`.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SearchHitData"
+          },
+          "matchField": {
+            "type": "string"
+          },
+          "matchType": {
+            "$ref": "#/components/schemas/MatchType"
+          },
+          "score": {
+            "format": "double",
+            "type": "number"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "score",
+          "matchField",
+          "matchType",
+          "data"
+        ],
+        "type": "object"
+      },
+      "SearchHitData": {
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "aliases"
+        ],
+        "type": "object"
+      },
+      "SearchQuery": {
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "SearchRequest": {
+        "description": "`POST /search` request body. `query.text` is the term; `context` is\naccepted and ignored (parity with the orchestrator's wire shape).",
+        "properties": {
+          "context": {},
+          "query": {
+            "$ref": "#/components/schemas/SearchQuery"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SearchResponse": {
+        "description": "`POST /search` response body.",
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "hits"
+        ],
+        "type": "object"
+      },
+      "UpdateEntityBody": {
+        "description": "Body accepted by `PATCH /entities/:id`. Every field is optional; a present\nfield (even `null` for the nullable columns) is applied, an absent field is\nleft untouched. The nullable columns use `Option<Option<T>>` to tell\n\"absent\" (outer `None` — leave the column alone) apart from \"set to null\"\n(`Some(None)` — clear the column). serde collapses a JSON `null` into the\nouter `None` by default, so those fields deserialize through\n[`double_option`], which preserves the present-but-null case.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
         "type": "object"
       }
     }
@@ -63,6 +448,283 @@
         ]
       }
     },
+    "/entities": {
+      "get": {
+        "operationId": "entities.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityListResponse"
+                }
+              }
+            },
+            "description": "Paginated entity list"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "post": {
+        "operationId": "entities.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEntityBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityMutation"
+                }
+              }
+            },
+            "description": "Created entity"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Invalid body"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Duplicate name"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
+    "/entities/lookup": {
+      "post": {
+        "operationId": "entities.lookup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LookupBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupResponse"
+                }
+              }
+            },
+            "description": "Bulk match columns"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
+    "/entities/{id}": {
+      "delete": {
+        "operationId": "entities.delete",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "get": {
+        "operationId": "entities.get",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityResponse"
+                }
+              }
+            },
+            "description": "The entity"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "patch": {
+        "operationId": "entities.update",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEntityBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityMutation"
+                }
+              }
+            },
+            "description": "Updated entity"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Duplicate name"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
     "/health": {
       "get": {
         "operationId": "health.get",
@@ -81,6 +743,36 @@
         "summary": "Liveness probe.",
         "tags": [
           "crate::health"
+        ]
+      }
+    },
+    "/search": {
+      "post": {
+        "operationId": "search.search",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Ranked contact hits"
+          }
+        },
+        "tags": [
+          "crate::search::routes"
         ]
       }
     }

--- a/pillars/contacts/src/api.rs
+++ b/pillars/contacts/src/api.rs
@@ -1,0 +1,124 @@
+//! Shared HTTP response building blocks for the contacts API surface.
+//!
+//! The error envelope (`{ message, code? }`) and pagination meta shapes are
+//! byte-identical to core's `ErrorBodySchema` / `PaginationMetaSchema` so a
+//! consumer's generated client treats a contacts error exactly like a core
+//! one.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Error envelope returned by every fallible route. `code` carries the
+/// originating error class name (e.g. `NotFoundError`) so clients can branch
+/// without parsing `message`.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ErrorBody {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+/// A typed API error that renders to the shared `{ message, code }` envelope
+/// with the right status code.
+#[derive(Debug, Clone)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub message: String,
+    pub code: &'static str,
+}
+
+impl ApiError {
+    pub fn not_found(resource: &str, id: &str) -> Self {
+        ApiError {
+            status: StatusCode::NOT_FOUND,
+            message: format!("{resource} '{id}' not found"),
+            code: "NotFoundError",
+        }
+    }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        ApiError {
+            status: StatusCode::CONFLICT,
+            message: message.into(),
+            code: "ConflictError",
+        }
+    }
+
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        ApiError {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+            code: "BadRequestError",
+        }
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+            code: "InternalError",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorBody {
+            message: self.message,
+            code: Some(self.code.to_string()),
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+/// Pagination envelope returned by every list endpoint. Mirrors core's
+/// `PaginationMetaSchema`.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginationMeta {
+    pub total: i64,
+    pub limit: i64,
+    pub offset: i64,
+    pub has_more: bool,
+}
+
+impl PaginationMeta {
+    /// Build the envelope for a `total`-row result set returned at `limit` /
+    /// `offset`. `has_more` is true when rows remain past this page.
+    pub fn new(total: i64, limit: i64, offset: i64) -> Self {
+        PaginationMeta {
+            total,
+            limit,
+            offset,
+            has_more: offset + limit < total,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pagination_reports_more_when_rows_remain() {
+        let meta = PaginationMeta::new(10, 2, 4);
+        assert!(meta.has_more);
+        let meta = PaginationMeta::new(10, 2, 8);
+        assert!(!meta.has_more);
+        let meta = PaginationMeta::new(10, 50, 0);
+        assert!(!meta.has_more);
+    }
+
+    #[test]
+    fn error_body_omits_absent_code() {
+        let json = serde_json::to_string(&ErrorBody {
+            message: "x".to_string(),
+            code: None,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"message":"x"}"#);
+    }
+}

--- a/pillars/contacts/src/app.rs
+++ b/pillars/contacts/src/app.rs
@@ -22,13 +22,17 @@ async fn openapi_document() -> impl IntoResponse {
     ([(CONTENT_TYPE, "application/json")], openapi_30_json())
 }
 
-/// Build the contacts router. N0 mounts the root banner, `/health`, and
-/// `/openapi`; entities/search/settings routers mount here in later nodes.
+/// Build the contacts router. Mounts the root banner, `/health`, `/openapi`,
+/// the entities CRUD + bulk-lookup surface (N1), and the search slice (N1);
+/// the registry lifecycle, URI resolve, and settings routers join in later
+/// nodes.
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/", get(root))
         .route("/health", get(health))
         .route("/openapi", get(openapi_document))
+        .merge(crate::entities::router())
+        .merge(crate::search::router())
         .with_state(state)
 }
 

--- a/pillars/contacts/src/entities/mod.rs
+++ b/pillars/contacts/src/entities/mod.rs
@@ -1,0 +1,13 @@
+//! The entities (contact) domain — the contacts pillar's authoritative store.
+//!
+//! - [`model`] — wire ↔ row mapping and the request/response body shapes.
+//! - [`repo`] — parameterized data access (list/get/create/update/delete plus
+//!   the bulk lookup and find-by-name idempotency helpers).
+//! - [`routes`] — the axum handlers carrying the DOTTED `entities.*`
+//!   operationIds.
+
+pub mod model;
+pub mod repo;
+pub mod routes;
+
+pub use routes::router;

--- a/pillars/contacts/src/entities/model.rs
+++ b/pillars/contacts/src/entities/model.rs
@@ -1,0 +1,282 @@
+//! Wire ↔ row mapping for the entities (contact) domain.
+//!
+//! The wire [`Entity`] is camelCase JSON with `aliases`/`defaultTags` as string
+//! arrays; the stored [`EntityRow`] is snake_case with `aliases` as opaque CSV
+//! and `default_tags` as opaque JSON text. The two array columns are encoded
+//! exactly as core's TS service encodes them (`join(', ')` for aliases,
+//! `JSON.stringify` for tags) so a migrated row round-trips byte-for-byte and a
+//! contact created here reads identically in any other consumer.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The entity discriminator. Mirrors `ENTITY_TYPES` in core's contract; a
+/// contact is the superset of core's + finance's entities so the full set is
+/// accepted. Stored verbatim as the `type` column (no enum coercion at the DB
+/// layer — validation happens at the route boundary).
+pub const ENTITY_TYPES: [&str; 7] = [
+    "company",
+    "person",
+    "government",
+    "bank",
+    "place",
+    "brand",
+    "organisation",
+];
+
+/// Default `type` applied when a create omits it. Matches the core column
+/// default and the TS `CreateEntityBody` default.
+pub const DEFAULT_ENTITY_TYPE: &str = "company";
+
+/// The wire shape served by every entities route — the `toEntity` projection.
+/// `notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed
+/// (internal/integration columns), matching core's `EntitySchema`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Entity {
+    pub id: String,
+    pub name: String,
+    pub r#type: String,
+    pub abn: Option<String>,
+    pub aliases: Vec<String>,
+    pub default_transaction_type: Option<String>,
+    pub default_tags: Vec<String>,
+    pub notes: Option<String>,
+    pub last_edited_time: String,
+}
+
+/// A row as stored in the `entities` table. `aliases` is CSV, `default_tags`
+/// is a JSON array string; both are decoded only when projecting to [`Entity`].
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EntityRow {
+    pub id: String,
+    pub name: String,
+    pub r#type: String,
+    pub abn: Option<String>,
+    pub aliases: Option<String>,
+    pub default_transaction_type: Option<String>,
+    pub default_tags: Option<String>,
+    pub notes: Option<String>,
+    pub last_edited_time: String,
+}
+
+impl From<EntityRow> for Entity {
+    fn from(row: EntityRow) -> Self {
+        Entity {
+            id: row.id,
+            name: row.name,
+            r#type: row.r#type,
+            abn: row.abn,
+            aliases: decode_aliases(row.aliases.as_deref()),
+            default_transaction_type: row.default_transaction_type,
+            default_tags: decode_default_tags(row.default_tags.as_deref()),
+            notes: row.notes,
+            last_edited_time: row.last_edited_time,
+        }
+    }
+}
+
+/// Match-relevant slice of a contact returned by the bulk lookup — the finance
+/// import matcher only needs `id`, `name`, and `aliases`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EntityLookupRow {
+    pub id: String,
+    pub name: String,
+    pub aliases: Option<String>,
+}
+
+/// Wire shape of one bulk-lookup entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityLookup {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+}
+
+impl From<EntityLookupRow> for EntityLookup {
+    fn from(row: EntityLookupRow) -> Self {
+        EntityLookup {
+            id: row.id,
+            name: row.name,
+            aliases: decode_aliases(row.aliases.as_deref()),
+        }
+    }
+}
+
+/// Decode the CSV `aliases` column into a trimmed, empty-filtered vector.
+/// Mirrors core's `parseAliases`: split on `,`, trim, drop empties.
+pub fn decode_aliases(raw: Option<&str>) -> Vec<String> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Encode an alias vector to the CSV column value (`join(', ')`), or `None`
+/// when empty — matching core's `aliases?.length ? aliases.join(', ') : null`.
+pub fn encode_aliases(aliases: &[String]) -> Option<String> {
+    if aliases.is_empty() {
+        None
+    } else {
+        Some(aliases.join(", "))
+    }
+}
+
+/// Decode the JSON `default_tags` column. A non-array / malformed value yields
+/// an empty vector rather than erroring — the column is best-effort denorm.
+pub fn decode_default_tags(raw: Option<&str>) -> Vec<String> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+    serde_json::from_str::<Vec<String>>(raw).unwrap_or_default()
+}
+
+/// Encode a tag vector to the JSON column value (`JSON.stringify`), or `None`
+/// when empty — matching core's `defaultTags?.length ? JSON.stringify(...) : null`.
+pub fn encode_default_tags(tags: &[String]) -> Option<String> {
+    if tags.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(tags).expect("string vector serializes to a JSON array"))
+    }
+}
+
+/// Body accepted by `POST /entities`. `type` defaults to `company`; the array
+/// fields default to empty.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateEntityBody {
+    pub name: String,
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub abn: Option<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub default_transaction_type: Option<String>,
+    #[serde(default)]
+    pub default_tags: Vec<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// Body accepted by `PATCH /entities/:id`. Every field is optional; a present
+/// field (even `null` for the nullable columns) is applied, an absent field is
+/// left untouched. The nullable columns use `Option<Option<T>>` to tell
+/// "absent" (outer `None` — leave the column alone) apart from "set to null"
+/// (`Some(None)` — clear the column). serde collapses a JSON `null` into the
+/// outer `None` by default, so those fields deserialize through
+/// [`double_option`], which preserves the present-but-null case.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateEntityBody {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub r#type: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    #[schema(value_type = Option<String>)]
+    pub abn: Option<Option<String>>,
+    #[serde(default)]
+    pub aliases: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "double_option")]
+    #[schema(value_type = Option<String>)]
+    pub default_transaction_type: Option<Option<String>>,
+    #[serde(default)]
+    pub default_tags: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "double_option")]
+    #[schema(value_type = Option<String>)]
+    pub notes: Option<Option<String>>,
+}
+
+/// Deserialize a present field into `Some(...)` even when its value is JSON
+/// `null` (yielding `Some(None)`), so a PATCH can distinguish clearing a
+/// nullable column from leaving it untouched. Absent fields use the field's
+/// `#[serde(default)]`, which is the outer `None`.
+fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliases_round_trip_preserves_values() {
+        let aliases = vec!["Acme".to_string(), "ACME Corp".to_string()];
+        let encoded = encode_aliases(&aliases);
+        assert_eq!(encoded.as_deref(), Some("Acme, ACME Corp"));
+        assert_eq!(decode_aliases(encoded.as_deref()), aliases);
+    }
+
+    #[test]
+    fn empty_aliases_encode_to_null() {
+        assert_eq!(encode_aliases(&[]), None);
+        assert_eq!(decode_aliases(None), Vec::<String>::new());
+    }
+
+    #[test]
+    fn aliases_decode_trims_and_drops_empties() {
+        assert_eq!(
+            decode_aliases(Some(" a ,, b ,")),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn default_tags_round_trip_is_json() {
+        let tags = vec!["food".to_string(), "rent".to_string()];
+        let encoded = encode_default_tags(&tags);
+        assert_eq!(encoded.as_deref(), Some(r#"["food","rent"]"#));
+        assert_eq!(decode_default_tags(encoded.as_deref()), tags);
+    }
+
+    #[test]
+    fn malformed_default_tags_decode_to_empty() {
+        assert_eq!(decode_default_tags(Some("not json")), Vec::<String>::new());
+        assert_eq!(decode_default_tags(None), Vec::<String>::new());
+    }
+
+    #[test]
+    fn patch_distinguishes_absent_from_null() {
+        let absent: UpdateEntityBody = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            absent.abn, None,
+            "an absent field leaves the column untouched"
+        );
+
+        let cleared: UpdateEntityBody = serde_json::from_str(r#"{"abn":null}"#).unwrap();
+        assert_eq!(cleared.abn, Some(None), "a present null clears the column");
+
+        let set: UpdateEntityBody = serde_json::from_str(r#"{"abn":"123"}"#).unwrap();
+        assert_eq!(set.abn, Some(Some("123".to_string())));
+    }
+
+    #[test]
+    fn row_projects_to_wire_entity() {
+        let row = EntityRow {
+            id: "e1".to_string(),
+            name: "Acme".to_string(),
+            r#type: "company".to_string(),
+            abn: Some("123".to_string()),
+            aliases: Some("Acme, ACME Corp".to_string()),
+            default_transaction_type: None,
+            default_tags: Some(r#"["x"]"#.to_string()),
+            notes: None,
+            last_edited_time: "2026-06-21T00:00:00.000Z".to_string(),
+        };
+        let entity: Entity = row.into();
+        assert_eq!(entity.aliases, vec!["Acme", "ACME Corp"]);
+        assert_eq!(entity.default_tags, vec!["x"]);
+        assert_eq!(entity.r#type, "company");
+    }
+}

--- a/pillars/contacts/src/entities/repo.rs
+++ b/pillars/contacts/src/entities/repo.rs
@@ -1,0 +1,511 @@
+//! Data access for the entities domain.
+//!
+//! Every query is parameterized — values are bound, never interpolated into
+//! SQL — so the layer is injection-safe. (The N1 node uses sqlx's runtime
+//! query API rather than the compile-time `query!` macros: the macros require
+//! a build-time database or a committed `.sqlx/` offline cache, and neither the
+//! offline cache nor `sqlx-cli` lands until the Phase 6 toolchain node. The
+//! conversion to compile-time-checked queries rides that node.)
+//!
+//! Create/update semantics mirror core's `entities/service.ts` exactly:
+//! name-uniqueness raises a conflict, `last_edited_time` is bumped to the
+//! current instant on create and on any non-empty update, and ordering is
+//! case-insensitive by name.
+
+use sqlx::{Row, SqlitePool};
+
+use super::model::{
+    encode_aliases, encode_default_tags, CreateEntityBody, EntityLookupRow, EntityRow,
+    UpdateEntityBody, DEFAULT_ENTITY_TYPE,
+};
+use crate::time::now_rfc3339;
+
+/// Search-candidate slice of a contact (`id`, `name`, `type`, `aliases`) — the
+/// columns the search ranker and hit projection need.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EntityNameRow {
+    pub id: String,
+    pub name: String,
+    pub r#type: String,
+    pub aliases: Option<String>,
+}
+
+/// Failure modes of a write that are NOT raw SQL errors.
+#[derive(Debug)]
+pub enum RepoError {
+    /// A unique-name (or `notion_id`) constraint was violated.
+    Conflict(String),
+    /// The addressed entity does not exist.
+    NotFound,
+    /// An underlying sqlx failure.
+    Db(sqlx::Error),
+}
+
+impl From<sqlx::Error> for RepoError {
+    fn from(err: sqlx::Error) -> Self {
+        RepoError::Db(err)
+    }
+}
+
+const SELECT_COLUMNS: &str = "id, name, type, abn, aliases, default_transaction_type, \
+     default_tags, notes, last_edited_time";
+
+/// List entities filtered by an optional case-insensitive name `search` and an
+/// optional exact `type`, ordered case-insensitively by name, with `limit` /
+/// `offset` pagination. Returns the page plus the total matching count.
+pub async fn list(
+    pool: &SqlitePool,
+    search: Option<&str>,
+    ty: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> Result<(Vec<EntityRow>, i64), sqlx::Error> {
+    let like = search.map(|s| format!("%{s}%"));
+
+    let rows_sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM entities \
+         WHERE (?1 IS NULL OR name LIKE ?1) AND (?2 IS NULL OR type = ?2) \
+         ORDER BY name COLLATE NOCASE LIMIT ?3 OFFSET ?4"
+    );
+    let rows = sqlx::query_as::<_, EntityRow>(&rows_sql)
+        .bind(like.as_deref())
+        .bind(ty)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+
+    let total: i64 = sqlx::query(
+        "SELECT COUNT(*) AS total FROM entities \
+         WHERE (?1 IS NULL OR name LIKE ?1) AND (?2 IS NULL OR type = ?2)",
+    )
+    .bind(like.as_deref())
+    .bind(ty)
+    .fetch_one(pool)
+    .await?
+    .get("total");
+
+    Ok((rows, total))
+}
+
+/// Fetch one entity by id, or `None` if it does not exist.
+pub async fn get(pool: &SqlitePool, id: &str) -> Result<Option<EntityRow>, sqlx::Error> {
+    let sql = format!("SELECT {SELECT_COLUMNS} FROM entities WHERE id = ?1");
+    sqlx::query_as::<_, EntityRow>(&sql)
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Fetch one entity by exact name, or `None`. Backs the finance commit
+/// create-or-fetch-by-name idempotency path (a 409 on create fetches here).
+pub async fn find_by_name(pool: &SqlitePool, name: &str) -> Result<Option<EntityRow>, sqlx::Error> {
+    let sql = format!("SELECT {SELECT_COLUMNS} FROM entities WHERE name = ?1");
+    sqlx::query_as::<_, EntityRow>(&sql)
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Insert a new entity. The name must be unique (a duplicate raises
+/// [`RepoError::Conflict`]). A v4 UUID id and the current `last_edited_time`
+/// are generated server-side.
+pub async fn create(pool: &SqlitePool, body: CreateEntityBody) -> Result<EntityRow, RepoError> {
+    if name_exists(pool, &body.name, None).await? {
+        return Err(RepoError::Conflict(format!(
+            "Entity with name '{}' already exists",
+            body.name
+        )));
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = now_rfc3339();
+    let ty = body
+        .r#type
+        .unwrap_or_else(|| DEFAULT_ENTITY_TYPE.to_string());
+
+    sqlx::query(
+        "INSERT INTO entities \
+         (id, name, type, abn, aliases, default_transaction_type, default_tags, notes, last_edited_time) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+    )
+    .bind(&id)
+    .bind(&body.name)
+    .bind(&ty)
+    .bind(body.abn.as_deref())
+    .bind(encode_aliases(&body.aliases))
+    .bind(body.default_transaction_type.as_deref())
+    .bind(encode_default_tags(&body.default_tags))
+    .bind(body.notes.as_deref())
+    .bind(&now)
+    .execute(pool)
+    .await?;
+
+    get(pool, &id).await?.ok_or(RepoError::NotFound)
+}
+
+/// Apply a partial update. Absent fields are left untouched; a present nullable
+/// field set to `null` clears the column. A rename to a name another entity
+/// already owns raises [`RepoError::Conflict`]. `last_edited_time` is bumped
+/// only when at least one column actually changes.
+pub async fn update(
+    pool: &SqlitePool,
+    id: &str,
+    patch: UpdateEntityBody,
+) -> Result<EntityRow, RepoError> {
+    if get(pool, id).await?.is_none() {
+        return Err(RepoError::NotFound);
+    }
+    if let Some(name) = patch.name.as_deref() {
+        if name_exists(pool, name, Some(id)).await? {
+            return Err(RepoError::Conflict(format!(
+                "Entity with name '{name}' already exists"
+            )));
+        }
+    }
+
+    let mut builder = UpdateBuilder::new();
+    if let Some(name) = &patch.name {
+        builder.set_text("name", name.clone());
+    }
+    if let Some(ty) = &patch.r#type {
+        builder.set_text("type", ty.clone());
+    }
+    if let Some(abn) = &patch.abn {
+        builder.set_nullable("abn", abn.clone());
+    }
+    if let Some(dtt) = &patch.default_transaction_type {
+        builder.set_nullable("default_transaction_type", dtt.clone());
+    }
+    if let Some(notes) = &patch.notes {
+        builder.set_nullable("notes", notes.clone());
+    }
+    if let Some(aliases) = &patch.aliases {
+        builder.set_nullable("aliases", encode_aliases(aliases));
+    }
+    if let Some(tags) = &patch.default_tags {
+        builder.set_nullable("default_tags", encode_default_tags(tags));
+    }
+
+    if !builder.is_empty() {
+        builder.execute(pool, id).await?;
+    }
+
+    get(pool, id).await?.ok_or(RepoError::NotFound)
+}
+
+/// Delete an entity by id. Returns `true` if a row was removed, `false` if no
+/// entity had that id.
+pub async fn delete(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM entities WHERE id = ?1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Return the whole contact set's match-relevant columns (`id`, `name`,
+/// `aliases`) in one round-trip. Backs the finance import matcher and the
+/// entity-usage rollup.
+pub async fn lookup_bulk(pool: &SqlitePool) -> Result<Vec<EntityLookupRow>, sqlx::Error> {
+    sqlx::query_as::<_, EntityLookupRow>(
+        "SELECT id, name, aliases FROM entities ORDER BY name COLLATE NOCASE",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Candidate rows for a name search — every entity whose name matches the
+/// `LIKE %text%` scan. Scoring/classification happens above the repo.
+pub async fn search_candidates(
+    pool: &SqlitePool,
+    text: &str,
+) -> Result<Vec<EntityNameRow>, sqlx::Error> {
+    let like = format!("%{text}%");
+    sqlx::query_as::<_, EntityNameRow>(
+        "SELECT id, name, type, aliases FROM entities WHERE name LIKE ?1",
+    )
+    .bind(like)
+    .fetch_all(pool)
+    .await
+}
+
+/// Whether an entity with `name` exists, optionally excluding the row `exclude`
+/// (so a no-op rename of an entity to its own name is not a conflict).
+async fn name_exists(
+    pool: &SqlitePool,
+    name: &str,
+    exclude: Option<&str>,
+) -> Result<bool, sqlx::Error> {
+    let found: Option<String> = sqlx::query_scalar(
+        "SELECT id FROM entities WHERE name = ?1 AND (?2 IS NULL OR id <> ?2) LIMIT 1",
+    )
+    .bind(name)
+    .bind(exclude)
+    .fetch_optional(pool)
+    .await?;
+    Ok(found.is_some())
+}
+
+/// Accumulates `SET col = ?` assignments for a partial update so the statement
+/// only touches the columns the patch actually changed, then appends the
+/// `last_edited_time` bump. Each value is bound, never interpolated.
+struct UpdateBuilder {
+    assignments: Vec<String>,
+    text_binds: Vec<(usize, String)>,
+    nullable_binds: Vec<(usize, Option<String>)>,
+}
+
+impl UpdateBuilder {
+    fn new() -> Self {
+        UpdateBuilder {
+            assignments: Vec::new(),
+            text_binds: Vec::new(),
+            nullable_binds: Vec::new(),
+        }
+    }
+
+    fn next_index(&self) -> usize {
+        self.assignments.len() + 1
+    }
+
+    fn set_text(&mut self, column: &str, value: String) {
+        let idx = self.next_index();
+        self.assignments.push(format!("{column} = ?{idx}"));
+        self.text_binds.push((idx, value));
+    }
+
+    fn set_nullable(&mut self, column: &str, value: Option<String>) {
+        let idx = self.next_index();
+        self.assignments.push(format!("{column} = ?{idx}"));
+        self.nullable_binds.push((idx, value));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.assignments.is_empty()
+    }
+
+    async fn execute(self, pool: &SqlitePool, id: &str) -> Result<(), sqlx::Error> {
+        let stamp_idx = self.next_index();
+        let id_idx = stamp_idx + 1;
+        let mut clauses = self.assignments.clone();
+        clauses.push(format!("last_edited_time = ?{stamp_idx}"));
+        let sql = format!(
+            "UPDATE entities SET {} WHERE id = ?{id_idx}",
+            clauses.join(", ")
+        );
+
+        let mut ordered: Vec<(usize, Option<String>)> = self
+            .text_binds
+            .into_iter()
+            .map(|(i, v)| (i, Some(v)))
+            .chain(self.nullable_binds)
+            .collect();
+        ordered.sort_by_key(|(i, _)| *i);
+
+        let mut query = sqlx::query(&sql);
+        for (_, value) in ordered {
+            query = query.bind(value);
+        }
+        query = query.bind(now_rfc3339()).bind(id);
+        query.execute(pool).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use crate::entities::model::Entity;
+
+    async fn pool() -> SqlitePool {
+        db::connect("sqlite::memory:")
+            .await
+            .expect("in-memory pool connects and migrates")
+    }
+
+    fn body(name: &str) -> CreateEntityBody {
+        CreateEntityBody {
+            name: name.to_string(),
+            r#type: None,
+            abn: None,
+            aliases: Vec::new(),
+            default_transaction_type: None,
+            default_tags: Vec::new(),
+            notes: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_assigns_id_default_type_and_timestamp() {
+        let pool = pool().await;
+        let row = create(&pool, body("Acme")).await.expect("create");
+        assert!(!row.id.is_empty());
+        assert_eq!(row.r#type, "company");
+        assert!(row.last_edited_time.ends_with('Z'));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_duplicate_name() {
+        let pool = pool().await;
+        create(&pool, body("Acme")).await.expect("first create");
+        let err = create(&pool, body("Acme")).await.unwrap_err();
+        assert!(matches!(err, RepoError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_search_and_type_and_orders_case_insensitively() {
+        let pool = pool().await;
+        for (name, ty) in [
+            ("zebra", "company"),
+            ("Apple", "person"),
+            ("apricot", "company"),
+        ] {
+            let mut b = body(name);
+            b.r#type = Some(ty.to_string());
+            create(&pool, b).await.expect("create");
+        }
+
+        let (rows, total) = list(&pool, None, None, 50, 0).await.expect("list all");
+        assert_eq!(total, 3);
+        let names: Vec<&str> = rows.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["Apple", "apricot", "zebra"]);
+
+        let (rows, total) = list(&pool, Some("ap"), None, 50, 0)
+            .await
+            .expect("list search");
+        assert_eq!(total, 2);
+        assert_eq!(rows.len(), 2);
+
+        let (rows, total) = list(&pool, None, Some("person"), 50, 0)
+            .await
+            .expect("list type");
+        assert_eq!(total, 1);
+        assert_eq!(rows[0].name, "Apple");
+    }
+
+    #[tokio::test]
+    async fn list_paginates() {
+        let pool = pool().await;
+        for n in 0..5 {
+            create(&pool, body(&format!("e{n}"))).await.expect("create");
+        }
+        let (rows, total) = list(&pool, None, None, 2, 2).await.expect("page");
+        assert_eq!(total, 5);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "e2");
+        assert_eq!(rows[1].name, "e3");
+    }
+
+    #[tokio::test]
+    async fn update_applies_partial_changes_and_bumps_timestamp() {
+        let pool = pool().await;
+        let created = create(&pool, body("Acme")).await.expect("create");
+
+        let patch = UpdateEntityBody {
+            notes: Some(Some("hello".to_string())),
+            ..Default::default()
+        };
+        let updated = update(&pool, &created.id, patch).await.expect("update");
+        assert_eq!(updated.notes.as_deref(), Some("hello"));
+        assert_eq!(updated.name, "Acme");
+        assert!(updated.last_edited_time >= created.last_edited_time);
+    }
+
+    #[tokio::test]
+    async fn update_can_clear_a_nullable_field() {
+        let pool = pool().await;
+        let mut b = body("Acme");
+        b.abn = Some("123".to_string());
+        let created = create(&pool, b).await.expect("create");
+        assert_eq!(created.abn.as_deref(), Some("123"));
+
+        let patch = UpdateEntityBody {
+            abn: Some(None),
+            ..Default::default()
+        };
+        let updated = update(&pool, &created.id, patch).await.expect("update");
+        assert_eq!(updated.abn, None);
+    }
+
+    #[tokio::test]
+    async fn update_rejects_rename_to_existing_name() {
+        let pool = pool().await;
+        create(&pool, body("Acme")).await.expect("create a");
+        let b = create(&pool, body("Beta")).await.expect("create b");
+
+        let patch = UpdateEntityBody {
+            name: Some("Acme".to_string()),
+            ..Default::default()
+        };
+        let err = update(&pool, &b.id, patch).await.unwrap_err();
+        assert!(matches!(err, RepoError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn update_allows_renaming_an_entity_to_its_own_name() {
+        let pool = pool().await;
+        let created = create(&pool, body("Acme")).await.expect("create");
+        let patch = UpdateEntityBody {
+            name: Some("Acme".to_string()),
+            ..Default::default()
+        };
+        let updated = update(&pool, &created.id, patch).await.expect("update");
+        assert_eq!(updated.name, "Acme");
+    }
+
+    #[tokio::test]
+    async fn update_missing_entity_is_not_found() {
+        let pool = pool().await;
+        let err = update(&pool, "nope", UpdateEntityBody::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RepoError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn delete_reports_whether_a_row_was_removed() {
+        let pool = pool().await;
+        let created = create(&pool, body("Acme")).await.expect("create");
+        assert!(delete(&pool, &created.id).await.expect("delete"));
+        assert!(!delete(&pool, &created.id).await.expect("delete again"));
+        assert!(get(&pool, &created.id).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_bulk_returns_match_columns() {
+        let pool = pool().await;
+        let mut b = body("Acme");
+        b.aliases = vec!["ACME Corp".to_string()];
+        create(&pool, b).await.expect("create");
+        let rows = lookup_bulk(&pool).await.expect("lookup");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "Acme");
+        assert_eq!(rows[0].aliases.as_deref(), Some("ACME Corp"));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_round_trips() {
+        let pool = pool().await;
+        create(&pool, body("Acme")).await.expect("create");
+        assert!(find_by_name(&pool, "Acme").await.expect("find").is_some());
+        assert!(find_by_name(&pool, "Nope").await.expect("find").is_none());
+    }
+
+    #[tokio::test]
+    async fn aliases_and_tags_survive_a_db_round_trip() {
+        let pool = pool().await;
+        let mut b = body("Acme");
+        b.aliases = vec!["a".to_string(), "b".to_string()];
+        b.default_tags = vec!["food".to_string()];
+        let created = create(&pool, b).await.expect("create");
+        let fetched = get(&pool, &created.id)
+            .await
+            .expect("get")
+            .expect("present");
+        let entity: Entity = fetched.into();
+        assert_eq!(entity.aliases, vec!["a", "b"]);
+        assert_eq!(entity.default_tags, vec!["food"]);
+    }
+}

--- a/pillars/contacts/src/entities/routes.rs
+++ b/pillars/contacts/src/entities/routes.rs
@@ -1,0 +1,297 @@
+//! Axum routes for the entities (contact) CRUD surface + bulk lookup.
+//!
+//! Every `#[utoipa::path]` pins `operation_id` to the DOTTED `<router>.<proc>`
+//! string (`entities.list`, `entities.create`, …). This is load-bearing: the
+//! SDK route map keys on the dotted operationId and hey-api derives the
+//! camelCase client method names from it, so a derived (Rust fn name) id would
+//! silently break every consumer. utoipa's default id is the fn name and
+//! cannot contain a dot, hence the explicit override on each route.
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+use super::model::{CreateEntityBody, Entity, EntityLookup, UpdateEntityBody, ENTITY_TYPES};
+use super::repo;
+use crate::api::{ApiError, PaginationMeta};
+use crate::app::AppState;
+use crate::time::now_rfc3339;
+
+/// Default page size when `limit` is omitted, matching the core entities list.
+const DEFAULT_LIMIT: i64 = 50;
+/// Hard cap on `limit` so a caller cannot request an unbounded page.
+const MAX_LIMIT: i64 = 200;
+
+/// Query params for `GET /entities`.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQuery {
+    pub search: Option<String>,
+    #[param(rename = "type")]
+    pub r#type: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// `GET /entities` response body.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct EntityListResponse {
+    pub data: Vec<Entity>,
+    pub pagination: PaginationMeta,
+}
+
+/// `GET /entities/:id` response body.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct EntityResponse {
+    pub data: Entity,
+}
+
+/// Create/update response body — the entity plus a human-readable message.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct EntityMutation {
+    pub data: Entity,
+    pub message: String,
+}
+
+/// Bare `{ message }` body returned by delete.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct MessageResponse {
+    pub message: String,
+}
+
+/// `POST /entities/lookup` body — reserved for a future field selector; an
+/// empty body fetches the default match columns.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+pub struct LookupBody {
+    #[serde(default)]
+    pub fields: Option<Vec<String>>,
+}
+
+/// `POST /entities/lookup` response — the whole contact set's match columns in
+/// one round-trip, plus the fetch instant for the caller's in-run cache.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LookupResponse {
+    pub entities: Vec<EntityLookup>,
+    pub fetched_at: String,
+}
+
+/// Mount the entities routes onto a router sharing [`AppState`].
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/entities", get(list).post(create))
+        .route(
+            "/entities/:id",
+            get(get_one).patch(update).delete(delete_one),
+        )
+        .route("/entities/lookup", post(lookup))
+}
+
+#[utoipa::path(
+    get,
+    path = "/entities",
+    operation_id = "entities.list",
+    params(ListQuery),
+    responses((status = 200, description = "Paginated entity list", body = EntityListResponse))
+)]
+pub async fn list(
+    State(state): State<AppState>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<EntityListResponse>, ApiError> {
+    if let Some(ty) = query.r#type.as_deref() {
+        validate_type(ty)?;
+    }
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = query.offset.unwrap_or(0).max(0);
+
+    let (rows, total) = repo::list(
+        &state.pool,
+        query.search.as_deref(),
+        query.r#type.as_deref(),
+        limit,
+        offset,
+    )
+    .await
+    .map_err(db_error)?;
+
+    Ok(Json(EntityListResponse {
+        data: rows.into_iter().map(Entity::from).collect(),
+        pagination: PaginationMeta::new(total, limit, offset),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/entities/{id}",
+    operation_id = "entities.get",
+    params(("id" = String, Path, description = "Entity id")),
+    responses(
+        (status = 200, description = "The entity", body = EntityResponse),
+        (status = 404, description = "No such entity", body = crate::api::ErrorBody)
+    )
+)]
+pub async fn get_one(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<EntityResponse>, ApiError> {
+    let row = repo::get(&state.pool, &id)
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| ApiError::not_found("Entity", &id))?;
+    Ok(Json(EntityResponse { data: row.into() }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/entities",
+    operation_id = "entities.create",
+    request_body = CreateEntityBody,
+    responses(
+        (status = 201, description = "Created entity", body = EntityMutation),
+        (status = 400, description = "Invalid body", body = crate::api::ErrorBody),
+        (status = 409, description = "Duplicate name", body = crate::api::ErrorBody)
+    )
+)]
+pub async fn create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateEntityBody>,
+) -> Result<(StatusCode, Json<EntityMutation>), ApiError> {
+    if body.name.trim().is_empty() {
+        return Err(ApiError::bad_request("Name is required"));
+    }
+    if let Some(ty) = body.r#type.as_deref() {
+        validate_type(ty)?;
+    }
+
+    let row = repo::create(&state.pool, body).await.map_err(repo_error)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(EntityMutation {
+            data: row.into(),
+            message: "Entity created".to_string(),
+        }),
+    ))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/entities/{id}",
+    operation_id = "entities.update",
+    params(("id" = String, Path, description = "Entity id")),
+    request_body = UpdateEntityBody,
+    responses(
+        (status = 200, description = "Updated entity", body = EntityMutation),
+        (status = 404, description = "No such entity", body = crate::api::ErrorBody),
+        (status = 409, description = "Duplicate name", body = crate::api::ErrorBody)
+    )
+)]
+pub async fn update(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(patch): Json<UpdateEntityBody>,
+) -> Result<Json<EntityMutation>, ApiError> {
+    if let Some(name) = patch.name.as_deref() {
+        if name.trim().is_empty() {
+            return Err(ApiError::bad_request("Name cannot be empty"));
+        }
+    }
+    if let Some(ty) = patch.r#type.as_deref() {
+        validate_type(ty)?;
+    }
+
+    let row = repo::update(&state.pool, &id, patch)
+        .await
+        .map_err(|err| repo_not_found(err, &id))?;
+    Ok(Json(EntityMutation {
+        data: row.into(),
+        message: "Entity updated".to_string(),
+    }))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/entities/{id}",
+    operation_id = "entities.delete",
+    params(("id" = String, Path, description = "Entity id")),
+    responses(
+        (status = 200, description = "Deleted", body = MessageResponse),
+        (status = 404, description = "No such entity", body = crate::api::ErrorBody)
+    )
+)]
+pub async fn delete_one(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<MessageResponse>, ApiError> {
+    let removed = repo::delete(&state.pool, &id).await.map_err(db_error)?;
+    if !removed {
+        return Err(ApiError::not_found("Entity", &id));
+    }
+    Ok(Json(MessageResponse {
+        message: "Entity deleted".to_string(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/entities/lookup",
+    operation_id = "entities.lookup",
+    request_body = LookupBody,
+    responses((status = 200, description = "Bulk match columns", body = LookupResponse))
+)]
+pub async fn lookup(
+    State(state): State<AppState>,
+    body: Option<Json<LookupBody>>,
+) -> Result<Json<LookupResponse>, ApiError> {
+    let _ = body;
+    let rows = repo::lookup_bulk(&state.pool).await.map_err(db_error)?;
+    Ok(Json(LookupResponse {
+        entities: rows.into_iter().map(EntityLookup::from).collect(),
+        fetched_at: now_rfc3339(),
+    }))
+}
+
+/// Reject a `type` value outside the accepted entity discriminator set with a
+/// 400, listing the legal values.
+fn validate_type(ty: &str) -> Result<(), ApiError> {
+    if ENTITY_TYPES.contains(&ty) {
+        Ok(())
+    } else {
+        Err(ApiError::bad_request(format!(
+            "Invalid type '{ty}'. Expected one of: {}",
+            ENTITY_TYPES.join(", ")
+        )))
+    }
+}
+
+fn db_error(err: sqlx::Error) -> ApiError {
+    ApiError::internal(err.to_string())
+}
+
+fn repo_error(err: repo::RepoError) -> ApiError {
+    match err {
+        repo::RepoError::Conflict(message) => ApiError::conflict(message),
+        repo::RepoError::NotFound => ApiError::not_found("Entity", "unknown"),
+        repo::RepoError::Db(e) => db_error(e),
+    }
+}
+
+fn repo_not_found(err: repo::RepoError, id: &str) -> ApiError {
+    match err {
+        repo::RepoError::NotFound => ApiError::not_found("Entity", id),
+        other => repo_error(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unknown_type() {
+        assert!(validate_type("wizard").is_err());
+        assert!(validate_type("person").is_ok());
+    }
+}

--- a/pillars/contacts/src/health.rs
+++ b/pillars/contacts/src/health.rs
@@ -2,13 +2,12 @@
 //! serves (`ok`, `status`, `pillar`, `version`, `ts`) so the registry health
 //! check and the shell treat contacts identically.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use axum::Json;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::app::AppState;
+use crate::time::now_rfc3339;
 
 /// `GET /health` response body. Field-for-field identical to the TS pillar
 /// health envelope: `ok`, `status`, `pillar`, `version`, `ts` (an RFC 3339 /
@@ -52,89 +51,4 @@ pub async fn health(
 )]
 pub async fn root() -> &'static str {
     "pops contacts pillar"
-}
-
-/// Current UTC time as an RFC 3339 / ISO 8601 string with millisecond
-/// precision and a `Z` offset, e.g. `2026-06-21T09:24:33.482Z`.
-///
-/// Mirrors the TS pillars' `new Date().toISOString()`. Implemented against
-/// `std` (no chrono/time dependency) via the civil-from-days algorithm so the
-/// reference pillar carries no extra crate just to stamp a timestamp.
-fn now_rfc3339() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
-    format_rfc3339_millis(now.as_secs() as i64, now.subsec_millis())
-}
-
-/// Format `unix_secs` (seconds since the Unix epoch, UTC) plus `millis` as an
-/// RFC 3339 UTC string. Split out from `now_rfc3339` so it is deterministically
-/// testable.
-fn format_rfc3339_millis(unix_secs: i64, millis: u32) -> String {
-    let days = unix_secs.div_euclid(86_400);
-    let secs_of_day = unix_secs.rem_euclid(86_400);
-    let (year, month, day) = civil_from_days(days);
-    let hour = secs_of_day / 3_600;
-    let minute = (secs_of_day % 3_600) / 60;
-    let second = secs_of_day % 60;
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
-}
-
-/// Convert a count of days since the Unix epoch (1970-01-01) to a proleptic
-/// Gregorian `(year, month, day)`. Howard Hinnant's `civil_from_days`
-/// algorithm — exact for the full range of representable dates.
-fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
-    let z = days_since_epoch + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-    let year = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
-    let year = if month <= 2 { year + 1 } else { year };
-    (year, month, day)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn formats_known_instants_as_iso8601_utc() {
-        // Both expected strings verified against an independent epoch
-        // converter (Python `datetime.fromtimestamp(_, tz=utc)`).
-        assert_eq!(
-            format_rfc3339_millis(1_782_466_473, 482),
-            "2026-06-26T09:34:33.482Z"
-        );
-        assert_eq!(
-            format_rfc3339_millis(1_750_000_000, 0),
-            "2025-06-15T15:06:40.000Z"
-        );
-    }
-
-    #[test]
-    fn formats_the_epoch() {
-        assert_eq!(format_rfc3339_millis(0, 0), "1970-01-01T00:00:00.000Z");
-    }
-
-    #[test]
-    fn handles_a_leap_day() {
-        // 2024-02-29T12:00:00.000Z — leap year, last day of February.
-        assert_eq!(
-            format_rfc3339_millis(1_709_208_000, 0),
-            "2024-02-29T12:00:00.000Z"
-        );
-    }
-
-    #[test]
-    fn now_is_well_formed_and_zulu() {
-        let ts = now_rfc3339();
-        assert!(ts.ends_with('Z'), "timestamp is UTC (Z offset): {ts}");
-        assert_eq!(ts.len(), "1970-01-01T00:00:00.000Z".len());
-        assert_eq!(&ts[4..5], "-");
-        assert_eq!(&ts[10..11], "T");
-    }
 }

--- a/pillars/contacts/src/lib.rs
+++ b/pillars/contacts/src/lib.rs
@@ -4,8 +4,12 @@
 //! generator) share these modules so the served document and the committed
 //! `openapi/contacts.openapi.json` are generated from one source.
 
+pub mod api;
 pub mod app;
 pub mod config;
 pub mod db;
+pub mod entities;
 pub mod health;
 pub mod openapi;
+pub mod search;
+pub mod time;

--- a/pillars/contacts/src/openapi.rs
+++ b/pillars/contacts/src/openapi.rs
@@ -21,22 +21,62 @@
 use serde_json::{Map, Value};
 use utoipa::OpenApi;
 
+use crate::api::{ErrorBody, PaginationMeta};
+use crate::entities::model::{CreateEntityBody, Entity, EntityLookup, UpdateEntityBody};
+use crate::entities::routes::{
+    EntityListResponse, EntityMutation, EntityResponse, LookupBody, LookupResponse, MessageResponse,
+};
 use crate::health::HealthResponse;
+use crate::search::routes::{
+    MatchType, SearchHit, SearchHitData, SearchQuery, SearchRequest, SearchResponse,
+};
 
-/// The contacts OpenAPI surface. N0 documents `/health` and the stub root;
-/// the entities/search/settings paths join in later nodes.
+/// The contacts OpenAPI surface. Documents `/health`, the stub root, the
+/// entities CRUD + bulk-lookup routes (DOTTED `entities.*` operationIds), and
+/// the search slice (`search.search`). The registry/uri/settings paths join in
+/// later nodes.
 ///
 /// Path handlers are referenced fully-qualified so the `OpenApi` derive
-/// resolves the `__path_*` items `#[utoipa::path]` generates in their
-/// defining module (`crate::health`).
+/// resolves the `__path_*` items `#[utoipa::path]` generates in their defining
+/// module.
 #[derive(OpenApi)]
 #[openapi(
     info(
         title = "POPS Contacts",
         description = "Contacts pillar — authoritative entities store (first Rust pillar)."
     ),
-    paths(crate::health::health, crate::health::root),
-    components(schemas(HealthResponse))
+    paths(
+        crate::health::health,
+        crate::health::root,
+        crate::entities::routes::list,
+        crate::entities::routes::get_one,
+        crate::entities::routes::create,
+        crate::entities::routes::update,
+        crate::entities::routes::delete_one,
+        crate::entities::routes::lookup,
+        crate::search::routes::search,
+    ),
+    components(schemas(
+        HealthResponse,
+        Entity,
+        EntityLookup,
+        CreateEntityBody,
+        UpdateEntityBody,
+        EntityListResponse,
+        EntityResponse,
+        EntityMutation,
+        MessageResponse,
+        LookupBody,
+        LookupResponse,
+        PaginationMeta,
+        ErrorBody,
+        SearchRequest,
+        SearchQuery,
+        SearchResponse,
+        SearchHit,
+        SearchHitData,
+        MatchType,
+    ))
 )]
 pub struct ApiDoc;
 

--- a/pillars/contacts/src/search/mod.rs
+++ b/pillars/contacts/src/search/mod.rs
@@ -1,0 +1,12 @@
+//! The unified-search slice for contacts.
+//!
+//! `POST /search` (operationId `search.search`) returns ranked contact hits to
+//! the orchestrator's federated search. The operationId is PINNED to
+//! `search.search`: the orchestrator resolves `pillar(id).search.search`, so a
+//! wrong id means contacts search never federates. Ranking and the cap mirror
+//! core's search handler verbatim (exact 1.0 / prefix 0.8 / contains 0.5, cap
+//! 20) and the hit `uri` is the canonical single-colon `pops:contacts/contact/<id>`.
+
+pub mod routes;
+
+pub use routes::router;

--- a/pillars/contacts/src/search/routes.rs
+++ b/pillars/contacts/src/search/routes.rs
@@ -1,0 +1,147 @@
+//! `POST /search` — contacts' slice of unified search.
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::api::ApiError;
+use crate::app::AppState;
+use crate::entities::model::decode_aliases;
+use crate::entities::repo;
+
+/// Cap on returned hits, matching core's `DEFAULT_LIMIT`.
+const HIT_CAP: usize = 20;
+
+/// `POST /search` request body. `query.text` is the term; `context` is
+/// accepted and ignored (parity with the orchestrator's wire shape).
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct SearchRequest {
+    pub query: SearchQuery,
+    #[serde(default)]
+    pub context: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct SearchQuery {
+    pub text: String,
+}
+
+/// `POST /search` response body.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SearchResponse {
+    pub hits: Vec<SearchHit>,
+}
+
+/// One ranked search hit. `uri` is the canonical `pops:contacts/contact/<id>`.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchHit {
+    pub uri: String,
+    pub score: f64,
+    pub match_field: String,
+    pub match_type: MatchType,
+    pub data: SearchHitData,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchType {
+    Exact,
+    Prefix,
+    Contains,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SearchHitData {
+    pub name: String,
+    pub r#type: String,
+    pub aliases: Vec<String>,
+}
+
+/// Mount `POST /search`.
+pub fn router() -> Router<AppState> {
+    Router::new().route("/search", post(search))
+}
+
+#[utoipa::path(
+    post,
+    path = "/search",
+    operation_id = "search.search",
+    request_body = SearchRequest,
+    responses((status = 200, description = "Ranked contact hits", body = SearchResponse))
+)]
+pub async fn search(
+    State(state): State<AppState>,
+    Json(request): Json<SearchRequest>,
+) -> Result<Json<SearchResponse>, ApiError> {
+    let text = request.query.text.trim().to_string();
+    if text.is_empty() {
+        return Ok(Json(SearchResponse { hits: Vec::new() }));
+    }
+
+    let candidates = repo::search_candidates(&state.pool, &text)
+        .await
+        .map_err(|err| ApiError::internal(err.to_string()))?;
+
+    let mut hits: Vec<SearchHit> = candidates
+        .into_iter()
+        .filter_map(|row| {
+            score_and_classify(&row.name, &text).map(|(score, match_type)| SearchHit {
+                uri: format!("pops:contacts/contact/{}", row.id),
+                score,
+                match_field: "name".to_string(),
+                match_type,
+                data: SearchHitData {
+                    name: row.name,
+                    r#type: row.r#type,
+                    aliases: decode_aliases(row.aliases.as_deref()),
+                },
+            })
+        })
+        .collect();
+
+    hits.sort_by(|a, b| b.score.total_cmp(&a.score));
+    hits.truncate(HIT_CAP);
+    Ok(Json(SearchResponse { hits }))
+}
+
+/// Classify a candidate name against the query: exact 1.0 / prefix 0.8 /
+/// contains 0.5, case-insensitive. `None` when the name does not contain the
+/// query at all (the `LIKE` scan can over-match on collation edge cases).
+fn score_and_classify(name: &str, query: &str) -> Option<(f64, MatchType)> {
+    let lower = name.to_lowercase();
+    let q = query.to_lowercase();
+    if lower == q {
+        Some((1.0, MatchType::Exact))
+    } else if lower.starts_with(&q) {
+        Some((0.8, MatchType::Prefix))
+    } else if lower.contains(&q) {
+        Some((0.5, MatchType::Contains))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoring_ranks_exact_then_prefix_then_contains() {
+        assert_eq!(
+            score_and_classify("Acme", "acme"),
+            Some((1.0, MatchType::Exact))
+        );
+        assert_eq!(
+            score_and_classify("Acme Corp", "acme"),
+            Some((0.8, MatchType::Prefix))
+        );
+        assert_eq!(
+            score_and_classify("The Acme", "acme"),
+            Some((0.5, MatchType::Contains))
+        );
+        assert_eq!(score_and_classify("Other", "acme"), None);
+    }
+}

--- a/pillars/contacts/src/time.rs
+++ b/pillars/contacts/src/time.rs
@@ -1,0 +1,87 @@
+//! RFC 3339 / ISO 8601 UTC timestamp formatting, byte-for-byte matching the
+//! TS pillars' `new Date().toISOString()` (millisecond precision, `Z` offset).
+//!
+//! Implemented against `std` via Howard Hinnant's civil-from-days algorithm so
+//! the reference pillar carries no chrono/time dependency just to stamp a
+//! timestamp. Shared by `/health` and the entities `last_edited_time` bump so
+//! every stored/served instant has the identical shape.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Current UTC time as an RFC 3339 / ISO 8601 string with millisecond
+/// precision and a `Z` offset, e.g. `2026-06-21T09:24:33.482Z`.
+pub fn now_rfc3339() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format_rfc3339_millis(now.as_secs() as i64, now.subsec_millis())
+}
+
+/// Format `unix_secs` (seconds since the Unix epoch, UTC) plus `millis` as an
+/// RFC 3339 UTC string. Split out from [`now_rfc3339`] so it is
+/// deterministically testable.
+pub fn format_rfc3339_millis(unix_secs: i64, millis: u32) -> String {
+    let days = unix_secs.div_euclid(86_400);
+    let secs_of_day = unix_secs.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hour = secs_of_day / 3_600;
+    let minute = (secs_of_day % 3_600) / 60;
+    let second = secs_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+/// Convert a count of days since the Unix epoch (1970-01-01) to a proleptic
+/// Gregorian `(year, month, day)`. Howard Hinnant's `civil_from_days`
+/// algorithm — exact for the full range of representable dates.
+fn civil_from_days(days_since_epoch: i64) -> (i64, u32, u32) {
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let year = if month <= 2 { year + 1 } else { year };
+    (year, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_known_instants_as_iso8601_utc() {
+        assert_eq!(
+            format_rfc3339_millis(1_782_466_473, 482),
+            "2026-06-26T09:34:33.482Z"
+        );
+        assert_eq!(
+            format_rfc3339_millis(1_750_000_000, 0),
+            "2025-06-15T15:06:40.000Z"
+        );
+    }
+
+    #[test]
+    fn formats_the_epoch() {
+        assert_eq!(format_rfc3339_millis(0, 0), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn handles_a_leap_day() {
+        assert_eq!(
+            format_rfc3339_millis(1_709_208_000, 0),
+            "2024-02-29T12:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn now_is_well_formed_and_zulu() {
+        let ts = now_rfc3339();
+        assert!(ts.ends_with('Z'), "timestamp is UTC (Z offset): {ts}");
+        assert_eq!(ts.len(), "1970-01-01T00:00:00.000Z".len());
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[10..11], "T");
+    }
+}

--- a/pillars/contacts/tests/entities.rs
+++ b/pillars/contacts/tests/entities.rs
@@ -1,0 +1,329 @@
+//! Per-route integration tests for the entities CRUD + bulk-lookup + search
+//! surface, driving the fully assembled axum router through
+//! `tower::ServiceExt::oneshot` against a migrated in-memory SQLite DB. These
+//! exercise the whole request → handler → DB → serialization path, including
+//! status codes and the JSON wire shape, not just the repo functions in
+//! isolation.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use contacts::app::{build_router, AppState};
+use contacts::db;
+
+async fn app() -> axum::Router {
+    let pool = db::connect("sqlite::memory:")
+        .await
+        .expect("in-memory pool connects and migrates");
+    build_router(AppState {
+        pool,
+        version: "1.2.3-test".to_string(),
+    })
+}
+
+async fn send(app: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.expect("router responds");
+    let status = response.status();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body collects")
+        .to_bytes();
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("response body is JSON")
+    };
+    (status, body)
+}
+
+fn post(path: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn patch(path: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("PATCH")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn get(path: &str) -> Request<Body> {
+    Request::builder().uri(path).body(Body::empty()).unwrap()
+}
+
+fn delete(path: &str) -> Request<Body> {
+    Request::builder()
+        .method("DELETE")
+        .uri(path)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn create_contact(app: &axum::Router, body: Value) -> Value {
+    let (status, body) = send(app, post("/entities", body)).await;
+    assert_eq!(status, StatusCode::CREATED, "create returns 201: {body}");
+    body["data"].clone()
+}
+
+#[tokio::test]
+async fn create_returns_201_with_the_projected_entity() {
+    let app = app().await;
+    let data = create_contact(
+        &app,
+        json!({
+            "name": "Acme",
+            "type": "company",
+            "abn": "123",
+            "aliases": ["ACME Corp", "Acme Inc"],
+            "defaultTags": ["vendor"],
+            "notes": "primary supplier"
+        }),
+    )
+    .await;
+
+    assert!(data["id"].as_str().is_some());
+    assert_eq!(data["name"], "Acme");
+    assert_eq!(data["type"], "company");
+    assert_eq!(data["abn"], "123");
+    assert_eq!(data["aliases"], json!(["ACME Corp", "Acme Inc"]));
+    assert_eq!(data["defaultTags"], json!(["vendor"]));
+    assert!(data["lastEditedTime"].as_str().unwrap().ends_with('Z'));
+    assert!(
+        data.get("notionId").is_none(),
+        "the integration columns are never exposed on the wire"
+    );
+    assert!(data.get("ownerUri").is_none());
+}
+
+#[tokio::test]
+async fn create_defaults_type_to_company() {
+    let app = app().await;
+    let data = create_contact(&app, json!({ "name": "NoType" })).await;
+    assert_eq!(data["type"], "company");
+    assert_eq!(data["aliases"], json!([]));
+    assert_eq!(data["defaultTags"], json!([]));
+    assert_eq!(data["abn"], Value::Null);
+}
+
+#[tokio::test]
+async fn duplicate_name_create_is_a_409() {
+    let app = app().await;
+    create_contact(&app, json!({ "name": "Dup" })).await;
+    let (status, body) = send(&app, post("/entities", json!({ "name": "Dup" }))).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["code"], "ConflictError");
+    assert!(body["message"].as_str().unwrap().contains("Dup"));
+}
+
+#[tokio::test]
+async fn empty_name_create_is_a_400() {
+    let app = app().await;
+    let (status, _) = send(&app, post("/entities", json!({ "name": "   " }))).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn invalid_type_create_is_a_400() {
+    let app = app().await;
+    let (status, body) = send(
+        &app,
+        post("/entities", json!({ "name": "X", "type": "wizard" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["message"].as_str().unwrap().contains("wizard"));
+}
+
+#[tokio::test]
+async fn get_returns_the_entity_then_404_after_delete() {
+    let app = app().await;
+    let created = create_contact(&app, json!({ "name": "Gettable" })).await;
+    let id = created["id"].as_str().unwrap();
+
+    let (status, body) = send(&app, get(&format!("/entities/{id}"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["name"], "Gettable");
+
+    let (status, body) = send(&app, delete(&format!("/entities/{id}"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["message"], "Entity deleted");
+
+    let (status, _) = send(&app, get(&format!("/entities/{id}"))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_unknown_id_is_a_404() {
+    let app = app().await;
+    let (status, body) = send(&app, get("/entities/nope")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["code"], "NotFoundError");
+}
+
+#[tokio::test]
+async fn delete_unknown_id_is_a_404() {
+    let app = app().await;
+    let (status, _) = send(&app, delete("/entities/nope")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn list_filters_paginates_and_orders_case_insensitively() {
+    let app = app().await;
+    for (name, ty) in [
+        ("zebra", "company"),
+        ("Apple", "person"),
+        ("apricot", "company"),
+    ] {
+        create_contact(&app, json!({ "name": name, "type": ty })).await;
+    }
+
+    let (status, body) = send(&app, get("/entities")).await;
+    assert_eq!(status, StatusCode::OK);
+    let names: Vec<&str> = body["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["Apple", "apricot", "zebra"]);
+    assert_eq!(body["pagination"]["total"], 3);
+    assert_eq!(body["pagination"]["hasMore"], false);
+
+    let (_, body) = send(&app, get("/entities?search=ap")).await;
+    assert_eq!(body["pagination"]["total"], 2);
+
+    let (_, body) = send(&app, get("/entities?type=person")).await;
+    assert_eq!(body["pagination"]["total"], 1);
+    assert_eq!(body["data"][0]["name"], "Apple");
+
+    let (_, body) = send(&app, get("/entities?limit=2&offset=0")).await;
+    assert_eq!(body["data"].as_array().unwrap().len(), 2);
+    assert_eq!(body["pagination"]["hasMore"], true);
+}
+
+#[tokio::test]
+async fn list_rejects_an_invalid_type_filter() {
+    let app = app().await;
+    let (status, _) = send(&app, get("/entities?type=wizard")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_applies_partial_changes_and_can_clear_nullable_fields() {
+    let app = app().await;
+    let created = create_contact(
+        &app,
+        json!({ "name": "Patchable", "abn": "999", "notes": "old" }),
+    )
+    .await;
+    let id = created["id"].as_str().unwrap();
+
+    let (status, body) = send(
+        &app,
+        patch(
+            &format!("/entities/{id}"),
+            json!({ "notes": "new", "abn": null, "aliases": ["x"] }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["notes"], "new");
+    assert_eq!(body["data"]["abn"], Value::Null);
+    assert_eq!(body["data"]["aliases"], json!(["x"]));
+    assert_eq!(body["data"]["name"], "Patchable");
+}
+
+#[tokio::test]
+async fn patch_rename_to_existing_name_is_a_409() {
+    let app = app().await;
+    create_contact(&app, json!({ "name": "First" })).await;
+    let second = create_contact(&app, json!({ "name": "Second" })).await;
+    let id = second["id"].as_str().unwrap();
+
+    let (status, _) = send(
+        &app,
+        patch(&format!("/entities/{id}"), json!({ "name": "First" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn patch_unknown_id_is_a_404() {
+    let app = app().await;
+    let (status, _) = send(&app, patch("/entities/nope", json!({ "notes": "x" }))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn bulk_lookup_returns_the_whole_match_set() {
+    let app = app().await;
+    create_contact(&app, json!({ "name": "Acme", "aliases": ["ACME Corp"] })).await;
+    create_contact(&app, json!({ "name": "Beta" })).await;
+
+    let (status, body) = send(&app, post("/entities/lookup", json!({}))).await;
+    assert_eq!(status, StatusCode::OK);
+    let entities = body["entities"].as_array().unwrap();
+    assert_eq!(entities.len(), 2);
+    assert!(body["fetchedAt"].as_str().unwrap().ends_with('Z'));
+
+    let acme = entities.iter().find(|e| e["name"] == "Acme").unwrap();
+    assert_eq!(acme["aliases"], json!(["ACME Corp"]));
+    assert!(
+        acme.get("notes").is_none(),
+        "lookup returns only the match columns (id, name, aliases)"
+    );
+}
+
+#[tokio::test]
+async fn search_ranks_and_caps_hits() {
+    let app = app().await;
+    for name in ["Acme", "Acme Corp", "The Acme Group", "Unrelated"] {
+        create_contact(&app, json!({ "name": name })).await;
+    }
+
+    let (status, body) = send(
+        &app,
+        post("/search", json!({ "query": { "text": "Acme" } })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let hits = body["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 3, "Unrelated does not contain the term");
+
+    assert_eq!(hits[0]["data"]["name"], "Acme");
+    assert_eq!(hits[0]["score"], 1.0);
+    assert_eq!(hits[0]["matchType"], "exact");
+    assert!(hits[0]["uri"]
+        .as_str()
+        .unwrap()
+        .starts_with("pops:contacts/contact/"));
+
+    let scores: Vec<f64> = hits.iter().map(|h| h["score"].as_f64().unwrap()).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] >= w[1]),
+        "hits are sorted by descending score: {scores:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_with_empty_text_returns_no_hits() {
+    let app = app().await;
+    create_contact(&app, json!({ "name": "Acme" })).await;
+    let (status, body) = send(&app, post("/search", json!({ "query": { "text": "  " } }))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["hits"], json!([]));
+}

--- a/pillars/contacts/tests/openapi_contract.rs
+++ b/pillars/contacts/tests/openapi_contract.rs
@@ -1,0 +1,114 @@
+//! Contract guards on the emitted OpenAPI document.
+//!
+//! These pin the two properties every downstream consumer relies on and which
+//! the plan flags as the most dangerous defects:
+//!
+//!   1. The `operationId`s are the DOTTED `<router>.<proc>` strings the SDK
+//!      route map keys on and hey-api derives camelCase method names from. A
+//!      camelCase or fn-name-derived id silently breaks finance's live-fetch
+//!      client and the orchestrator's search federation.
+//!   2. The document is OpenAPI 3.0.x — utoipa emits 3.1 by default, which
+//!      `@hey-api/openapi-ts` cannot consume.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use contacts::openapi::openapi_30_value;
+
+fn operation_ids(doc: &Value) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    let paths = doc["paths"].as_object().expect("paths object");
+    for methods in paths.values() {
+        for op in methods.as_object().expect("method map").values() {
+            if let Some(id) = op.get("operationId").and_then(Value::as_str) {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+    ids
+}
+
+#[test]
+fn entities_and_search_operation_ids_are_dotted() {
+    let doc = openapi_30_value();
+    let ids = operation_ids(&doc);
+
+    let required = [
+        "entities.list",
+        "entities.get",
+        "entities.create",
+        "entities.update",
+        "entities.delete",
+        "entities.lookup",
+        "search.search",
+    ];
+    for id in required {
+        assert!(
+            ids.contains(id),
+            "the document must carry the DOTTED operationId `{id}`; present ids: {ids:?}"
+        );
+    }
+}
+
+#[test]
+fn every_operation_id_is_dotted_never_camel_case() {
+    let doc = openapi_30_value();
+    for id in operation_ids(&doc) {
+        assert!(
+            id.contains('.'),
+            "operationId `{id}` is not dotted — hey-api would derive the wrong client method name"
+        );
+        assert!(
+            !id.chars().any(|c| c.is_ascii_uppercase()),
+            "operationId `{id}` contains uppercase — the dotted convention is lowercase `<router>.<proc>`"
+        );
+    }
+}
+
+#[test]
+fn document_is_openapi_30() {
+    let doc = openapi_30_value();
+    let version = doc["openapi"].as_str().expect("openapi version string");
+    assert!(
+        version.starts_with("3.0"),
+        "hey-api targets OpenAPI 3.0; got {version}"
+    );
+}
+
+#[test]
+fn entity_wire_schema_omits_internal_columns() {
+    let doc = openapi_30_value();
+    let props = doc["components"]["schemas"]["Entity"]["properties"]
+        .as_object()
+        .expect("Entity schema properties");
+    for hidden in ["notionId", "ownerUri", "ownerUriStaleAt"] {
+        assert!(
+            !props.contains_key(hidden),
+            "the wire Entity must not expose the internal column `{hidden}`"
+        );
+    }
+    for exposed in [
+        "id",
+        "name",
+        "type",
+        "aliases",
+        "defaultTags",
+        "lastEditedTime",
+    ] {
+        assert!(
+            props.contains_key(exposed),
+            "the wire Entity must expose `{exposed}`"
+        );
+    }
+}
+
+#[test]
+fn search_hit_uri_is_contacts_namespaced() {
+    let doc = openapi_30_value();
+    let paths = doc["paths"].as_object().unwrap();
+    assert!(
+        paths.contains_key("/search"),
+        "the search route must be present so the orchestrator can federate it"
+    );
+}


### PR DESCRIPTION
## Stage 2d — contacts N1: entities domain on the Rust contacts pillar

Implements the **N1** node of `docs/plans/01-contacts-pillar-rust.md` (Phase 1): the entities (contact) CRUD domain + its REST wire surface on the contacts pillar (axum + sqlx + utoipa). A contact is the superset of core's + finance's entity fields. This is the authoritative-store surface only — **no** data migration from core, **no** finance live-fetch cutover, **no** registry self-registration (those are N2+/later nodes).

### Entities schema (`migrations/0002_entities.sql`)

Column-for-column mirror of core's `entities` table:

| Column | Type | Notes |
| --- | --- | --- |
| `id` | TEXT PK | server-generated v4 UUID |
| `notion_id` | TEXT UNIQUE | integration key (not exposed on the wire) |
| `name` | TEXT NOT NULL | name-uniqueness enforced (409) |
| `type` | TEXT NOT NULL DEFAULT 'company' | person/company/government/bank/place/brand/organisation |
| `abn` | TEXT | nullable |
| `aliases` | TEXT | opaque CSV (`join(', ')`), byte-preserved |
| `default_transaction_type` | TEXT | nullable |
| `default_tags` | TEXT | opaque JSON array (`JSON.stringify`), byte-preserved |
| `notes` | TEXT | nullable |
| `last_edited_time` | TEXT NOT NULL | bumped on create/update |
| `owner_uri` | TEXT | denorm backfill pointer (not exposed); `idx_entities_owner_uri` |
| `owner_uri_stale_at` | TEXT | not exposed |

Wire `Entity` (camelCase) = `{ id, name, type, abn|null, aliases[], defaultTransactionType|null, defaultTags[], notes|null, lastEditedTime }` — `notionId`/`ownerUri`/`ownerUriStaleAt` are deliberately not projected, matching core's `EntitySchema`.

### Routes → operationId (DOTTED — the plan's #1 risk)

| Method | Path | operationId | hey-api method |
| --- | --- | --- | --- |
| GET | `/entities` | `entities.list` | entitiesList |
| GET | `/entities/{id}` | `entities.get` | entitiesGet |
| POST | `/entities` | `entities.create` | entitiesCreate |
| PATCH | `/entities/{id}` | `entities.update` | entitiesUpdate |
| DELETE | `/entities/{id}` | `entities.delete` | entitiesDelete |
| POST | `/entities/lookup` | `entities.lookup` | entitiesLookup |
| POST | `/search` | `search.search` | searchSearch |

Every `#[utoipa::path]` pins `operation_id` to the literal dotted `<router>.<proc>` string (utoipa's default id is the Rust fn name and cannot contain a dot). The SDK route map keys on the dotted operationId and hey-api derives the camelCase method names from it, so this is load-bearing for finance's future live-fetch client and the orchestrator's search federation. (`health.get`/`root.get` from the N0 scaffold remain.)

### Behaviour

- **create** → 201, name-uniqueness → 409, empty name / unknown type → 400, `type` defaults to `company`.
- **list** → `{ data, pagination:{total,limit,offset,hasMore} }`; `search` (LIKE on name), `type` (exact), `limit`/`offset`; ordered `name COLLATE NOCASE`.
- **get / delete** → 404 on unknown id.
- **patch** → partial; distinguishes an absent field from a present `null` (`double_option`) so nullable columns can be cleared; rename-to-existing → 409; `last_edited_time` bumps only when a column actually changes.
- **lookup** → the whole contact set's match columns (`id`,`name`,`aliases`) in one round-trip + `fetchedAt`.
- **search** → exact 1.0 / prefix 0.8 / contains 0.5 ranking, cap 20, hits namespaced `pops:contacts/contact/<id>`.

### OpenAPI: 3.0 + dotted ids confirmed

- `openapi: "3.0.3"` (utoipa 5 defaults to 3.1; the N0 downgrade pass forces 3.0 — no `"null"`-type unions remain).
- Committed `pillars/contacts/openapi/contacts.openapi.json` re-emitted and tracked; the CI drift gate (`emit-openapi` → `git diff --exit-code`) passes locally.
- `tests/openapi_contract.rs` asserts the dotted operationId set `{entities.list, entities.get, entities.create, entities.update, entities.delete, entities.lookup, search.search}` is present, that **every** id is dotted/lowercase, that the doc is 3.0.x, and that the wire `Entity` omits the internal columns.
- The spec is oxfmt-excluded (existing contacts-only ignore in `.oxfmtrc.json`); no other pillar's spec touched.

### Verification

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo build --all-targets` — green.
- `cargo test --all` — **66 passed, 0 failed** (42 unit + 16 entities HTTP integration + 3 health + 5 openapi-contract). Integration tests run against a migrated in-memory SQLite with the pool capped to one connection (the N0 fix).
- No TS touched (`.rs`/`.sql`/`Cargo`/openapi-json only), so `pnpm typecheck`/`lint`/`oxfmt` are unaffected.

### Resolved ambiguity

- **sqlx compile-time macros vs runtime queries.** CI runs `cargo build` offline with no `DATABASE_URL`, no committed `.sqlx/`, and `sqlx-cli` is not installed; the offline-cache toolchain + Dockerfile are the Phase 6 node. So N1 uses sqlx's **runtime** query API — fully parameterized (bound values, no string interpolation into SQL), CI-safe. Conversion to compile-time-checked `query!` macros rides the Phase 6 `.sqlx/` node. Documented in `entities/repo.rs`.
- **search route is N1.** The execution graph names N1 "entities domain", but Gate G1 / §8 require the committed spec's operationId set to include `search.search`. The search **route + operationId** therefore ship here; search **federation** (orchestrator static maps) remains N4d. `/uri/resolve` is NOT in the Gate G1 set, so it is left to a later node.

DO NOT MERGE.
