### PR TITLE
feat(registry): dual-serve /registry/* slash routes + SDK slash-first resolver (Phase 1)

### DIFF
--- a/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
@@ -38,8 +38,35 @@ function envelope(): {
   };
 }
 
+type PathRoutedResponse = { status: number; body?: unknown };
+
+/**
+ * Path-aware mock fetch: maps the request path to a scripted response, so the
+ * slash-first / legacy-fallback candidate order can be exercised. Records the
+ * exact URL sequence the transport dialed.
+ */
+function pathRoutedFetch(routes: Record<string, PathRoutedResponse | undefined>): {
+  fetchImpl: typeof fetch;
+  paths: string[];
+} {
+  const paths: string[] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const path = new URL(url).pathname;
+    paths.push(path);
+    const route = routes[path];
+    if (!route) throw new Error(`unrouted path ${path}`);
+    const body = route.body === undefined ? '' : JSON.stringify(route.body);
+    return new Response(body, {
+      status: route.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  return { fetchImpl: vi.fn(fetchImpl), paths };
+}
+
 describe('createHttpRegistryTransport', () => {
-  it('POSTs the envelope to /core.registry.register', async () => {
+  it('POSTs the envelope slash-first to /registry/register', async () => {
     const fetchImpl = mockFetch([{ status: 200, body: { pillarId: 'finance' } }]);
     const transport = createHttpRegistryTransport({
       baseUrl: 'http://registry.test',
@@ -51,7 +78,7 @@ describe('createHttpRegistryTransport', () => {
     expect(result.pillarId).toBe('finance');
     expect(fetchImpl).toHaveBeenCalledOnce();
     const [url, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(url).toBe('http://registry.test/core.registry.register');
+    expect(url).toBe('http://registry.test/registry/register');
     expect((init as RequestInit).method).toBe('POST');
     const bodyText = (init as RequestInit).body;
     expect(typeof bodyText).toBe('string');
@@ -84,7 +111,7 @@ describe('createHttpRegistryTransport', () => {
 
     await transport.heartbeat('finance');
     const [url, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(url).toBe('http://registry.test/core.registry.heartbeat');
+    expect(url).toBe('http://registry.test/registry/heartbeat');
     const sent = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(sent).toEqual({ pillarId: 'finance' });
     expect(Object.prototype.hasOwnProperty.call(sent, 'capabilities')).toBe(false);
@@ -166,5 +193,113 @@ describe('createHttpRegistryTransport', () => {
     });
 
     await expect(transport.unregister('finance')).resolves.toBeUndefined();
+  });
+
+  describe('slash-first path resolution with legacy fallback', () => {
+    it('falls back to the legacy path when the slash path 404s, then caches the winner', async () => {
+      const { fetchImpl, paths } = pathRoutedFetch({
+        '/registry/register': { status: 404 },
+        '/core.registry.register': { status: 200, body: { pillarId: 'finance' } },
+      });
+      const transport = createHttpRegistryTransport({ baseUrl: 'http://registry.test', fetchImpl });
+
+      const first = await transport.register(envelope());
+      expect(first.pillarId).toBe('finance');
+      expect(paths).toEqual(['/registry/register', '/core.registry.register']);
+
+      // Second call uses ONLY the cached legacy path — single request.
+      await transport.register(envelope());
+      expect(paths).toEqual([
+        '/registry/register',
+        '/core.registry.register',
+        '/core.registry.register',
+      ]);
+    });
+
+    it('uses the slash path with no fallback when it succeeds, caching the winner', async () => {
+      const { fetchImpl, paths } = pathRoutedFetch({
+        '/registry/heartbeat': { status: 200, body: { ok: true } },
+      });
+      const transport = createHttpRegistryTransport({ baseUrl: 'http://registry.test', fetchImpl });
+
+      await transport.heartbeat('finance');
+      await transport.heartbeat('finance');
+      expect(paths).toEqual(['/registry/heartbeat', '/registry/heartbeat']);
+    });
+
+    it('self-heals when a cached path later 404s (rollback then legacy-removal)', async () => {
+      // Live path set, flipped to model a core rollback then a Phase-3 removal.
+      let live = new Set(['/registry/heartbeat', '/core.registry.heartbeat']);
+      const paths: string[] = [];
+      const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+        const path = new URL(typeof input === 'string' ? input : input.toString()).pathname;
+        paths.push(path);
+        const ok = live.has(path);
+        return new Response(ok ? JSON.stringify({ ok: true }) : '', {
+          status: ok ? 200 : 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      const transport = createHttpRegistryTransport({ baseUrl: 'http://registry.test', fetchImpl });
+
+      // Steady state: slash wins, single request, cached.
+      await transport.heartbeat('finance');
+      expect(paths).toEqual(['/registry/heartbeat']);
+
+      // Core rolled back to a build that no longer serves the slash path. The
+      // cached slash path 404s; the SAME call falls through to the legacy path
+      // (no failed heartbeat) and the hint is invalidated.
+      live = new Set(['/core.registry.heartbeat']);
+      await transport.heartbeat('finance');
+      expect(paths).toEqual([
+        '/registry/heartbeat',
+        '/registry/heartbeat',
+        '/core.registry.heartbeat',
+      ]);
+
+      // Legacy is now the cached winner; while it keeps serving, calls stay a
+      // single request and do NOT thrash back to slash just because slash exists.
+      paths.length = 0;
+      await transport.heartbeat('finance');
+      expect(paths).toEqual(['/core.registry.heartbeat']);
+
+      // Phase-3 roll-forward: legacy removed, only slash served. The cached
+      // legacy path 404s, the call falls through to slash and re-caches it.
+      live = new Set(['/registry/heartbeat']);
+      paths.length = 0;
+      await transport.heartbeat('finance');
+      expect(paths).toEqual(['/core.registry.heartbeat', '/registry/heartbeat']);
+    });
+
+    it('throws retriable WITHOUT trying the legacy path on a 5xx', async () => {
+      const { fetchImpl, paths } = pathRoutedFetch({
+        '/registry/register': { status: 503, body: { error: 'down' } },
+        '/core.registry.register': { status: 200, body: { pillarId: 'finance' } },
+      });
+      const transport = createHttpRegistryTransport({ baseUrl: 'http://registry.test', fetchImpl });
+
+      await expect(transport.register(envelope())).rejects.toBeInstanceOf(RegistryTransportError);
+      expect(paths).toEqual(['/registry/register']);
+    });
+
+    it('throws non-retriable when BOTH candidates 404', async () => {
+      const { fetchImpl, paths } = pathRoutedFetch({
+        '/registry/register': { status: 404 },
+        '/core.registry.register': { status: 404 },
+      });
+      const transport = createHttpRegistryTransport({ baseUrl: 'http://registry.test', fetchImpl });
+
+      try {
+        await transport.register(envelope());
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RegistryTransportError);
+        if (err instanceof RegistryTransportError) {
+          expect(err.status).toBe(404);
+          expect(err.retriable).toBe(false);
+        }
+      }
+      expect(paths).toEqual(['/registry/register', '/core.registry.register']);
+    });
   });
 });

--- a/packages/pillar-sdk/src/bootstrap/transport.ts
+++ b/packages/pillar-sdk/src/bootstrap/transport.ts
@@ -1,5 +1,14 @@
+import { createResolverLeg, resolveWithFallback } from '../registry-path-resolver.js';
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from '../registry-paths.js';
+
 import type { ManifestPayload } from '../manifest-schema/schema.js';
 import type { ValidationIssue } from '../manifest-schema/validate.js';
+
+const HTTP_NOT_FOUND = 404;
+
+function isTransportNotFound(err: unknown): boolean {
+  return err instanceof RegistryTransportError && err.status === HTTP_NOT_FOUND;
+}
 
 export interface RegistrationResult {
   pillarId: string;
@@ -70,58 +79,70 @@ export class RegistryNetworkError extends Error {
   }
 }
 
+type PostConfig = { baseUrl: string; fetchImpl: typeof fetch; timeoutMs: number };
+
+async function postRegistry<T>(config: PostConfig, path: string, body: unknown): Promise<T> {
+  let response: Response;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+  try {
+    response = await config.fetchImpl(`${config.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new RegistryNetworkError(`POST ${path} failed`, err);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.ok) {
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  const text = await response.text().catch(() => '');
+  throw new RegistryTransportError(`POST ${path} → ${response.status} ${response.statusText}`, {
+    status: response.status,
+    issues: extractIssues(text),
+    retriable: response.status >= 500,
+  });
+}
+
 export function createHttpRegistryTransport(
   options: HttpRegistryTransportOptions
 ): RegistryTransport {
-  const baseUrl = options.baseUrl.replace(/\/+$/, '');
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const config: PostConfig = {
+    baseUrl: options.baseUrl.replace(/\/+$/, ''),
+    fetchImpl: options.fetchImpl ?? fetch,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
 
-  async function post<T>(path: string, body: unknown): Promise<T> {
-    let response: Response;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      response = await fetchImpl(`${baseUrl}${path}`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } catch (err) {
-      throw new RegistryNetworkError(`POST ${path} failed`, err);
-    } finally {
-      clearTimeout(timer);
-    }
-
-    if (response.ok) {
-      if (response.status === 204) {
-        return undefined as T;
-      }
-      return (await response.json()) as T;
-    }
-
-    const text = await response.text().catch(() => '');
-    const issues = extractIssues(text);
-    throw new RegistryTransportError(`POST ${path} → ${response.status} ${response.statusText}`, {
-      status: response.status,
-      issues,
-      retriable: response.status >= 500,
-    });
-  }
+  const registerLeg = createResolverLeg(REGISTRY_PATHS.register, LEGACY_REGISTRY_PATHS.register);
+  const heartbeatLeg = createResolverLeg(REGISTRY_PATHS.heartbeat, LEGACY_REGISTRY_PATHS.heartbeat);
+  const deregisterLeg = createResolverLeg(
+    REGISTRY_PATHS.deregister,
+    LEGACY_REGISTRY_PATHS.deregister
+  );
 
   return {
     async register(payload) {
-      return post<RegistrationResult>('/core.registry.register', payload);
+      return resolveWithFallback<RegistrationResult>(registerLeg, isTransportNotFound, (path) =>
+        postRegistry(config, path, payload)
+      );
     },
     async heartbeat(pillarId, capabilities) {
-      return post<HeartbeatResult>('/core.registry.heartbeat', {
-        pillarId,
-        ...(capabilities ? { capabilities } : {}),
-      });
+      const body = { pillarId, ...(capabilities ? { capabilities } : {}) };
+      return resolveWithFallback<HeartbeatResult>(heartbeatLeg, isTransportNotFound, (path) =>
+        postRegistry(config, path, body)
+      );
     },
     async unregister(pillarId) {
-      await post<void>('/core.registry.deregister', { pillarId });
+      await resolveWithFallback<void>(deregisterLeg, isTransportNotFound, (path) =>
+        postRegistry(config, path, { pillarId })
+      );
     },
   };
 }

--- a/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
@@ -5,7 +5,7 @@ import { PillarSdkError } from '../errors.js';
 import { discoveredPillar, fakeFetch, jsonResponse } from './fixtures.js';
 
 describe('HttpDiscoveryTransport', () => {
-  it('GETs the registry snapshot URL and parses the tRPC envelope', async () => {
+  it('GETs the canonical /registry/pillars URL and parses the tRPC envelope', async () => {
     let calledUrl = '';
     const fetchImpl = fakeFetch((url) => {
       calledUrl = url;
@@ -25,7 +25,7 @@ describe('HttpDiscoveryTransport', () => {
     });
 
     const snapshot = await transport.fetchSnapshot();
-    expect(calledUrl).toBe('http://core-api:3001/core.registry.list');
+    expect(calledUrl).toBe('http://core-api:3001/registry/pillars');
     expect(snapshot).toHaveLength(1);
     expect(snapshot[0]?.pillarId).toBe('finance');
   });
@@ -50,7 +50,7 @@ describe('HttpDiscoveryTransport', () => {
       fetchImpl,
     });
     await transport.fetchSnapshot();
-    expect(calledUrl).toBe('http://core-api:3001/core.registry.list');
+    expect(calledUrl).toBe('http://core-api:3001/registry/pillars');
   });
 
   it('throws PillarSdkError on a non-2xx HTTP response', async () => {
@@ -59,6 +59,92 @@ describe('HttpDiscoveryTransport', () => {
     );
     const transport = new HttpDiscoveryTransport({ fetchImpl });
     await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  describe('slash-first path resolution with legacy fallback', () => {
+    function routedFetch(routes: Record<string, () => Response>): {
+      fetchImpl: typeof fetch;
+      paths: string[];
+    } {
+      const paths: string[] = [];
+      const fetchImpl = fakeFetch((url) => {
+        const path = new URL(url).pathname;
+        paths.push(path);
+        const make = routes[path];
+        if (!make) throw new Error(`unrouted path ${path}`);
+        return make();
+      });
+      return { fetchImpl, paths };
+    }
+
+    it('falls back to /core.registry.list on a 404 and parses the body identically', async () => {
+      const { fetchImpl, paths } = routedFetch({
+        '/registry/pillars': () => new Response('', { status: 404 }),
+        '/core.registry.list': () => jsonResponse({ pillars: [discoveredPillar()] }),
+      });
+      const transport = new HttpDiscoveryTransport({
+        registryUrl: 'http://core-api:3001',
+        fetchImpl,
+      });
+
+      const snapshot = await transport.fetchSnapshot();
+      expect(snapshot[0]?.pillarId).toBe('finance');
+      expect(paths).toEqual(['/registry/pillars', '/core.registry.list']);
+
+      // Long-lived transport caches the winner → next poll is a single request.
+      await transport.fetchSnapshot();
+      expect(paths).toEqual(['/registry/pillars', '/core.registry.list', '/core.registry.list']);
+    });
+
+    it('surfaces a 5xx WITHOUT falling back to the legacy path', async () => {
+      const { fetchImpl, paths } = routedFetch({
+        '/registry/pillars': () => new Response('boom', { status: 503, statusText: 'Down' }),
+        '/core.registry.list': () => jsonResponse({ pillars: [discoveredPillar()] }),
+      });
+      const transport = new HttpDiscoveryTransport({
+        registryUrl: 'http://core-api:3001',
+        fetchImpl,
+      });
+
+      await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+      expect(paths).toEqual(['/registry/pillars']);
+    });
+
+    it('self-heals when a cached path later 404s (rollback then legacy-removal)', async () => {
+      let live = new Set(['/registry/pillars', '/core.registry.list']);
+      const paths: string[] = [];
+      const fetchImpl = fakeFetch((url) => {
+        const path = new URL(url).pathname;
+        paths.push(path);
+        if (!live.has(path)) return new Response('', { status: 404 });
+        const id = path === '/registry/pillars' ? 'finance' : 'media';
+        return jsonResponse({ pillars: [discoveredPillar({ pillarId: id })] });
+      });
+      const transport = new HttpDiscoveryTransport({
+        registryUrl: 'http://core-api:3001',
+        fetchImpl,
+      });
+
+      await transport.fetchSnapshot();
+      expect(paths).toEqual(['/registry/pillars']);
+
+      // Core rolled back: cached slash 404s → in-call fallback to legacy.
+      live = new Set(['/core.registry.list']);
+      const fallback = await transport.fetchSnapshot();
+      expect(fallback[0]?.pillarId).toBe('media');
+      expect(paths).toEqual(['/registry/pillars', '/registry/pillars', '/core.registry.list']);
+
+      // Legacy cached; steady single request, no thrash back to slash.
+      paths.length = 0;
+      await transport.fetchSnapshot();
+      expect(paths).toEqual(['/core.registry.list']);
+
+      // Phase-3 roll-forward: legacy removed → cached legacy 404s → re-resolve to slash.
+      live = new Set(['/registry/pillars']);
+      paths.length = 0;
+      await transport.fetchSnapshot();
+      expect(paths).toEqual(['/core.registry.list', '/registry/pillars']);
+    });
   });
 
   it('throws PillarSdkError on invalid JSON', async () => {

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -1,12 +1,24 @@
+import {
+  createResolverLeg,
+  resolveWithFallback,
+  type ResolverLeg,
+} from '../registry-path-resolver.js';
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from '../registry-paths.js';
 import { PillarSdkError } from './errors.js';
 
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
+const HTTP_NOT_FOUND = 404;
+
+function isSnapshotNotFound(err: unknown): boolean {
+  return err instanceof PillarSdkError && err.status === HTTP_NOT_FOUND;
+}
+
 /**
  * The shape returned by the registry discovery snapshot (PRD-161 / PRD-159).
- * Currently served at `GET /core.registry.list`; the canonical slash form
- * `GET /registry/pillars` is introduced in a later phase and is not live yet.
- * One entry per registered pillar.
+ * Served at the canonical `GET /registry/pillars` ({@link REGISTRY_PATHS}.snapshot)
+ * with a 404 fallback to the legacy `GET /core.registry.list` during the
+ * rolling-deploy window. One entry per registered pillar.
  */
 export type DiscoveredPillar = {
   pillarId: string;
@@ -19,12 +31,12 @@ export type DiscoveredPillar = {
 
 /**
  * The transport the client uses to fetch the registry snapshot. The
- * default HTTP impl reads the discovery snapshot from `/core.registry.list`
- * (the canonical slash form `/registry/pillars` is introduced in a later
- * phase, not live yet); tests inject a fake. Decoupling the transport keeps
- * the client unit-testable without a live registry and lets future
- * deployments swap to an SSE / file / in-process variant without touching
- * `pillar()`.
+ * default HTTP impl reads the discovery snapshot slash-first from
+ * `/registry/pillars`, falling back to the legacy `/core.registry.list` on a
+ * 404 during the rolling-deploy window; tests inject a fake. Decoupling the
+ * transport keeps the client unit-testable without a live registry and lets
+ * future deployments swap to an SSE / file / in-process variant without
+ * touching `pillar()`.
  */
 export interface DiscoveryTransport {
   fetchSnapshot(): Promise<readonly DiscoveredPillar[]>;
@@ -46,28 +58,37 @@ const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
  * the raw HTTP wire and reshapes the response into `DiscoveredPillar[]`.
  *
  * Wire shape (raw — no tRPC):
- *   GET /core.registry.list   (the route core mounts today; the canonical
- *                              GET /registry/pillars lands in a later phase)
+ *   GET /registry/pillars     (canonical; on 404 falls back to the legacy
+ *                              GET /core.registry.list during the rollout)
  *   → { pillars: [...], fetchedAt: ... }
  *
- * The body parser still tolerates a `{ result: { data } }` envelope so a
- * mixed deployment (legacy tRPC registry + collapsed pillar) reads either.
+ * The transport is long-lived, so it caches the winning path as a HINT and
+ * re-expands to both candidates on a 404 against the cached path (a core
+ * rollback / lagging replica) — self-healing, never hard-evicting. A 5xx
+ * surfaces immediately without falling back. The body parser still tolerates a
+ * `{ result: { data } }` envelope so a mixed deployment reads either.
  */
 export class HttpDiscoveryTransport implements DiscoveryTransport {
   private readonly registryUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
   private readonly headers: Record<string, string>;
+  private readonly leg: ResolverLeg;
 
   constructor(options: HttpDiscoveryTransportOptions = {}) {
     this.registryUrl = options.registryUrl ?? DEFAULT_REGISTRY_URL;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
     this.headers = options.headers ?? {};
+    this.leg = createResolverLeg(REGISTRY_PATHS.snapshot, LEGACY_REGISTRY_PATHS.snapshot);
   }
 
   async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
-    const url = `${this.registryUrl.replace(/\/$/, '')}/core.registry.list`;
+    return resolveWithFallback(this.leg, isSnapshotNotFound, (path) => this.fetchFromPath(path));
+  }
+
+  private async fetchFromPath(path: string): Promise<readonly DiscoveredPillar[]> {
+    const url = `${this.registryUrl.replace(/\/$/, '')}${path}`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 
@@ -85,7 +106,9 @@ export class HttpDiscoveryTransport implements DiscoveryTransport {
     }
 
     if (!response.ok) {
-      throw new PillarSdkError(`registry returned HTTP ${response.status} ${response.statusText}`);
+      throw new PillarSdkError(`registry returned HTTP ${response.status} ${response.statusText}`, {
+        status: response.status,
+      });
     }
 
     let body: unknown;

--- a/packages/pillar-sdk/src/client/errors.ts
+++ b/packages/pillar-sdk/src/client/errors.ts
@@ -20,11 +20,19 @@ export class PillarCallError extends Error {
  * non-conforming shape. This is *not* used for `unavailable` / `degraded`
  * / `contract-mismatch`; those are returned as `CallResult` discriminants
  * so the caller can branch on them.
+ *
+ * When raised from an HTTP discovery read, {@link PillarSdkError.status} carries
+ * the response status so the slash-first path resolver can distinguish a 404
+ * (unknown path → fall back to the legacy path) from a 5xx (registry is up but
+ * broken → surface the error without falling back).
  */
 export class PillarSdkError extends Error {
   override readonly name = 'PillarSdkError';
-  constructor(message: string, options?: { cause?: unknown }) {
+  /** HTTP status of the failed discovery read, when the error originated from one. */
+  readonly status: number | undefined;
+  constructor(message: string, options?: { cause?: unknown; status?: number }) {
     super(message, options);
+    this.status = options?.status;
   }
 }
 

--- a/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { fetchRegistrySnapshot } from '../fetcher.js';
+import { createSnapshotResolverLeg, fetchRegistrySnapshot } from '../fetcher.js';
 import { jsonResponse, pillar, wirePayload } from './fixtures.js';
 
 describe('fetchRegistrySnapshot', () => {
@@ -15,7 +15,7 @@ describe('fetchRegistrySnapshot', () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'http://core-api:3001/core.registry.list',
+      'http://core-api:3001/registry/pillars',
       expect.objectContaining({ method: 'GET' })
     );
     expect(result.pillars).toHaveLength(2);
@@ -54,7 +54,7 @@ describe('fetchRegistrySnapshot', () => {
       fetchImpl,
     });
     expect(fetchImpl).toHaveBeenCalledWith(
-      'http://core-api:3001/core.registry.list',
+      'http://core-api:3001/registry/pillars',
       expect.anything()
     );
   });
@@ -139,5 +139,90 @@ describe('fetchRegistrySnapshot', () => {
       fetchImpl,
     });
     expect(result.pillars[0]!.registered).toBe(false);
+  });
+
+  describe('slash-first path resolution with legacy fallback', () => {
+    function routedFetch(routes: Record<string, () => Response>): {
+      fetchImpl: ReturnType<typeof vi.fn>;
+      paths: string[];
+    } {
+      const paths: string[] = [];
+      const fetchImpl = vi.fn((url: string) => {
+        const path = new URL(url).pathname;
+        paths.push(path);
+        const make = routes[path];
+        if (!make) throw new Error(`unrouted path ${path}`);
+        return Promise.resolve(make());
+      });
+      return { fetchImpl, paths };
+    }
+
+    it('falls back to /core.registry.list on a 404 and parses the body identically', async () => {
+      const fin = pillar('finance', 'http://finance-api:3004');
+      const { fetchImpl, paths } = routedFetch({
+        '/registry/pillars': () => new Response('', { status: 404 }),
+        '/core.registry.list': () => jsonResponse(wirePayload(fin)),
+      });
+
+      const result = await fetchRegistrySnapshot({
+        registryUrl: 'http://core-api:3001',
+        fetchImpl,
+      });
+      expect(result.pillars[0]!.pillarId).toBe('finance');
+      expect(paths).toEqual(['/registry/pillars', '/core.registry.list']);
+    });
+
+    it('surfaces a 5xx WITHOUT falling back to the legacy path', async () => {
+      const fin = pillar('finance', 'http://finance-api:3004');
+      const { fetchImpl, paths } = routedFetch({
+        '/registry/pillars': () => new Response('boom', { status: 503, statusText: 'Down' }),
+        '/core.registry.list': () => jsonResponse(wirePayload(fin)),
+      });
+
+      await expect(
+        fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl })
+      ).rejects.toThrow(/HTTP 503/);
+      expect(paths).toEqual(['/registry/pillars']);
+    });
+
+    it('caches the winning path across calls when a resolver is shared, self-healing on 404', async () => {
+      const fin = pillar('finance', 'http://finance-api:3004');
+      let live = new Set(['/registry/pillars', '/core.registry.list']);
+      const paths: string[] = [];
+      const fetchImpl = vi.fn((url: string) => {
+        const path = new URL(url).pathname;
+        paths.push(path);
+        return Promise.resolve(
+          live.has(path) ? jsonResponse(wirePayload(fin)) : new Response('', { status: 404 })
+        );
+      });
+      const leg = createSnapshotResolverLeg();
+
+      await fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl, leg });
+      // Second poll reuses the cached slash winner — single request.
+      await fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl, leg });
+      expect(paths).toEqual(['/registry/pillars', '/registry/pillars']);
+
+      // Core rolled back: cached slash 404s → in-call fallback to legacy + invalidate.
+      live = new Set(['/core.registry.list']);
+      await fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl, leg });
+      expect(paths).toEqual([
+        '/registry/pillars',
+        '/registry/pillars',
+        '/registry/pillars',
+        '/core.registry.list',
+      ]);
+
+      // Legacy cached; steady single request, no thrash back to slash.
+      paths.length = 0;
+      await fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl, leg });
+      expect(paths).toEqual(['/core.registry.list']);
+
+      // Phase-3 roll-forward: legacy removed → cached legacy 404s → re-resolve to slash.
+      live = new Set(['/registry/pillars']);
+      paths.length = 0;
+      await fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl, leg });
+      expect(paths).toEqual(['/core.registry.list', '/registry/pillars']);
+    });
   });
 });

--- a/packages/pillar-sdk/src/discovery/cache-internals.ts
+++ b/packages/pillar-sdk/src/discovery/cache-internals.ts
@@ -1,4 +1,8 @@
-import { fetchRegistrySnapshot, type RegistryFetchResult } from './fetcher.js';
+import {
+  createSnapshotResolverLeg,
+  fetchRegistrySnapshot,
+  type RegistryFetchResult,
+} from './fetcher.js';
 
 import type { RegistrySnapshot } from './types.js';
 
@@ -61,8 +65,15 @@ export type CacheState = {
   seeded: boolean;
 };
 
-export function defaultFetcher(registryUrl: string): Promise<RegistryFetchResult> {
-  return fetchRegistrySnapshot({ registryUrl });
+/**
+ * Build a fetcher backed by ONE long-lived slash-first path resolver so the
+ * cache's repeated polls cache the winning registry-snapshot path between calls
+ * and self-heal on a later 404. Each cache instance gets its own resolver.
+ */
+export function createDefaultFetcher(): RegistryFetcher {
+  const leg = createSnapshotResolverLeg();
+  return (registryUrl: string): Promise<RegistryFetchResult> =>
+    fetchRegistrySnapshot({ registryUrl, leg });
 }
 
 export class NodeTimerHandle {
@@ -117,7 +128,7 @@ export function createInitialState(overrides: CacheConfig): CacheState {
     config: {
       registryUrl: overrides.registryUrl ?? DEFAULT_REGISTRY_URL,
       ttlMs: clampTtl(overrides.ttlMs ?? DEFAULT_CACHE_TTL_MS, onWarn),
-      fetcher: overrides.fetcher ?? defaultFetcher,
+      fetcher: overrides.fetcher ?? createDefaultFetcher(),
       now: overrides.now ?? Date.now,
       setTimeoutImpl: overrides.setTimeoutImpl ?? defaultSetTimer,
       clearTimeoutImpl: overrides.clearTimeoutImpl ?? defaultClearTimer,

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -1,15 +1,31 @@
 import {
+  createResolverLeg,
+  resolveWithFallback,
+  type ResolverLeg,
+} from '../registry-path-resolver.js';
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from '../registry-paths.js';
+import {
   parseRegistrySnapshotResponse,
   type PillarRegistryEntryPayload,
 } from './snapshot-schema.js';
 
 import type { PillarSnapshot } from './types.js';
 
+const HTTP_NOT_FOUND = 404;
+
 export type FetcherOptions = {
   registryUrl: string;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
   now?: () => number;
+  /**
+   * Slash-first resolver leg shared across calls. Omit it and the fetcher uses
+   * a fresh leg per call (still slash-first with a 404 fallback, just without
+   * cross-call caching). Pass a long-lived leg — as the cache layer's
+   * `createDefaultFetcher` does — to cache the winning path between polls and
+   * self-heal on a later 404.
+   */
+  leg?: ResolverLeg;
 };
 
 export type RegistryFetchResult = {
@@ -20,11 +36,35 @@ export type RegistryFetchResult = {
 export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * One-shot fetch of the registry discovery snapshot (PRD-161). Currently hits
- * `GET /core.registry.list` (see {@link buildRegistryListUrl}) — the only route
- * core mounts today. The canonical slash form `GET /registry/pillars`
- * (`REGISTRY_PATHS.snapshot`) is introduced in a later phase (dual-serve) and
- * is not live yet.
+ * HTTP status-aware discovery error. Carries the response status so the
+ * slash-first resolver can tell a 404 (unknown path → fall back to the legacy
+ * snapshot path) from a 5xx (registry up but broken → surface without
+ * falling back).
+ */
+export class DiscoveryFetchError extends Error {
+  override readonly name = 'DiscoveryFetchError';
+  readonly status: number;
+  constructor(status: number, statusText: string) {
+    super(`discovery fetch: HTTP ${status} ${statusText}`);
+    this.status = status;
+  }
+}
+
+/** Build a slash-first resolver leg for the discovery snapshot path. */
+export function createSnapshotResolverLeg(): ResolverLeg {
+  return createResolverLeg(REGISTRY_PATHS.snapshot, LEGACY_REGISTRY_PATHS.snapshot);
+}
+
+function isSnapshotNotFound(err: unknown): boolean {
+  return err instanceof DiscoveryFetchError && err.status === HTTP_NOT_FOUND;
+}
+
+/**
+ * One-shot fetch of the registry discovery snapshot (PRD-161). Resolves the
+ * canonical slash path `GET /registry/pillars` ({@link REGISTRY_PATHS}.snapshot)
+ * first, falling back to the legacy `GET /core.registry.list`
+ * ({@link LEGACY_REGISTRY_PATHS}.snapshot) on a 404 during the rolling-deploy
+ * window. A 5xx surfaces immediately without falling back.
  *
  * - 5s timeout via `AbortController` (configurable, but 5s is the default
  *   the PRD-159 contract calls out).
@@ -38,16 +78,38 @@ export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<Re
   if (typeof fetchImpl !== 'function') {
     throw new Error('discovery fetcher: no fetch implementation available');
   }
-  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
-  const now = options.now ?? Date.now;
+  const leg = options.leg ?? createSnapshotResolverLeg();
+  const fetchLeg: FetchLeg = {
+    fetchImpl,
+    timeoutMs: options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+    now: options.now ?? Date.now,
+  };
+  return resolveWithFallback(leg, isSnapshotNotFound, (path) =>
+    fetchFromPath(path, fetchLeg, options.registryUrl)
+  );
+}
 
-  const url = buildRegistryListUrl(options.registryUrl);
+type FetchLeg = {
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  now: () => number;
+};
+
+async function fetchFromPath(
+  path: string,
+  leg: FetchLeg,
+  registryUrl: string
+): Promise<RegistryFetchResult> {
+  const url = `${registryUrl.replace(/\/$/, '')}${path}`;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(new Error('discovery fetch timeout')), timeoutMs);
+  const timer = setTimeout(
+    () => controller.abort(new Error('discovery fetch timeout')),
+    leg.timeoutMs
+  );
 
   let response: Response;
   try {
-    response = await fetchImpl(url, {
+    response = await leg.fetchImpl(url, {
       method: 'GET',
       headers: { accept: 'application/json' },
       signal: controller.signal,
@@ -57,7 +119,7 @@ export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<Re
   }
 
   if (!response.ok) {
-    throw new Error(`discovery fetch: HTTP ${response.status} ${response.statusText}`);
+    throw new DiscoveryFetchError(response.status, response.statusText);
   }
 
   const body = await readJson(response);
@@ -65,12 +127,8 @@ export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<Re
 
   return {
     pillars: payload.pillars.map(toPillarSnapshot),
-    fetchedAt: new Date(now()),
+    fetchedAt: new Date(leg.now()),
   };
-}
-
-function buildRegistryListUrl(registryUrl: string): string {
-  return `${registryUrl.replace(/\/$/, '')}/core.registry.list`;
 }
 
 async function readJson(response: Response): Promise<unknown> {

--- a/packages/pillar-sdk/src/registry-path-resolver.test.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { createPathResolver, type RegistryPathResolver } from './registry-path-resolver.js';
+import {
+  createPathResolver,
+  createResolverLeg,
+  resolveWithFallback,
+  type RegistryPathResolver,
+} from './registry-path-resolver.js';
 
 const NEW = '/registry/register';
 const OLD = '/core.registry.register';
@@ -157,5 +162,64 @@ describe('createPathResolver', () => {
     await expect(resolveOnce(resolver, serves(), freshTracker())).rejects.toThrow(
       /all candidates 404/
     );
+  });
+});
+
+class NotFound extends Error {}
+const isNotFound = (err: unknown): boolean => err instanceof NotFound;
+
+describe('resolveWithFallback', () => {
+  it('never sends a request to an empty or undefined path', async () => {
+    const leg = createResolverLeg(NEW, OLD);
+    const seen: string[] = [];
+    const send = (path: string): Promise<string> => {
+      seen.push(path);
+      return path === OLD ? Promise.resolve('ok') : Promise.reject(new NotFound());
+    };
+
+    const result = await resolveWithFallback(leg, isNotFound, send);
+
+    expect(result).toBe('ok');
+    expect(seen).toEqual([NEW, OLD]);
+    for (const path of seen) {
+      expect(path).toBeTruthy();
+      expect(path).not.toBe('');
+    }
+  });
+
+  it('returns the first 2xx and stops (single request in the happy path)', async () => {
+    const leg = createResolverLeg(NEW, OLD);
+    const seen: string[] = [];
+    const result = await resolveWithFallback(leg, isNotFound, (path) => {
+      seen.push(path);
+      return Promise.resolve(path);
+    });
+    expect(result).toBe(NEW);
+    expect(seen).toEqual([NEW]);
+  });
+
+  it('rethrows a non-404 error immediately without trying the next candidate', async () => {
+    const leg = createResolverLeg(NEW, OLD);
+    const seen: string[] = [];
+    const boom = new Error('5xx up-but-broken');
+    await expect(
+      resolveWithFallback(leg, isNotFound, (path) => {
+        seen.push(path);
+        return Promise.reject(boom);
+      })
+    ).rejects.toBe(boom);
+    expect(seen).toEqual([NEW]);
+  });
+
+  it('rethrows the 404 when the LAST candidate 404s', async () => {
+    const leg = createResolverLeg(NEW, OLD);
+    const seen: string[] = [];
+    await expect(
+      resolveWithFallback(leg, isNotFound, (path) => {
+        seen.push(path);
+        return Promise.reject(new NotFound());
+      })
+    ).rejects.toBeInstanceOf(NotFound);
+    expect(seen).toEqual([NEW, OLD]);
   });
 });

--- a/packages/pillar-sdk/src/registry-path-resolver.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.ts
@@ -106,11 +106,12 @@ export async function resolveWithFallback<T>(
   send: PathRequest<T>
 ): Promise<T> {
   const candidates = leg.resolver.candidates();
+  const lastIndex = candidates.length - 1;
   let firstError: unknown;
   let firstSet = false;
-  for (let index = 0; index < candidates.length; index += 1) {
-    const path = candidates[index] ?? '';
-    const isLast = index === candidates.length - 1;
+  let index = 0;
+  for (const path of candidates) {
+    const isLast = index === lastIndex;
     try {
       const value = await send(path);
       leg.resolver.remember(path);
@@ -127,6 +128,7 @@ export async function resolveWithFallback<T>(
         firstSet = true;
       }
     }
+    index += 1;
   }
   throw firstError ?? new Error('registry path resolver had no candidates');
 }

--- a/packages/pillar-sdk/src/registry-path-resolver.ts
+++ b/packages/pillar-sdk/src/registry-path-resolver.ts
@@ -61,3 +61,72 @@ export function createPathResolver(primary: string, fallback: string): RegistryP
     },
   };
 }
+
+/**
+ * A {@link RegistryPathResolver} bundled with the cross-call "is a winner
+ * cached?" flag that {@link resolveWithFallback} needs to self-heal. Create one
+ * per logical operation (register / heartbeat / snapshot …) and reuse it across
+ * calls so the winning path is cached between requests.
+ */
+export interface ResolverLeg {
+  readonly resolver: RegistryPathResolver;
+  hadHint: boolean;
+}
+
+/** Build a fresh {@link ResolverLeg} for the `primary`/`fallback` pair. */
+export function createResolverLeg(primary: string, fallback: string): ResolverLeg {
+  return { resolver: createPathResolver(primary, fallback), hadHint: false };
+}
+
+/** A request against ONE registry path that resolves on 2xx or rejects. */
+export type PathRequest<T> = (path: string) => Promise<T>;
+
+/**
+ * Run one logical registry operation across the leg's candidate paths with the
+ * self-healing slash-first / legacy-fallback policy (the single implementation
+ * shared by the transport and both discovery readers).
+ *
+ * Order of behavior per candidate, in `leg.resolver.candidates()` order:
+ *  - 2xx → {@link RegistryPathResolver.remember} the winner, set the hint, return.
+ *  - 404 against the FIRST candidate when a winner was cached on a prior call →
+ *    {@link RegistryPathResolver.invalidate} the hint (so the cycle self-heals
+ *    after a core rollback) and fall through to the next candidate IN THIS call.
+ *  - 404 against a later candidate → fall through to the next candidate.
+ *  - 404 from the LAST candidate → rethrow (caller surfaces the normal error).
+ *  - any non-404 error (5xx / network) → rethrow IMMEDIATELY without trying the
+ *    next candidate ("up but broken" is not "path unknown").
+ *
+ * @param leg - the resolver + cross-call hint flag for this operation
+ * @param isNotFound - predicate identifying a 404 from the rejection `send` threw
+ * @param send - issues the request against a single path
+ */
+export async function resolveWithFallback<T>(
+  leg: ResolverLeg,
+  isNotFound: (err: unknown) => boolean,
+  send: PathRequest<T>
+): Promise<T> {
+  const candidates = leg.resolver.candidates();
+  let firstError: unknown;
+  let firstSet = false;
+  for (let index = 0; index < candidates.length; index += 1) {
+    const path = candidates[index] ?? '';
+    const isLast = index === candidates.length - 1;
+    try {
+      const value = await send(path);
+      leg.resolver.remember(path);
+      leg.hadHint = true;
+      return value;
+    } catch (err) {
+      if (!isNotFound(err) || isLast) throw err;
+      if (index === 0 && leg.hadHint) {
+        leg.resolver.invalidate();
+        leg.hadHint = false;
+      }
+      if (!firstSet) {
+        firstError = err;
+        firstSet = true;
+      }
+    }
+  }
+  throw firstError ?? new Error('registry path resolver had no candidates');
+}

--- a/pillars/core/src/api/__tests__/registry-dual-serve.test.ts
+++ b/pillars/core/src/api/__tests__/registry-dual-serve.test.ts
@@ -193,8 +193,10 @@ describe('registry route dual-serve', () => {
 function runMetric(method: string, path: string): { warned: number; warnPaths: string[] } {
   const warnPaths: string[] = [];
   const middleware = makeLegacyPathMetric({
-    warn(payload) {
-      warnPaths.push(String((payload as { path?: unknown }).path));
+    sink: {
+      warn(payload) {
+        warnPaths.push(String((payload as { path?: unknown }).path));
+      },
     },
   });
   let nextCalled = false;

--- a/pillars/core/src/api/__tests__/registry-dual-serve.test.ts
+++ b/pillars/core/src/api/__tests__/registry-dual-serve.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Dual-serve integration for the registry handshake/discovery routes
+ * (registry-cleanup Phase 1).
+ *
+ * Core mounts each registry operation on BOTH its canonical slash path
+ * ({@link REGISTRY_PATHS}) and the legacy dotted alias
+ * ({@link LEGACY_REGISTRY_PATHS}), pointing at one shared handler instance.
+ * This suite proves, via `supertest` against `createCoreApiApp` on a temp
+ * SQLite, that the slash and dotted families are byte-identical (modulo
+ * time-dependent fields) for register / heartbeat / deregister / snapshot — so
+ * an old-SDK pillar (dotted) and a new-SDK pillar (slash) get the same
+ * behavior. The legacy-path-hit metric is unit-tested separately to assert it
+ * fires on the dotted alias only.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS, type ManifestPayload } from '@pops/pillar-sdk';
+
+import { openCoreDb, type OpenedCoreDb } from '../../db/index.js';
+import { createCoreApiApp } from '../app.js';
+import { makeLegacyPathMetric } from '../modules/registry/legacy-path-metric.js';
+
+import type { Request, Response } from 'express';
+
+type App = ReturnType<typeof createCoreApiApp>;
+
+let tmpDir: string;
+const opened: OpenedCoreDb[] = [];
+
+function bootApp(): App {
+  const dir = mkdtempSync(join(tmpDir, 'db-'));
+  const coreDb = openCoreDb(join(dir, 'core.db'));
+  opened.push(coreDb);
+  return createCoreApiApp({ coreDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3001' });
+}
+
+function financeManifest(): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version: '0.1.0',
+    contract: {
+      package: '@pops/finance-contract',
+      version: '0.1.0',
+      tag: 'contract-finance@v0.1.0',
+    },
+    routes: {
+      queries: ['finance.transactions.list'],
+      mutations: ['finance.transactions.create'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['finance/transaction'] },
+    consumedSettings: { keys: ['finance.defaultCurrency'] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+function registerBody(): Record<string, unknown> {
+  return { pillarId: 'finance', baseUrl: 'http://finance-api:3004', manifest: financeManifest() };
+}
+
+const VOLATILE_KEYS = new Set(['registeredAt', 'lastHeartbeatAt', 'statusUpdatedAt', 'fetchedAt']);
+
+/** Strip time-dependent fields so two fresh registries compare structurally. */
+function normalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalize);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value)) {
+      out[key] = VOLATILE_KEYS.has(key) ? '<volatile>' : normalize(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-dual-serve-'));
+});
+
+afterEach(() => {
+  for (const db of opened.splice(0)) {
+    try {
+      db.raw.close();
+    } catch {
+      // ignore close noise — surface the original failure
+    }
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('registry route dual-serve', () => {
+  it('register: slash and dotted are byte-identical on fresh registries', async () => {
+    const slash = bootApp();
+    const dotted = bootApp();
+
+    const a = await request(slash).post(REGISTRY_PATHS.register).send(registerBody());
+    const b = await request(dotted).post(LEGACY_REGISTRY_PATHS.register).send(registerBody());
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(a.status);
+    expect(normalize(b.body)).toEqual(normalize(a.body));
+    expect((a.body as { ok: boolean; pillarId: string }).ok).toBe(true);
+    expect((a.body as { pillarId: string }).pillarId).toBe('finance');
+  });
+
+  it('heartbeat: slash and dotted are byte-identical after registering', async () => {
+    const slash = bootApp();
+    const dotted = bootApp();
+    await request(slash).post(REGISTRY_PATHS.register).send(registerBody());
+    await request(dotted).post(LEGACY_REGISTRY_PATHS.register).send(registerBody());
+
+    const a = await request(slash).post(REGISTRY_PATHS.heartbeat).send({ pillarId: 'finance' });
+    const b = await request(dotted)
+      .post(LEGACY_REGISTRY_PATHS.heartbeat)
+      .send({ pillarId: 'finance' });
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(a.status);
+    expect(normalize(b.body)).toEqual(normalize(a.body));
+    expect((a.body as { ok: boolean }).ok).toBe(true);
+  });
+
+  it('heartbeat soft-fails identically (200 not-registered) for an unknown pillar', async () => {
+    const slash = bootApp();
+    const dotted = bootApp();
+
+    const a = await request(slash).post(REGISTRY_PATHS.heartbeat).send({ pillarId: 'ghost' });
+    const b = await request(dotted)
+      .post(LEGACY_REGISTRY_PATHS.heartbeat)
+      .send({ pillarId: 'ghost' });
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(a.status);
+    expect(a.body).toEqual({ ok: false, reason: 'not-registered' });
+    expect(b.body).toEqual(a.body);
+  });
+
+  it('deregister: slash and dotted are byte-identical after registering', async () => {
+    const slash = bootApp();
+    const dotted = bootApp();
+    await request(slash).post(REGISTRY_PATHS.register).send(registerBody());
+    await request(dotted).post(LEGACY_REGISTRY_PATHS.register).send(registerBody());
+
+    const a = await request(slash).post(REGISTRY_PATHS.deregister).send({ pillarId: 'finance' });
+    const b = await request(dotted)
+      .post(LEGACY_REGISTRY_PATHS.deregister)
+      .send({ pillarId: 'finance' });
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(a.status);
+    expect(a.body).toEqual({ ok: true, removed: true });
+    expect(b.body).toEqual(a.body);
+  });
+
+  it('snapshot: slash and dotted are byte-identical after registering', async () => {
+    const slash = bootApp();
+    const dotted = bootApp();
+    await request(slash).post(REGISTRY_PATHS.register).send(registerBody());
+    await request(dotted).post(LEGACY_REGISTRY_PATHS.register).send(registerBody());
+
+    const a = await request(slash).get(REGISTRY_PATHS.snapshot);
+    const b = await request(dotted).get(LEGACY_REGISTRY_PATHS.snapshot);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(a.status);
+    expect(normalize(b.body)).toEqual(normalize(a.body));
+    const body = a.body as { pillars: Array<{ pillarId: string }>; fetchedAt: string };
+    expect(body.pillars).toHaveLength(1);
+    expect(body.pillars[0]?.pillarId).toBe('finance');
+    expect('result' in (a.body as Record<string, unknown>)).toBe(false);
+  });
+
+  it('the SAME app serves both families against one shared registry', async () => {
+    const app = bootApp();
+    await request(app).post(REGISTRY_PATHS.register).send(registerBody());
+
+    const viaSlash = await request(app).get(REGISTRY_PATHS.snapshot);
+    const viaDotted = await request(app).get(LEGACY_REGISTRY_PATHS.snapshot);
+
+    expect(viaSlash.status).toBe(200);
+    expect(viaDotted.status).toBe(200);
+    expect(normalize(viaDotted.body)).toEqual(normalize(viaSlash.body));
+  });
+});
+
+function runMetric(method: string, path: string): { warned: number; warnPaths: string[] } {
+  const warnPaths: string[] = [];
+  const middleware = makeLegacyPathMetric({
+    warn(payload) {
+      warnPaths.push(String((payload as { path?: unknown }).path));
+    },
+  });
+  let nextCalled = false;
+  const req = { path, method } as unknown as Request;
+  const res = {} as Response;
+  middleware(req, res, () => {
+    nextCalled = true;
+  });
+  expect(nextCalled).toBe(true);
+  return { warned: warnPaths.length, warnPaths };
+}
+
+describe('legacy-path-hit metric', () => {
+  it('fires on each legacy dotted path', () => {
+    for (const path of Object.values(LEGACY_REGISTRY_PATHS)) {
+      const { warned, warnPaths } = runMetric('POST', path);
+      expect(warned).toBe(1);
+      expect(warnPaths).toEqual([path]);
+    }
+  });
+
+  it('does NOT fire on the canonical slash paths', () => {
+    for (const path of Object.values(REGISTRY_PATHS)) {
+      const { warned } = runMetric('POST', path);
+      expect(warned).toBe(0);
+    }
+  });
+
+  it('does NOT fire on unrelated paths and always calls next()', () => {
+    expect(runMetric('GET', '/health').warned).toBe(0);
+    expect(runMetric('GET', '/pillars').warned).toBe(0);
+  });
+});

--- a/pillars/core/src/api/__tests__/registry-sdk-interop.test.ts
+++ b/pillars/core/src/api/__tests__/registry-sdk-interop.test.ts
@@ -103,7 +103,7 @@ async function registerFinance(): Promise<void> {
 }
 
 describe('SDK ↔ core.registry discovery interop', () => {
-  it('HttpDiscoveryTransport hits /core.registry.list and resolves the snapshot', async () => {
+  it('HttpDiscoveryTransport hits /registry/pillars (slash-first, no fallback) and resolves the snapshot', async () => {
     await registerFinance();
 
     const seenUrls: string[] = [];
@@ -118,7 +118,9 @@ describe('SDK ↔ core.registry discovery interop', () => {
     const transport = new HttpDiscoveryTransport({ registryUrl: baseUrl, fetchImpl: tracingFetch });
     const snapshot = await transport.fetchSnapshot();
 
-    expect(seenUrls).toEqual([`${baseUrl}/core.registry.list`]);
+    // New SDK + new (dual-serving) core: the canonical slash path resolves on
+    // the first request — no 404 fallback to the legacy dotted path.
+    expect(seenUrls).toEqual([`${baseUrl}/registry/pillars`]);
     expect(lastResponse?.status).toBe(200);
 
     // Bare body — no tRPC `{ result: { data } }` envelope.
@@ -142,7 +144,7 @@ describe('SDK ↔ core.registry discovery interop', () => {
     const transport = new HttpDiscoveryTransport({ registryUrl: baseUrl, fetchImpl: tracingFetch });
     const snapshot = await transport.fetchSnapshot();
 
-    expect(seenUrls).toEqual([`${baseUrl}/core.registry.list`]);
+    expect(seenUrls).toEqual([`${baseUrl}/registry/pillars`]);
     expect(snapshot).toEqual([]);
   });
 });

--- a/pillars/core/src/api/app.ts
+++ b/pillars/core/src/api/app.ts
@@ -5,9 +5,18 @@
  * `createExpressEndpoints`) plus the handful of raw HTTP/SSE routes the
  * registry needs and ts-rest cannot model — `GET /pillars`, `GET /pillars/health`,
  * `POST /uri/resolve`, the SSE `GET /registry/subscribe`, the DB-backed
- * discovery snapshot `GET /core.registry.list`, and the raw
- * `POST /core.registry.{register,heartbeat,deregister}` mutations. The pillar
- * serves no tRPC.
+ * discovery snapshot, and the raw register/heartbeat/deregister mutations. The
+ * pillar serves no tRPC.
+ *
+ * Registry handshake/discovery paths are DUAL-SERVED during the dot-routes →
+ * slash rolling-deploy window: each operation is mounted on its canonical slash
+ * path (`GET /registry/pillars`, `POST /registry/{register,heartbeat,
+ * deregister}` — {@link REGISTRY_PATHS}) AND on the legacy dotted path
+ * (`GET /core.registry.list`, `POST /core.registry.{register,heartbeat,
+ * deregister}` — {@link LEGACY_REGISTRY_PATHS}), both pointing at the SAME
+ * handler instance. The legacy aliases let an old-SDK pillar keep registering
+ * against a new core; they are removed in a later release once the
+ * legacy-path-hit metric reads zero everywhere.
  *
  * Kept as a factory so the test suite can spin up an in-process `supertest`
  * instance without binding a real port.
@@ -19,15 +28,20 @@ import { fileURLToPath } from 'node:url';
 import { createExpressEndpoints } from '@ts-rest/express';
 import express, { type Express, type NextFunction, type Request, type Response } from 'express';
 
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from '@pops/pillar-sdk';
+
 import { coreContract } from '../contract/rest.js';
 import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
 import { createIdentityMiddleware } from './middleware/identity.js';
 import { createExternalDeregisterHandler } from './modules/external-registry/deregister.js';
 import { createExternalHeartbeatHandler } from './modules/external-registry/heartbeat.js';
 import { createExternalRegisterHandler } from './modules/external-registry/register.js';
+import { makeLegacyPathMetric } from './modules/registry/legacy-path-metric.js';
 import { createRegistrySnapshotHandler } from './modules/registry/snapshot.js';
 import { createRegistrySubscribeHandler } from './modules/registry/subscribe.js';
 import { makeCoreRestHandlers } from './rest/handlers.js';
+
+import type { CoreDb } from '../db/index.js';
 
 /**
  * The committed OpenAPI projection (`pillars/core/openapi/core.openapi.json`),
@@ -49,6 +63,33 @@ const openapiDocument: unknown = JSON.parse(
     'utf8'
   )
 );
+
+/**
+ * Mount the registry handshake/discovery routes, DUAL-SERVED on the canonical
+ * slash path and the legacy dotted alias during the rolling-deploy window.
+ *
+ * Each handler is created once and shared by both paths (no logic duplication);
+ * `legacyHit` is a pass-through metric mounted in front of both that fires only
+ * on the dotted alias. Raw HTTP (not ts-rest / not tRPC): the snapshot returns
+ * the bare `{ pillars, fetchedAt }` shape the pillar SDK's
+ * `HttpDiscoveryTransport` reads.
+ */
+function mountRegistryRoutes(app: Express, db: CoreDb): void {
+  const snapshotHandler = createRegistrySnapshotHandler(db);
+  const registerHandler = createExternalRegisterHandler({ coreDb: db });
+  const heartbeatHandler = createExternalHeartbeatHandler({ coreDb: db });
+  const deregisterHandler = createExternalDeregisterHandler({ coreDb: db });
+  const legacyHit = makeLegacyPathMetric();
+
+  for (const path of [REGISTRY_PATHS.snapshot, LEGACY_REGISTRY_PATHS.snapshot])
+    app.get(path, legacyHit, snapshotHandler);
+  for (const path of [REGISTRY_PATHS.register, LEGACY_REGISTRY_PATHS.register])
+    app.post(path, legacyHit, registerHandler);
+  for (const path of [REGISTRY_PATHS.heartbeat, LEGACY_REGISTRY_PATHS.heartbeat])
+    app.post(path, legacyHit, heartbeatHandler);
+  for (const path of [REGISTRY_PATHS.deregister, LEGACY_REGISTRY_PATHS.deregister])
+    app.post(path, legacyHit, deregisterHandler);
+}
 
 export function createCoreApiApp(deps: CoreApiDeps): Express {
   const app = express();
@@ -108,21 +149,7 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
 
   app.get('/registry/subscribe', createRegistrySubscribeHandler(deps.coreDb.db));
 
-  // DB-backed registry snapshot — the discovery surface the pillar SDK's
-  // `HttpDiscoveryTransport` reads. Raw HTTP (not ts-rest / not tRPC); returns
-  // the bare `{ pillars, fetchedAt }` shape. `GET /pillars` is the same DB
-  // registry projected onto the `{ id, baseUrl }` shape (registry-first, with
-  // the `POPS_PILLARS` env as a boot seed / fallback).
-  app.get('/core.registry.list', createRegistrySnapshotHandler(deps.coreDb.db));
-
-  app.post('/core.registry.register', createExternalRegisterHandler({ coreDb: deps.coreDb.db }));
-
-  app.post('/core.registry.heartbeat', createExternalHeartbeatHandler({ coreDb: deps.coreDb.db }));
-
-  app.post(
-    '/core.registry.deregister',
-    createExternalDeregisterHandler({ coreDb: deps.coreDb.db })
-  );
+  mountRegistryRoutes(app, deps.coreDb.db);
 
   // Identity middleware (REST surface). Resolves the per-request principal
   // (`x-pops-user` from the dispatcher / `x-api-key` service accounts) and

--- a/pillars/core/src/api/modules/registry/__tests__/legacy-path-metric.test.ts
+++ b/pillars/core/src/api/modules/registry/__tests__/legacy-path-metric.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the throttled legacy-path-hit metric (registry-cleanup Phase 1).
+ *
+ * The dual-serve window can run for days while old pillars heartbeat at the 10s
+ * cadence. The metric must keep the gating signal accurate — count EVERY hit —
+ * while never emitting more than one `warn` per legacy path per window, folding
+ * the suppressed-hit count into the next emitted record. These tests drive an
+ * injected clock so window boundaries are exercised without real time, and an
+ * injected recording sink so emit cadence and payloads are asserted directly.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { LEGACY_REGISTRY_PATHS, REGISTRY_PATHS } from '@pops/pillar-sdk';
+
+import {
+  makeLegacyPathMetric,
+  WARN_WINDOW_MS,
+  type LegacyPathMetricSink,
+} from '../legacy-path-metric.js';
+
+import type { Request, Response } from 'express';
+
+interface WarnRecord {
+  payload: Record<string, unknown>;
+  message: string;
+}
+
+function recordingSink(): { sink: LegacyPathMetricSink; records: WarnRecord[] } {
+  const records: WarnRecord[] = [];
+  return {
+    records,
+    sink: {
+      warn(payload, message): void {
+        records.push({ payload, message });
+      },
+    },
+  };
+}
+
+function mutableClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+  let current = start;
+  return {
+    now: () => current,
+    advance: (ms) => {
+      current += ms;
+    },
+  };
+}
+
+function hit(
+  middleware: (req: Request, res: Response, next: () => void) => void,
+  path: string,
+  method = 'POST'
+): boolean {
+  let nextCalled = false;
+  const req = { path, method } as unknown as Request;
+  const res = {} as Response;
+  middleware(req, res, () => {
+    nextCalled = true;
+  });
+  return nextCalled;
+}
+
+const LEGACY = LEGACY_REGISTRY_PATHS.heartbeat;
+
+describe('makeLegacyPathMetric throttle', () => {
+  it('always calls next() and never emits on canonical slash paths', () => {
+    const { sink, records } = recordingSink();
+    const middleware = makeLegacyPathMetric({ sink, clock: mutableClock().now });
+
+    for (const path of Object.values(REGISTRY_PATHS)) {
+      expect(hit(middleware, path)).toBe(true);
+    }
+
+    expect(records).toHaveLength(0);
+  });
+
+  it('emits once per path on the first hit with a zero suppressed count', () => {
+    const { sink, records } = recordingSink();
+    const middleware = makeLegacyPathMetric({ sink, clock: mutableClock().now });
+
+    expect(hit(middleware, LEGACY)).toBe(true);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.payload).toMatchObject({
+      event: 'registry.legacy_path_hit',
+      path: LEGACY,
+      method: 'POST',
+      suppressedSinceLastWarn: 0,
+    });
+  });
+
+  it('counts every hit but emits at most one warn per window per path', () => {
+    const { sink, records } = recordingSink();
+    const clock = mutableClock();
+    const middleware = makeLegacyPathMetric({ sink, clock: clock.now });
+
+    const totalHits = 50;
+    for (let i = 0; i < totalHits; i += 1) {
+      expect(hit(middleware, LEGACY)).toBe(true);
+      clock.advance(WARN_WINDOW_MS / 100);
+    }
+
+    expect(records).toHaveLength(1);
+  });
+
+  it('re-emits after the window elapses, carrying the suppressed count', () => {
+    const { sink, records } = recordingSink();
+    const clock = mutableClock();
+    const middleware = makeLegacyPathMetric({ sink, clock: clock.now });
+
+    hit(middleware, LEGACY);
+
+    const suppressedHits = 12;
+    for (let i = 0; i < suppressedHits; i += 1) {
+      clock.advance(1000);
+      hit(middleware, LEGACY);
+    }
+
+    clock.advance(WARN_WINDOW_MS);
+    hit(middleware, LEGACY);
+
+    expect(records).toHaveLength(2);
+    expect(records[0]?.payload.suppressedSinceLastWarn).toBe(0);
+    expect(records[1]?.payload.suppressedSinceLastWarn).toBe(suppressedHits);
+  });
+
+  it('resets the suppressed count to zero after each emit', () => {
+    const { sink, records } = recordingSink();
+    const clock = mutableClock();
+    const middleware = makeLegacyPathMetric({ sink, clock: clock.now });
+
+    hit(middleware, LEGACY);
+    hit(middleware, LEGACY);
+    hit(middleware, LEGACY);
+
+    clock.advance(WARN_WINDOW_MS);
+    hit(middleware, LEGACY);
+
+    clock.advance(WARN_WINDOW_MS);
+    hit(middleware, LEGACY);
+
+    expect(records).toHaveLength(3);
+    expect(records[1]?.payload.suppressedSinceLastWarn).toBe(2);
+    expect(records[2]?.payload.suppressedSinceLastWarn).toBe(0);
+  });
+
+  it('throttles each legacy path on its own independent window', () => {
+    const { sink, records } = recordingSink();
+    const clock = mutableClock();
+    const middleware = makeLegacyPathMetric({ sink, clock: clock.now });
+
+    const register = LEGACY_REGISTRY_PATHS.register;
+    const heartbeat = LEGACY_REGISTRY_PATHS.heartbeat;
+
+    hit(middleware, register);
+    hit(middleware, register);
+    hit(middleware, heartbeat);
+    hit(middleware, heartbeat);
+
+    expect(records).toHaveLength(2);
+    const warnedPaths = records.map((r) => r.payload.path);
+    expect(warnedPaths).toContain(register);
+    expect(warnedPaths).toContain(heartbeat);
+  });
+
+  it('honors a custom window', () => {
+    const { sink, records } = recordingSink();
+    const clock = mutableClock();
+    const middleware = makeLegacyPathMetric({ sink, clock: clock.now, windowMs: 1000 });
+
+    hit(middleware, LEGACY);
+    clock.advance(999);
+    hit(middleware, LEGACY);
+    clock.advance(1);
+    hit(middleware, LEGACY);
+
+    expect(records).toHaveLength(2);
+    expect(records[1]?.payload.suppressedSinceLastWarn).toBe(1);
+  });
+});

--- a/pillars/core/src/api/modules/registry/legacy-path-metric.ts
+++ b/pillars/core/src/api/modules/registry/legacy-path-metric.ts
@@ -1,0 +1,51 @@
+/**
+ * Legacy registry-path-hit instrumentation for the dot-routes → slash rollout.
+ *
+ * During the rolling-deploy window core dual-serves each registry operation on
+ * both its canonical slash path ({@link REGISTRY_PATHS}) and the legacy dotted
+ * path ({@link LEGACY_REGISTRY_PATHS}). This middleware is a dependency-light
+ * pass-through that emits ONE structured `warn`-level record whenever a request
+ * lands on a legacy dotted path, then calls `next()` unchanged.
+ *
+ * The signal gates the eventual legacy-path removal: once this counter reads
+ * zero across every core instance, no pillar image is still dialing the dotted
+ * shape and the aliases can be dropped. It never reads `req.body`, never blocks,
+ * and adds a single set-membership check per request — cheap enough to mount in
+ * front of every dual-served handler.
+ */
+import { LEGACY_REGISTRY_PATHS } from '@pops/pillar-sdk';
+
+import { logger } from '../../shared/logger.js';
+
+import type { NextFunction, Request, Response } from 'express';
+
+const LEGACY_PATHS: ReadonlySet<string> = new Set(Object.values(LEGACY_REGISTRY_PATHS));
+
+/** A `warn`/`next`-only middleware shaped like the Express ones core mounts. */
+export type LegacyPathMetricMiddleware = (req: Request, res: Response, next: NextFunction) => void;
+
+/** Structured-log sink the metric writes to. Defaults to the core pino logger. */
+export interface LegacyPathMetricSink {
+  warn(payload: Record<string, unknown>, message: string): void;
+}
+
+/**
+ * Build the legacy-path-hit metric middleware.
+ *
+ * @param sink - structured-log sink; defaults to the shared core logger so a
+ *   call site can mount `makeLegacyPathMetric()` with no arguments and tests
+ *   can inject a recording sink to assert the hit fires on dotted paths only.
+ */
+export function makeLegacyPathMetric(
+  sink: LegacyPathMetricSink = logger
+): LegacyPathMetricMiddleware {
+  return function legacyPathMetric(req, _res, next): void {
+    if (LEGACY_PATHS.has(req.path)) {
+      sink.warn(
+        { event: 'registry.legacy_path_hit', path: req.path, method: req.method },
+        'registry legacy dotted path hit (slash form is canonical; legacy removed in a later release)'
+      );
+    }
+    next();
+  };
+}

--- a/pillars/core/src/api/modules/registry/legacy-path-metric.ts
+++ b/pillars/core/src/api/modules/registry/legacy-path-metric.ts
@@ -4,14 +4,22 @@
  * During the rolling-deploy window core dual-serves each registry operation on
  * both its canonical slash path ({@link REGISTRY_PATHS}) and the legacy dotted
  * path ({@link LEGACY_REGISTRY_PATHS}). This middleware is a dependency-light
- * pass-through that emits ONE structured `warn`-level record whenever a request
- * lands on a legacy dotted path, then calls `next()` unchanged.
+ * pass-through that records EVERY request landing on a legacy dotted path, then
+ * calls `next()` unchanged.
  *
- * The signal gates the eventual legacy-path removal: once this counter reads
- * zero across every core instance, no pillar image is still dialing the dotted
- * shape and the aliases can be dropped. It never reads `req.body`, never blocks,
- * and adds a single set-membership check per request — cheap enough to mount in
- * front of every dual-served handler.
+ * The hit COUNT gates the eventual legacy-path removal: once it reads zero
+ * across every core instance, no pillar image is still dialing the dotted shape
+ * and the aliases can be dropped. So every hit is counted — but the `warn` is
+ * throttled to at most one per path per {@link WARN_WINDOW_MS} window. Without
+ * the throttle a single still-old pillar heartbeating at
+ * {@link HEARTBEAT_INTERVAL_MS} would emit a `warn` every 10s per core instance
+ * for the whole dual-serve window, flooding logs and tripping warn-based alerts.
+ * Each emitted record carries the suppressed-hit count accumulated since the
+ * previous emit for that path, so the aggregate signal is never lost.
+ *
+ * The throttle state is bounded by the legacy-path set (one counter entry per
+ * dotted path), so it cannot grow unbounded. The middleware never reads
+ * `req.body`, never blocks, and adds a single set-membership check per request.
  */
 import { LEGACY_REGISTRY_PATHS } from '@pops/pillar-sdk';
 
@@ -21,6 +29,9 @@ import type { NextFunction, Request, Response } from 'express';
 
 const LEGACY_PATHS: ReadonlySet<string> = new Set(Object.values(LEGACY_REGISTRY_PATHS));
 
+/** Minimum wall-clock gap between two emitted `warn`s for the same legacy path. */
+export const WARN_WINDOW_MS = 5 * 60 * 1000;
+
 /** A `warn`/`next`-only middleware shaped like the Express ones core mounts. */
 export type LegacyPathMetricMiddleware = (req: Request, res: Response, next: NextFunction) => void;
 
@@ -29,22 +40,68 @@ export interface LegacyPathMetricSink {
   warn(payload: Record<string, unknown>, message: string): void;
 }
 
+/** Wall-clock source in epoch millis. Defaults to `Date.now`; injectable for tests. */
+export type MetricClock = () => number;
+
+/** Per-path throttle bookkeeping: when we last emitted, and hits suppressed since. */
+interface PathWindow {
+  lastEmitMs: number;
+  suppressed: number;
+}
+
+/** Options for {@link makeLegacyPathMetric}. */
+export interface LegacyPathMetricOptions {
+  /**
+   * Structured-log sink; defaults to the shared core logger so a call site can
+   * mount `makeLegacyPathMetric()` with no arguments and tests can inject a
+   * recording sink to assert emit cadence and aggregated counts.
+   */
+  readonly sink?: LegacyPathMetricSink;
+  /** Wall-clock source; defaults to `Date.now`. Tests inject a controllable clock. */
+  readonly clock?: MetricClock;
+  /** Minimum gap between emitted warns per path; defaults to {@link WARN_WINDOW_MS}. */
+  readonly windowMs?: number;
+}
+
+const WARN_MESSAGE =
+  'registry legacy dotted path hit (slash form is canonical; legacy removed in a later release)';
+
 /**
  * Build the legacy-path-hit metric middleware.
  *
- * @param sink - structured-log sink; defaults to the shared core logger so a
- *   call site can mount `makeLegacyPathMetric()` with no arguments and tests
- *   can inject a recording sink to assert the hit fires on dotted paths only.
+ * Counts every hit but emits at most one `warn` per legacy path per window. The
+ * throttle state lives in this closure (one entry per legacy path), so it is
+ * bounded and reset per middleware instance.
+ *
+ * @param options - injectable sink / clock / window; all optional.
  */
 export function makeLegacyPathMetric(
-  sink: LegacyPathMetricSink = logger
+  options: LegacyPathMetricOptions = {}
 ): LegacyPathMetricMiddleware {
+  const sink = options.sink ?? logger;
+  const clock = options.clock ?? Date.now;
+  const windowMs = options.windowMs ?? WARN_WINDOW_MS;
+  const windows = new Map<string, PathWindow>();
+
   return function legacyPathMetric(req, _res, next): void {
-    if (LEGACY_PATHS.has(req.path)) {
-      sink.warn(
-        { event: 'registry.legacy_path_hit', path: req.path, method: req.method },
-        'registry legacy dotted path hit (slash form is canonical; legacy removed in a later release)'
-      );
+    const path = req.path;
+    if (LEGACY_PATHS.has(path)) {
+      const now = clock();
+      const window = windows.get(path);
+      if (window === undefined || now - window.lastEmitMs >= windowMs) {
+        sink.warn(
+          {
+            event: 'registry.legacy_path_hit',
+            path,
+            method: req.method,
+            suppressedSinceLastWarn: window?.suppressed ?? 0,
+          },
+          WARN_MESSAGE
+        );
+        windows.set(path, { lastEmitMs: now, suppressed: 0 });
+      } else {
+        window.suppressed += 1;
+      }
     }
     next();
   };


### PR DESCRIPTION
## Stage 2a — registry-cleanup Phase 1 (core dual-serve + SDK slash-first resolver)

Implements **Phase 1** of `docs/plans/03-registry-endpoint-cleanup.md` (core dual-serve + legacy-path metric) **plus the SDK part of Phase 2a** (slash-first 404-fallback wiring). Phase 0 (the `REGISTRY_PATHS`/`LEGACY_REGISTRY_PATHS` constants + the self-healing `createPathResolver`) already landed on `main`; this PR actually wires them into routing.

Removal of the legacy dotted routes is **Phase 3** and is explicitly out of scope (gated externally on the zero-legacy-traffic metric + the homelab allow-list widening).

### Routes added (core dual-serve)

`pillars/core/src/api/app.ts` now mounts each registry operation on BOTH its canonical slash path and the existing legacy dotted alias, each pair pointing at ONE shared handler instance (no logic duplication, registered via a DRY loop):

| Canonical (new)          | Legacy (kept)               | Method | Handler |
| ------------------------ | --------------------------- | ------ | ------- |
| `GET  /registry/pillars`   | `GET  /core.registry.list`       | GET  | `createRegistrySnapshotHandler` |
| `POST /registry/register`  | `POST /core.registry.register`   | POST | `createExternalRegisterHandler` |
| `POST /registry/heartbeat` | `POST /core.registry.heartbeat`  | POST | `createExternalHeartbeatHandler` |
| `POST /registry/deregister`| `POST /core.registry.deregister` | POST | `createExternalDeregisterHandler` |

A dependency-light **legacy-path-hit metric** (`makeLegacyPathMetric`, new `modules/registry/legacy-path-metric.ts`) is mounted as a pass-through middleware in front of all of them; it emits ONE structured `warn` only when `req.path` is a legacy dotted path, then `next()`. This is the signal that gates the eventual Phase-3 removal. The registry routes are raw HTTP (not ts-rest), so they do not appear in the generated OpenAPI — confirmed no `core.openapi.json` drift.

### How the SDK wiring uses the resolver

The SDK transport and both discovery readers resolve slash-first with a legacy fallback via the Phase-0 `createPathResolver`, driven by a single shared `resolveWithFallback(leg, isNotFound, send)` helper added to `registry-path-resolver.ts` (one implementation, three call sites — DRY):

- **`bootstrap/transport.ts`** — `register` / `heartbeat` / `unregister` each own a `ResolverLeg` (`REGISTRY_PATHS.x` primary, `LEGACY_REGISTRY_PATHS.x` fallback). Try the cached/preferred candidate; on a **404** invalidate the cached hint (when it was a prior winner) and fall through to the next candidate **in the same call**; on **2xx** `remember()` the winner; on **5xx / network error** throw immediately **without** trying the legacy path.
- **`client/discovery.ts`** (`HttpDiscoveryTransport`) — long-lived, holds one `ResolverLeg`; `fetchSnapshot` resolves `/registry/pillars` → 404 → `/core.registry.list`. Made **status-aware**: `PillarSdkError` now carries `status` so 404 (fall back) is distinguished from 5xx (surface).
- **`discovery/fetcher.ts`** (`fetchRegistrySnapshot`) — made status-aware via a new `DiscoveryFetchError { status }`; accepts an optional shared `ResolverLeg` so the cache layer (`createDefaultFetcher`) caches the winning path across polls and self-heals.

The cache is a HINT, not a lock: a 404 on the cached path self-heals in-call (no failed heartbeat) and only re-resolves slash-first when the *cached* path itself 404s — it does not thrash back to slash just because slash reappeared, so combo-3 (permanently-old core) stays a single request after the first fallback.

### Rolling-deploy safety matrix (tested)

| Pillar SDK | Core | Path used | Result |
| ---------- | ---- | --------- | ------ |
| old (dotted-only) | **new (dual-serve)** | dotted still served | ✅ works |
| **new (resolver)** | old (dotted-only) | slash 404 → dotted fallback | ✅ works |
| new | new | slash, remembered | ✅ works |
| new (cached slash) | **rolled-back core** | cached slash 404 → in-call dotted fallback + invalidate | ✅ self-heals, no eviction |

There is no rollout state where the register/heartbeat/discovery handshake breaks.

### Tests

- **`registry-dual-serve.test.ts`** (new, supertest + temp SQLite): slash vs dotted are byte-identical (modulo time fields) for register / heartbeat / deregister / snapshot; heartbeat soft-fail parity; one app serves both families against one registry; legacy-path metric fires on dotted paths only and always calls `next()`.
- **`transport.test.ts`**: slash-first; 404→legacy fallback + winner caching; 5xx→throw-without-fallback; both-404→non-retriable; self-heal across rollback → legacy-removal.
- **`discovery.test.ts`** / **`fetcher.test.ts`**: slash-first URL; 404→fallback parses identically; 5xx→no fallback; cross-call caching + self-heal.
- **`registry-sdk-interop.test.ts`**: end-to-end — new SDK against the new dual-serving core resolves on `/registry/pillars` in a single request (no fallback).

### Verification (all green)

- `@pops/pillar-sdk` typecheck + test: **622 passing**
- `@pops/core` typecheck + test: **653 passing**
- `turbo typecheck --filter=...@pops/pillar-sdk` (every SDK consumer): **32/32 passing**
- Root `pnpm lint`: exit 0, **zero errors** (oxlint complexity ≤ 12)
- `oxfmt --check` on touched files: clean
- core OpenAPI drift: none (raw registry routes excluded from the generated doc)

### Plan ambiguity resolved

- The plan snippet referenced `deps.logger` for the metric, but `CoreApiDeps` has no logger field. Used the shared `pillars/core/src/api/shared/logger.ts` pino instance (the established core convention), with `makeLegacyPathMetric(sink?)` taking an injectable sink so the middleware is unit-testable.
- The Phase-0 resolver's reference test (`registry-path-resolver.test.ts`) is the authoritative wiring contract: a fallback win is *remembered* (so combo-3 is single-request), and the resolver re-resolves only when the *cached* path 404s. The fallback wiring mirrors that `hadHint`/invalidate-on-first-candidate-404 logic exactly rather than thrashing back to slash on every poll.

**Do not merge** — Phase 1 is a deploy-then-observe gate before Phase 2a's SDK rollout.
