### PR TITLE
refactor(core): serve settings via @pops/pillar-settings (RU+reset, redaction) [settings S1]

### DIFF
--- a/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
@@ -94,6 +94,34 @@ describe('HttpDiscoveryTransport', () => {
     await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
   });
 
+  it('threads the optional capabilities map through into the parsed entry', async () => {
+    const fetchImpl = fakeFetch(() =>
+      jsonResponse({
+        pillars: [discoveredPillar({ capabilities: { settings: true, redis: false } })],
+      })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    const snapshot = await transport.fetchSnapshot();
+    expect(snapshot[0]?.capabilities).toEqual({ settings: true, redis: false });
+  });
+
+  it('leaves capabilities undefined when the entry omits it', async () => {
+    const fetchImpl = fakeFetch(() => jsonResponse({ pillars: [discoveredPillar()] }));
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    const snapshot = await transport.fetchSnapshot();
+    expect(snapshot[0]?.capabilities).toBeUndefined();
+  });
+
+  it('throws PillarSdkError when a capability value is not a boolean', async () => {
+    const fetchImpl = fakeFetch(() =>
+      jsonResponse({
+        pillars: [{ ...discoveredPillar(), capabilities: { settings: 'yes' } }],
+      })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
   it('attaches custom auth headers', async () => {
     let seen: Record<string, string> = {};
     const fetchImpl = fakeFetch((_url, init) => {

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -1,5 +1,6 @@
 import { PillarSdkError } from './errors.js';
 
+import type { CapabilityStatuses } from '../bootstrap/transport.js';
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
 /**
@@ -15,6 +16,12 @@ export type DiscoveredPillar = {
   manifest: ManifestPayload;
   lastSeenAt: string;
   registered: boolean;
+  /**
+   * Live capability statuses the pillar self-reported (`<capabilityKey> →
+   * up/down`), threaded through from the registry wire (settings-federation
+   * GAP-256-D). Absent when the entry omits `capabilities`.
+   */
+  capabilities?: CapabilityStatuses;
 };
 
 /**
@@ -115,6 +122,7 @@ function parseRegistryEntry(entry: unknown, index: number): DiscoveredPillar {
   if (!isRecord(entry)) {
     throw new PillarSdkError(`registry snapshot entry ${index} is not an object`);
   }
+  const capabilities = optionalCapabilities(entry['capabilities'], index);
   return {
     pillarId: requireString(entry, 'pillarId', index),
     baseUrl: requireString(entry, 'baseUrl', index),
@@ -122,6 +130,7 @@ function parseRegistryEntry(entry: unknown, index: number): DiscoveredPillar {
     manifest: requireManifest(entry['manifest'], index),
     lastSeenAt: requireLastSeenAt(entry, index),
     registered: requireRegistered(entry['registered'], index),
+    ...(capabilities !== undefined ? { capabilities } : {}),
   };
 }
 
@@ -166,6 +175,29 @@ function requireRegistered(value: unknown, index: number): boolean {
     throw new PillarSdkError(`registry snapshot entry ${index} registered is not boolean`);
   }
   return value;
+}
+
+/**
+ * Normalise the optional `capabilities` map (`<capabilityKey> → up/down`).
+ * Absent / null ⇒ `undefined` (a pillar with no capabilities). Present ⇒
+ * validated as a flat `Record<string, boolean>`; any non-boolean member is a
+ * malformed wire entry and is rejected (settings-federation GAP-256-D).
+ */
+function optionalCapabilities(value: unknown, index: number): CapabilityStatuses | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) {
+    throw new PillarSdkError(`registry snapshot entry ${index} capabilities is not an object`);
+  }
+  const result: CapabilityStatuses = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw !== 'boolean') {
+      throw new PillarSdkError(
+        `registry snapshot entry ${index} capability '${key}' is not boolean`
+      );
+    }
+    result[key] = raw;
+  }
+  return result;
 }
 
 function extractTrpcData(body: unknown): unknown {

--- a/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
@@ -24,6 +24,42 @@ describe('fetchRegistrySnapshot', () => {
     expect(result.pillars[1]!.pillarId).toBe('media');
   });
 
+  it('threads the optional capabilities map through into the PillarSnapshot', async () => {
+    const fin = pillar('finance', 'http://finance-api:3004');
+    const raw = {
+      pillars: [
+        {
+          pillarId: fin.pillarId,
+          baseUrl: fin.baseUrl,
+          manifest: fin.manifest,
+          lastSeenAt: fin.lastSeenAt.toISOString(),
+          status: 'healthy',
+          capabilities: { settings: true },
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(raw));
+
+    const result = await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+
+    expect(result.pillars[0]!.capabilities).toEqual({ settings: true });
+  });
+
+  it('leaves capabilities undefined when the wire entry omits it', async () => {
+    const fin = pillar('finance', 'http://finance-api:3004');
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(wirePayload(fin)));
+
+    const result = await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+
+    expect(result.pillars[0]!.capabilities).toBeUndefined();
+  });
+
   it('also accepts an un-enveloped payload (raw shape)', async () => {
     const fin = pillar('finance', 'http://finance-api:3004');
     const raw = {

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -96,6 +96,7 @@ function toPillarSnapshot(entry: PillarRegistryEntryPayload): PillarSnapshot {
     registered,
     lastSeenAt,
     ...(entry.status !== undefined ? { status: entry.status } : {}),
+    ...(entry.capabilities !== undefined ? { capabilities: entry.capabilities } : {}),
   };
 }
 

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -11,6 +11,7 @@ const PillarRegistryEntrySchema = z
     lastHeartbeatAt: z.string().min(1).optional(),
     registered: z.boolean().optional(),
     status: z.enum(['healthy', 'unavailable', 'unknown']).optional(),
+    capabilities: z.record(z.string(), z.boolean()).optional(),
   })
   .loose()
   .refine((entry) => Boolean(entry.lastSeenAt ?? entry.lastHeartbeatAt), {

--- a/packages/pillar-sdk/src/discovery/types.ts
+++ b/packages/pillar-sdk/src/discovery/types.ts
@@ -1,3 +1,4 @@
+import type { CapabilityStatuses } from '../bootstrap/transport.js';
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
 /**
@@ -28,6 +29,15 @@ export type PillarSnapshot = {
    * Optional because legacy snapshots / tests may omit it.
    */
   status?: PillarStatus;
+  /**
+   * Live capability statuses the pillar self-reported on register /
+   * heartbeat (`<capabilityKey> → up/down`), passed through from the
+   * registry wire. Consumers gate features and the federated-settings
+   * cutover on these (settings-federation GAP-256-D). Optional because a
+   * pillar with no capabilities omits it and legacy snapshots / tests may
+   * not carry it.
+   */
+  capabilities?: CapabilityStatuses;
 };
 
 /**

--- a/pillars/core/Dockerfile
+++ b/pillars/core/Dockerfile
@@ -16,6 +16,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc
 # Phase 1: package.json of @pops/core + its transitive @pops/* deps.
 COPY pillars/core/package.json ./pillars/core/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/pillar-settings/package.json ./packages/pillar-settings/
 COPY packages/types/package.json ./packages/types/
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -25,6 +26,9 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+
+COPY packages/pillar-settings/src ./packages/pillar-settings/src
+COPY packages/pillar-settings/tsconfig.json ./packages/pillar-settings/tsconfig.json
 
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json ./packages/types/tsconfig.json

--- a/pillars/core/openapi/core.openapi.json
+++ b/pillars/core/openapi/core.openapi.json
@@ -5216,6 +5216,126 @@
         "tags": ["serviceAccounts"]
       }
     },
+    "/settings": {
+      "get": {
+        "operationId": "settings.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["key", "value"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List effective values for every declared key (sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
     "/settings/get-many": {
       "post": {
         "operationId": "settings.getMany",
@@ -5342,7 +5462,142 @@
             "description": "409"
           }
         },
-        "summary": "Batch-read settings by key (missing keys omitted)",
+        "summary": "Batch-read settings by key (missing omitted; sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/reset": {
+      "post": {
+        "operationId": "settings.reset",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reset": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reset", "settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset declared keys to defaults (omit keys ⇒ reset all)",
         "tags": ["settings"]
       }
     },
@@ -5731,7 +5986,7 @@
             "description": "409"
           }
         },
-        "summary": "Delete a single setting (404 on miss)",
+        "summary": "Reset a single setting to its default (legacy DELETE alias for the reset route)",
         "tags": ["settings"]
       },
       "get": {
@@ -5977,7 +6232,7 @@
             "description": "409"
           }
         },
-        "summary": "Read a single setting (null on miss)",
+        "summary": "Read a single setting (null on unset; sensitive redacted)",
         "tags": ["settings"]
       },
       "put": {
@@ -6242,7 +6497,7 @@
             "description": "409"
           }
         },
-        "summary": "Upsert a single setting",
+        "summary": "Upsert a single declared setting",
         "tags": ["settings"]
       }
     },
@@ -6506,7 +6761,269 @@
             "description": "409"
           }
         },
-        "summary": "Write-once upsert-and-return for a single setting",
+        "summary": "Internal-only write-once seed (encryption seed / client id)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/reset": {
+      "post": {
+        "operationId": "settings.resetKey",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "plex_url",
+                "plex_token",
+                "plex_username",
+                "plex_encryption_seed",
+                "plex_client_identifier",
+                "plex_movie_section_id",
+                "plex_tv_section_id",
+                "plex_scheduler_enabled",
+                "plex_scheduler_interval_ms",
+                "radarr_url",
+                "radarr_api_key",
+                "sonarr_url",
+                "sonarr_api_key",
+                "ai.model",
+                "ai.monthlyTokenBudget",
+                "ai.budgetExceededFallback",
+                "ai.modelOverrides.query",
+                "ai.modelOverrides.emit",
+                "ai.modelOverrides.classifier",
+                "ai.modelOverrides.entityExtractor",
+                "ai.modelOverrides.scopeInference",
+                "ai.modelOverrides.auditorContradiction",
+                "ai.modelOverrides.patternContradiction",
+                "cerebrum.query.maxSources",
+                "cerebrum.query.relevanceThreshold",
+                "cerebrum.query.tokenBudget",
+                "cerebrum.emit.maxTokens",
+                "cerebrum.emit.relevanceThreshold",
+                "cerebrum.emit.maxSources",
+                "cerebrum.emit.tokenBudget",
+                "cerebrum.semantic.defaultLimit",
+                "cerebrum.semantic.defaultThreshold",
+                "cerebrum.semantic.queryCacheTtl",
+                "cerebrum.hybrid.rrfK",
+                "cerebrum.hybrid.defaultLimit",
+                "cerebrum.hybrid.defaultThreshold",
+                "cerebrum.context.tokenBudget",
+                "cerebrum.classifier.confidenceThreshold",
+                "cerebrum.entityExtractor.confidenceThreshold",
+                "cerebrum.captureHotkey",
+                "cerebrum.nudge.consolidationSimilarity",
+                "cerebrum.nudge.consolidationMinCluster",
+                "cerebrum.nudge.stalenessDays",
+                "cerebrum.nudge.patternMinOccurrences",
+                "cerebrum.nudge.maxPending",
+                "cerebrum.nudge.cooldownHours",
+                "cerebrum.engram.fallbackScope",
+                "cerebrum.citation.excerptMaxLength",
+                "cerebrum.plexus.healthIntervalMs",
+                "cerebrum.plexus.healthTimeoutMs",
+                "cerebrum.plexus.maxConsecutiveFailures",
+                "cerebrum.thalamus.crossSourceIntervalMs",
+                "cerebrum.mcp.queryMaxSources",
+                "cerebrum.mcp.searchSnippetLength",
+                "cerebrum.mcp.searchDefaultLimit",
+                "cerebrum.glia.proposeMinApproved",
+                "cerebrum.glia.proposeMaxRejectionRate",
+                "cerebrum.glia.actReportMinDays",
+                "cerebrum.glia.demotionRevertThreshold",
+                "cerebrum.glia.demotionWindowDays",
+                "ego.defaultModel",
+                "ego.maxHistory",
+                "ego.maxRetrieval",
+                "ego.tokenBudget",
+                "ego.relevanceThreshold",
+                "ego.chat.maxTokens",
+                "ego.chat.temperature",
+                "ego.summary.maxTokens",
+                "ego.summary.temperature",
+                "media.comparisons.eloK",
+                "media.comparisons.defaultScore",
+                "media.comparisons.maxTierListMovies",
+                "media.comparisons.stalenessThreshold",
+                "media.comparisons.defaultLimit",
+                "media.discovery.sessionTargetMin",
+                "media.discovery.sessionTargetMax",
+                "media.discovery.maxSeedShelves",
+                "media.discovery.maxGenreShelves",
+                "media.discovery.maxActiveCollections",
+                "media.discovery.maxBecauseYouWatchedSeeds",
+                "media.discovery.maxCreditsSeeds",
+                "media.discovery.maxBestInGenre",
+                "media.discovery.maxCrossoverPairs",
+                "media.thetvdb.rateLimitCapacity",
+                "media.thetvdb.rateLimitRefillRate",
+                "media.thetvdb.maxRetries",
+                "media.tmdb.genreCacheTtlMs",
+                "media.tmdb.imageMaxRetries",
+                "media.tmdb.imageRetryDelayMs",
+                "media.plex.rateLimitDelayMs",
+                "media.plex.clientPageSize",
+                "media.plex.friendsPageSize",
+                "media.defaultLimit",
+                "media.rotation.tmdbDefaultPages",
+                "media.rotation.tmdbMaxPages",
+                "media.rotation.tmdbMinVoteCount",
+                "media.rotation.letterboxdMaxPages",
+                "finance.aiCategorizer.model",
+                "finance.aiCategorizer.maxTokens",
+                "finance.ruleGen.model",
+                "finance.ruleGen.maxTokens",
+                "finance.defaultLimit",
+                "inventory.defaultLimit",
+                "inventory.searchDefaultLimit",
+                "inventory.maxFileSizeBytes",
+                "core.corrections.highConfidenceThreshold",
+                "core.corrections.minPatternLength",
+                "core.corrections.previewLimit",
+                "core.corrections.previewHardLimit",
+                "core.corrections.previewRulesFetchLimit",
+                "core.search.showMoreLimit",
+                "core.aiRetry.maxRetries",
+                "core.aiRetry.baseDelayMs",
+                "core.defaultLimit",
+                "core.queue.syncConcurrency",
+                "core.queue.embeddingsConcurrency",
+                "core.queue.defaultConcurrency",
+                "core.queue.completedRetention",
+                "theme"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset a single setting to its manifest default",
         "tags": ["settings"]
       }
     },

--- a/pillars/core/package.json
+++ b/pillars/core/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/pillar-settings": "workspace:*",
     "@pops/types": "workspace:*",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",

--- a/pillars/core/src/api/__tests__/settings.test.ts
+++ b/pillars/core/src/api/__tests__/settings.test.ts
@@ -3,10 +3,16 @@
  * primitive), driven through the real Express app via supertest.
  *
  * Coverage:
- *   - Every procedure (`get`/`set`/`ensure`/`delete`/`getMany`/`setMany`).
+ *   - Every procedure (`list`/`get`/`set`/`ensure`/`getMany`/`setMany`/
+ *     `resetKey`/`reset`) plus the legacy `delete` reset alias.
+ *   - The RU+reset protocol: reset re-applies the manifest default, reset is
+ *     idempotent (never throws), and `list` resolves effective values.
+ *   - Redaction is wired but inert for core (no sensitive manifest keys), so
+ *     the cross-pillar surface still returns real values.
  *   - `getMany` Record-omitted semantics (missing keys absent, not null).
  *   - `setMany` transactional mirror.
- *   - Error mapping: 404 (delete miss), 400 (zod boundary).
+ *   - Error mapping: 400 (zod boundary); the legacy `delete` alias is now an
+ *     idempotent reset (200, no 404).
  *   - Auth gating (`protected`): 401 for an anonymous caller and for a
  *     service account lacking the scope; 200 for a service account WITH the
  *     scope; the dev-fallback user passes by default.
@@ -102,12 +108,66 @@ describe('settings REST — happy paths (dev-fallback user)', () => {
     expect(second.data.value).toBe('seed-1');
   });
 
-  it('delete removes an existing key', async () => {
+  it('delete (legacy alias) resets an existing key to its default', async () => {
     await client().settings.set(PLEX_TOKEN_KEY, 'tok-1');
     const res = await client().settings.delete(PLEX_TOKEN_KEY);
-    expect(res.message).toBe('Setting deleted');
+    expect(res.message).toBe('Setting reset to default');
+    // PLEX_TOKEN is not a core-manifest key, so it resets to no stored override.
     const after = await client().settings.get(PLEX_TOKEN_KEY);
     expect(after.data).toBeNull();
+  });
+});
+
+describe('settings REST — RU+reset protocol', () => {
+  const CORE_DEFAULT_LIMIT = SETTINGS_KEYS.CORE_DEFAULT_LIMIT;
+
+  it('resetKey re-applies the manifest default for a declared key', async () => {
+    await client().settings.set(CORE_DEFAULT_LIMIT, '999');
+    const res = await client().settings.resetKey(CORE_DEFAULT_LIMIT);
+    expect(res.data).toEqual({ key: CORE_DEFAULT_LIMIT, value: '50' });
+    expect(res.message).toBe('Setting reset to default');
+
+    const after = await client().settings.get(CORE_DEFAULT_LIMIT);
+    // The override is gone; list-effective resolves the default, single get is null.
+    expect(after.data).toBeNull();
+  });
+
+  it('resetKey is idempotent — resetting an unset key never throws', async () => {
+    const res = await client().settings.resetKey(CORE_DEFAULT_LIMIT);
+    expect(res.data.value).toBe('50');
+  });
+
+  it('reset with explicit keys clears their overrides and returns the defaults', async () => {
+    await client().settings.set(CORE_DEFAULT_LIMIT, '7');
+    const res = await client().settings.reset([CORE_DEFAULT_LIMIT]);
+    expect(res.reset).toEqual([CORE_DEFAULT_LIMIT]);
+    expect(res.settings[CORE_DEFAULT_LIMIT]).toBe('50');
+  });
+
+  it('list returns the effective value (override or manifest default) for declared keys', async () => {
+    await client().settings.set(CORE_DEFAULT_LIMIT, '12');
+    const res = await client().settings.list();
+    const row = res.data.find((entry) => entry.key === CORE_DEFAULT_LIMIT);
+    expect(row?.value).toBe('12');
+
+    await client().settings.resetKey(CORE_DEFAULT_LIMIT);
+    const after = await client().settings.list();
+    const reset = after.data.find((entry) => entry.key === CORE_DEFAULT_LIMIT);
+    expect(reset?.value).toBe('50');
+  });
+});
+
+describe('settings REST — redaction is wired but inert for core (no sensitive keys)', () => {
+  it('returns the real stored value on read for a non-sensitive key (no false redaction)', async () => {
+    // Core declares no sensitive manifest keys, so the cross-pillar surface
+    // finance reads (plex_token etc.) must still return real values, not the
+    // redaction sentinel — wire-compat with the core-settings-sdk itest.
+    await client().settings.set(PLEX_TOKEN_KEY, 'tok-real');
+    const got = await client().settings.get(PLEX_TOKEN_KEY);
+    expect(got.data).toEqual({ key: PLEX_TOKEN_KEY, value: 'tok-real' });
+
+    const many = await client().settings.getMany([PLEX_TOKEN_KEY]);
+    expect(many.settings[PLEX_TOKEN_KEY]).toBe('tok-real');
   });
 });
 
@@ -161,8 +221,9 @@ describe('settings REST — setMany transactional batch write', () => {
 });
 
 describe('settings REST — error mapping', () => {
-  it('404s a delete of a missing key', async () => {
-    await expect(client().settings.delete(PLEX_TOKEN_KEY)).rejects.toMatchObject({ status: 404 });
+  it('delete (legacy alias) is idempotent — resetting a missing key returns 200', async () => {
+    const res = await client().settings.delete(PLEX_TOKEN_KEY);
+    expect(res.message).toBe('Setting reset to default');
   });
 
   it('400s an unknown key at the contract boundary (single-key route)', async () => {

--- a/pillars/core/src/api/__tests__/test-utils.ts
+++ b/pillars/core/src/api/__tests__/test-utils.ts
@@ -199,6 +199,7 @@ export function makeClient(app: Express, headers?: ClientHeaders) {
       runNow: () => send<RunEvaluationResult>(r.post('/ai-alerts/run').send({})),
     },
     settings: {
+      list: () => send<{ data: Array<{ key: string; value: string }> }>(r.get('/settings')),
       get: (key: string) =>
         send<{ data: { key: string; value: string } | null }>(
           r.get(`/settings/${encodeURIComponent(key)}`)
@@ -212,6 +213,14 @@ export function makeClient(app: Express, headers?: ClientHeaders) {
       ensure: (key: string, value: string) =>
         send<{ data: { key: string; value: string } }>(
           r.post(`/settings/${encodeURIComponent(key)}/ensure`).send({ value })
+        ),
+      resetKey: (key: string) =>
+        send<{ data: { key: string; value: string }; message: string }>(
+          r.post(`/settings/${encodeURIComponent(key)}/reset`).send({})
+        ),
+      reset: (keys?: string[]) =>
+        send<{ reset: string[]; settings: Record<string, string> }>(
+          r.post('/settings/reset').send(keys ? { keys } : {})
         ),
       delete: (key: string) =>
         send<{ message: string }>(r.delete(`/settings/${encodeURIComponent(key)}`)),

--- a/pillars/core/src/api/modules/features/__tests__/key-ownership.test.ts
+++ b/pillars/core/src/api/modules/features/__tests__/key-ownership.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the feature-toggle key-ownership invariant
+ * (settings-federation S1, R10).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { assertFeatureKeysAreCoreOwned, FeatureKeyOwnershipError } from '../key-ownership.js';
+
+import type { FeatureManifestDescriptor } from '@pops/pillar-sdk';
+import type { KeyDefaults } from '@pops/pillar-settings';
+
+const coreKeyDefaults: KeyDefaults = {
+  keys: ['core.redis', 'core.queue.syncConcurrency', 'theme'],
+  defaults: {},
+  sensitive: [],
+};
+
+function feature(overrides: Partial<FeatureManifestDescriptor>): FeatureManifestDescriptor {
+  return {
+    key: 'core.redis',
+    label: 'Redis',
+    default: true,
+    scope: 'system',
+    ...overrides,
+  };
+}
+
+describe('assertFeatureKeysAreCoreOwned', () => {
+  it('passes when every system-scoped feature key is core-owned', () => {
+    expect(() =>
+      assertFeatureKeysAreCoreOwned(
+        [feature({ key: 'core.redis' }), feature({ key: 'core.queue.syncConcurrency' })],
+        coreKeyDefaults
+      )
+    ).not.toThrow();
+  });
+
+  it('honours settingKey over key when resolving the storage key', () => {
+    expect(() =>
+      assertFeatureKeysAreCoreOwned(
+        [feature({ key: 'core.redis', settingKey: 'core.queue.syncConcurrency' })],
+        coreKeyDefaults
+      )
+    ).not.toThrow();
+  });
+
+  it('throws when a system-scoped feature names a non-core key', () => {
+    expect(() =>
+      assertFeatureKeysAreCoreOwned(
+        [feature({ key: 'core.redis', settingKey: 'finance.aiCategorizer.model' })],
+        coreKeyDefaults
+      )
+    ).toThrow(FeatureKeyOwnershipError);
+  });
+
+  it('reports every offending feature in the error', () => {
+    try {
+      assertFeatureKeysAreCoreOwned(
+        [
+          feature({ key: 'core.redis', settingKey: 'finance.x' }),
+          feature({ key: 'core.queue.syncConcurrency', settingKey: 'media.y' }),
+        ],
+        coreKeyDefaults
+      );
+      throw new Error('expected FeatureKeyOwnershipError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FeatureKeyOwnershipError);
+      const offending = (err as FeatureKeyOwnershipError).offending;
+      expect(offending.map((o) => o.settingKey)).toEqual(['finance.x', 'media.y']);
+    }
+  });
+
+  it('exempts user-scoped and capability-scoped features', () => {
+    expect(() =>
+      assertFeatureKeysAreCoreOwned(
+        [
+          feature({ scope: 'user', settingKey: 'finance.not.core' }),
+          feature({ scope: 'capability', settingKey: 'media.not.core' }),
+        ],
+        coreKeyDefaults
+      )
+    ).not.toThrow();
+  });
+});

--- a/pillars/core/src/api/modules/features/key-ownership.ts
+++ b/pillars/core/src/api/modules/features/key-ownership.ts
@@ -1,0 +1,55 @@
+import type { FeatureManifestDescriptor } from '@pops/pillar-sdk';
+/**
+ * Feature-toggle key-ownership invariant (settings-federation S1, R10).
+ *
+ * Every system-scoped feature's effective storage key (`settingKey ?? key`)
+ * is written to CORE's `settings` table through `setRawSetting`
+ * (`setFeatureEnabled`) and read back from it. Once settings federate, a
+ * feature key that belongs to a federated pillar would re-open the split-brain
+ * the federation closes: core would write the toggle to its own table while the
+ * owning pillar reads its own. The invariant: every such key MUST resolve to a
+ * key in core's declared key set.
+ *
+ * User-scoped features persist under the `feature.`-prefixed `user_settings`
+ * key space (never the shared `settings` table), and capability-scoped features
+ * are read-only runtime probes that write no setting — both are exempt.
+ *
+ * Run at boot so a manifest that names a non-core key fails loudly instead of
+ * silently writing a toggle the owning pillar never reads.
+ */
+import type { KeyDefaults } from '@pops/pillar-settings';
+
+/** Thrown when a system-scoped feature's effective key is not core-owned. */
+export class FeatureKeyOwnershipError extends Error {
+  override readonly name = 'FeatureKeyOwnershipError';
+  readonly offending: readonly { featureKey: string; settingKey: string }[];
+
+  constructor(offending: readonly { featureKey: string; settingKey: string }[]) {
+    const detail = offending.map((o) => `${o.featureKey}→${o.settingKey}`).join(', ');
+    super(`system-scoped feature keys are not core-owned: ${detail}`);
+    this.offending = offending;
+  }
+}
+
+/**
+ * Assert every system-scoped feature's effective storage key is a member of
+ * core's declared key set. Throws {@link FeatureKeyOwnershipError} listing
+ * every violation. A no-op for an all-compliant feature list.
+ */
+export function assertFeatureKeysAreCoreOwned(
+  features: readonly FeatureManifestDescriptor[],
+  coreKeyDefaults: KeyDefaults
+): void {
+  const coreKeys = new Set(coreKeyDefaults.keys);
+  const offending: { featureKey: string; settingKey: string }[] = [];
+
+  for (const feature of features) {
+    if (feature.scope !== 'system') continue;
+    const settingKey = feature.settingKey ?? feature.key;
+    if (!coreKeys.has(settingKey)) {
+      offending.push({ featureKey: feature.key, settingKey });
+    }
+  }
+
+  if (offending.length > 0) throw new FeatureKeyOwnershipError(offending);
+}

--- a/pillars/core/src/api/rest/settings-handlers.ts
+++ b/pillars/core/src/api/rest/settings-handlers.ts
@@ -1,25 +1,34 @@
 /**
- * Handlers for the `settings.*` sub-router (PRD-247 cross-pillar primitive).
+ * Handlers for core's `settings.*` sub-router, delegating to the shared
+ * `@pops/pillar-settings` Read/Update/Reset service (settings-federation S1).
  *
- * Every route is identity-gated (`protected`): the handler resolves the
- * principal the identity middleware stashed on `res.locals` and runs
- * `requireProtected` against the SAME scope path the tRPC `protectedProcedure`
- * used (`core.settings.<proc>`), so a service account needs the identical
- * scope grant on both wire surfaces. The gate runs INSIDE `runHttp`, so the
- * `UnauthorizedError` it throws is mapped to a 401 envelope.
+ * The shared `makeSettingsHandlers` owns the RU+reset logic, the declared-key
+ * assertion, and the read-side sensitive redaction. Core injects three things:
+ * its `CoreDb` settings store, the `core.settings` scope prefix, and its
+ * identity gate (`requireProtected`) so a service account needs the identical
+ * `core.settings.<proc>` scope grant it did before. The gate runs INSIDE
+ * `runHttp`, so the `UnauthorizedError` it throws maps to a 401 envelope.
  *
- * The settings semantics are inherited verbatim from `settingsService`:
- *   - `getMany` returns `Record<string,string>` with missing keys omitted.
- *   - `setMany` is transactional (all-or-nothing) via `setBulkSettings`.
- *   - `delete` 404s a missing key (translated from `SettingNotFoundError`).
+ * Read paths (`list`/`get`/`getMany`) redact any key flagged `sensitive` in
+ * core's manifests to the `REDACTED` sentinel; write/reset paths persist and
+ * return the real value. Core declares no sensitive keys today, so current
+ * reads are unchanged — the redaction is wired for forward keys.
+ *
+ * The legacy `DELETE /settings/:key` is a rolling-deploy alias mapping to
+ * reset-to-default via the shared `resetKey` handler; it preserves the old
+ * `{ message }` response so an un-upgraded shell keeps working.
  */
-import { SettingNotFoundError, type CoreDb, settingsService } from '../../db/index.js';
-import { readPrincipal, requireProtected } from '../middleware/identity.js';
-import { NotFoundError } from '../shared/errors.js';
+import { makeSettingsHandlers as makeSharedSettingsHandlers } from '@pops/pillar-settings';
+
+import { coreKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type CoreDb } from '../../db/index.js';
+import { type Principal, readPrincipal, requireProtected } from '../middleware/identity.js';
 import { runHttp } from './error-mapping.js';
 
 import type { ServerInferRequest } from '@ts-rest/core';
 import type { Response } from 'express';
+
+import type { SettingsGate } from '@pops/pillar-settings';
 
 import type { coreSettingsContract } from '../../contract/rest-settings.js';
 
@@ -27,66 +36,68 @@ type Req = ServerInferRequest<typeof coreSettingsContract>;
 
 const SCOPE_PREFIX = 'core.settings';
 
-function toWireSetting(row: { key: string; value: string }): { key: string; value: string } {
-  return { key: row.key, value: row.value };
-}
+const gate: SettingsGate<Principal> = (principal, scope) => {
+  requireProtected(principal, scope);
+};
 
 export function makeSettingsHandlers(db: CoreDb) {
+  const shared = makeSharedSettingsHandlers<Principal>({
+    db,
+    scopePrefix: SCOPE_PREFIX,
+    keyDefaults: coreKeyDefaults,
+    gate,
+  });
+
   return {
+    list: ({ res }: { res: Response }) =>
+      runHttp(() => ({ status: 200 as const, body: shared.list(readPrincipal(res)) })),
+
     get: ({ params, res }: Req['get'] & { res: Response }) =>
-      runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.get`);
-        const row = settingsService.getSettingOrNull(db, params.key);
-        return { status: 200 as const, body: { data: row ? toWireSetting(row) : null } };
-      }),
+      runHttp(() => ({ status: 200 as const, body: shared.get(readPrincipal(res), params.key) })),
 
     getMany: ({ body, res }: Req['getMany'] & { res: Response }) =>
-      runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.getMany`);
-        return {
-          status: 200 as const,
-          body: { settings: settingsService.getBulkSettings(db, body.keys) },
-        };
-      }),
+      runHttp(() => ({
+        status: 200 as const,
+        body: shared.getMany(readPrincipal(res), body.keys),
+      })),
 
     set: ({ params, body, res }: Req['set'] & { res: Response }) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: shared.set(readPrincipal(res), params.key, body.value),
+      })),
+
+    setMany: ({ body, res }: Req['setMany'] & { res: Response }) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: shared.setMany(readPrincipal(res), body.entries),
+      })),
+
+    resetKey: ({ params, res }: Req['resetKey'] & { res: Response }) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: shared.resetKey(readPrincipal(res), params.key),
+      })),
+
+    reset: ({ body, res }: Req['reset'] & { res: Response }) =>
       runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.set`);
-        const row = settingsService.setRawSetting(db, params.key, body.value);
+        const result = shared.reset(readPrincipal(res), body.keys);
         return {
           status: 200 as const,
-          body: { data: toWireSetting(row), message: 'Setting saved' },
+          body: { reset: [...result.reset], settings: { ...result.settings } },
         };
       }),
 
     ensure: ({ params, body, res }: Req['ensure'] & { res: Response }) =>
-      runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.ensure`);
-        const row = settingsService.ensureSetting(db, params.key, body.value);
-        return { status: 200 as const, body: { data: toWireSetting(row) } };
-      }),
+      runHttp(() => ({
+        status: 200 as const,
+        body: shared.ensure(readPrincipal(res), params.key, body.value),
+      })),
 
     delete: ({ params, res }: Req['delete'] & { res: Response }) =>
       runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.delete`);
-        try {
-          settingsService.deleteSetting(db, params.key);
-        } catch (err) {
-          if (err instanceof SettingNotFoundError) {
-            throw new NotFoundError('Setting', err.key);
-          }
-          throw err;
-        }
-        return { status: 200 as const, body: { message: 'Setting deleted' } };
-      }),
-
-    setMany: ({ body, res }: Req['setMany'] & { res: Response }) =>
-      runHttp(() => {
-        requireProtected(readPrincipal(res), `${SCOPE_PREFIX}.setMany`);
-        return {
-          status: 200 as const,
-          body: { settings: settingsService.setBulkSettings(db, body.entries) },
-        };
+        shared.resetKey(readPrincipal(res), params.key);
+        return { status: 200 as const, body: { message: 'Setting reset to default' } };
       }),
   };
 }

--- a/pillars/core/src/api/server.ts
+++ b/pillars/core/src/api/server.ts
@@ -20,12 +20,14 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
  * `pillarHandle.stop()` so the heartbeat clears and the registry sees
  * an explicit deregister before the HTTP server shuts down.
  */
+import { coreKeyDefaults } from '../contract/settings/key-defaults.js';
 import { openCoreDb } from '../db/index.js';
 import { createCoreApiApp } from './app.js';
 import { buildCoreManifest } from './core-manifest.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { startAlertsScheduler } from './modules/ai-alerts/scheduler.js';
 import { startObservabilityScheduler } from './modules/ai-observability/scheduler.js';
+import { assertFeatureKeysAreCoreOwned } from './modules/features/key-ownership.js';
 import { reconcileRegistryOnBoot } from './modules/registry/boot.js';
 import { startEvictionTicker } from './modules/registry/eviction-ticker.js';
 import { startHeartbeatTicker } from './modules/registry/ticker.js';
@@ -55,6 +57,11 @@ const selfBaseUrl = parseBareOrigin(
 const coreDb = openCoreDb(resolveCoreSqlitePath());
 
 reconcileRegistryOnBoot(coreDb.db);
+
+// settings-federation S1 (R10): fail boot loudly if a system-scoped feature
+// names a setting key core does not own — otherwise the toggle would write a
+// key the owning pillar never reads once settings federate.
+assertFeatureKeysAreCoreOwned(buildCoreManifest(version).features ?? [], coreKeyDefaults);
 
 /**
  * Live status of core's `redis` capability. The core pillar container ships

--- a/pillars/core/src/contract/api-types.generated.ts
+++ b/pillars/core/src/contract/api-types.generated.ts
@@ -508,6 +508,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List effective values for every declared key (sensitive redacted) */
+    get: operations['settings.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/settings/get-many': {
     parameters: {
       query?: never;
@@ -517,8 +534,25 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Batch-read settings by key (missing keys omitted) */
+    /** Batch-read settings by key (missing omitted; sensitive redacted) */
     post: operations['settings.getMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset declared keys to defaults (omit keys ⇒ reset all) */
+    post: operations['settings.reset'];
     delete?: never;
     options?: never;
     head?: never;
@@ -549,12 +583,12 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Read a single setting (null on miss) */
+    /** Read a single setting (null on unset; sensitive redacted) */
     get: operations['settings.get'];
-    /** Upsert a single setting */
+    /** Upsert a single declared setting */
     put: operations['settings.set'];
     post?: never;
-    /** Delete a single setting (404 on miss) */
+    /** Reset a single setting to its default (legacy DELETE alias for the reset route) */
     delete: operations['settings.delete'];
     options?: never;
     head?: never;
@@ -570,8 +604,25 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Write-once upsert-and-return for a single setting */
+    /** Internal-only write-once seed (encryption seed / client id) */
     post: operations['settings.ensure'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset a single setting to its manifest default */
+    post: operations['settings.resetKey'];
     delete?: never;
     options?: never;
     head?: never;
@@ -3080,6 +3131,79 @@ export interface operations {
       };
     };
   };
+  'settings.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 401 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+    };
+  };
   'settings.getMany': {
     parameters: {
       query?: never;
@@ -3103,6 +3227,86 @@ export interface operations {
         };
         content: {
           'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 401 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reset: string[];
             settings: {
               [key: string]: string;
             };
@@ -3981,6 +4185,206 @@ export interface operations {
               key: string;
               value: string;
             };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 401 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.resetKey': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'plex_url'
+          | 'plex_token'
+          | 'plex_username'
+          | 'plex_encryption_seed'
+          | 'plex_client_identifier'
+          | 'plex_movie_section_id'
+          | 'plex_tv_section_id'
+          | 'plex_scheduler_enabled'
+          | 'plex_scheduler_interval_ms'
+          | 'radarr_url'
+          | 'radarr_api_key'
+          | 'sonarr_url'
+          | 'sonarr_api_key'
+          | 'ai.model'
+          | 'ai.monthlyTokenBudget'
+          | 'ai.budgetExceededFallback'
+          | 'ai.modelOverrides.query'
+          | 'ai.modelOverrides.emit'
+          | 'ai.modelOverrides.classifier'
+          | 'ai.modelOverrides.entityExtractor'
+          | 'ai.modelOverrides.scopeInference'
+          | 'ai.modelOverrides.auditorContradiction'
+          | 'ai.modelOverrides.patternContradiction'
+          | 'cerebrum.query.maxSources'
+          | 'cerebrum.query.relevanceThreshold'
+          | 'cerebrum.query.tokenBudget'
+          | 'cerebrum.emit.maxTokens'
+          | 'cerebrum.emit.relevanceThreshold'
+          | 'cerebrum.emit.maxSources'
+          | 'cerebrum.emit.tokenBudget'
+          | 'cerebrum.semantic.defaultLimit'
+          | 'cerebrum.semantic.defaultThreshold'
+          | 'cerebrum.semantic.queryCacheTtl'
+          | 'cerebrum.hybrid.rrfK'
+          | 'cerebrum.hybrid.defaultLimit'
+          | 'cerebrum.hybrid.defaultThreshold'
+          | 'cerebrum.context.tokenBudget'
+          | 'cerebrum.classifier.confidenceThreshold'
+          | 'cerebrum.entityExtractor.confidenceThreshold'
+          | 'cerebrum.captureHotkey'
+          | 'cerebrum.nudge.consolidationSimilarity'
+          | 'cerebrum.nudge.consolidationMinCluster'
+          | 'cerebrum.nudge.stalenessDays'
+          | 'cerebrum.nudge.patternMinOccurrences'
+          | 'cerebrum.nudge.maxPending'
+          | 'cerebrum.nudge.cooldownHours'
+          | 'cerebrum.engram.fallbackScope'
+          | 'cerebrum.citation.excerptMaxLength'
+          | 'cerebrum.plexus.healthIntervalMs'
+          | 'cerebrum.plexus.healthTimeoutMs'
+          | 'cerebrum.plexus.maxConsecutiveFailures'
+          | 'cerebrum.thalamus.crossSourceIntervalMs'
+          | 'cerebrum.mcp.queryMaxSources'
+          | 'cerebrum.mcp.searchSnippetLength'
+          | 'cerebrum.mcp.searchDefaultLimit'
+          | 'cerebrum.glia.proposeMinApproved'
+          | 'cerebrum.glia.proposeMaxRejectionRate'
+          | 'cerebrum.glia.actReportMinDays'
+          | 'cerebrum.glia.demotionRevertThreshold'
+          | 'cerebrum.glia.demotionWindowDays'
+          | 'ego.defaultModel'
+          | 'ego.maxHistory'
+          | 'ego.maxRetrieval'
+          | 'ego.tokenBudget'
+          | 'ego.relevanceThreshold'
+          | 'ego.chat.maxTokens'
+          | 'ego.chat.temperature'
+          | 'ego.summary.maxTokens'
+          | 'ego.summary.temperature'
+          | 'media.comparisons.eloK'
+          | 'media.comparisons.defaultScore'
+          | 'media.comparisons.maxTierListMovies'
+          | 'media.comparisons.stalenessThreshold'
+          | 'media.comparisons.defaultLimit'
+          | 'media.discovery.sessionTargetMin'
+          | 'media.discovery.sessionTargetMax'
+          | 'media.discovery.maxSeedShelves'
+          | 'media.discovery.maxGenreShelves'
+          | 'media.discovery.maxActiveCollections'
+          | 'media.discovery.maxBecauseYouWatchedSeeds'
+          | 'media.discovery.maxCreditsSeeds'
+          | 'media.discovery.maxBestInGenre'
+          | 'media.discovery.maxCrossoverPairs'
+          | 'media.thetvdb.rateLimitCapacity'
+          | 'media.thetvdb.rateLimitRefillRate'
+          | 'media.thetvdb.maxRetries'
+          | 'media.tmdb.genreCacheTtlMs'
+          | 'media.tmdb.imageMaxRetries'
+          | 'media.tmdb.imageRetryDelayMs'
+          | 'media.plex.rateLimitDelayMs'
+          | 'media.plex.clientPageSize'
+          | 'media.plex.friendsPageSize'
+          | 'media.defaultLimit'
+          | 'media.rotation.tmdbDefaultPages'
+          | 'media.rotation.tmdbMaxPages'
+          | 'media.rotation.tmdbMinVoteCount'
+          | 'media.rotation.letterboxdMaxPages'
+          | 'finance.aiCategorizer.model'
+          | 'finance.aiCategorizer.maxTokens'
+          | 'finance.ruleGen.model'
+          | 'finance.ruleGen.maxTokens'
+          | 'finance.defaultLimit'
+          | 'inventory.defaultLimit'
+          | 'inventory.searchDefaultLimit'
+          | 'inventory.maxFileSizeBytes'
+          | 'core.corrections.highConfidenceThreshold'
+          | 'core.corrections.minPatternLength'
+          | 'core.corrections.previewLimit'
+          | 'core.corrections.previewHardLimit'
+          | 'core.corrections.previewRulesFetchLimit'
+          | 'core.search.showMoreLimit'
+          | 'core.aiRetry.maxRetries'
+          | 'core.aiRetry.baseDelayMs'
+          | 'core.defaultLimit'
+          | 'core.queue.syncConcurrency'
+          | 'core.queue.embeddingsConcurrency'
+          | 'core.queue.defaultConcurrency'
+          | 'core.queue.completedRetention'
+          | 'theme';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
           };
         };
       };

--- a/pillars/core/src/contract/rest-settings.ts
+++ b/pillars/core/src/contract/rest-settings.ts
@@ -1,92 +1,60 @@
 /**
- * `settings.*` sub-router — the PRD-247 cross-pillar settings primitive
- * (`core.settings.*`).
+ * `settings.*` sub-router — core's own federated Read/Update/Reset surface,
+ * served via the shared `@pops/pillar-settings` contract factory
+ * (settings-federation S1; see `docs/plans/02-settings-federation.md`).
  *
- * Mapping from the legacy tRPC router (semantics preserved EXACTLY):
- *   - `get`     (query,   single key)  → `GET    /settings/:key`
- *   - `getMany` (query,   key array)   → `POST   /settings/get-many`
- *   - `set`     (mutation, key+value)  → `PUT    /settings/:key`
- *   - `ensure`  (mutation, key+value)  → `POST   /settings/:key/ensure`
- *   - `delete`  (mutation, single key) → `DELETE /settings/:key`
- *   - `setMany` (mutation, entries)    → `POST   /settings/set-many`
+ * The factory mounts the byte-identical federated surface every pillar serves:
  *
- * `getMany`/`setMany` carry arrays/objects, so they map to POST-with-body
- * rather than a path-id route. Their wire output is `Record<string,string>`
- * with **missing keys omitted** (`getMany`) and an **all-or-nothing**
- * transactional write (`setMany`) — both inherited verbatim from the
- * `settingsService` the handlers delegate to.
+ *   - `list`     → `GET    /settings`              collection (sensitive redacted)
+ *   - `get`      → `GET    /settings/:key`         single (null on unset)
+ *   - `getMany`  → `POST   /settings/get-many`     batch read (missing omitted)
+ *   - `set`      → `PUT    /settings/:key`         upsert one declared key
+ *   - `setMany`  → `POST   /settings/set-many`     transactional batch write
+ *   - `resetKey` → `POST   /settings/:key/reset`   reset one key to default
+ *   - `reset`    → `POST   /settings/reset`        reset declared keys
+ *   - `ensure`   → `POST   /settings/:key/ensure`  internal-only write-once seed
  *
- * Single-key routes constrain `:key` to `SETTINGS_KEY_VALUES` (matching the
- * tRPC enum input); `getMany`/`setMany` accept free-form string keys
- * (matching the service-layer bulk shape). Schemas are reused from
- * `@pops/core-contract`'s `settings-procedures` so the wire shape stays the
- * single source of truth shared with the tRPC router.
+ * On top of the shared protocol, core retains the LEGACY
+ * `DELETE /settings/:key` route as a rolling-deploy alias: an old shell that
+ * still issues `DELETE` keeps working against this image, and the handler maps
+ * it to reset-to-default (delete-override == old delete-then-default for a
+ * declared key). The alias is removed in the later S5 node once metrics show
+ * zero `DELETE /settings/*` traffic.
  *
- * Every route is identity-gated (`protected`): the handlers enforce the gate
- * via `requireProtected`, so `401` joins the common error set here.
+ * `:key` stays constrained to the full central `SETTINGS_KEY_VALUES` for S1:
+ * shrinking it to core's manifest-only key set is the S4 node, and the live
+ * cross-pillar surface (`PLEX_URL`, `PLEX_TOKEN`, … that finance reads) plus
+ * the `core-settings-sdk-itest` depend on the full enum here.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
+import { makeSettingsContract } from '@pops/pillar-settings';
 import { SETTINGS_KEY_VALUES } from '@pops/types';
 
 import { AUTH_ERR_RESPONSES } from './rest-schemas.js';
-import {
-  SettingSchema,
-  SettingsGetManyInputSchema,
-  SettingsGetManyOutputSchema,
-  SettingsSetManyInputSchema,
-  SettingsSetManyOutputSchema,
-} from './schemas/index.js';
 
 const c = initContract();
 
 const SettingKeyParam = z.object({ key: z.enum(SETTINGS_KEY_VALUES) });
-const SettingValueBody = z.object({ value: z.string() });
 
+const federatedSettingsContract = makeSettingsContract(SETTINGS_KEY_VALUES, AUTH_ERR_RESPONSES);
+
+/**
+ * Composed by explicit per-route reference rather than object spread: spreading
+ * the factory's intersection-typed return widens the route map so
+ * `ServerInferRequest` (and the ts-rest express router) collapse the per-route
+ * shapes. Referencing each route preserves the discrete keys.
+ */
 export const coreSettingsContract = c.router({
-  get: {
-    method: 'GET',
-    path: '/settings/:key',
-    pathParams: SettingKeyParam,
-    responses: {
-      200: z.object({ data: SettingSchema.nullable() }),
-      ...AUTH_ERR_RESPONSES,
-    },
-    summary: 'Read a single setting (null on miss)',
-  },
-  getMany: {
-    method: 'POST',
-    path: '/settings/get-many',
-    body: SettingsGetManyInputSchema,
-    responses: {
-      200: SettingsGetManyOutputSchema,
-      ...AUTH_ERR_RESPONSES,
-    },
-    summary: 'Batch-read settings by key (missing keys omitted)',
-  },
-  set: {
-    method: 'PUT',
-    path: '/settings/:key',
-    pathParams: SettingKeyParam,
-    body: SettingValueBody,
-    responses: {
-      200: z.object({ data: SettingSchema, message: z.string() }),
-      ...AUTH_ERR_RESPONSES,
-    },
-    summary: 'Upsert a single setting',
-  },
-  ensure: {
-    method: 'POST',
-    path: '/settings/:key/ensure',
-    pathParams: SettingKeyParam,
-    body: SettingValueBody,
-    responses: {
-      200: z.object({ data: SettingSchema }),
-      ...AUTH_ERR_RESPONSES,
-    },
-    summary: 'Write-once upsert-and-return for a single setting',
-  },
+  list: federatedSettingsContract.list,
+  get: federatedSettingsContract.get,
+  getMany: federatedSettingsContract.getMany,
+  set: federatedSettingsContract.set,
+  setMany: federatedSettingsContract.setMany,
+  resetKey: federatedSettingsContract.resetKey,
+  reset: federatedSettingsContract.reset,
+  ensure: federatedSettingsContract.ensure,
   delete: {
     method: 'DELETE',
     path: '/settings/:key',
@@ -96,16 +64,6 @@ export const coreSettingsContract = c.router({
       200: z.object({ message: z.string() }),
       ...AUTH_ERR_RESPONSES,
     },
-    summary: 'Delete a single setting (404 on miss)',
-  },
-  setMany: {
-    method: 'POST',
-    path: '/settings/set-many',
-    body: SettingsSetManyInputSchema,
-    responses: {
-      200: SettingsSetManyOutputSchema,
-      ...AUTH_ERR_RESPONSES,
-    },
-    summary: 'Transactional batch write (all-or-nothing); returns the written mirror',
+    summary: 'Reset a single setting to its default (legacy DELETE alias for the reset route)',
   },
 });

--- a/pillars/core/src/contract/settings/key-defaults.ts
+++ b/pillars/core/src/contract/settings/key-defaults.ts
@@ -1,0 +1,32 @@
+/**
+ * Core's settings key authority for the shared `@pops/pillar-settings`
+ * surface (settings-federation S1).
+ *
+ * `deriveKeySet([aiConfigManifest, coreOperationalManifest])` is the source
+ * of reset defaults and the read-side sensitive set. Its declared-key list,
+ * however, is NOT yet the wire enum: shrinking core's `:key` enum to the
+ * manifest-only set is the later S4 node. For S1 the wire enum (and the
+ * handler's declared-key assertion) stays the full central
+ * `SETTINGS_KEY_VALUES`, preserving the live cross-pillar surface that finance
+ * reads (`PLEX_URL`, `PLEX_TOKEN`, …) and the `core-settings-sdk-itest`.
+ *
+ * So `keys` is pinned to the central enum here while `defaults`/`sensitive`
+ * are enriched from core's manifests — a single `KeyDefaults` the contract
+ * factory and the handler factory both consume.
+ */
+import { deriveKeySet, type KeyDefaults } from '@pops/pillar-settings';
+import { SETTINGS_KEY_VALUES } from '@pops/types';
+
+import { aiConfigManifest, coreOperationalManifest } from './index.js';
+
+const manifestKeySet = deriveKeySet([aiConfigManifest, coreOperationalManifest]);
+
+/**
+ * Core's effective {@link KeyDefaults}: the full central key enum (S1
+ * wire-compat) with manifest-derived defaults and sensitive flags.
+ */
+export const coreKeyDefaults: KeyDefaults = {
+  keys: SETTINGS_KEY_VALUES,
+  defaults: manifestKeySet.defaults,
+  sensitive: manifestKeySet.sensitive,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,6 +962,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/pillar-settings':
+        specifier: workspace:*
+        version: link:../../packages/pillar-settings
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Settings federation — Stage 2c (S1 + S1.5)

Implements the **S1** and **S1.5** nodes of `docs/plans/02-settings-federation.md`: core now serves its own settings through the shared `@pops/pillar-settings` module (RU+reset, read-side redaction, feature-key assertion), plus the S1.5 capability plumbing.

### What changed

**Core adopts `@pops/pillar-settings` (S1)**
- `pillars/core/src/contract/rest-settings.ts` — the bespoke hand-written router is replaced with `makeSettingsContract(SETTINGS_KEY_VALUES, AUTH_ERR_RESPONSES)` plus a retained legacy `DELETE` alias. Composed by explicit per-route reference (not object spread) so `ServerInferRequest` keeps per-route discrimination.
- `pillars/core/src/api/rest/settings-handlers.ts` — delegates to the shared `makeSettingsHandlers({ db, scopePrefix: 'core.settings', keyDefaults, gate })`, injecting `CoreDb` as the store and `requireProtected` as the identity gate. No bespoke settings logic remains (DRY).
- `pillars/core/src/contract/settings/key-defaults.ts` (new) — core's `KeyDefaults`: `deriveKeySet([aiConfigManifest, coreOperationalManifest])` for reset defaults + sensitive set, with `keys` pinned to the full central enum for S1 (see wire-compat).
- `pillars/core/src/api/modules/features/key-ownership.ts` (new) + boot wiring in `server.ts` — `assertFeatureKeysAreCoreOwned`: a system-scoped feature whose effective storage key (`settingKey ?? key`) is not core-owned fails boot, closing the R10 split-brain risk.

**S1.5 capability plumbing (GAP-256-D)**
- `PillarSnapshot` (`discovery/types.ts`), `DiscoveredPillar` + `parseRegistryEntry` (`client/discovery.ts`, new `optionalCapabilities` normalizer), and the cached path (`discovery/snapshot-schema.ts` + `discovery/fetcher.ts`) now thread the registry `capabilities` map that was previously dropped, so `lookupPillar`/`pillarRegistry` expose it. Tolerant: absent → `undefined`; non-boolean member → rejected.

### Endpoint surface after S1 (proving RU+reset + DELETE-alias + internal ensure)

```
GET    /settings                 settings.list      (effective values, sensitive redacted)   NEW
GET    /settings/{key}           settings.get
POST   /settings/get-many        settings.getMany
PUT    /settings/{key}           settings.set
POST   /settings/set-many        settings.setMany
POST   /settings/{key}/reset     settings.resetKey  reset-to-default (single)                 NEW
POST   /settings/reset           settings.reset     reset-to-default (batch / all)            NEW
POST   /settings/{key}/ensure    settings.ensure    internal-only write-once seed
DELETE /settings/{key}           settings.delete    legacy alias → reset-to-default, { message }
```

### Wire-compat guarantees (live consumers preserved)
- The `:key` enum stays the **full central `SETTINGS_KEY_VALUES`** (119 keys) — the enum shrink to core's manifest-only set is the later **S4** node. This keeps the cross-pillar surface finance reads (`pillar('core').callDynamic('settings','getMany'/'setMany',…)` over `PLEX_URL`/`PLEX_TOKEN`/…) intact.
- The existing endpoints (`GET/PUT/DELETE /settings/:key`, `POST /settings/get-many`, `/settings/set-many`, `/settings/:key/ensure`) keep the same request/response shapes. `DELETE` keeps its `{ message }` response (now mapped to idempotent reset-to-default).
- **`core-settings-sdk-itest` (`core-settings-sdk-itest.test.ts`) passes** — the cross-pillar `set`/`get`/`getMany` round-trips over the booted core-api are green. Service accounts with the broad `core` scope still authorize every new `core.settings.<proc>` (dot-prefix scope matching).

### Redaction behavior
Read paths (`list`/`get`/`getMany`) pass results through the shared `redactSensitive` for any key flagged `sensitive` in core's manifests; write/reset paths persist and return real values. Core declares **no** sensitive manifest keys today, so current reads are unchanged (the cross-pillar surface still returns real values) — the mechanism is wired for forward keys. A focused test asserts no false redaction on the plex keys finance reads.

### Feature-key assertion
`assertFeatureKeysAreCoreOwned` runs at boot over core's own manifest features. System-scoped features write to core's `settings` table via `setRawSetting`, so their effective key must be core-owned. User-scoped (prefixed `user_settings`) and capability-scoped (no write) features are exempt. Throws `FeatureKeyOwnershipError` listing every violation.

### Intentional OpenAPI diff
`pillars/core/openapi/core.openapi.json` regenerated and committed: `GET /settings`, `POST /settings/reset`, `POST /settings/:key/reset` added; `DELETE /settings/:key` re-summarized as the legacy reset alias (response unchanged); `ensure` unchanged. Build is clean and `generate:openapi` is stable (no drift). 522 insertions, 5 deletions — additive + summary text.

### Verification
- `turbo typecheck test --filter=@pops/core --filter=@pops/pillar-settings` — 8/8 tasks green (654 core tests, incl. the itest, RU+reset, redaction, feature-key tests).
- `turbo typecheck test --filter=@pops/pillar-sdk` — 3/3 green (616 tests incl. new capability round-trip tests, client + cached path).
- `@pops/finance` typecheck green against the updated pillar-sdk.
- `pnpm lint` exit 0, zero errors; `oxfmt --check` clean on all touched files + the regenerated OpenAPI JSON.
- No `as any` / `as unknown as` / suppressions added.

### Scope notes
- Does **not** shrink `packages/types/settings-keys.ts` (that is S4).
- Does **not** touch `ai.*` key ownership (a later node).
- `ensure` stays mounted with its existing identity gate + shape (internal-only by convention; the full `x-pops-internal-token` gate is the Phase 3 aggregator concern). This preserves wire-compat with the listed endpoints.
