### PR TITLE
feat(settings): per-pillar federation — finance, media, inventory, cerebrum [S2]

### DIFF
--- a/packages/pillar-settings/src/__tests__/manifest-keys.test.ts
+++ b/packages/pillar-settings/src/__tests__/manifest-keys.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveKeySet, type DeclaredSettingsManifest } from '../manifest-keys.js';
+import { deriveKeySet, keyValuesFor, type DeclaredSettingsManifest } from '../manifest-keys.js';
 
 const manifests: DeclaredSettingsManifest[] = [
   {
@@ -57,5 +57,22 @@ describe('deriveKeySet', () => {
   it('handles manifests with empty groups', () => {
     const kd = deriveKeySet([{ groups: [] }]);
     expect(kd.keys).toEqual([]);
+  });
+});
+
+describe('keyValuesFor', () => {
+  it('returns the declared keys as a non-empty tuple preserving order', () => {
+    const kd = deriveKeySet(manifests);
+    expect(keyValuesFor(kd)).toEqual([
+      'finance.aiCategorizer.model',
+      'finance.apiToken',
+      'finance.retentionDays',
+      'finance.enabled',
+    ]);
+  });
+
+  it('throws when the pillar declares no settings keys', () => {
+    const kd = deriveKeySet([]);
+    expect(() => keyValuesFor(kd)).toThrow(/at least one settings key/);
   });
 });

--- a/packages/pillar-settings/src/index.ts
+++ b/packages/pillar-settings/src/index.ts
@@ -18,6 +18,7 @@ export { settingsTable, type SettingRow, type SettingsDb } from './schema.js';
 
 export {
   deriveKeySet,
+  keyValuesFor,
   type DeclaredSettingsField,
   type DeclaredSettingsGroup,
   type DeclaredSettingsManifest,

--- a/packages/pillar-settings/src/manifest-keys.ts
+++ b/packages/pillar-settings/src/manifest-keys.ts
@@ -65,3 +65,23 @@ export function deriveKeySet(manifests: readonly DeclaredSettingsManifest[]): Ke
   }
   return { keys: acc.keys, defaults: acc.defaults, sensitive: acc.sensitive };
 }
+
+/**
+ * Narrows a pillar's declared key list to the non-empty tuple
+ * `makeSettingsContract` requires for its `:key` enum. The contract factory's
+ * `KeyEnum extends [string, ...string[]]` bound cannot be satisfied by the
+ * `readonly string[]` {@link deriveKeySet} yields, so this checks non-emptiness
+ * at runtime and returns the same values under the precise type — a guarded
+ * narrowing, not an unchecked widening.
+ *
+ * Throws if the key set is empty: a federated pillar with zero declared
+ * settings keys cannot build a `z.enum`, and silently producing an empty enum
+ * would be a latent boot failure.
+ */
+export function keyValuesFor(kd: KeyDefaults): [string, ...string[]] {
+  const [first, ...rest] = kd.keys;
+  if (first === undefined) {
+    throw new Error('keyValuesFor: a federated pillar must declare at least one settings key');
+  }
+  return [first, ...rest];
+}

--- a/pillars/cerebrum/Dockerfile
+++ b/pillars/cerebrum/Dockerfile
@@ -18,6 +18,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc
 COPY pillars/cerebrum/package.json ./pillars/cerebrum/
 COPY packages/ai-telemetry/package.json ./packages/ai-telemetry/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/pillar-settings/package.json ./packages/pillar-settings/
 COPY packages/types/package.json ./packages/types/
 
 # Install pnpm + only the deps of the @pops/cerebrum subgraph.
@@ -31,6 +32,9 @@ COPY packages/ai-telemetry/tsconfig.json ./packages/ai-telemetry/tsconfig.json
 # @pops/pillar-sdk
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+# @pops/pillar-settings
+COPY packages/pillar-settings/src ./packages/pillar-settings/src
+COPY packages/pillar-settings/tsconfig.json ./packages/pillar-settings/tsconfig.json
 # @pops/types
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json ./packages/types/tsconfig.json

--- a/pillars/cerebrum/migrations/0057_settings_baseline.sql
+++ b/pillars/cerebrum/migrations/0057_settings_baseline.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);

--- a/pillars/cerebrum/migrations/meta/_journal.json
+++ b/pillars/cerebrum/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782345600000,
       "tag": "0056_reflex_executions_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1782432000000,
+      "tag": "0057_settings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/cerebrum/openapi/cerebrum.openapi.json
+++ b/pillars/cerebrum/openapi/cerebrum.openapi.json
@@ -11420,6 +11420,1190 @@
         "tags": ["scopes"]
       }
     },
+    "/settings": {
+      "get": {
+        "operationId": "settings.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["key", "value"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List effective values for every declared key (sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/get-many": {
+      "post": {
+        "operationId": "settings.getMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["keys"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Batch-read settings by key (missing omitted; sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/reset": {
+      "post": {
+        "operationId": "settings.reset",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reset": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reset", "settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset declared keys to defaults (omit keys ⇒ reset all)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/set-many": {
+      "post": {
+        "operationId": "settings.setMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "entries": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["entries"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Transactional batch write (all-or-nothing); returns the written mirror",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}": {
+      "get": {
+        "operationId": "settings.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "cerebrum.query.maxSources",
+                "cerebrum.query.relevanceThreshold",
+                "cerebrum.query.tokenBudget",
+                "cerebrum.emit.maxTokens",
+                "cerebrum.emit.relevanceThreshold",
+                "cerebrum.emit.maxSources",
+                "cerebrum.emit.tokenBudget",
+                "cerebrum.semantic.defaultLimit",
+                "cerebrum.semantic.defaultThreshold",
+                "cerebrum.semantic.queryCacheTtl",
+                "cerebrum.hybrid.rrfK",
+                "cerebrum.hybrid.defaultLimit",
+                "cerebrum.hybrid.defaultThreshold",
+                "cerebrum.context.tokenBudget",
+                "cerebrum.classifier.confidenceThreshold",
+                "cerebrum.entityExtractor.confidenceThreshold",
+                "cerebrum.captureHotkey",
+                "cerebrum.nudge.consolidationSimilarity",
+                "cerebrum.nudge.consolidationMinCluster",
+                "cerebrum.nudge.stalenessDays",
+                "cerebrum.nudge.patternMinOccurrences",
+                "cerebrum.nudge.maxPending",
+                "cerebrum.nudge.cooldownHours",
+                "cerebrum.engram.fallbackScope",
+                "cerebrum.citation.excerptMaxLength",
+                "cerebrum.plexus.healthIntervalMs",
+                "cerebrum.plexus.healthTimeoutMs",
+                "cerebrum.plexus.maxConsecutiveFailures",
+                "cerebrum.thalamus.crossSourceIntervalMs",
+                "cerebrum.glia.proposeMinApproved",
+                "cerebrum.glia.proposeMaxRejectionRate",
+                "cerebrum.glia.actReportMinDays",
+                "cerebrum.glia.demotionRevertThreshold",
+                "cerebrum.glia.demotionWindowDays",
+                "cerebrum.mcp.queryMaxSources",
+                "cerebrum.mcp.searchSnippetLength",
+                "cerebrum.mcp.searchDefaultLimit",
+                "ego.defaultModel",
+                "ego.maxHistory",
+                "ego.maxRetrieval",
+                "ego.tokenBudget",
+                "ego.relevanceThreshold",
+                "ego.chat.maxTokens",
+                "ego.chat.temperature",
+                "ego.summary.maxTokens",
+                "ego.summary.temperature"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Read a single setting (null on unset; sensitive redacted)",
+        "tags": ["settings"]
+      },
+      "put": {
+        "operationId": "settings.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "cerebrum.query.maxSources",
+                "cerebrum.query.relevanceThreshold",
+                "cerebrum.query.tokenBudget",
+                "cerebrum.emit.maxTokens",
+                "cerebrum.emit.relevanceThreshold",
+                "cerebrum.emit.maxSources",
+                "cerebrum.emit.tokenBudget",
+                "cerebrum.semantic.defaultLimit",
+                "cerebrum.semantic.defaultThreshold",
+                "cerebrum.semantic.queryCacheTtl",
+                "cerebrum.hybrid.rrfK",
+                "cerebrum.hybrid.defaultLimit",
+                "cerebrum.hybrid.defaultThreshold",
+                "cerebrum.context.tokenBudget",
+                "cerebrum.classifier.confidenceThreshold",
+                "cerebrum.entityExtractor.confidenceThreshold",
+                "cerebrum.captureHotkey",
+                "cerebrum.nudge.consolidationSimilarity",
+                "cerebrum.nudge.consolidationMinCluster",
+                "cerebrum.nudge.stalenessDays",
+                "cerebrum.nudge.patternMinOccurrences",
+                "cerebrum.nudge.maxPending",
+                "cerebrum.nudge.cooldownHours",
+                "cerebrum.engram.fallbackScope",
+                "cerebrum.citation.excerptMaxLength",
+                "cerebrum.plexus.healthIntervalMs",
+                "cerebrum.plexus.healthTimeoutMs",
+                "cerebrum.plexus.maxConsecutiveFailures",
+                "cerebrum.thalamus.crossSourceIntervalMs",
+                "cerebrum.glia.proposeMinApproved",
+                "cerebrum.glia.proposeMaxRejectionRate",
+                "cerebrum.glia.actReportMinDays",
+                "cerebrum.glia.demotionRevertThreshold",
+                "cerebrum.glia.demotionWindowDays",
+                "cerebrum.mcp.queryMaxSources",
+                "cerebrum.mcp.searchSnippetLength",
+                "cerebrum.mcp.searchDefaultLimit",
+                "ego.defaultModel",
+                "ego.maxHistory",
+                "ego.maxRetrieval",
+                "ego.tokenBudget",
+                "ego.relevanceThreshold",
+                "ego.chat.maxTokens",
+                "ego.chat.temperature",
+                "ego.summary.maxTokens",
+                "ego.summary.temperature"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Upsert a single declared setting",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/ensure": {
+      "post": {
+        "operationId": "settings.ensure",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "cerebrum.query.maxSources",
+                "cerebrum.query.relevanceThreshold",
+                "cerebrum.query.tokenBudget",
+                "cerebrum.emit.maxTokens",
+                "cerebrum.emit.relevanceThreshold",
+                "cerebrum.emit.maxSources",
+                "cerebrum.emit.tokenBudget",
+                "cerebrum.semantic.defaultLimit",
+                "cerebrum.semantic.defaultThreshold",
+                "cerebrum.semantic.queryCacheTtl",
+                "cerebrum.hybrid.rrfK",
+                "cerebrum.hybrid.defaultLimit",
+                "cerebrum.hybrid.defaultThreshold",
+                "cerebrum.context.tokenBudget",
+                "cerebrum.classifier.confidenceThreshold",
+                "cerebrum.entityExtractor.confidenceThreshold",
+                "cerebrum.captureHotkey",
+                "cerebrum.nudge.consolidationSimilarity",
+                "cerebrum.nudge.consolidationMinCluster",
+                "cerebrum.nudge.stalenessDays",
+                "cerebrum.nudge.patternMinOccurrences",
+                "cerebrum.nudge.maxPending",
+                "cerebrum.nudge.cooldownHours",
+                "cerebrum.engram.fallbackScope",
+                "cerebrum.citation.excerptMaxLength",
+                "cerebrum.plexus.healthIntervalMs",
+                "cerebrum.plexus.healthTimeoutMs",
+                "cerebrum.plexus.maxConsecutiveFailures",
+                "cerebrum.thalamus.crossSourceIntervalMs",
+                "cerebrum.glia.proposeMinApproved",
+                "cerebrum.glia.proposeMaxRejectionRate",
+                "cerebrum.glia.actReportMinDays",
+                "cerebrum.glia.demotionRevertThreshold",
+                "cerebrum.glia.demotionWindowDays",
+                "cerebrum.mcp.queryMaxSources",
+                "cerebrum.mcp.searchSnippetLength",
+                "cerebrum.mcp.searchDefaultLimit",
+                "ego.defaultModel",
+                "ego.maxHistory",
+                "ego.maxRetrieval",
+                "ego.tokenBudget",
+                "ego.relevanceThreshold",
+                "ego.chat.maxTokens",
+                "ego.chat.temperature",
+                "ego.summary.maxTokens",
+                "ego.summary.temperature"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Internal-only write-once seed (encryption seed / client id)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/reset": {
+      "post": {
+        "operationId": "settings.resetKey",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "cerebrum.query.maxSources",
+                "cerebrum.query.relevanceThreshold",
+                "cerebrum.query.tokenBudget",
+                "cerebrum.emit.maxTokens",
+                "cerebrum.emit.relevanceThreshold",
+                "cerebrum.emit.maxSources",
+                "cerebrum.emit.tokenBudget",
+                "cerebrum.semantic.defaultLimit",
+                "cerebrum.semantic.defaultThreshold",
+                "cerebrum.semantic.queryCacheTtl",
+                "cerebrum.hybrid.rrfK",
+                "cerebrum.hybrid.defaultLimit",
+                "cerebrum.hybrid.defaultThreshold",
+                "cerebrum.context.tokenBudget",
+                "cerebrum.classifier.confidenceThreshold",
+                "cerebrum.entityExtractor.confidenceThreshold",
+                "cerebrum.captureHotkey",
+                "cerebrum.nudge.consolidationSimilarity",
+                "cerebrum.nudge.consolidationMinCluster",
+                "cerebrum.nudge.stalenessDays",
+                "cerebrum.nudge.patternMinOccurrences",
+                "cerebrum.nudge.maxPending",
+                "cerebrum.nudge.cooldownHours",
+                "cerebrum.engram.fallbackScope",
+                "cerebrum.citation.excerptMaxLength",
+                "cerebrum.plexus.healthIntervalMs",
+                "cerebrum.plexus.healthTimeoutMs",
+                "cerebrum.plexus.maxConsecutiveFailures",
+                "cerebrum.thalamus.crossSourceIntervalMs",
+                "cerebrum.glia.proposeMinApproved",
+                "cerebrum.glia.proposeMaxRejectionRate",
+                "cerebrum.glia.actReportMinDays",
+                "cerebrum.glia.demotionRevertThreshold",
+                "cerebrum.glia.demotionWindowDays",
+                "cerebrum.mcp.queryMaxSources",
+                "cerebrum.mcp.searchSnippetLength",
+                "cerebrum.mcp.searchDefaultLimit",
+                "ego.defaultModel",
+                "ego.maxHistory",
+                "ego.maxRetrieval",
+                "ego.tokenBudget",
+                "ego.relevanceThreshold",
+                "ego.chat.maxTokens",
+                "ego.chat.temperature",
+                "ego.summary.maxTokens",
+                "ego.summary.temperature"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset a single setting to its manifest default",
+        "tags": ["settings"]
+      }
+    },
     "/tags": {
       "get": {
         "operationId": "tags.list",

--- a/pillars/cerebrum/package.json
+++ b/pillars/cerebrum/package.json
@@ -43,6 +43,7 @@
     "@anthropic-ai/sdk": "^0.104.1",
     "@pops/ai-telemetry": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/pillar-settings": "workspace:*",
     "@pops/types": "workspace:*",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",

--- a/pillars/cerebrum/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/settings-federation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration tests for cerebrum's federated `/settings/*` surface
+ * (settings-federation S2).
+ *
+ * Boots the production `createCerebrumApiApp` factory against a per-test temp
+ * `cerebrum.db` and drives the RU+reset surface over real HTTP via supertest:
+ * the `0057_settings_baseline.sql` migration creates the table, `listEffective`
+ * resolves manifest defaults across BOTH the `cerebrum.*` and `ego.*` key
+ * spaces, update persists to cerebrum's OWN database, reset re-applies the
+ * default, and a free-form `set-many` addressing an undeclared key is rejected
+ * with a 400. Cerebrum declares no sensitive keys, so reads are not redacted.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cerebrumKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { openCerebrumDb, type OpenedCerebrumDb } from '../../db/index.js';
+import { createCerebrumApiApp } from '../app.js';
+import { makeEmptyPeerClients, makeReflexService, makeTemplateRegistry } from './test-utils.js';
+
+import type { TemplateRegistry } from '../modules/templates/registry.js';
+
+let tmpDir: string;
+let engramRoot: string;
+let templateRegistry: TemplateRegistry;
+let cerebrumDb: OpenedCerebrumDb;
+
+function app() {
+  return createCerebrumApiApp({
+    cerebrumDb,
+    templateRegistry,
+    engramRoot,
+    reflexService: makeReflexService(cerebrumDb.db, join(tmpDir, 'reflexes.toml')),
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3007',
+    peerClients: makeEmptyPeerClients(),
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-settings-test-'));
+  engramRoot = mkdtempSync(join(tmpdir(), 'cerebrum-settings-root-'));
+  templateRegistry = makeTemplateRegistry();
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(engramRoot, { recursive: true, force: true });
+});
+
+describe('cerebrum federated /settings', () => {
+  it('lists every declared key (cerebrum + ego) resolved to its manifest default', async () => {
+    const res = await request(app()).get('/settings');
+    expect(res.status).toBe(200);
+    const byKey = new Map<string, string>(
+      (res.body.data as { key: string; value: string }[]).map((row) => [row.key, row.value])
+    );
+    expect(byKey.get('cerebrum.query.maxSources')).toBe('10');
+    expect(byKey.get('cerebrum.captureHotkey')).toBe('c');
+    expect(byKey.get('ego.defaultModel')).toBe('claude-sonnet-4-6');
+    expect(byKey.get('ego.chat.temperature')).toBe('0.3');
+  });
+
+  it('round-trips an update through cerebrum.db and resets to the default', async () => {
+    const put = await request(app()).put('/settings/ego.maxHistory').send({ value: '99' });
+    expect(put.status).toBe(200);
+    expect(put.body.data).toEqual({ key: 'ego.maxHistory', value: '99' });
+
+    const afterSet = await request(app()).get('/settings/ego.maxHistory');
+    expect(afterSet.body.data).toEqual({ key: 'ego.maxHistory', value: '99' });
+
+    const reset = await request(app()).post('/settings/ego.maxHistory/reset');
+    expect(reset.status).toBe(200);
+    expect(reset.body.data).toEqual({ key: 'ego.maxHistory', value: '20' });
+
+    const afterReset = await request(app()).get('/settings/ego.maxHistory');
+    expect(afterReset.body.data).toBeNull();
+  });
+
+  it('reset with no keys restores every declared key to its default', async () => {
+    await request(app()).put('/settings/cerebrum.query.maxSources').send({ value: '3' });
+    const reset = await request(app()).post('/settings/reset').send({});
+    expect(reset.status).toBe(200);
+    expect([...reset.body.reset].toSorted()).toEqual([...cerebrumKeyDefaults.keys].toSorted());
+    expect(reset.body.settings['cerebrum.query.maxSources']).toBe('10');
+  });
+
+  it('rejects a set-many addressing an undeclared key with a 400', async () => {
+    const res = await request(app())
+      .post('/settings/set-many')
+      .send({ entries: [{ key: 'cerebrum.notAThing', value: 'x' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a single-key write outside the declared enum with a 400', async () => {
+    const res = await request(app()).put('/settings/totally.unknown').send({ value: 'x' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/cerebrum/src/api/rest/handlers.ts
+++ b/pillars/cerebrum/src/api/rest/handlers.ts
@@ -36,6 +36,7 @@ import { makeQueryHandlers } from './query-handlers.js';
 import { makeReflexHandlers } from './reflex-handlers.js';
 import { makeRetrievalHandlers } from './retrieval-handlers.js';
 import { makeScopesHandlers } from './scopes-handlers.js';
+import { makeSettingsHandlers } from './settings-handlers.js';
 import { makeTagsHandlers } from './tags-handlers.js';
 import { makeTemplatesHandlers } from './templates-handlers.js';
 import { makeWorkersHandlers } from './workers-handlers.js';
@@ -117,5 +118,6 @@ export function makeCerebrumRestHandlers(
     }),
     embeddings: makeEmbeddingsHandlers(db),
     debrief: makeDebriefHandlers(db),
+    settings: makeSettingsHandlers(db),
   });
 }

--- a/pillars/cerebrum/src/api/rest/settings-handlers.ts
+++ b/pillars/cerebrum/src/api/rest/settings-handlers.ts
@@ -1,0 +1,101 @@
+/**
+ * Handlers for cerebrum's `settings.*` sub-router, delegating to the shared
+ * `@pops/pillar-settings` Read/Update/Reset service (settings-federation S2).
+ *
+ * The shared `makeSettingsHandlers` owns the RU+reset logic, the declared-key
+ * assertion, and read-side sensitive redaction. Cerebrum injects its
+ * `CerebrumDb` settings store, the `cerebrum.settings` scope prefix, and a
+ * NO-OP gate: the cerebrum pillar trusts the docker network and runs no
+ * per-request auth (parity with every other cerebrum route), so there is no
+ * principal to enforce a scope against.
+ *
+ * `UnknownSettingKeyError` (a free-form `setMany`/`set` addressing an undeclared
+ * key) is remapped to the pillar's `ValidationError` so `runHttp` returns a 400
+ * rather than letting it escape as a 500.
+ */
+import {
+  makeSettingsHandlers as makeSharedSettingsHandlers,
+  UnknownSettingKeyError,
+  type SettingsGate,
+} from '@pops/pillar-settings';
+
+import { cerebrumKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type CerebrumDb } from '../../db/index.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { cerebrumSettingsContract } from '../../contract/rest-settings.js';
+
+type Req = ServerInferRequest<typeof cerebrumSettingsContract>;
+
+const SCOPE_PREFIX = 'cerebrum.settings';
+
+/** Cerebrum runs no per-request auth, so the gate is a no-op. */
+const gate: SettingsGate<unknown> = () => {};
+
+/**
+ * Runs a handler body, remapping the shared package's
+ * {@link UnknownSettingKeyError} to a 400 `ValidationError` (the shared error is
+ * not a cerebrum `HttpError`, so `runHttp` would otherwise re-throw it as a
+ * 500).
+ */
+function runSettings<T extends { status: number; body: unknown }>(
+  fn: () => T
+): ReturnType<typeof runHttp<T>> {
+  return runHttp(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof UnknownSettingKeyError) throw new ValidationError(err.message);
+      throw err;
+    }
+  });
+}
+
+export function makeSettingsHandlers(db: CerebrumDb) {
+  const shared = makeSharedSettingsHandlers<unknown>({
+    db,
+    scopePrefix: SCOPE_PREFIX,
+    keyDefaults: cerebrumKeyDefaults,
+    gate,
+  });
+
+  return {
+    list: () => runSettings(() => ({ status: 200 as const, body: shared.list(undefined) })),
+
+    get: ({ params }: Req['get']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.get(undefined, params.key) })),
+
+    getMany: ({ body }: Req['getMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.getMany(undefined, body.keys) })),
+
+    set: ({ params, body }: Req['set']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.set(undefined, params.key, body.value),
+      })),
+
+    setMany: ({ body }: Req['setMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.setMany(undefined, body.entries) })),
+
+    resetKey: ({ params }: Req['resetKey']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.resetKey(undefined, params.key) })),
+
+    reset: ({ body }: Req['reset']) =>
+      runSettings(() => {
+        const result = shared.reset(undefined, body.keys);
+        return {
+          status: 200 as const,
+          body: { reset: [...result.reset], settings: { ...result.settings } },
+        };
+      }),
+
+    ensure: ({ params, body }: Req['ensure']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.ensure(undefined, params.key, body.value),
+      })),
+  };
+}

--- a/pillars/cerebrum/src/contract/api-types.generated.ts
+++ b/pillars/cerebrum/src/contract/api-types.generated.ts
@@ -1503,6 +1503,126 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List effective values for every declared key (sensitive redacted) */
+    get: operations['settings.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/get-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Batch-read settings by key (missing omitted; sensitive redacted) */
+    post: operations['settings.getMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset declared keys to defaults (omit keys ⇒ reset all) */
+    post: operations['settings.reset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/set-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Transactional batch write (all-or-nothing); returns the written mirror */
+    post: operations['settings.setMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read a single setting (null on unset; sensitive redacted) */
+    get: operations['settings.get'];
+    /** Upsert a single declared setting */
+    put: operations['settings.set'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Internal-only write-once seed (encryption seed / client id) */
+    post: operations['settings.ensure'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset a single setting to its manifest default */
+    post: operations['settings.resetKey'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/tags': {
     parameters: {
       query?: never;
@@ -6554,6 +6674,753 @@ export interface operations {
             errors?: string[];
             scope?: string;
             valid: boolean;
+          };
+        };
+      };
+    };
+  };
+  'settings.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.getMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reset: string[];
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.setMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          entries: {
+            key: string;
+            value: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'cerebrum.query.maxSources'
+          | 'cerebrum.query.relevanceThreshold'
+          | 'cerebrum.query.tokenBudget'
+          | 'cerebrum.emit.maxTokens'
+          | 'cerebrum.emit.relevanceThreshold'
+          | 'cerebrum.emit.maxSources'
+          | 'cerebrum.emit.tokenBudget'
+          | 'cerebrum.semantic.defaultLimit'
+          | 'cerebrum.semantic.defaultThreshold'
+          | 'cerebrum.semantic.queryCacheTtl'
+          | 'cerebrum.hybrid.rrfK'
+          | 'cerebrum.hybrid.defaultLimit'
+          | 'cerebrum.hybrid.defaultThreshold'
+          | 'cerebrum.context.tokenBudget'
+          | 'cerebrum.classifier.confidenceThreshold'
+          | 'cerebrum.entityExtractor.confidenceThreshold'
+          | 'cerebrum.captureHotkey'
+          | 'cerebrum.nudge.consolidationSimilarity'
+          | 'cerebrum.nudge.consolidationMinCluster'
+          | 'cerebrum.nudge.stalenessDays'
+          | 'cerebrum.nudge.patternMinOccurrences'
+          | 'cerebrum.nudge.maxPending'
+          | 'cerebrum.nudge.cooldownHours'
+          | 'cerebrum.engram.fallbackScope'
+          | 'cerebrum.citation.excerptMaxLength'
+          | 'cerebrum.plexus.healthIntervalMs'
+          | 'cerebrum.plexus.healthTimeoutMs'
+          | 'cerebrum.plexus.maxConsecutiveFailures'
+          | 'cerebrum.thalamus.crossSourceIntervalMs'
+          | 'cerebrum.glia.proposeMinApproved'
+          | 'cerebrum.glia.proposeMaxRejectionRate'
+          | 'cerebrum.glia.actReportMinDays'
+          | 'cerebrum.glia.demotionRevertThreshold'
+          | 'cerebrum.glia.demotionWindowDays'
+          | 'cerebrum.mcp.queryMaxSources'
+          | 'cerebrum.mcp.searchSnippetLength'
+          | 'cerebrum.mcp.searchDefaultLimit'
+          | 'ego.defaultModel'
+          | 'ego.maxHistory'
+          | 'ego.maxRetrieval'
+          | 'ego.tokenBudget'
+          | 'ego.relevanceThreshold'
+          | 'ego.chat.maxTokens'
+          | 'ego.chat.temperature'
+          | 'ego.summary.maxTokens'
+          | 'ego.summary.temperature';
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'cerebrum.query.maxSources'
+          | 'cerebrum.query.relevanceThreshold'
+          | 'cerebrum.query.tokenBudget'
+          | 'cerebrum.emit.maxTokens'
+          | 'cerebrum.emit.relevanceThreshold'
+          | 'cerebrum.emit.maxSources'
+          | 'cerebrum.emit.tokenBudget'
+          | 'cerebrum.semantic.defaultLimit'
+          | 'cerebrum.semantic.defaultThreshold'
+          | 'cerebrum.semantic.queryCacheTtl'
+          | 'cerebrum.hybrid.rrfK'
+          | 'cerebrum.hybrid.defaultLimit'
+          | 'cerebrum.hybrid.defaultThreshold'
+          | 'cerebrum.context.tokenBudget'
+          | 'cerebrum.classifier.confidenceThreshold'
+          | 'cerebrum.entityExtractor.confidenceThreshold'
+          | 'cerebrum.captureHotkey'
+          | 'cerebrum.nudge.consolidationSimilarity'
+          | 'cerebrum.nudge.consolidationMinCluster'
+          | 'cerebrum.nudge.stalenessDays'
+          | 'cerebrum.nudge.patternMinOccurrences'
+          | 'cerebrum.nudge.maxPending'
+          | 'cerebrum.nudge.cooldownHours'
+          | 'cerebrum.engram.fallbackScope'
+          | 'cerebrum.citation.excerptMaxLength'
+          | 'cerebrum.plexus.healthIntervalMs'
+          | 'cerebrum.plexus.healthTimeoutMs'
+          | 'cerebrum.plexus.maxConsecutiveFailures'
+          | 'cerebrum.thalamus.crossSourceIntervalMs'
+          | 'cerebrum.glia.proposeMinApproved'
+          | 'cerebrum.glia.proposeMaxRejectionRate'
+          | 'cerebrum.glia.actReportMinDays'
+          | 'cerebrum.glia.demotionRevertThreshold'
+          | 'cerebrum.glia.demotionWindowDays'
+          | 'cerebrum.mcp.queryMaxSources'
+          | 'cerebrum.mcp.searchSnippetLength'
+          | 'cerebrum.mcp.searchDefaultLimit'
+          | 'ego.defaultModel'
+          | 'ego.maxHistory'
+          | 'ego.maxRetrieval'
+          | 'ego.tokenBudget'
+          | 'ego.relevanceThreshold'
+          | 'ego.chat.maxTokens'
+          | 'ego.chat.temperature'
+          | 'ego.summary.maxTokens'
+          | 'ego.summary.temperature';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'cerebrum.query.maxSources'
+          | 'cerebrum.query.relevanceThreshold'
+          | 'cerebrum.query.tokenBudget'
+          | 'cerebrum.emit.maxTokens'
+          | 'cerebrum.emit.relevanceThreshold'
+          | 'cerebrum.emit.maxSources'
+          | 'cerebrum.emit.tokenBudget'
+          | 'cerebrum.semantic.defaultLimit'
+          | 'cerebrum.semantic.defaultThreshold'
+          | 'cerebrum.semantic.queryCacheTtl'
+          | 'cerebrum.hybrid.rrfK'
+          | 'cerebrum.hybrid.defaultLimit'
+          | 'cerebrum.hybrid.defaultThreshold'
+          | 'cerebrum.context.tokenBudget'
+          | 'cerebrum.classifier.confidenceThreshold'
+          | 'cerebrum.entityExtractor.confidenceThreshold'
+          | 'cerebrum.captureHotkey'
+          | 'cerebrum.nudge.consolidationSimilarity'
+          | 'cerebrum.nudge.consolidationMinCluster'
+          | 'cerebrum.nudge.stalenessDays'
+          | 'cerebrum.nudge.patternMinOccurrences'
+          | 'cerebrum.nudge.maxPending'
+          | 'cerebrum.nudge.cooldownHours'
+          | 'cerebrum.engram.fallbackScope'
+          | 'cerebrum.citation.excerptMaxLength'
+          | 'cerebrum.plexus.healthIntervalMs'
+          | 'cerebrum.plexus.healthTimeoutMs'
+          | 'cerebrum.plexus.maxConsecutiveFailures'
+          | 'cerebrum.thalamus.crossSourceIntervalMs'
+          | 'cerebrum.glia.proposeMinApproved'
+          | 'cerebrum.glia.proposeMaxRejectionRate'
+          | 'cerebrum.glia.actReportMinDays'
+          | 'cerebrum.glia.demotionRevertThreshold'
+          | 'cerebrum.glia.demotionWindowDays'
+          | 'cerebrum.mcp.queryMaxSources'
+          | 'cerebrum.mcp.searchSnippetLength'
+          | 'cerebrum.mcp.searchDefaultLimit'
+          | 'ego.defaultModel'
+          | 'ego.maxHistory'
+          | 'ego.maxRetrieval'
+          | 'ego.tokenBudget'
+          | 'ego.relevanceThreshold'
+          | 'ego.chat.maxTokens'
+          | 'ego.chat.temperature'
+          | 'ego.summary.maxTokens'
+          | 'ego.summary.temperature';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.resetKey': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'cerebrum.query.maxSources'
+          | 'cerebrum.query.relevanceThreshold'
+          | 'cerebrum.query.tokenBudget'
+          | 'cerebrum.emit.maxTokens'
+          | 'cerebrum.emit.relevanceThreshold'
+          | 'cerebrum.emit.maxSources'
+          | 'cerebrum.emit.tokenBudget'
+          | 'cerebrum.semantic.defaultLimit'
+          | 'cerebrum.semantic.defaultThreshold'
+          | 'cerebrum.semantic.queryCacheTtl'
+          | 'cerebrum.hybrid.rrfK'
+          | 'cerebrum.hybrid.defaultLimit'
+          | 'cerebrum.hybrid.defaultThreshold'
+          | 'cerebrum.context.tokenBudget'
+          | 'cerebrum.classifier.confidenceThreshold'
+          | 'cerebrum.entityExtractor.confidenceThreshold'
+          | 'cerebrum.captureHotkey'
+          | 'cerebrum.nudge.consolidationSimilarity'
+          | 'cerebrum.nudge.consolidationMinCluster'
+          | 'cerebrum.nudge.stalenessDays'
+          | 'cerebrum.nudge.patternMinOccurrences'
+          | 'cerebrum.nudge.maxPending'
+          | 'cerebrum.nudge.cooldownHours'
+          | 'cerebrum.engram.fallbackScope'
+          | 'cerebrum.citation.excerptMaxLength'
+          | 'cerebrum.plexus.healthIntervalMs'
+          | 'cerebrum.plexus.healthTimeoutMs'
+          | 'cerebrum.plexus.maxConsecutiveFailures'
+          | 'cerebrum.thalamus.crossSourceIntervalMs'
+          | 'cerebrum.glia.proposeMinApproved'
+          | 'cerebrum.glia.proposeMaxRejectionRate'
+          | 'cerebrum.glia.actReportMinDays'
+          | 'cerebrum.glia.demotionRevertThreshold'
+          | 'cerebrum.glia.demotionWindowDays'
+          | 'cerebrum.mcp.queryMaxSources'
+          | 'cerebrum.mcp.searchSnippetLength'
+          | 'cerebrum.mcp.searchDefaultLimit'
+          | 'ego.defaultModel'
+          | 'ego.maxHistory'
+          | 'ego.maxRetrieval'
+          | 'ego.tokenBudget'
+          | 'ego.relevanceThreshold'
+          | 'ego.chat.maxTokens'
+          | 'ego.chat.temperature'
+          | 'ego.summary.maxTokens'
+          | 'ego.summary.temperature';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/cerebrum/src/contract/rest-settings.ts
+++ b/pillars/cerebrum/src/contract/rest-settings.ts
@@ -1,0 +1,32 @@
+/**
+ * `settings.*` sub-router — cerebrum's own federated Read/Update/Reset surface,
+ * served via the shared `@pops/pillar-settings` contract factory
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Cerebrum owns its `cerebrum.*` and `ego.*` keys in its own DB. The `:key` enum
+ * is derived from cerebrum's OWN manifests
+ * (`deriveKeySet([cerebrumManifest, egoManifest])`), NOT the central settings
+ * enum — the manifests are the single key authority for this pillar. The factory
+ * mounts the byte-identical federated surface every pillar serves
+ * (`list`/`get`/`getMany`/`set`/`setMany`/`resetKey`/`reset`/`ensure`).
+ *
+ * Cerebrum trusts the docker network and declares no 401 surface, so the
+ * contract reuses the pillar's `{400,404,409}` error bodies (cerebrum has no
+ * shared `ERR_RESPONSES` constant — sub-contracts declare errors inline — so the
+ * map is composed here from `errorBodySchema`); an unknown setting key is mapped
+ * to a 400 by the handler.
+ */
+import { keyValuesFor, makeSettingsContract } from '@pops/pillar-settings';
+
+import { errorBodySchema } from './rest-schemas.js';
+import { cerebrumKeyDefaults } from './settings/key-defaults.js';
+
+const ERR_RESPONSES = {
+  400: errorBodySchema,
+  404: errorBodySchema,
+  409: errorBodySchema,
+} as const;
+
+const cerebrumKeyValues = keyValuesFor(cerebrumKeyDefaults);
+
+export const cerebrumSettingsContract = makeSettingsContract(cerebrumKeyValues, ERR_RESPONSES);

--- a/pillars/cerebrum/src/contract/rest.ts
+++ b/pillars/cerebrum/src/contract/rest.ts
@@ -26,6 +26,7 @@ import { cerebrumQueryContract } from './rest-query.js';
 import { cerebrumReflexContract } from './rest-reflex.js';
 import { cerebrumRetrievalContract } from './rest-retrieval.js';
 import { cerebrumScopesContract } from './rest-scopes.js';
+import { cerebrumSettingsContract } from './rest-settings.js';
 import { cerebrumTagsContract } from './rest-tags.js';
 import { cerebrumTemplatesContract } from './rest-templates.js';
 import { cerebrumWorkersContract } from './rest-workers.js';
@@ -51,6 +52,7 @@ export const cerebrumContract = c.router(
     query: cerebrumQueryContract,
     embeddings: cerebrumEmbeddingsContract,
     debrief: cerebrumDebriefContract,
+    settings: cerebrumSettingsContract,
   },
   {
     pathPrefix: '',

--- a/pillars/cerebrum/src/contract/settings/key-defaults.ts
+++ b/pillars/cerebrum/src/contract/settings/key-defaults.ts
@@ -1,0 +1,18 @@
+/**
+ * Cerebrum's settings key authority for the shared `@pops/pillar-settings`
+ * surface (settings-federation S2).
+ *
+ * `deriveKeySet([cerebrumManifest, egoManifest])` is the single source of the
+ * declared key set, the reset defaults, and the read-side sensitive set —
+ * cerebrum's own manifests are the only authority for its keys (no central
+ * enum). The pillar serves BOTH the `cerebrum.*` and `ego.*` key spaces from one
+ * federated surface, so both manifests feed the same `KeyDefaults`. The same
+ * `KeyDefaults` feeds the contract's `:key` enum and the handler's declared-key
+ * assertion + default resolution.
+ */
+import { deriveKeySet, type KeyDefaults } from '@pops/pillar-settings';
+
+import { cerebrumManifest, egoManifest } from './index.js';
+
+/** Cerebrum's effective {@link KeyDefaults}, derived from its own manifests. */
+export const cerebrumKeyDefaults: KeyDefaults = deriveKeySet([cerebrumManifest, egoManifest]);

--- a/pillars/cerebrum/src/db/schema.ts
+++ b/pillars/cerebrum/src/db/schema.ts
@@ -44,3 +44,4 @@ export { gliaActions, gliaTrustState } from './schema/glia.js';
 export { nudgeLog } from './schema/nudge-log.js';
 export { plexusAdapters, plexusFilters } from './schema/plexus.js';
 export { reflexExecutions } from './schema/reflex-executions.js';
+export { settings } from './schema/settings.js';

--- a/pillars/cerebrum/src/db/schema/settings.ts
+++ b/pillars/cerebrum/src/db/schema/settings.ts
@@ -1,0 +1,12 @@
+/**
+ * Cerebrum's federated settings table — the flat key/value store the shared
+ * `@pops/pillar-settings` Read/Update/Reset surface operates over
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Re-exports the shared `settingsTable` factory so the cerebrum pillar owns its
+ * own `settings` table in its own database, identical in shape to every other
+ * federated pillar. It holds both the `cerebrum.*` and `ego.*` declared keys
+ * (cerebrum serves both manifests). The `0057_settings_baseline.sql` migration
+ * creates it.
+ */
+export { settingsTable as settings } from '@pops/pillar-settings';

--- a/pillars/finance/Dockerfile
+++ b/pillars/finance/Dockerfile
@@ -18,6 +18,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc
 COPY pillars/finance/package.json ./pillars/finance/
 COPY packages/ai-telemetry/package.json ./packages/ai-telemetry/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/pillar-settings/package.json ./packages/pillar-settings/
 COPY packages/types/package.json ./packages/types/
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -31,6 +32,9 @@ COPY packages/ai-telemetry/tsconfig.json ./packages/ai-telemetry/tsconfig.json
 
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+
+COPY packages/pillar-settings/src ./packages/pillar-settings/src
+COPY packages/pillar-settings/tsconfig.json ./packages/pillar-settings/tsconfig.json
 
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json ./packages/types/tsconfig.json

--- a/pillars/finance/migrations/0056_settings_baseline.sql
+++ b/pillars/finance/migrations/0056_settings_baseline.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);

--- a/pillars/finance/migrations/meta/_journal.json
+++ b/pillars/finance/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781913600000,
       "tag": "0055_budgets_owner_uri",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781913600001,
+      "tag": "0056_settings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -10306,6 +10306,1026 @@
         "tags": ["search"]
       }
     },
+    "/settings": {
+      "get": {
+        "operationId": "settings.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["key", "value"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List effective values for every declared key (sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/get-many": {
+      "post": {
+        "operationId": "settings.getMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["keys"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Batch-read settings by key (missing omitted; sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/reset": {
+      "post": {
+        "operationId": "settings.reset",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reset": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reset", "settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset declared keys to defaults (omit keys ⇒ reset all)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/set-many": {
+      "post": {
+        "operationId": "settings.setMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "entries": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["entries"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Transactional batch write (all-or-nothing); returns the written mirror",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}": {
+      "get": {
+        "operationId": "settings.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "finance.aiCategorizer.model",
+                "finance.aiCategorizer.maxTokens",
+                "finance.ruleGen.model",
+                "finance.ruleGen.maxTokens",
+                "finance.defaultLimit"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Read a single setting (null on unset; sensitive redacted)",
+        "tags": ["settings"]
+      },
+      "put": {
+        "operationId": "settings.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "finance.aiCategorizer.model",
+                "finance.aiCategorizer.maxTokens",
+                "finance.ruleGen.model",
+                "finance.ruleGen.maxTokens",
+                "finance.defaultLimit"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Upsert a single declared setting",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/ensure": {
+      "post": {
+        "operationId": "settings.ensure",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "finance.aiCategorizer.model",
+                "finance.aiCategorizer.maxTokens",
+                "finance.ruleGen.model",
+                "finance.ruleGen.maxTokens",
+                "finance.defaultLimit"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Internal-only write-once seed (encryption seed / client id)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/reset": {
+      "post": {
+        "operationId": "settings.resetKey",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "finance.aiCategorizer.model",
+                "finance.aiCategorizer.maxTokens",
+                "finance.ruleGen.model",
+                "finance.ruleGen.maxTokens",
+                "finance.defaultLimit"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset a single setting to its manifest default",
+        "tags": ["settings"]
+      }
+    },
     "/tag-rules/apply": {
       "post": {
         "operationId": "tagRules.apply",

--- a/pillars/finance/package.json
+++ b/pillars/finance/package.json
@@ -40,6 +40,7 @@
     "@anthropic-ai/sdk": "^0.104.1",
     "@pops/ai-telemetry": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/pillar-settings": "workspace:*",
     "@pops/types": "workspace:*",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",

--- a/pillars/finance/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/finance/src/api/__tests__/settings-federation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration tests for finance's federated `/settings/*` surface
+ * (settings-federation S2).
+ *
+ * Boots the production `createFinanceApiApp` factory against a per-test temp
+ * `finance.db` and drives the RU+reset surface over real HTTP via supertest:
+ * the `0056_settings_baseline.sql` migration creates the table, `listEffective`
+ * resolves manifest defaults, update persists to finance's OWN database, reset
+ * re-applies the default, and a free-form `set-many` addressing an undeclared
+ * key is rejected with a 400. Finance declares no sensitive keys, so reads are
+ * not redacted.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { financeKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { openFinanceDb, type OpenedFinanceDb } from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+function app() {
+  return createFinanceApiApp({
+    financeDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3004',
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-settings-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('finance federated /settings', () => {
+  it('lists every declared key resolved to its manifest default', async () => {
+    const res = await request(app()).get('/settings');
+    expect(res.status).toBe(200);
+    const byKey = new Map<string, string>(
+      (res.body.data as { key: string; value: string }[]).map((row) => [row.key, row.value])
+    );
+    expect(byKey.get('finance.aiCategorizer.model')).toBe('claude-haiku-4-5-20251001');
+    expect(byKey.get('finance.aiCategorizer.maxTokens')).toBe('200');
+    expect(byKey.get('finance.defaultLimit')).toBe('50');
+  });
+
+  it('round-trips an update through finance.db and resets to the default', async () => {
+    const put = await request(app()).put('/settings/finance.defaultLimit').send({ value: '99' });
+    expect(put.status).toBe(200);
+    expect(put.body.data).toEqual({ key: 'finance.defaultLimit', value: '99' });
+
+    const afterSet = await request(app()).get('/settings/finance.defaultLimit');
+    expect(afterSet.body.data).toEqual({ key: 'finance.defaultLimit', value: '99' });
+
+    const reset = await request(app()).post('/settings/finance.defaultLimit/reset');
+    expect(reset.status).toBe(200);
+    expect(reset.body.data).toEqual({ key: 'finance.defaultLimit', value: '50' });
+
+    const afterReset = await request(app()).get('/settings/finance.defaultLimit');
+    expect(afterReset.body.data).toBeNull();
+  });
+
+  it('reset with no keys restores every declared key to its default', async () => {
+    await request(app()).put('/settings/finance.aiCategorizer.maxTokens').send({ value: '500' });
+    const reset = await request(app()).post('/settings/reset').send({});
+    expect(reset.status).toBe(200);
+    expect([...reset.body.reset].toSorted()).toEqual([...financeKeyDefaults.keys].toSorted());
+    expect(reset.body.settings['finance.aiCategorizer.maxTokens']).toBe('200');
+  });
+
+  it('rejects a set-many addressing an undeclared key with a 400', async () => {
+    const res = await request(app())
+      .post('/settings/set-many')
+      .send({ entries: [{ key: 'finance.notAThing', value: 'x' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a single-key write outside the declared enum with a 400', async () => {
+    const res = await request(app()).put('/settings/totally.unknown').send({ value: 'x' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/finance/src/api/rest/handlers.ts
+++ b/pillars/finance/src/api/rest/handlers.ts
@@ -14,6 +14,7 @@ import { makeCorrectionsHandlers } from './corrections-handlers.js';
 import { makeEntityUsageHandlers } from './entity-usage-handlers.js';
 import { makeImportsHandlers } from './imports-handlers.js';
 import { makeSearchHandlers } from './search-handlers.js';
+import { makeSettingsHandlers } from './settings-handlers.js';
 import { makeTagRulesHandlers } from './tag-rules-handlers.js';
 import { makeTransactionsHandlers } from './transactions-handlers.js';
 import { makeWishlistHandlers } from './wishlist-handlers.js';
@@ -33,5 +34,6 @@ export function makeFinanceRestHandlers(deps: {
     entityUsage: makeEntityUsageHandlers(db),
     imports: makeImportsHandlers(db),
     search: makeSearchHandlers(db),
+    settings: makeSettingsHandlers(db),
   });
 }

--- a/pillars/finance/src/api/rest/settings-handlers.ts
+++ b/pillars/finance/src/api/rest/settings-handlers.ts
@@ -1,0 +1,101 @@
+/**
+ * Handlers for finance's `settings.*` sub-router, delegating to the shared
+ * `@pops/pillar-settings` Read/Update/Reset service (settings-federation S2).
+ *
+ * The shared `makeSettingsHandlers` owns the RU+reset logic, the declared-key
+ * assertion, and read-side sensitive redaction. Finance injects its `FinanceDb`
+ * settings store, the `finance.settings` scope prefix, and a NO-OP gate: the
+ * finance pillar trusts the docker network and runs no per-request auth (parity
+ * with every other finance route), so there is no principal to enforce a scope
+ * against.
+ *
+ * `UnknownSettingKeyError` (a free-form `setMany`/`set` addressing an undeclared
+ * key) is remapped to the pillar's `ValidationError` so `runHttp` returns a 400
+ * rather than letting it escape as a 500.
+ */
+import {
+  makeSettingsHandlers as makeSharedSettingsHandlers,
+  UnknownSettingKeyError,
+  type SettingsGate,
+} from '@pops/pillar-settings';
+
+import { financeKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type FinanceDb } from '../../db/index.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { financeSettingsContract } from '../../contract/rest-settings.js';
+
+type Req = ServerInferRequest<typeof financeSettingsContract>;
+
+const SCOPE_PREFIX = 'finance.settings';
+
+/** Finance runs no per-request auth, so the gate is a no-op. */
+const gate: SettingsGate<unknown> = () => {};
+
+/**
+ * Runs a handler body, remapping the shared package's
+ * {@link UnknownSettingKeyError} to a 400 `ValidationError` (the shared error is
+ * not a finance `HttpError`, so `runHttp` would otherwise re-throw it as a
+ * 500).
+ */
+function runSettings<T extends { status: number; body: unknown }>(
+  fn: () => T
+): ReturnType<typeof runHttp<T>> {
+  return runHttp(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof UnknownSettingKeyError) throw new ValidationError(err.message);
+      throw err;
+    }
+  });
+}
+
+export function makeSettingsHandlers(db: FinanceDb) {
+  const shared = makeSharedSettingsHandlers<unknown>({
+    db,
+    scopePrefix: SCOPE_PREFIX,
+    keyDefaults: financeKeyDefaults,
+    gate,
+  });
+
+  return {
+    list: () => runSettings(() => ({ status: 200 as const, body: shared.list(undefined) })),
+
+    get: ({ params }: Req['get']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.get(undefined, params.key) })),
+
+    getMany: ({ body }: Req['getMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.getMany(undefined, body.keys) })),
+
+    set: ({ params, body }: Req['set']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.set(undefined, params.key, body.value),
+      })),
+
+    setMany: ({ body }: Req['setMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.setMany(undefined, body.entries) })),
+
+    resetKey: ({ params }: Req['resetKey']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.resetKey(undefined, params.key) })),
+
+    reset: ({ body }: Req['reset']) =>
+      runSettings(() => {
+        const result = shared.reset(undefined, body.keys);
+        return {
+          status: 200 as const,
+          body: { reset: [...result.reset], settings: { ...result.settings } },
+        };
+      }),
+
+    ensure: ({ params, body }: Req['ensure']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.ensure(undefined, params.key, body.value),
+      })),
+  };
+}

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -417,6 +417,126 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List effective values for every declared key (sensitive redacted) */
+    get: operations['settings.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/get-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Batch-read settings by key (missing omitted; sensitive redacted) */
+    post: operations['settings.getMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset declared keys to defaults (omit keys ⇒ reset all) */
+    post: operations['settings.reset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/set-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Transactional batch write (all-or-nothing); returns the written mirror */
+    post: operations['settings.setMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read a single setting (null on unset; sensitive redacted) */
+    get: operations['settings.get'];
+    /** Upsert a single declared setting */
+    put: operations['settings.set'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Internal-only write-once seed (encryption seed / client id) */
+    post: operations['settings.ensure'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset a single setting to its manifest default */
+    post: operations['settings.resetKey'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/tag-rules/apply': {
     parameters: {
       query?: never;
@@ -4610,6 +4730,589 @@ export interface operations {
               score: number;
               uri: string;
             }[];
+          };
+        };
+      };
+    };
+  };
+  'settings.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.getMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reset: string[];
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.setMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          entries: {
+            key: string;
+            value: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'finance.aiCategorizer.model'
+          | 'finance.aiCategorizer.maxTokens'
+          | 'finance.ruleGen.model'
+          | 'finance.ruleGen.maxTokens'
+          | 'finance.defaultLimit';
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'finance.aiCategorizer.model'
+          | 'finance.aiCategorizer.maxTokens'
+          | 'finance.ruleGen.model'
+          | 'finance.ruleGen.maxTokens'
+          | 'finance.defaultLimit';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'finance.aiCategorizer.model'
+          | 'finance.aiCategorizer.maxTokens'
+          | 'finance.ruleGen.model'
+          | 'finance.ruleGen.maxTokens'
+          | 'finance.defaultLimit';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.resetKey': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'finance.aiCategorizer.model'
+          | 'finance.aiCategorizer.maxTokens'
+          | 'finance.ruleGen.model'
+          | 'finance.ruleGen.maxTokens'
+          | 'finance.defaultLimit';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/finance/src/contract/rest-settings.ts
+++ b/pillars/finance/src/contract/rest-settings.ts
@@ -1,0 +1,23 @@
+/**
+ * `settings.*` sub-router — finance's own federated Read/Update/Reset surface,
+ * served via the shared `@pops/pillar-settings` contract factory
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Finance owns its `finance.*` keys in its own DB. The `:key` enum is derived
+ * from finance's OWN manifest (`deriveKeySet([financeManifest])`), NOT the
+ * central settings enum — the manifest is the single key authority for this
+ * pillar. The factory mounts the byte-identical federated surface every pillar
+ * serves (`list`/`get`/`getMany`/`set`/`setMany`/`resetKey`/`reset`/`ensure`).
+ *
+ * Finance trusts the docker network and declares no 401 surface, so the
+ * contract reuses the pillar's existing `{400,404,409}` error set; an unknown
+ * setting key is mapped to a 400 by the handler.
+ */
+import { keyValuesFor, makeSettingsContract } from '@pops/pillar-settings';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+import { financeKeyDefaults } from './settings/key-defaults.js';
+
+const financeKeyValues = keyValuesFor(financeKeyDefaults);
+
+export const financeSettingsContract = makeSettingsContract(financeKeyValues, ERR_RESPONSES);

--- a/pillars/finance/src/contract/rest.ts
+++ b/pillars/finance/src/contract/rest.ts
@@ -17,6 +17,7 @@ import { financeCorrectionsContract } from './rest-corrections.js';
 import { financeEntityUsageContract } from './rest-entity-usage.js';
 import { financeImportsContract } from './rest-imports.js';
 import { financeSearchContract } from './rest-search.js';
+import { financeSettingsContract } from './rest-settings.js';
 import { financeTagRulesContract } from './rest-tag-rules.js';
 import { financeTransactionsContract } from './rest-transactions.js';
 import { financeWishlistContract } from './rest-wishlist.js';
@@ -33,6 +34,7 @@ export const financeContract = c.router(
     entityUsage: financeEntityUsageContract,
     imports: financeImportsContract,
     search: financeSearchContract,
+    settings: financeSettingsContract,
   },
   {
     pathPrefix: '',

--- a/pillars/finance/src/contract/settings/key-defaults.ts
+++ b/pillars/finance/src/contract/settings/key-defaults.ts
@@ -1,0 +1,16 @@
+/**
+ * Finance's settings key authority for the shared `@pops/pillar-settings`
+ * surface (settings-federation S2).
+ *
+ * `deriveKeySet([financeManifest])` is the single source of the declared key
+ * set, the reset defaults, and the read-side sensitive set — the finance
+ * manifest is the only authority for its keys (no central enum). The same
+ * `KeyDefaults` feeds both the contract's `:key` enum and the handler's
+ * declared-key assertion + default resolution.
+ */
+import { deriveKeySet, type KeyDefaults } from '@pops/pillar-settings';
+
+import { financeManifest } from './finance-manifest.js';
+
+/** Finance's effective {@link KeyDefaults}, derived from its own manifest. */
+export const financeKeyDefaults: KeyDefaults = deriveKeySet([financeManifest]);

--- a/pillars/finance/src/db/schema.ts
+++ b/pillars/finance/src/db/schema.ts
@@ -15,6 +15,7 @@ export { budgets } from './schema/budgets.js';
 export { transactionCorrections } from './schema/corrections.js';
 export { tagVocabulary } from './schema/tag-vocabulary.js';
 export { tierOverrides } from './schema/tier-overrides.js';
+export { settings } from './schema/settings.js';
 export { transactionTagRules } from './schema/transaction-tag-rules.js';
 export { transactions } from './schema/transactions.js';
 export { wishList } from './schema/wishlist.js';

--- a/pillars/finance/src/db/schema/settings.ts
+++ b/pillars/finance/src/db/schema/settings.ts
@@ -1,0 +1,10 @@
+/**
+ * Finance's federated settings table — the flat key/value store the shared
+ * `@pops/pillar-settings` Read/Update/Reset surface operates over
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Re-exports the shared `settingsTable` factory so the finance pillar owns its
+ * own `settings` table in its own database, identical in shape to every other
+ * federated pillar. The `0056_settings_baseline.sql` migration creates it.
+ */
+export { settingsTable as settings } from '@pops/pillar-settings';

--- a/pillars/inventory/Dockerfile
+++ b/pillars/inventory/Dockerfile
@@ -17,6 +17,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc
 # in this image's build context.
 COPY pillars/inventory/package.json ./pillars/inventory/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/pillar-settings/package.json ./packages/pillar-settings/
 COPY packages/types/package.json ./packages/types/
 
 # Install pnpm + only the deps of the @pops/inventory subgraph.
@@ -27,6 +28,9 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/pillar-sdk
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+# @pops/pillar-settings
+COPY packages/pillar-settings/src ./packages/pillar-settings/src
+COPY packages/pillar-settings/tsconfig.json ./packages/pillar-settings/tsconfig.json
 # @pops/types
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json ./packages/types/tsconfig.json

--- a/pillars/inventory/migrations/0009_settings_baseline.sql
+++ b/pillars/inventory/migrations/0009_settings_baseline.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);

--- a/pillars/inventory/migrations/meta/_journal.json
+++ b/pillars/inventory/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781650200002,
       "tag": "0008_cross_pillar_uri_denorm",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781650200003,
+      "tag": "0009_settings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/inventory/openapi/inventory.openapi.json
+++ b/pillars/inventory/openapi/inventory.openapi.json
@@ -6395,6 +6395,1018 @@
         "tags": ["search"]
       }
     },
+    "/settings": {
+      "get": {
+        "operationId": "settings.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["key", "value"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List effective values for every declared key (sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/get-many": {
+      "post": {
+        "operationId": "settings.getMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["keys"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Batch-read settings by key (missing omitted; sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/reset": {
+      "post": {
+        "operationId": "settings.reset",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reset": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reset", "settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset declared keys to defaults (omit keys ⇒ reset all)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/set-many": {
+      "post": {
+        "operationId": "settings.setMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "entries": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["entries"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Transactional batch write (all-or-nothing); returns the written mirror",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}": {
+      "get": {
+        "operationId": "settings.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "inventory.defaultLimit",
+                "inventory.searchDefaultLimit",
+                "inventory.maxFileSizeBytes"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Read a single setting (null on unset; sensitive redacted)",
+        "tags": ["settings"]
+      },
+      "put": {
+        "operationId": "settings.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "inventory.defaultLimit",
+                "inventory.searchDefaultLimit",
+                "inventory.maxFileSizeBytes"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Upsert a single declared setting",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/ensure": {
+      "post": {
+        "operationId": "settings.ensure",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "inventory.defaultLimit",
+                "inventory.searchDefaultLimit",
+                "inventory.maxFileSizeBytes"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Internal-only write-once seed (encryption seed / client id)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/reset": {
+      "post": {
+        "operationId": "settings.resetKey",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "inventory.defaultLimit",
+                "inventory.searchDefaultLimit",
+                "inventory.maxFileSizeBytes"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset a single setting to its manifest default",
+        "tags": ["settings"]
+      }
+    },
     "/uploads/{id}": {
       "delete": {
         "operationId": "documentFiles.removeUpload",

--- a/pillars/inventory/package.json
+++ b/pillars/inventory/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/pillar-settings": "workspace:*",
     "@pops/types": "workspace:*",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",

--- a/pillars/inventory/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/inventory/src/api/__tests__/settings-federation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration tests for inventory's federated `/settings/*` surface
+ * (settings-federation S2).
+ *
+ * Boots the production `createInventoryApiApp` factory against a per-test temp
+ * `inventory.db` and drives the RU+reset surface over real HTTP via supertest:
+ * the `0009_settings_baseline.sql` migration creates the table, `listEffective`
+ * resolves manifest defaults, update persists to inventory's OWN database, reset
+ * re-applies the default, and a free-form `set-many` addressing an undeclared
+ * key is rejected with a 400. Inventory declares no sensitive keys, so reads are
+ * not redacted.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { inventoryKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { openInventoryDb, type OpenedInventoryDb } from '../../db/index.js';
+import { createInventoryApiApp } from '../app.js';
+
+let tmpDir: string;
+let inventoryDb: OpenedInventoryDb;
+
+function app() {
+  return createInventoryApiApp({
+    inventoryDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3002',
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-settings-test-'));
+  inventoryDb = openInventoryDb(join(tmpDir, 'inventory.db'));
+});
+
+afterEach(() => {
+  inventoryDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('inventory federated /settings', () => {
+  it('lists every declared key resolved to its manifest default', async () => {
+    const res = await request(app()).get('/settings');
+    expect(res.status).toBe(200);
+    const byKey = new Map<string, string>(
+      (res.body.data as { key: string; value: string }[]).map((row) => [row.key, row.value])
+    );
+    expect(byKey.get('inventory.defaultLimit')).toBe('50');
+    expect(byKey.get('inventory.searchDefaultLimit')).toBe('20');
+    expect(byKey.get('inventory.maxFileSizeBytes')).toBe('10485760');
+  });
+
+  it('round-trips an update through inventory.db and resets to the default', async () => {
+    const put = await request(app()).put('/settings/inventory.defaultLimit').send({ value: '99' });
+    expect(put.status).toBe(200);
+    expect(put.body.data).toEqual({ key: 'inventory.defaultLimit', value: '99' });
+
+    const afterSet = await request(app()).get('/settings/inventory.defaultLimit');
+    expect(afterSet.body.data).toEqual({ key: 'inventory.defaultLimit', value: '99' });
+
+    const reset = await request(app()).post('/settings/inventory.defaultLimit/reset');
+    expect(reset.status).toBe(200);
+    expect(reset.body.data).toEqual({ key: 'inventory.defaultLimit', value: '50' });
+
+    const afterReset = await request(app()).get('/settings/inventory.defaultLimit');
+    expect(afterReset.body.data).toBeNull();
+  });
+
+  it('reset with no keys restores every declared key to its default', async () => {
+    await request(app()).put('/settings/inventory.searchDefaultLimit').send({ value: '5' });
+    const reset = await request(app()).post('/settings/reset').send({});
+    expect(reset.status).toBe(200);
+    expect([...reset.body.reset].toSorted()).toEqual([...inventoryKeyDefaults.keys].toSorted());
+    expect(reset.body.settings['inventory.searchDefaultLimit']).toBe('20');
+  });
+
+  it('rejects a set-many addressing an undeclared key with a 400', async () => {
+    const res = await request(app())
+      .post('/settings/set-many')
+      .send({ entries: [{ key: 'inventory.notAThing', value: 'x' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a single-key write outside the declared enum with a 400', async () => {
+    const res = await request(app()).put('/settings/totally.unknown').send({ value: 'x' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/inventory/src/api/rest/handlers.ts
+++ b/pillars/inventory/src/api/rest/handlers.ts
@@ -19,6 +19,7 @@ import { makePaperlessHandlers } from './paperless-handlers.js';
 import { makePhotosHandlers } from './photos-handlers.js';
 import { makeReportsHandlers } from './reports-handlers.js';
 import { makeSearchHandlers } from './search-handlers.js';
+import { makeSettingsHandlers } from './settings-handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
 
@@ -37,5 +38,6 @@ export function makeInventoryRestHandlers(deps: {
     reports: makeReportsHandlers(db),
     paperless: makePaperlessHandlers(),
     search: makeSearchHandlers(db),
+    settings: makeSettingsHandlers(db),
   });
 }

--- a/pillars/inventory/src/api/rest/settings-handlers.ts
+++ b/pillars/inventory/src/api/rest/settings-handlers.ts
@@ -1,0 +1,101 @@
+/**
+ * Handlers for inventory's `settings.*` sub-router, delegating to the shared
+ * `@pops/pillar-settings` Read/Update/Reset service (settings-federation S2).
+ *
+ * The shared `makeSettingsHandlers` owns the RU+reset logic, the declared-key
+ * assertion, and read-side sensitive redaction. Inventory injects its
+ * `InventoryDb` settings store, the `inventory.settings` scope prefix, and a
+ * NO-OP gate: the inventory pillar trusts the docker network and runs no
+ * per-request auth (parity with every other inventory route), so there is no
+ * principal to enforce a scope against.
+ *
+ * `UnknownSettingKeyError` (a free-form `setMany`/`set` addressing an undeclared
+ * key) is remapped to the pillar's `ValidationError` so `runHttp` returns a 400
+ * rather than letting it escape as a 500.
+ */
+import {
+  makeSettingsHandlers as makeSharedSettingsHandlers,
+  UnknownSettingKeyError,
+  type SettingsGate,
+} from '@pops/pillar-settings';
+
+import { inventoryKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type InventoryDb } from '../../db/index.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { inventorySettingsContract } from '../../contract/rest-settings.js';
+
+type Req = ServerInferRequest<typeof inventorySettingsContract>;
+
+const SCOPE_PREFIX = 'inventory.settings';
+
+/** Inventory runs no per-request auth, so the gate is a no-op. */
+const gate: SettingsGate<unknown> = () => {};
+
+/**
+ * Runs a handler body, remapping the shared package's
+ * {@link UnknownSettingKeyError} to a 400 `ValidationError` (the shared error is
+ * not an inventory `HttpError`, so `runHttp` would otherwise re-throw it as a
+ * 500).
+ */
+function runSettings<T extends { status: number; body: unknown }>(
+  fn: () => T
+): ReturnType<typeof runHttp<T>> {
+  return runHttp(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof UnknownSettingKeyError) throw new ValidationError(err.message);
+      throw err;
+    }
+  });
+}
+
+export function makeSettingsHandlers(db: InventoryDb) {
+  const shared = makeSharedSettingsHandlers<unknown>({
+    db,
+    scopePrefix: SCOPE_PREFIX,
+    keyDefaults: inventoryKeyDefaults,
+    gate,
+  });
+
+  return {
+    list: () => runSettings(() => ({ status: 200 as const, body: shared.list(undefined) })),
+
+    get: ({ params }: Req['get']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.get(undefined, params.key) })),
+
+    getMany: ({ body }: Req['getMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.getMany(undefined, body.keys) })),
+
+    set: ({ params, body }: Req['set']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.set(undefined, params.key, body.value),
+      })),
+
+    setMany: ({ body }: Req['setMany']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.setMany(undefined, body.entries) })),
+
+    resetKey: ({ params }: Req['resetKey']) =>
+      runSettings(() => ({ status: 200 as const, body: shared.resetKey(undefined, params.key) })),
+
+    reset: ({ body }: Req['reset']) =>
+      runSettings(() => {
+        const result = shared.reset(undefined, body.keys);
+        return {
+          status: 200 as const,
+          body: { reset: [...result.reset], settings: { ...result.settings } },
+        };
+      }),
+
+    ensure: ({ params, body }: Req['ensure']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: shared.ensure(undefined, params.key, body.value),
+      })),
+  };
+}

--- a/pillars/inventory/src/contract/api-types.generated.ts
+++ b/pillars/inventory/src/contract/api-types.generated.ts
@@ -596,6 +596,126 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List effective values for every declared key (sensitive redacted) */
+    get: operations['settings.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/get-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Batch-read settings by key (missing omitted; sensitive redacted) */
+    post: operations['settings.getMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset declared keys to defaults (omit keys ⇒ reset all) */
+    post: operations['settings.reset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/set-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Transactional batch write (all-or-nothing); returns the written mirror */
+    post: operations['settings.setMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read a single setting (null on unset; sensitive redacted) */
+    get: operations['settings.get'];
+    /** Upsert a single declared setting */
+    put: operations['settings.set'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Internal-only write-once seed (encryption seed / client id) */
+    post: operations['settings.ensure'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset a single setting to its manifest default */
+    post: operations['settings.resetKey'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/uploads/{id}': {
     parameters: {
       query?: never;
@@ -3591,6 +3711,581 @@ export interface operations {
               score: number;
               uri: string;
             }[];
+          };
+        };
+      };
+    };
+  };
+  'settings.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.getMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reset: string[];
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.setMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          entries: {
+            key: string;
+            value: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'inventory.defaultLimit'
+          | 'inventory.searchDefaultLimit'
+          | 'inventory.maxFileSizeBytes';
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'inventory.defaultLimit'
+          | 'inventory.searchDefaultLimit'
+          | 'inventory.maxFileSizeBytes';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'inventory.defaultLimit'
+          | 'inventory.searchDefaultLimit'
+          | 'inventory.maxFileSizeBytes';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.resetKey': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'inventory.defaultLimit'
+          | 'inventory.searchDefaultLimit'
+          | 'inventory.maxFileSizeBytes';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/inventory/src/contract/rest-settings.ts
+++ b/pillars/inventory/src/contract/rest-settings.ts
@@ -1,0 +1,24 @@
+/**
+ * `settings.*` sub-router — inventory's own federated Read/Update/Reset surface,
+ * served via the shared `@pops/pillar-settings` contract factory
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Inventory owns its `inventory.*` keys in its own DB. The `:key` enum is
+ * derived from inventory's OWN manifest (`deriveKeySet([inventoryManifest])`),
+ * NOT the central settings enum — the manifest is the single key authority for
+ * this pillar. The factory mounts the byte-identical federated surface every
+ * pillar serves (`list`/`get`/`getMany`/`set`/`setMany`/`resetKey`/`reset`/
+ * `ensure`).
+ *
+ * Inventory trusts the docker network and declares no 401 surface, so the
+ * contract reuses the pillar's existing `{400,404,409}` error set; an unknown
+ * setting key is mapped to a 400 by the handler.
+ */
+import { keyValuesFor, makeSettingsContract } from '@pops/pillar-settings';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+import { inventoryKeyDefaults } from './settings/key-defaults.js';
+
+const inventoryKeyValues = keyValuesFor(inventoryKeyDefaults);
+
+export const inventorySettingsContract = makeSettingsContract(inventoryKeyValues, ERR_RESPONSES);

--- a/pillars/inventory/src/contract/rest.ts
+++ b/pillars/inventory/src/contract/rest.ts
@@ -22,6 +22,7 @@ import { inventoryPaperlessContract } from './rest-paperless.js';
 import { inventoryPhotosContract } from './rest-photos.js';
 import { inventoryReportsContract } from './rest-reports.js';
 import { inventorySearchContract } from './rest-search.js';
+import { inventorySettingsContract } from './rest-settings.js';
 
 const c = initContract();
 
@@ -37,6 +38,7 @@ export const inventoryContract = c.router(
     reports: inventoryReportsContract,
     paperless: inventoryPaperlessContract,
     search: inventorySearchContract,
+    settings: inventorySettingsContract,
   },
   {
     pathPrefix: '',

--- a/pillars/inventory/src/contract/settings/key-defaults.ts
+++ b/pillars/inventory/src/contract/settings/key-defaults.ts
@@ -1,0 +1,16 @@
+/**
+ * Inventory's settings key authority for the shared `@pops/pillar-settings`
+ * surface (settings-federation S2).
+ *
+ * `deriveKeySet([inventoryManifest])` is the single source of the declared key
+ * set, the reset defaults, and the read-side sensitive set — the inventory
+ * manifest is the only authority for its keys (no central enum). The same
+ * `KeyDefaults` feeds both the contract's `:key` enum and the handler's
+ * declared-key assertion + default resolution.
+ */
+import { deriveKeySet, type KeyDefaults } from '@pops/pillar-settings';
+
+import { inventoryManifest } from './inventory-manifest.js';
+
+/** Inventory's effective {@link KeyDefaults}, derived from its own manifest. */
+export const inventoryKeyDefaults: KeyDefaults = deriveKeySet([inventoryManifest]);

--- a/pillars/inventory/src/db/schema.ts
+++ b/pillars/inventory/src/db/schema.ts
@@ -15,3 +15,4 @@ export { itemFixtureConnections } from './schema/item-fixture-connections.js';
 export { itemPhotos } from './schema/item-photos.js';
 export { itemUploadedFiles } from './schema/item-uploaded-files.js';
 export { locations } from './schema/locations.js';
+export { settings } from './schema/settings.js';

--- a/pillars/inventory/src/db/schema/settings.ts
+++ b/pillars/inventory/src/db/schema/settings.ts
@@ -1,0 +1,10 @@
+/**
+ * Inventory's federated settings table — the flat key/value store the shared
+ * `@pops/pillar-settings` Read/Update/Reset surface operates over
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Re-exports the shared `settingsTable` factory so the inventory pillar owns its
+ * own `settings` table in its own database, identical in shape to every other
+ * federated pillar. The `0009_settings_baseline.sql` migration creates it.
+ */
+export { settingsTable as settings } from '@pops/pillar-settings';

--- a/pillars/media/Dockerfile
+++ b/pillars/media/Dockerfile
@@ -17,6 +17,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc
 # this image's build context.
 COPY pillars/media/package.json ./pillars/media/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/pillar-settings/package.json ./packages/pillar-settings/
 COPY packages/types/package.json ./packages/types/
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -27,6 +28,9 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+
+COPY packages/pillar-settings/src ./packages/pillar-settings/src
+COPY packages/pillar-settings/tsconfig.json ./packages/pillar-settings/tsconfig.json
 
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json ./packages/types/tsconfig.json

--- a/pillars/media/migrations/0038_settings_baseline.sql
+++ b/pillars/media/migrations/0038_settings_baseline.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);

--- a/pillars/media/migrations/meta/_journal.json
+++ b/pillars/media/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1798000005000,
       "tag": "0037_rotation_settings_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1798000006000,
+      "tag": "0038_settings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/media/openapi/media.openapi.json
+++ b/pillars/media/openapi/media.openapi.json
@@ -16580,6 +16580,1194 @@
         "tags": ["tvShows"]
       }
     },
+    "/settings": {
+      "get": {
+        "operationId": "settings.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["key", "value"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List effective values for every declared key (sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/get-many": {
+      "post": {
+        "operationId": "settings.getMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["keys"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Batch-read settings by key (missing omitted; sensitive redacted)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/reset": {
+      "post": {
+        "operationId": "settings.reset",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "keys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reset": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["reset", "settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset declared keys to defaults (omit keys ⇒ reset all)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/set-many": {
+      "post": {
+        "operationId": "settings.setMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "entries": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["entries"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "settings": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": ["settings"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Transactional batch write (all-or-nothing); returns the written mirror",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}": {
+      "get": {
+        "operationId": "settings.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "plex_url",
+                "plex_token",
+                "plex_movie_section_id",
+                "plex_tv_section_id",
+                "plex_scheduler_enabled",
+                "plex_scheduler_interval_ms",
+                "radarr_url",
+                "radarr_api_key",
+                "sonarr_url",
+                "sonarr_api_key",
+                "rotation_quality_profile_id",
+                "rotation_root_folder_path",
+                "rotation_enabled",
+                "rotation_cron_expression",
+                "rotation_target_free_gb",
+                "rotation_avg_movie_gb",
+                "rotation_protected_days",
+                "rotation_daily_additions",
+                "rotation_leaving_days",
+                "media.comparisons.eloK",
+                "media.comparisons.defaultScore",
+                "media.comparisons.maxTierListMovies",
+                "media.comparisons.stalenessThreshold",
+                "media.comparisons.defaultLimit",
+                "media.discovery.sessionTargetMin",
+                "media.discovery.sessionTargetMax",
+                "media.discovery.maxSeedShelves",
+                "media.discovery.maxGenreShelves",
+                "media.discovery.maxActiveCollections",
+                "media.discovery.maxBecauseYouWatchedSeeds",
+                "media.discovery.maxCreditsSeeds",
+                "media.discovery.maxBestInGenre",
+                "media.discovery.maxCrossoverPairs",
+                "media.thetvdb.rateLimitCapacity",
+                "media.thetvdb.rateLimitRefillRate",
+                "media.thetvdb.maxRetries",
+                "media.tmdb.genreCacheTtlMs",
+                "media.tmdb.imageMaxRetries",
+                "media.tmdb.imageRetryDelayMs",
+                "media.plex.rateLimitDelayMs",
+                "media.plex.clientPageSize",
+                "media.plex.friendsPageSize",
+                "media.defaultLimit",
+                "media.rotation.tmdbDefaultPages",
+                "media.rotation.tmdbMaxPages",
+                "media.rotation.tmdbMinVoteCount",
+                "media.rotation.letterboxdMaxPages"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Read a single setting (null on unset; sensitive redacted)",
+        "tags": ["settings"]
+      },
+      "put": {
+        "operationId": "settings.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "plex_url",
+                "plex_token",
+                "plex_movie_section_id",
+                "plex_tv_section_id",
+                "plex_scheduler_enabled",
+                "plex_scheduler_interval_ms",
+                "radarr_url",
+                "radarr_api_key",
+                "sonarr_url",
+                "sonarr_api_key",
+                "rotation_quality_profile_id",
+                "rotation_root_folder_path",
+                "rotation_enabled",
+                "rotation_cron_expression",
+                "rotation_target_free_gb",
+                "rotation_avg_movie_gb",
+                "rotation_protected_days",
+                "rotation_daily_additions",
+                "rotation_leaving_days",
+                "media.comparisons.eloK",
+                "media.comparisons.defaultScore",
+                "media.comparisons.maxTierListMovies",
+                "media.comparisons.stalenessThreshold",
+                "media.comparisons.defaultLimit",
+                "media.discovery.sessionTargetMin",
+                "media.discovery.sessionTargetMax",
+                "media.discovery.maxSeedShelves",
+                "media.discovery.maxGenreShelves",
+                "media.discovery.maxActiveCollections",
+                "media.discovery.maxBecauseYouWatchedSeeds",
+                "media.discovery.maxCreditsSeeds",
+                "media.discovery.maxBestInGenre",
+                "media.discovery.maxCrossoverPairs",
+                "media.thetvdb.rateLimitCapacity",
+                "media.thetvdb.rateLimitRefillRate",
+                "media.thetvdb.maxRetries",
+                "media.tmdb.genreCacheTtlMs",
+                "media.tmdb.imageMaxRetries",
+                "media.tmdb.imageRetryDelayMs",
+                "media.plex.rateLimitDelayMs",
+                "media.plex.clientPageSize",
+                "media.plex.friendsPageSize",
+                "media.defaultLimit",
+                "media.rotation.tmdbDefaultPages",
+                "media.rotation.tmdbMaxPages",
+                "media.rotation.tmdbMinVoteCount",
+                "media.rotation.letterboxdMaxPages"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Upsert a single declared setting",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/ensure": {
+      "post": {
+        "operationId": "settings.ensure",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "plex_url",
+                "plex_token",
+                "plex_movie_section_id",
+                "plex_tv_section_id",
+                "plex_scheduler_enabled",
+                "plex_scheduler_interval_ms",
+                "radarr_url",
+                "radarr_api_key",
+                "sonarr_url",
+                "sonarr_api_key",
+                "rotation_quality_profile_id",
+                "rotation_root_folder_path",
+                "rotation_enabled",
+                "rotation_cron_expression",
+                "rotation_target_free_gb",
+                "rotation_avg_movie_gb",
+                "rotation_protected_days",
+                "rotation_daily_additions",
+                "rotation_leaving_days",
+                "media.comparisons.eloK",
+                "media.comparisons.defaultScore",
+                "media.comparisons.maxTierListMovies",
+                "media.comparisons.stalenessThreshold",
+                "media.comparisons.defaultLimit",
+                "media.discovery.sessionTargetMin",
+                "media.discovery.sessionTargetMax",
+                "media.discovery.maxSeedShelves",
+                "media.discovery.maxGenreShelves",
+                "media.discovery.maxActiveCollections",
+                "media.discovery.maxBecauseYouWatchedSeeds",
+                "media.discovery.maxCreditsSeeds",
+                "media.discovery.maxBestInGenre",
+                "media.discovery.maxCrossoverPairs",
+                "media.thetvdb.rateLimitCapacity",
+                "media.thetvdb.rateLimitRefillRate",
+                "media.thetvdb.maxRetries",
+                "media.tmdb.genreCacheTtlMs",
+                "media.tmdb.imageMaxRetries",
+                "media.tmdb.imageRetryDelayMs",
+                "media.plex.rateLimitDelayMs",
+                "media.plex.clientPageSize",
+                "media.plex.friendsPageSize",
+                "media.defaultLimit",
+                "media.rotation.tmdbDefaultPages",
+                "media.rotation.tmdbMaxPages",
+                "media.rotation.tmdbMinVoteCount",
+                "media.rotation.letterboxdMaxPages"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Internal-only write-once seed (encryption seed / client id)",
+        "tags": ["settings"]
+      }
+    },
+    "/settings/{key}/reset": {
+      "post": {
+        "operationId": "settings.resetKey",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "enum": [
+                "plex_url",
+                "plex_token",
+                "plex_movie_section_id",
+                "plex_tv_section_id",
+                "plex_scheduler_enabled",
+                "plex_scheduler_interval_ms",
+                "radarr_url",
+                "radarr_api_key",
+                "sonarr_url",
+                "sonarr_api_key",
+                "rotation_quality_profile_id",
+                "rotation_root_folder_path",
+                "rotation_enabled",
+                "rotation_cron_expression",
+                "rotation_target_free_gb",
+                "rotation_avg_movie_gb",
+                "rotation_protected_days",
+                "rotation_daily_additions",
+                "rotation_leaving_days",
+                "media.comparisons.eloK",
+                "media.comparisons.defaultScore",
+                "media.comparisons.maxTierListMovies",
+                "media.comparisons.stalenessThreshold",
+                "media.comparisons.defaultLimit",
+                "media.discovery.sessionTargetMin",
+                "media.discovery.sessionTargetMax",
+                "media.discovery.maxSeedShelves",
+                "media.discovery.maxGenreShelves",
+                "media.discovery.maxActiveCollections",
+                "media.discovery.maxBecauseYouWatchedSeeds",
+                "media.discovery.maxCreditsSeeds",
+                "media.discovery.maxBestInGenre",
+                "media.discovery.maxCrossoverPairs",
+                "media.thetvdb.rateLimitCapacity",
+                "media.thetvdb.rateLimitRefillRate",
+                "media.thetvdb.maxRetries",
+                "media.tmdb.genreCacheTtlMs",
+                "media.tmdb.imageMaxRetries",
+                "media.tmdb.imageRetryDelayMs",
+                "media.plex.rateLimitDelayMs",
+                "media.plex.clientPageSize",
+                "media.plex.friendsPageSize",
+                "media.defaultLimit",
+                "media.rotation.tmdbDefaultPages",
+                "media.rotation.tmdbMaxPages",
+                "media.rotation.tmdbMinVoteCount",
+                "media.rotation.letterboxdMaxPages"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "value"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reset a single setting to its manifest default",
+        "tags": ["settings"]
+      }
+    },
     "/shelf-impressions": {
       "post": {
         "operationId": "shelfImpressions.record",

--- a/pillars/media/package.json
+++ b/pillars/media/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/pillar-settings": "workspace:*",
     "@pops/types": "workspace:*",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/express": "3.53.0-rc.1",

--- a/pillars/media/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/media/src/api/__tests__/settings-federation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests for media's federated `/settings/*` surface
+ * (settings-federation S2, OD-2).
+ *
+ * Boots the production `createMediaApiApp` factory against a per-test temp
+ * `media.db` and drives the RU+reset surface over real HTTP via supertest. The
+ * load-bearing behaviour here is the translation ADAPTER: media's keys back onto
+ * THREE physical tables, not the shared single `settings` table. The suite
+ * asserts:
+ *   - manifest defaults resolve on the collection read,
+ *   - prefix routing lands each key in the right physical table
+ *     (`plex_*`→`plex_settings`, `rotation_*`→`rotation_settings`,
+ *     `media.*`/`radarr_*`→`settings`),
+ *   - the `rotation_enabled` boolean round-trips `'true'`/`'false'` over the wire
+ *     while persisting the legacy `'true'`/`''` encoding,
+ *   - an upsert bumps the carve-out table's `updated_at`,
+ *   - the sensitive `plex_token` is redacted on read but persisted intact,
+ *   - reset re-applies the manifest default, and
+ *   - a free-form write addressing an undeclared key is rejected with a 400.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { sql } from 'drizzle-orm';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { REDACTED } from '@pops/pillar-settings';
+
+import { openMediaDb, type OpenedMediaDb } from '../../db/index.js';
+import { plexSettings, rotationSettings, settings } from '../../db/schema.js';
+import { createMediaApiApp } from '../app.js';
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+
+function app() {
+  return createMediaApiApp({
+    mediaDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3003',
+  });
+}
+
+function rawValue(
+  table: typeof plexSettings | typeof rotationSettings | typeof settings,
+  key: string
+) {
+  return mediaDb.db
+    .select({ value: table.value })
+    .from(table)
+    .where(sql`${table.key} = ${key}`)
+    .get();
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-settings-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('media federated /settings', () => {
+  it('lists every declared key resolved to its manifest default', async () => {
+    const res = await request(app()).get('/settings');
+    expect(res.status).toBe(200);
+    const byKey = new Map<string, string>(
+      (res.body.data as { key: string; value: string }[]).map((row) => [row.key, row.value])
+    );
+    expect(byKey.get('rotation_cron_expression')).toBe('0 3 * * *');
+    expect(byKey.get('rotation_target_free_gb')).toBe('100');
+    expect(byKey.get('media.comparisons.eloK')).toBe('32');
+    // Toggle with no manifest default resolves to the empty string, decoded off.
+    expect(byKey.get('rotation_enabled')).toBe('false');
+  });
+
+  it('routes each key prefix to its backing physical table', async () => {
+    await request(app()).put('/settings/plex_url').send({ value: 'http://plex.test:32400' });
+    await request(app()).put('/settings/rotation_target_free_gb').send({ value: '250' });
+    await request(app()).put('/settings/radarr_url').send({ value: 'http://radarr.test' });
+    await request(app()).put('/settings/media.defaultLimit').send({ value: '99' });
+
+    expect(rawValue(plexSettings, 'plex_url')?.value).toBe('http://plex.test:32400');
+    expect(rawValue(rotationSettings, 'rotation_target_free_gb')?.value).toBe('250');
+    expect(rawValue(settings, 'radarr_url')?.value).toBe('http://radarr.test');
+    expect(rawValue(settings, 'media.defaultLimit')?.value).toBe('99');
+    // Carve-out keys must NOT leak into the residual table.
+    expect(rawValue(settings, 'plex_url')).toBeUndefined();
+    expect(rawValue(settings, 'rotation_target_free_gb')).toBeUndefined();
+  });
+
+  it('round-trips the rotation_enabled toggle through the legacy true/empty encoding', async () => {
+    const on = await request(app()).put('/settings/rotation_enabled').send({ value: 'true' });
+    expect(on.body.data).toEqual({ key: 'rotation_enabled', value: 'true' });
+    expect(rawValue(rotationSettings, 'rotation_enabled')?.value).toBe('true');
+    expect((await request(app()).get('/settings/rotation_enabled')).body.data.value).toBe('true');
+
+    const off = await request(app()).put('/settings/rotation_enabled').send({ value: 'false' });
+    expect(off.body.data).toEqual({ key: 'rotation_enabled', value: 'false' });
+    // Disabled persists as the empty string, but reads back as the canonical 'false'.
+    expect(rawValue(rotationSettings, 'rotation_enabled')?.value).toBe('');
+    expect((await request(app()).get('/settings/rotation_enabled')).body.data.value).toBe('false');
+  });
+
+  it('bumps updated_at on a carve-out upsert', async () => {
+    await request(app()).put('/settings/plex_url').send({ value: 'http://a' });
+    const first = mediaDb.db
+      .select({ createdAt: plexSettings.createdAt, updatedAt: plexSettings.updatedAt })
+      .from(plexSettings)
+      .where(sql`${plexSettings.key} = 'plex_url'`)
+      .get();
+    // Force a clock tick so the datetime('now') value differs.
+    mediaDb.raw
+      .prepare("UPDATE plex_settings SET updated_at = '2000-01-01 00:00:00' WHERE key = 'plex_url'")
+      .run();
+    await request(app()).put('/settings/plex_url').send({ value: 'http://b' });
+    const second = rawValue(plexSettings, 'plex_url');
+    expect(second?.value).toBe('http://b');
+    const bumped = mediaDb.db
+      .select({ createdAt: plexSettings.createdAt, updatedAt: plexSettings.updatedAt })
+      .from(plexSettings)
+      .where(sql`${plexSettings.key} = 'plex_url'`)
+      .get();
+    expect(bumped?.updatedAt).not.toBe('2000-01-01 00:00:00');
+    expect(bumped?.createdAt).toBe(first?.createdAt);
+  });
+
+  it('redacts the sensitive plex_token on read but persists it intact', async () => {
+    await request(app()).put('/settings/plex_token').send({ value: 'super-secret-ciphertext' });
+    expect(rawValue(plexSettings, 'plex_token')?.value).toBe('super-secret-ciphertext');
+
+    const single = await request(app()).get('/settings/plex_token');
+    expect(single.body.data.value).toBe(REDACTED);
+
+    const many = await request(app())
+      .post('/settings/get-many')
+      .send({ keys: ['plex_token', 'plex_url'] });
+    expect(many.body.settings.plex_token).toBe(REDACTED);
+
+    const collection = await request(app()).get('/settings');
+    const tokenRow = (collection.body.data as { key: string; value: string }[]).find(
+      (row) => row.key === 'plex_token'
+    );
+    expect(tokenRow?.value).toBe(REDACTED);
+  });
+
+  it('resets a single key to its manifest default and reset-all restores every default', async () => {
+    await request(app()).put('/settings/rotation_target_free_gb').send({ value: '999' });
+    const reset = await request(app()).post('/settings/rotation_target_free_gb/reset');
+    expect(reset.body.data).toEqual({ key: 'rotation_target_free_gb', value: '100' });
+    expect(rawValue(rotationSettings, 'rotation_target_free_gb')).toBeUndefined();
+
+    await request(app()).put('/settings/media.comparisons.eloK').send({ value: '64' });
+    const resetAll = await request(app()).post('/settings/reset').send({});
+    expect(resetAll.status).toBe(200);
+    expect(resetAll.body.settings['media.comparisons.eloK']).toBe('32');
+    expect(resetAll.body.settings['rotation_cron_expression']).toBe('0 3 * * *');
+  });
+
+  it('rejects a set-many addressing an undeclared key with a 400', async () => {
+    const res = await request(app())
+      .post('/settings/set-many')
+      .send({ entries: [{ key: 'media.notAThing', value: 'x' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a single-key write outside the declared enum with a 400', async () => {
+    const res = await request(app()).put('/settings/totally.unknown').send({ value: 'x' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/pillars/media/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/media/src/api/__tests__/settings-federation.test.ts
@@ -172,4 +172,18 @@ describe('media federated /settings', () => {
     const res = await request(app()).put('/settings/totally.unknown').send({ value: 'x' });
     expect(res.status).toBe(400);
   });
+
+  it('treats ensure as a write-once seed that never clobbers the landed value', async () => {
+    const first = await request(app())
+      .post('/settings/plex_url/ensure')
+      .send({ value: 'http://first' });
+    expect(first.body.data).toEqual({ key: 'plex_url', value: 'http://first' });
+
+    const second = await request(app())
+      .post('/settings/plex_url/ensure')
+      .send({ value: 'http://second' });
+    // The seed is preserved: the second ensure returns the originally-landed value.
+    expect(second.body.data).toEqual({ key: 'plex_url', value: 'http://first' });
+    expect(rawValue(plexSettings, 'plex_url')?.value).toBe('http://first');
+  });
 });

--- a/pillars/media/src/api/rest/handlers.ts
+++ b/pillars/media/src/api/rest/handlers.ts
@@ -17,6 +17,7 @@ import { makeMoviesHandlers } from './movies-handlers.js';
 import { makePlexHandlers } from './plex-handlers.js';
 import { makeRotationHandlers } from './rotation-handlers.js';
 import { makeSearchHandlers } from './search-handlers.js';
+import { makeSettingsHandlers } from './settings-handlers.js';
 import { makeShelfImpressionsHandlers } from './shelf-impressions-handlers.js';
 import { makeTvShowsHandlers } from './tv-shows-handlers.js';
 import { makeWatchHistoryHandlers } from './watch-history-handlers.js';
@@ -41,5 +42,6 @@ export function makeMediaRestHandlers(deps: {
     rotation: makeRotationHandlers(db),
     discovery: makeDiscoveryHandlers(db),
     search: makeSearchHandlers(),
+    settings: makeSettingsHandlers(db),
   });
 }

--- a/pillars/media/src/api/rest/settings-handlers.ts
+++ b/pillars/media/src/api/rest/settings-handlers.ts
@@ -1,0 +1,131 @@
+/**
+ * Handlers for media's `settings.*` sub-router (settings-federation S2, OD-2).
+ *
+ * Unlike the other federated pillars, media does NOT delegate to the shared
+ * `@pops/pillar-settings` single-table service. Its keys back onto THREE
+ * physical tables (`plex_settings`, `rotation_settings`, and the residual
+ * `settings` table) with `'true'`/`''` boolean encoding, so the read/write
+ * logic runs through media's `settings-adapter`. The shared package still owns
+ * the redaction sentinel, the declared-key error, and the `KeyDefaults` shape;
+ * only the storage layer is media-specific.
+ *
+ * READ paths (`list`/`get`/`getMany`) redact sensitive keys (`plex_token`,
+ * `radarr_api_key`, `sonarr_api_key`) to the `__redacted__` sentinel; WRITE and
+ * RESET paths persist and return real values, and reject undeclared keys
+ * (`UnknownSettingKeyError` → 400 `ValidationError`) so a batch write can never
+ * become a backdoor create.
+ *
+ * Media trusts the docker network and runs no per-request auth (parity with
+ * every other media route), so there is no principal to gate against.
+ */
+import {
+  redactSensitive,
+  redactSensitiveMap,
+  UnknownSettingKeyError,
+  type SettingEntry,
+} from '@pops/pillar-settings';
+
+import { mediaKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type MediaDb } from '../../db/index.js';
+import * as adapter from '../../db/services/settings-adapter.js';
+import { ValidationError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { mediaSettingsContract } from '../../contract/rest-settings.js';
+
+type Req = ServerInferRequest<typeof mediaSettingsContract>;
+
+const SENSITIVE = new Set(mediaKeyDefaults.sensitive);
+const DECLARED = new Set(mediaKeyDefaults.keys);
+
+function assertDeclared(keys: readonly string[]): void {
+  const unknown = keys.filter((key) => !DECLARED.has(key));
+  if (unknown.length > 0) throw new UnknownSettingKeyError(unknown);
+}
+
+/**
+ * Runs a handler body, remapping the shared package's
+ * {@link UnknownSettingKeyError} to a 400 `ValidationError` (the shared error is
+ * not a media `HttpError`, so `runHttp` would otherwise re-throw it as a 500).
+ */
+function runSettings<T extends { status: number; body: unknown }>(
+  fn: () => T
+): ReturnType<typeof runHttp<T>> {
+  return runHttp(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof UnknownSettingKeyError) throw new ValidationError(err.message);
+      throw err;
+    }
+  });
+}
+
+export function makeSettingsHandlers(db: MediaDb) {
+  return {
+    list: () =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: { data: redactSensitive(adapter.listEffective(db, mediaKeyDefaults), SENSITIVE) },
+      })),
+
+    get: ({ params }: Req['get']) =>
+      runSettings(() => {
+        const row = adapter.getOrNull(db, params.key);
+        if (row === null) return { status: 200 as const, body: { data: null } };
+        const [redacted] = redactSensitive([row], SENSITIVE);
+        return { status: 200 as const, body: { data: redacted ?? row } };
+      }),
+
+    getMany: ({ body }: Req['getMany']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: { settings: redactSensitiveMap(adapter.getBulk(db, body.keys), SENSITIVE) },
+      })),
+
+    set: ({ params, body }: Req['set']) =>
+      runSettings(() => {
+        assertDeclared([params.key]);
+        return {
+          status: 200 as const,
+          body: { data: adapter.setRaw(db, params.key, body.value), message: 'Setting saved' },
+        };
+      }),
+
+    setMany: ({ body }: Req['setMany']) =>
+      runSettings(() => {
+        const entries: SettingEntry[] = body.entries;
+        assertDeclared(entries.map((entry) => entry.key));
+        return { status: 200 as const, body: { settings: adapter.setBulk(db, entries) } };
+      }),
+
+    resetKey: ({ params }: Req['resetKey']) =>
+      runSettings(() => {
+        assertDeclared([params.key]);
+        return {
+          status: 200 as const,
+          body: {
+            data: adapter.resetSetting(db, params.key, mediaKeyDefaults),
+            message: 'Setting reset to default',
+          },
+        };
+      }),
+
+    reset: ({ body }: Req['reset']) =>
+      runSettings(() => {
+        const result = adapter.resetSettings(db, body.keys, mediaKeyDefaults);
+        return {
+          status: 200 as const,
+          body: { reset: [...result.reset], settings: { ...result.settings } },
+        };
+      }),
+
+    ensure: ({ params, body }: Req['ensure']) =>
+      runSettings(() => ({
+        status: 200 as const,
+        body: { data: adapter.ensure(db, params.key, body.value) },
+      })),
+  };
+}

--- a/pillars/media/src/contract/api-types.generated.ts
+++ b/pillars/media/src/contract/api-types.generated.ts
@@ -1904,6 +1904,126 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List effective values for every declared key (sensitive redacted) */
+    get: operations['settings.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/get-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Batch-read settings by key (missing omitted; sensitive redacted) */
+    post: operations['settings.getMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset declared keys to defaults (omit keys ⇒ reset all) */
+    post: operations['settings.reset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/set-many': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Transactional batch write (all-or-nothing); returns the written mirror */
+    post: operations['settings.setMany'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Read a single setting (null on unset; sensitive redacted) */
+    get: operations['settings.get'];
+    /** Upsert a single declared setting */
+    put: operations['settings.set'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Internal-only write-once seed (encryption seed / client id) */
+    post: operations['settings.ensure'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/settings/{key}/reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset a single setting to its manifest default */
+    post: operations['settings.resetKey'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/shelf-impressions': {
     parameters: {
       query?: never;
@@ -9993,6 +10113,757 @@ export interface operations {
               stillPath: string | null;
               tvdbId: number;
               voteAverage: number | null;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.getMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.reset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          keys?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            reset: string[];
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.setMany': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          entries: {
+            key: string;
+            value: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            settings: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'plex_url'
+          | 'plex_token'
+          | 'plex_movie_section_id'
+          | 'plex_tv_section_id'
+          | 'plex_scheduler_enabled'
+          | 'plex_scheduler_interval_ms'
+          | 'radarr_url'
+          | 'radarr_api_key'
+          | 'sonarr_url'
+          | 'sonarr_api_key'
+          | 'rotation_quality_profile_id'
+          | 'rotation_root_folder_path'
+          | 'rotation_enabled'
+          | 'rotation_cron_expression'
+          | 'rotation_target_free_gb'
+          | 'rotation_avg_movie_gb'
+          | 'rotation_protected_days'
+          | 'rotation_daily_additions'
+          | 'rotation_leaving_days'
+          | 'media.comparisons.eloK'
+          | 'media.comparisons.defaultScore'
+          | 'media.comparisons.maxTierListMovies'
+          | 'media.comparisons.stalenessThreshold'
+          | 'media.comparisons.defaultLimit'
+          | 'media.discovery.sessionTargetMin'
+          | 'media.discovery.sessionTargetMax'
+          | 'media.discovery.maxSeedShelves'
+          | 'media.discovery.maxGenreShelves'
+          | 'media.discovery.maxActiveCollections'
+          | 'media.discovery.maxBecauseYouWatchedSeeds'
+          | 'media.discovery.maxCreditsSeeds'
+          | 'media.discovery.maxBestInGenre'
+          | 'media.discovery.maxCrossoverPairs'
+          | 'media.thetvdb.rateLimitCapacity'
+          | 'media.thetvdb.rateLimitRefillRate'
+          | 'media.thetvdb.maxRetries'
+          | 'media.tmdb.genreCacheTtlMs'
+          | 'media.tmdb.imageMaxRetries'
+          | 'media.tmdb.imageRetryDelayMs'
+          | 'media.plex.rateLimitDelayMs'
+          | 'media.plex.clientPageSize'
+          | 'media.plex.friendsPageSize'
+          | 'media.defaultLimit'
+          | 'media.rotation.tmdbDefaultPages'
+          | 'media.rotation.tmdbMaxPages'
+          | 'media.rotation.tmdbMinVoteCount'
+          | 'media.rotation.letterboxdMaxPages';
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            } | null;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'plex_url'
+          | 'plex_token'
+          | 'plex_movie_section_id'
+          | 'plex_tv_section_id'
+          | 'plex_scheduler_enabled'
+          | 'plex_scheduler_interval_ms'
+          | 'radarr_url'
+          | 'radarr_api_key'
+          | 'sonarr_url'
+          | 'sonarr_api_key'
+          | 'rotation_quality_profile_id'
+          | 'rotation_root_folder_path'
+          | 'rotation_enabled'
+          | 'rotation_cron_expression'
+          | 'rotation_target_free_gb'
+          | 'rotation_avg_movie_gb'
+          | 'rotation_protected_days'
+          | 'rotation_daily_additions'
+          | 'rotation_leaving_days'
+          | 'media.comparisons.eloK'
+          | 'media.comparisons.defaultScore'
+          | 'media.comparisons.maxTierListMovies'
+          | 'media.comparisons.stalenessThreshold'
+          | 'media.comparisons.defaultLimit'
+          | 'media.discovery.sessionTargetMin'
+          | 'media.discovery.sessionTargetMax'
+          | 'media.discovery.maxSeedShelves'
+          | 'media.discovery.maxGenreShelves'
+          | 'media.discovery.maxActiveCollections'
+          | 'media.discovery.maxBecauseYouWatchedSeeds'
+          | 'media.discovery.maxCreditsSeeds'
+          | 'media.discovery.maxBestInGenre'
+          | 'media.discovery.maxCrossoverPairs'
+          | 'media.thetvdb.rateLimitCapacity'
+          | 'media.thetvdb.rateLimitRefillRate'
+          | 'media.thetvdb.maxRetries'
+          | 'media.tmdb.genreCacheTtlMs'
+          | 'media.tmdb.imageMaxRetries'
+          | 'media.tmdb.imageRetryDelayMs'
+          | 'media.plex.rateLimitDelayMs'
+          | 'media.plex.clientPageSize'
+          | 'media.plex.friendsPageSize'
+          | 'media.defaultLimit'
+          | 'media.rotation.tmdbDefaultPages'
+          | 'media.rotation.tmdbMaxPages'
+          | 'media.rotation.tmdbMinVoteCount'
+          | 'media.rotation.letterboxdMaxPages';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.ensure': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'plex_url'
+          | 'plex_token'
+          | 'plex_movie_section_id'
+          | 'plex_tv_section_id'
+          | 'plex_scheduler_enabled'
+          | 'plex_scheduler_interval_ms'
+          | 'radarr_url'
+          | 'radarr_api_key'
+          | 'sonarr_url'
+          | 'sonarr_api_key'
+          | 'rotation_quality_profile_id'
+          | 'rotation_root_folder_path'
+          | 'rotation_enabled'
+          | 'rotation_cron_expression'
+          | 'rotation_target_free_gb'
+          | 'rotation_avg_movie_gb'
+          | 'rotation_protected_days'
+          | 'rotation_daily_additions'
+          | 'rotation_leaving_days'
+          | 'media.comparisons.eloK'
+          | 'media.comparisons.defaultScore'
+          | 'media.comparisons.maxTierListMovies'
+          | 'media.comparisons.stalenessThreshold'
+          | 'media.comparisons.defaultLimit'
+          | 'media.discovery.sessionTargetMin'
+          | 'media.discovery.sessionTargetMax'
+          | 'media.discovery.maxSeedShelves'
+          | 'media.discovery.maxGenreShelves'
+          | 'media.discovery.maxActiveCollections'
+          | 'media.discovery.maxBecauseYouWatchedSeeds'
+          | 'media.discovery.maxCreditsSeeds'
+          | 'media.discovery.maxBestInGenre'
+          | 'media.discovery.maxCrossoverPairs'
+          | 'media.thetvdb.rateLimitCapacity'
+          | 'media.thetvdb.rateLimitRefillRate'
+          | 'media.thetvdb.maxRetries'
+          | 'media.tmdb.genreCacheTtlMs'
+          | 'media.tmdb.imageMaxRetries'
+          | 'media.tmdb.imageRetryDelayMs'
+          | 'media.plex.rateLimitDelayMs'
+          | 'media.plex.clientPageSize'
+          | 'media.plex.friendsPageSize'
+          | 'media.defaultLimit'
+          | 'media.rotation.tmdbDefaultPages'
+          | 'media.rotation.tmdbMaxPages'
+          | 'media.rotation.tmdbMinVoteCount'
+          | 'media.rotation.letterboxdMaxPages';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          value: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.resetKey': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key:
+          | 'plex_url'
+          | 'plex_token'
+          | 'plex_movie_section_id'
+          | 'plex_tv_section_id'
+          | 'plex_scheduler_enabled'
+          | 'plex_scheduler_interval_ms'
+          | 'radarr_url'
+          | 'radarr_api_key'
+          | 'sonarr_url'
+          | 'sonarr_api_key'
+          | 'rotation_quality_profile_id'
+          | 'rotation_root_folder_path'
+          | 'rotation_enabled'
+          | 'rotation_cron_expression'
+          | 'rotation_target_free_gb'
+          | 'rotation_avg_movie_gb'
+          | 'rotation_protected_days'
+          | 'rotation_daily_additions'
+          | 'rotation_leaving_days'
+          | 'media.comparisons.eloK'
+          | 'media.comparisons.defaultScore'
+          | 'media.comparisons.maxTierListMovies'
+          | 'media.comparisons.stalenessThreshold'
+          | 'media.comparisons.defaultLimit'
+          | 'media.discovery.sessionTargetMin'
+          | 'media.discovery.sessionTargetMax'
+          | 'media.discovery.maxSeedShelves'
+          | 'media.discovery.maxGenreShelves'
+          | 'media.discovery.maxActiveCollections'
+          | 'media.discovery.maxBecauseYouWatchedSeeds'
+          | 'media.discovery.maxCreditsSeeds'
+          | 'media.discovery.maxBestInGenre'
+          | 'media.discovery.maxCrossoverPairs'
+          | 'media.thetvdb.rateLimitCapacity'
+          | 'media.thetvdb.rateLimitRefillRate'
+          | 'media.thetvdb.maxRetries'
+          | 'media.tmdb.genreCacheTtlMs'
+          | 'media.tmdb.imageMaxRetries'
+          | 'media.tmdb.imageRetryDelayMs'
+          | 'media.plex.rateLimitDelayMs'
+          | 'media.plex.clientPageSize'
+          | 'media.plex.friendsPageSize'
+          | 'media.defaultLimit'
+          | 'media.rotation.tmdbDefaultPages'
+          | 'media.rotation.tmdbMaxPages'
+          | 'media.rotation.tmdbMinVoteCount'
+          | 'media.rotation.letterboxdMaxPages';
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              key: string;
+              value: string;
             };
             message: string;
           };

--- a/pillars/media/src/contract/rest-settings.ts
+++ b/pillars/media/src/contract/rest-settings.ts
@@ -1,0 +1,29 @@
+/**
+ * `settings.*` sub-router — media's own federated Read/Update/Reset surface,
+ * served via the shared `@pops/pillar-settings` contract factory
+ * (settings-federation S2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Media owns its `plex_*`/`rotation_*`/`radarr_*`/`sonarr_*`/`media.*` keys in
+ * its OWN database. The `:key` enum is derived from media's OWN manifests
+ * (`deriveKeySet([...mediaManifests])`), NOT the central settings enum — the
+ * manifests are the single key authority for this pillar. The factory mounts the
+ * byte-identical federated surface every pillar serves
+ * (`list`/`get`/`getMany`/`set`/`setMany`/`resetKey`/`reset`/`ensure`).
+ *
+ * Unlike the other pillars, media's handlers back this surface onto three
+ * physical tables via a translation adapter (`db/services/settings-adapter.ts`),
+ * not the shared single-table service: `plex_*`/`rotation_*` keep their existing
+ * carve-out tables and `'true'`/`''` boolean encoding.
+ *
+ * Media trusts the docker network and declares no 401 surface, so the contract
+ * reuses the pillar's existing `{400,404,409}` error set; an unknown setting key
+ * is mapped to a 400 by the handler.
+ */
+import { keyValuesFor, makeSettingsContract } from '@pops/pillar-settings';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+import { mediaKeyDefaults } from './settings/key-defaults.js';
+
+const mediaKeyValues = keyValuesFor(mediaKeyDefaults);
+
+export const mediaSettingsContract = makeSettingsContract(mediaKeyValues, ERR_RESPONSES);

--- a/pillars/media/src/contract/rest.ts
+++ b/pillars/media/src/contract/rest.ts
@@ -19,6 +19,7 @@ import { mediaMoviesContract } from './rest-movies.js';
 import { mediaPlexContract } from './rest-plex.js';
 import { mediaRotationContract } from './rest-rotation.js';
 import { mediaSearchContract } from './rest-search.js';
+import { mediaSettingsContract } from './rest-settings.js';
 import { mediaShelfImpressionsContract } from './rest-shelf-impressions.js';
 import { mediaTvShowsContract } from './rest-tv-shows.js';
 import { mediaWatchHistoryContract } from './rest-watch-history.js';
@@ -40,6 +41,7 @@ export const mediaContract = c.router(
     rotation: mediaRotationContract,
     discovery: mediaDiscoveryContract,
     search: mediaSearchContract,
+    settings: mediaSettingsContract,
   },
   {
     pathPrefix: '',

--- a/pillars/media/src/contract/settings/key-defaults.ts
+++ b/pillars/media/src/contract/settings/key-defaults.ts
@@ -1,0 +1,24 @@
+/**
+ * Media's settings key authority for the shared `@pops/pillar-settings`
+ * surface (settings-federation S2).
+ *
+ * `deriveKeySet([...mediaManifests])` is the single source of the declared key
+ * set, the reset defaults, and the read-side sensitive set — media's own
+ * manifests are the only authority for its keys (no central enum). The same
+ * `KeyDefaults` feeds both the contract's `:key` enum and the settings adapter's
+ * declared-key assertion + default resolution.
+ *
+ * Sensitive keys (`plex_token`, `radarr_api_key`, `sonarr_api_key`) are
+ * redacted on read; the four manifests declare them via `sensitive: true`.
+ */
+import { deriveKeySet, type KeyDefaults } from '@pops/pillar-settings';
+
+import { arrManifest, mediaOperationalManifest, plexManifest, rotationManifest } from './index.js';
+
+/** Media's effective {@link KeyDefaults}, derived from its own manifests. */
+export const mediaKeyDefaults: KeyDefaults = deriveKeySet([
+  plexManifest,
+  arrManifest,
+  rotationManifest,
+  mediaOperationalManifest,
+]);

--- a/pillars/media/src/db/schema.ts
+++ b/pillars/media/src/db/schema.ts
@@ -23,6 +23,7 @@ export { rotationLog } from './schema/rotation-log.js';
 export { rotationSettings } from './schema/rotation-settings.js';
 export { rotationSources } from './schema/rotation-sources.js';
 export { seasons } from './schema/seasons.js';
+export { settings } from './schema/settings.js';
 export { shelfImpressions } from './schema/shelf-impressions.js';
 export { syncJobResults } from './schema/sync-job-results.js';
 export { syncLogs } from './schema/sync-logs.js';

--- a/pillars/media/src/db/schema/settings.ts
+++ b/pillars/media/src/db/schema/settings.ts
@@ -1,0 +1,13 @@
+/**
+ * Media's residual federated settings table — the flat key/value store for the
+ * keys that have no pre-existing carve-out table (`media.*`, `radarr_*`,
+ * `sonarr_*`). `plex_*` and `rotation_*` keys are NOT stored here; they route
+ * to the existing `plex_settings` / `rotation_settings` tables via the
+ * settings adapter (settings-federation S2; see
+ * `docs/plans/02-settings-federation.md`, OD-2).
+ *
+ * Re-exports the shared `settingsTable` factory so the residual table is
+ * identical in shape to every other federated pillar's `settings` table. The
+ * `0038_settings_baseline.sql` migration creates it.
+ */
+export { settingsTable as settings } from '@pops/pillar-settings';

--- a/pillars/media/src/db/services/settings-adapter.ts
+++ b/pillars/media/src/db/services/settings-adapter.ts
@@ -36,6 +36,15 @@ import type { MediaDb } from './internal.js';
 type KvTable = typeof plexSettings | typeof rotationSettings | typeof settings;
 
 /**
+ * A persistence handle: either the top-level `MediaDb` or the transaction handle
+ * drizzle hands the `db.transaction(...)` callback. Typed as their union so the
+ * low-level read/write/delete helpers run against whichever the caller holds —
+ * batch writes MUST pass the `tx` handle so their statements actually
+ * participate in the transaction.
+ */
+type Handle = MediaDb | Parameters<Parameters<MediaDb['transaction']>[0]>[0];
+
+/**
  * Keys whose stored form is the legacy `'true'`/`''` boolean encoding but whose
  * federated wire form is the canonical `'true'`/`'false'` toggle. The `plex_*`
  * scheduler flag and the rotation enable flag both follow this convention.
@@ -66,19 +75,29 @@ function decode(key: string, value: string): string {
   return value === 'true' ? 'true' : 'false';
 }
 
-function readRaw(db: MediaDb, key: string): string | null {
+function readRaw(db: Handle, key: string): string | null {
   const table = tableFor(key);
   const row = db.select({ value: table.value }).from(table).where(eq(table.key, key)).get();
   return row?.value ?? null;
 }
 
-function writeRaw(db: MediaDb, key: string, value: string): void {
+function writeRaw(db: Handle, key: string, value: string): void {
   const table = tableFor(key);
   const set = bumpsUpdatedAt(table) ? { value, updatedAt: sql`(datetime('now'))` } : { value };
   db.insert(table).values({ key, value }).onConflictDoUpdate({ target: table.key, set }).run();
 }
 
-function deleteRaw(db: MediaDb, key: string): void {
+/**
+ * Write-once insert: persists only when the key is absent, leaving an existing
+ * row untouched. Concurrent first-time callers converge on whichever row landed
+ * first (`ON CONFLICT DO NOTHING`), preserving the seed's write-once guarantee.
+ */
+function insertOnce(db: Handle, key: string, value: string): void {
+  const table = tableFor(key);
+  db.insert(table).values({ key, value }).onConflictDoNothing({ target: table.key }).run();
+}
+
+function deleteRaw(db: Handle, key: string): void {
   const table = tableFor(key);
   db.delete(table).where(eq(table.key, key)).run();
 }
@@ -136,8 +155,8 @@ export function setRaw(db: MediaDb, key: string, value: string): SettingRow {
  */
 export function setBulk(db: MediaDb, entries: readonly SettingEntry[]): Record<string, string> {
   if (entries.length === 0) return {};
-  db.transaction(() => {
-    for (const { key, value } of entries) writeRaw(db, key, encode(key, value));
+  db.transaction((tx) => {
+    for (const { key, value } of entries) writeRaw(tx, key, encode(key, value));
   });
   const out: Record<string, string> = {};
   for (const { key, value } of entries) out[key] = value;
@@ -150,10 +169,9 @@ export function setBulk(db: MediaDb, entries: readonly SettingEntry[]): Record<s
  * user-facing RU+reset surface.
  */
 export function ensure(db: MediaDb, key: string, value: string): SettingRow {
-  const existing = readRaw(db, key);
-  if (existing !== null) return { key, value: decode(key, existing) };
-  writeRaw(db, key, encode(key, value));
-  return { key, value };
+  insertOnce(db, key, encode(key, value));
+  const stored = readRaw(db, key);
+  return { key, value: stored !== null ? decode(key, stored) : value };
 }
 
 /**
@@ -184,8 +202,8 @@ export function resetSettings(
 ): ResetResult {
   const declared = new Set(kd.keys);
   const target = keys && keys.length > 0 ? keys.filter((key) => declared.has(key)) : [...kd.keys];
-  db.transaction(() => {
-    for (const key of target) deleteRaw(db, key);
+  db.transaction((tx) => {
+    for (const key of target) deleteRaw(tx, key);
   });
   const out: Record<string, string> = {};
   for (const key of target) out[key] = kd.defaults[key] ?? '';

--- a/pillars/media/src/db/services/settings-adapter.ts
+++ b/pillars/media/src/db/services/settings-adapter.ts
@@ -1,0 +1,193 @@
+/**
+ * Translation adapter backing media's federated `/settings/*` surface
+ * (settings-federation S2, OD-2; see `docs/plans/02-settings-federation.md`).
+ *
+ * Media keeps its pre-existing carve-out tables (`plex_settings`,
+ * `rotation_settings`) as the backing store for the federated surface rather
+ * than collapsing them into the shared single `settings` table. This adapter
+ * reconciles the three concerns that prevent the shared `@pops/pillar-settings`
+ * service from operating over them directly:
+ *
+ *   1. Prefix routing — `plex_*` → `plex_settings`; `rotation_*` →
+ *      `rotation_settings`; everything else (`media.*`, `radarr_*`, `sonarr_*`)
+ *      → the residual shared `settings` table.
+ *   2. Column reconciliation — `plex_settings`/`rotation_settings` carry
+ *      `created_at`/`updated_at` the shared table lacks. Upserts bump
+ *      `updated_at`; `created_at` is left to the column default on insert.
+ *   3. Boolean value-encoding — `rotation_enabled`/`plex_scheduler_enabled`
+ *      persist as `'true'`/`''` (the legacy rotation/plex scheduler encoding),
+ *      while the manifest toggle round-trips `'true'`/`'false'`. The adapter
+ *      encodes on write and decodes on read so the wire value stays canonical.
+ *      A reset deletes the row, so the next decoded read yields the default.
+ *
+ * The function surface mirrors the shared service (`getOrNull`, `getBulk`,
+ * `listEffective`, `setRaw`, `setBulk`, `resetSetting`, `resetSettings`,
+ * `ensure`) so media's settings handlers compose against it identically.
+ */
+import { eq, sql } from 'drizzle-orm';
+
+import { type KeyDefaults, type SettingEntry, type SettingRow } from '@pops/pillar-settings';
+
+import { plexSettings, rotationSettings, settings } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** A drizzle better-sqlite3 kv table with a `key` PK and a `value` column. */
+type KvTable = typeof plexSettings | typeof rotationSettings | typeof settings;
+
+/**
+ * Keys whose stored form is the legacy `'true'`/`''` boolean encoding but whose
+ * federated wire form is the canonical `'true'`/`'false'` toggle. The `plex_*`
+ * scheduler flag and the rotation enable flag both follow this convention.
+ */
+const BOOLEAN_KEYS = new Set(['rotation_enabled', 'plex_scheduler_enabled']);
+
+/** Resolve the physical kv table a key routes to by prefix. */
+function tableFor(key: string): KvTable {
+  if (key.startsWith('plex_')) return plexSettings;
+  if (key.startsWith('rotation_')) return rotationSettings;
+  return settings;
+}
+
+/** Whether a key routes to a carve-out table that owns `updated_at`. */
+function bumpsUpdatedAt(table: KvTable): boolean {
+  return table === plexSettings || table === rotationSettings;
+}
+
+/** Encode a canonical wire value into its stored form for boolean keys. */
+function encode(key: string, value: string): string {
+  if (!BOOLEAN_KEYS.has(key)) return value;
+  return value === 'true' ? 'true' : '';
+}
+
+/** Decode a stored value into its canonical wire form for boolean keys. */
+function decode(key: string, value: string): string {
+  if (!BOOLEAN_KEYS.has(key)) return value;
+  return value === 'true' ? 'true' : 'false';
+}
+
+function readRaw(db: MediaDb, key: string): string | null {
+  const table = tableFor(key);
+  const row = db.select({ value: table.value }).from(table).where(eq(table.key, key)).get();
+  return row?.value ?? null;
+}
+
+function writeRaw(db: MediaDb, key: string, value: string): void {
+  const table = tableFor(key);
+  const set = bumpsUpdatedAt(table) ? { value, updatedAt: sql`(datetime('now'))` } : { value };
+  db.insert(table).values({ key, value }).onConflictDoUpdate({ target: table.key, set }).run();
+}
+
+function deleteRaw(db: MediaDb, key: string): void {
+  const table = tableFor(key);
+  db.delete(table).where(eq(table.key, key)).run();
+}
+
+/**
+ * Read one stored override decoded to its wire form. Returns `null` when the
+ * key has no stored row (the caller applies the manifest default). Does NOT
+ * resolve the default itself — {@link listEffective} is the effective path.
+ */
+export function getOrNull(db: MediaDb, key: string): SettingRow | null {
+  const stored = readRaw(db, key);
+  if (stored === null) return null;
+  return { key, value: decode(key, stored) };
+}
+
+/**
+ * Batch-read stored overrides by key, decoded to wire form. Missing keys are
+ * omitted (absence means "not set"). Duplicate input keys are de-duped.
+ */
+export function getBulk(db: MediaDb, keys: readonly string[]): Record<string, string> {
+  if (keys.length === 0) return {};
+  const out: Record<string, string> = {};
+  for (const key of new Set(keys)) {
+    const stored = readRaw(db, key);
+    if (stored !== null) out[key] = decode(key, stored);
+  }
+  return out;
+}
+
+/**
+ * The effective value set: every declared key resolved to its stored override
+ * (decoded), else its manifest default, else the empty string. This is what the
+ * collection read (`GET /settings`) returns.
+ */
+export function listEffective(db: MediaDb, kd: KeyDefaults): SettingRow[] {
+  return kd.keys.map((key) => {
+    const stored = readRaw(db, key);
+    const raw = stored ?? kd.defaults[key] ?? '';
+    return { key, value: decode(key, raw) };
+  });
+}
+
+/**
+ * Upsert a single setting (UPDATE). Encodes boolean keys to their stored form,
+ * bumps `updated_at` for carve-out tables, and returns the persisted wire row.
+ */
+export function setRaw(db: MediaDb, key: string, value: string): SettingRow {
+  writeRaw(db, key, encode(key, value));
+  return { key, value };
+}
+
+/**
+ * Transactional batch write (UPDATE) — every entry lands or none do. Returns a
+ * mirror of the written wire entries (key → value) without re-reading.
+ */
+export function setBulk(db: MediaDb, entries: readonly SettingEntry[]): Record<string, string> {
+  if (entries.length === 0) return {};
+  db.transaction(() => {
+    for (const { key, value } of entries) writeRaw(db, key, encode(key, value));
+  });
+  const out: Record<string, string> = {};
+  for (const { key, value } of entries) out[key] = value;
+  return out;
+}
+
+/**
+ * Write-once seed (encryption seed / generated client id). Inserts only when
+ * absent, then returns the resolved wire row. INTERNAL-ONLY — not part of the
+ * user-facing RU+reset surface.
+ */
+export function ensure(db: MediaDb, key: string, value: string): SettingRow {
+  const existing = readRaw(db, key);
+  if (existing !== null) return { key, value: decode(key, existing) };
+  writeRaw(db, key, encode(key, value));
+  return { key, value };
+}
+
+/**
+ * RESET a single declared key to its manifest default by deleting any stored
+ * override (idempotent). Returns the default value the next read would observe.
+ */
+export function resetSetting(db: MediaDb, key: string, kd: KeyDefaults): SettingRow {
+  deleteRaw(db, key);
+  return { key, value: kd.defaults[key] ?? '' };
+}
+
+/** The outcome of a batch reset: the keys reset and their resolved defaults. */
+export interface ResetResult {
+  readonly reset: readonly string[];
+  readonly settings: Readonly<Record<string, string>>;
+}
+
+/**
+ * RESET declared keys to their manifest defaults transactionally. With `keys`
+ * omitted (or empty) ALL declared keys are reset; otherwise only the supplied
+ * keys that are actually declared (unknown keys are ignored). Returns the reset
+ * keys and their resolved defaults.
+ */
+export function resetSettings(
+  db: MediaDb,
+  keys: readonly string[] | undefined,
+  kd: KeyDefaults
+): ResetResult {
+  const declared = new Set(kd.keys);
+  const target = keys && keys.length > 0 ? keys.filter((key) => declared.has(key)) : [...kd.keys];
+  db.transaction(() => {
+    for (const key of target) deleteRaw(db, key);
+  });
+  const out: Record<string, string> = {};
+  for (const key of target) out[key] = kd.defaults[key] ?? '';
+  return { reset: target, settings: out };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1217,6 +1217,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/pillar-settings':
+        specifier: workspace:*
+        version: link:../../packages/pillar-settings
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1954,6 +1954,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/pillar-settings':
+        specifier: workspace:*
+        version: link:../../packages/pillar-settings
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1626,6 +1626,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/pillar-settings':
+        specifier: workspace:*
+        version: link:../../packages/pillar-settings
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,6 +889,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/pillar-settings':
+        specifier: workspace:*
+        version: link:../../packages/pillar-settings
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
Per-pillar settings federation [S2] — finance, media, inventory, cerebrum.

Each federated pillar now serves a byte-identical `/settings/*` Read/Update/Reset surface from its OWN database via the shared `@pops/pillar-settings` module, with its declared key set derived from its own settings manifest (no central enum). Builds on the inventory federation already on this branch.

## Per-pillar surface

| Pillar | Keys (authority) | Storage | Sensitive (redacted on read) | Migration |
| --- | --- | --- | --- | --- |
| finance | `financeManifest` (5 keys) | shared `settings` table | none | `0056_settings_baseline.sql` |
| media | `plex`/`arr`/`rotation`/`operational` manifests | translation adapter over `plex_settings` + `rotation_settings` + residual `settings` | `plex_token`, `radarr_api_key`, `sonarr_api_key` | `0038_settings_baseline.sql` |
| cerebrum | `cerebrumManifest` + `egoManifest` | shared `settings` table | none | `0057_settings_baseline.sql` |
| inventory | `inventoryManifest` | shared `settings` table | none | `0009_settings_baseline.sql` (pre-existing) |

Each pillar: drizzle `settings` schema + migration (journal updated), `makeSettingsContract`/`makeSettingsHandlers` mount (no-op gate — pillars trust the docker network), `KeyDefaults` via `deriveKeySet` + `keyValuesFor`, `@pops/pillar-settings` added to `package.json` + Dockerfile COPYs, regenerated `openapi/<id>.openapi.json` + api-types, and a `settings-federation.test.ts` integration suite.

## Media translation adapter (OD-2)

`pillars/media/src/db/services/settings-adapter.ts` reconciles three concerns so media keeps its pre-existing carve-out tables as the backing store rather than a destructive secret migration:

1. **Prefix routing** — `plex_*` → `plex_settings`; `rotation_*` → `rotation_settings`; else (`media.*`, `radarr_*`, `sonarr_*`) → the residual shared `settings` table.
2. **Column reconciliation** — carve-out tables carry `created_at`/`updated_at` the shared table lacks; upserts bump `updated_at`, `created_at` is left to the column default.
3. **Boolean value-encoding** — `rotation_enabled`/`plex_scheduler_enabled` persist as the legacy `'true'`/`''` while the wire round-trips canonical `'true'`/`'false'`; reset deletes the row so the next read yields the default.

Round-trip, prefix-routing, `updated_at`-bump, and `plex_token` redaction are all unit/integration tested.

## Constraints honoured

- Central `packages/types/settings-keys.ts` (S4) untouched — purely additive.
- Cross-pillar reads preserved (core settings itest + `pillar('<x>').settings.*` still green).
- No `as any` / suppressions; oxlint clean; DRY (shared module + media adapter only where storage genuinely differs).

## Verification

`turbo typecheck test` green for finance/media/cerebrum/inventory/pillar-settings; whole-repo `pnpm typecheck` (44 tasks) green; `pnpm lint` exit 0; `oxfmt --check` clean; core + pillar-sdk + types green.
