### PR TITLE
pops-ai + pops-settings Rust crates with cross-language parity

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -37,6 +37,7 @@
     "packages/*/openapi/*.openapi.json",
     "pillars/contacts/openapi/*.openapi.json",
     "**/__tests__/fixtures/*.json",
+    "crates/*/tests/fixtures/*.json",
     "*.csv",
     "*.jsonl",
     "**/*.tsbuildinfo",

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -36,6 +36,7 @@
     "package-lock.json",
     "packages/*/openapi/*.openapi.json",
     "pillars/contacts/openapi/*.openapi.json",
+    "**/__tests__/fixtures/*.json",
     "*.csv",
     "*.jsonl",
     "**/*.tsbuildinfo",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1126,6 +1126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pops-settings"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +381,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,8 +468,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -462,8 +496,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -474,7 +524,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -607,6 +657,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -615,13 +682,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -746,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,7 +988,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1026,6 +1113,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "pops-ai"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1163,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1225,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1084,8 +1245,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1095,7 +1266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1105,6 +1286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1155,6 +1345,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,11 +1409,52 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1318,7 +1601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1479,7 +1762,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -1517,7 +1800,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1592,6 +1875,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1686,6 +1972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +2006,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1787,6 +2101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2144,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1897,6 +2223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +2272,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2006,6 +2351,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,7 +2401,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2045,13 +2437,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2061,10 +2486,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2073,10 +2522,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2085,16 +2570,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -12,7 +12,7 @@
 # member by relative path.
 [workspace]
 resolver = "2"
-members = ["../pillars/contacts", "pops-ai"]
+members = ["../pillars/contacts", "pops-ai", "pops-settings"]
 
 [workspace.package]
 edition = "2021"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -12,7 +12,7 @@
 # member by relative path.
 [workspace]
 resolver = "2"
-members = ["../pillars/contacts"]
+members = ["../pillars/contacts", "pops-ai"]
 
 [workspace.package]
 edition = "2021"
@@ -33,3 +33,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
+async-trait = "0.1"
+thiserror = "2"
+anyhow = "1"
+futures = "0.3"

--- a/crates/pops-ai/Cargo.toml
+++ b/crates/pops-ai/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pops-ai"
+version = "0.1.0"
+# A direct member of the `crates/` cargo workspace (a sibling of `pops-settings`
+# and of the `pillars/contacts` crate). 1:1 Rust mirror of the TS
+# `@pops/ai-telemetry` wire contract — the cross-pillar AI-inference telemetry
+# sink. Standalone library: it has no in-tree consumer yet (the contacts Rust
+# pillar will adopt it), so it ships compiled + tested-but-unused, with a
+# golden-fixture parity test pinning the wire bytes against the TS schema.
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "POPS AI telemetry — Rust mirror of @pops/ai-telemetry's inference-record wire contract."
+
+[lib]
+name = "pops_ai"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/pops-ai/src/call.rs
+++ b/crates/pops-ai/src/call.rs
@@ -1,0 +1,192 @@
+//! The wrapping entrypoints — Rust mirrors of TS `callWithLogging` and
+//! `callWithLoggingStream`. Both measure latency, resolve pricing, and report
+//! the inference record fire-and-forget (off the hot path). Telemetry never
+//! alters control flow: a slow or failing sink never delays or fails the call.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use futures::stream::Stream;
+
+use crate::cost::compute_cost_usd;
+use crate::pricing::LookupPricing;
+use crate::record::{CallResult, InferenceContext, InferenceStatus, Usage};
+use crate::sink::ReportSink;
+
+/// Dependencies shared by both entrypoints — the injected sink and pricing
+/// resolver. Mirrors the TS `CallWithLoggingDeps` (`report` + `lookupPricing`).
+#[derive(Clone)]
+pub struct CallDeps {
+    pub sink: Arc<dyn ReportSink>,
+    pub lookup_pricing: Arc<dyn LookupPricing>,
+}
+
+/// Schedules a success report off the hot path: resolves pricing, computes
+/// cost, and fires the record. A pricing miss yields `cost_usd: 0.0`, matching
+/// the record the TS wrapper emits.
+fn spawn_success_report(deps: CallDeps, ctx: InferenceContext, usage: Usage, latency_ms: u32) {
+    tokio::spawn(async move {
+        let pricing = deps.lookup_pricing.lookup(&ctx.provider, &ctx.model).await;
+        let cost = compute_cost_usd(usage.input_tokens, usage.output_tokens, pricing.as_ref());
+        let record = ctx.into_record(
+            InferenceStatus::Success,
+            usage.input_tokens,
+            usage.output_tokens,
+            cost.cost_usd,
+            latency_ms,
+            None,
+        );
+        deps.sink.report(record).await;
+    });
+}
+
+/// Fires an error report (tokens 0, status error) off the hot path. Mirrors
+/// the TS error branch, which schedules the report BEFORE rethrowing.
+fn spawn_error_report(
+    deps: CallDeps,
+    ctx: InferenceContext,
+    latency_ms: u32,
+    error_message: String,
+) {
+    tokio::spawn(async move {
+        let record = ctx.into_record(
+            InferenceStatus::Error,
+            0,
+            0,
+            0.0,
+            latency_ms,
+            Some(error_message),
+        );
+        deps.sink.report(record).await;
+    });
+}
+
+fn elapsed_ms(start: Instant) -> u32 {
+    start.elapsed().as_millis().min(u128::from(u32::MAX)) as u32
+}
+
+/// Caps an error message to 1000 chars on a char boundary (mirrors the TS
+/// `String(err).slice(0, 1000)` length guard).
+fn cap_error(message: &str) -> String {
+    message.chars().take(1000).collect()
+}
+
+/// Wraps a non-streaming Claude call. Returns the response on the hot path
+/// unchanged; then, fire-and-forget, looks up pricing, computes cost, and
+/// reports a `success` record. On error it reports a `status: 'error'` record
+/// (tokens 0) BEFORE returning the error. Mirrors TS `callWithLogging`.
+///
+/// `call` returns `anyhow::Result<CallResult<T>>` so any error type funnels
+/// through; the error's `Display` becomes `error_message` (capped to 1000
+/// chars, matching the TS wire discipline).
+pub async fn call_with_logging<T, F, Fut>(
+    ctx: InferenceContext,
+    deps: CallDeps,
+    call: F,
+) -> anyhow::Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = anyhow::Result<CallResult<T>>>,
+{
+    let start = Instant::now();
+    match call().await {
+        Ok(CallResult { response, usage }) => {
+            spawn_success_report(deps, ctx, usage, elapsed_ms(start));
+            Ok(response)
+        }
+        Err(error) => {
+            spawn_error_report(deps, ctx, elapsed_ms(start), cap_error(&error.to_string()));
+            Err(error)
+        }
+    }
+}
+
+/// Wraps a Claude stream: re-yields every item verbatim with zero added
+/// latency. After the stream drains it resolves usage from the items seen,
+/// looks up pricing, and reports a `success` record off the hot path. Mirrors
+/// TS `callWithLoggingStream`.
+///
+/// `extract_usage` is applied to every item (mirroring the TS streaming
+/// callers, whose extractor returns `Some` only on the terminal `done` event):
+/// the most recent `Some` is what gets reported, and `None` everywhere records
+/// a `success` row with tokens 0 (the "usage unavailable" path). This avoids
+/// requiring `E: Clone` to retain the terminal event.
+pub fn call_with_logging_stream<E, S, X>(
+    ctx: InferenceContext,
+    deps: CallDeps,
+    stream: S,
+    extract_usage: X,
+) -> LoggingStream<E, S, X>
+where
+    S: Stream<Item = E>,
+    X: Fn(&E) -> Option<Usage>,
+{
+    LoggingStream {
+        inner: Box::pin(stream),
+        extract_usage,
+        usage: None,
+        start: Instant::now(),
+        state: Some((ctx, deps)),
+    }
+}
+
+/// The stream adapter returned by [`call_with_logging_stream`]. Passes each
+/// item through untouched; on stream end it fires the success report.
+///
+/// The inner stream is boxed-and-pinned so the adapter is `Unpin` and needs no
+/// `unsafe` pin projection — every remaining field is a plain owned value.
+pub struct LoggingStream<E, S, X>
+where
+    S: Stream<Item = E>,
+    X: Fn(&E) -> Option<Usage>,
+{
+    inner: Pin<Box<S>>,
+    extract_usage: X,
+    usage: Option<Usage>,
+    start: Instant,
+    state: Option<(InferenceContext, CallDeps)>,
+}
+
+// Sound: the only pin-sensitive field, `inner`, is already a `Pin<Box<S>>`
+// (always `Unpin`); every other field is a plain owned value. Asserting `Unpin`
+// unconditionally lets `poll_next` use safe `get_mut` without constraining `X`.
+impl<E, S, X> Unpin for LoggingStream<E, S, X>
+where
+    S: Stream<Item = E>,
+    X: Fn(&E) -> Option<Usage>,
+{
+}
+
+impl<E, S, X> Stream for LoggingStream<E, S, X>
+where
+    S: Stream<Item = E>,
+    X: Fn(&E) -> Option<Usage>,
+{
+    type Item = E;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<E>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(item)) => {
+                if let Some(usage) = (this.extract_usage)(&item) {
+                    this.usage = Some(usage);
+                }
+                Poll::Ready(Some(item))
+            }
+            Poll::Ready(None) => {
+                if let Some((ctx, deps)) = this.state.take() {
+                    let usage = this.usage.unwrap_or(Usage {
+                        input_tokens: 0,
+                        output_tokens: 0,
+                    });
+                    spawn_success_report(deps, ctx, usage, elapsed_ms(this.start));
+                }
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/crates/pops-ai/src/cost.rs
+++ b/crates/pops-ai/src/cost.rs
@@ -1,0 +1,46 @@
+//! Pricing entry + cost computation — the Rust mirror of TS `computeCostUsd`.
+
+use serde::{Deserialize, Serialize};
+
+/// Per-million-token USD pricing for a given provider/model. Mirrors the TS
+/// `PricingEntry` (`{ input, output }`) and the `GET /ai-pricing/:p/:m` body.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct PricingEntry {
+    pub input: f64,
+    pub output: f64,
+}
+
+/// The outcome of [`compute_cost_usd`]: the USD cost and whether pricing was
+/// missing. `missing: true` (with `cost_usd: 0.0`) lets a caller distinguish
+/// "free" from "unpriced", exactly as the TS function does.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CostResult {
+    pub cost_usd: f64,
+    pub missing: bool,
+}
+
+/// Computes the USD cost of a call from per-million-token pricing.
+///
+/// Byte-for-byte the same arithmetic as TS:
+/// `(input/1e6)*p.input + (output/1e6)*p.output`. Returns `missing: true`
+/// (and `cost_usd: 0.0`) when pricing is `None`.
+pub fn compute_cost_usd(
+    input_tokens: u32,
+    output_tokens: u32,
+    pricing: Option<&PricingEntry>,
+) -> CostResult {
+    match pricing {
+        None => CostResult {
+            cost_usd: 0.0,
+            missing: true,
+        },
+        Some(p) => {
+            let cost_usd = (input_tokens as f64 / 1_000_000.0) * p.input
+                + (output_tokens as f64 / 1_000_000.0) * p.output;
+            CostResult {
+                cost_usd,
+                missing: false,
+            }
+        }
+    }
+}

--- a/crates/pops-ai/src/lib.rs
+++ b/crates/pops-ai/src/lib.rs
@@ -1,0 +1,27 @@
+//! `pops-ai` — the Rust mirror of the TS `@pops/ai-telemetry` package.
+//!
+//! It provides a 1:1 wire-compatible [`InferenceRecord`] (serde camelCase,
+//! kebab-case status enum) for the cross-pillar `POST /ai-usage/record`
+//! telemetry sink, plus the wrapping entrypoints ([`call_with_logging`],
+//! [`call_with_logging_stream`]), cost math ([`compute_cost_usd`]), the
+//! [`ReportSink`] trait + best-effort [`EnvHttpSink`], and the HTTP pricing
+//! adapter ([`HttpLookupPricing`]).
+//!
+//! Parity with the TS schema is pinned by `tests/contract.rs`, which
+//! round-trips a shared golden fixture (`tests/fixtures/record.json`) that the
+//! TS `record-schema` test asserts is `InferenceRecordSchema.parse`-clean.
+//!
+//! This is a standalone library crate: it has no in-tree consumer yet (the
+//! contacts Rust pillar will adopt it), so it ships compiled + tested-but-unused.
+
+mod call;
+mod cost;
+mod pricing;
+mod record;
+mod sink;
+
+pub use call::{call_with_logging, call_with_logging_stream, CallDeps, LoggingStream};
+pub use cost::{compute_cost_usd, CostResult, PricingEntry};
+pub use pricing::{HttpLookupPricing, LookupPricing};
+pub use record::{CallResult, InferenceContext, InferenceRecord, InferenceStatus, Usage};
+pub use sink::{EnvHttpSink, ReportSink};

--- a/crates/pops-ai/src/pricing.rs
+++ b/crates/pops-ai/src/pricing.rs
@@ -1,0 +1,126 @@
+//! Cross-pillar HTTP pricing lookup — the Rust mirror of TS `pricing-http.ts`.
+
+use crate::cost::PricingEntry;
+
+/// A pricing resolver: returns the per-Mtok pricing for a provider/model, or
+/// `None` on any miss. Mirrors TS `LookupPricingFn`. Async, fallible-as-`None`
+/// (never returns an error — telemetry must not break callers).
+#[async_trait::async_trait]
+pub trait LookupPricing: Send + Sync {
+    async fn lookup(&self, provider: &str, model: &str) -> Option<PricingEntry>;
+}
+
+/// HTTP pricing adapter. Prefers the dedicated
+/// `GET /ai-pricing/:provider/:model` route (already shaped as a
+/// [`PricingEntry`]); falls back to `GET /ai-providers` and maps
+/// `models[].{inputCostPerMtok,outputCostPerMtok}` → `{ input, output }` when
+/// the dedicated route is absent (an older ai pillar). Returns `None` on any
+/// miss and never errors — exactly like TS `httpLookupPricing`.
+pub struct HttpLookupPricing {
+    base: String,
+    client: reqwest::Client,
+}
+
+impl HttpLookupPricing {
+    /// Builds an adapter against an ai pillar base URL (a trailing slash is
+    /// trimmed, mirroring the TS normalization).
+    pub fn new(ai_api_base_url: impl Into<String>) -> Self {
+        let raw = ai_api_base_url.into();
+        let base = raw.strip_suffix('/').unwrap_or(&raw).to_string();
+        Self {
+            base,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    async fn read_json(&self, url: &str) -> Option<serde_json::Value> {
+        let response = self.client.get(url).send().await.ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        response.json::<serde_json::Value>().await.ok()
+    }
+
+    async fn fetch_pricing_entry(&self, provider: &str, model: &str) -> Option<PricingEntry> {
+        let url = format!(
+            "{}/ai-pricing/{}/{}",
+            self.base,
+            encode_segment(provider),
+            encode_segment(model)
+        );
+        let body = self.read_json(&url).await?;
+        let input = as_number(body.get("input"))?;
+        let output = as_number(body.get("output"))?;
+        Some(PricingEntry { input, output })
+    }
+
+    async fn fetch_provider_fallback(&self, provider: &str, model: &str) -> Option<PricingEntry> {
+        let url = format!("{}/ai-providers", self.base);
+        let body = self.read_json(&url).await?;
+        let providers = providers_array(&body);
+        let provider_entry = providers
+            .iter()
+            .find(|entry| field_equals(entry, &["id", "provider"], provider))?;
+        let models = to_array(provider_entry.get("models"));
+        let model_entry = models
+            .iter()
+            .find(|entry| field_equals(entry, &["model", "id"], model))?;
+        pricing_from_model(model_entry)
+    }
+}
+
+#[async_trait::async_trait]
+impl LookupPricing for HttpLookupPricing {
+    async fn lookup(&self, provider: &str, model: &str) -> Option<PricingEntry> {
+        if let Some(direct) = self.fetch_pricing_entry(provider, model).await {
+            return Some(direct);
+        }
+        self.fetch_provider_fallback(provider, model).await
+    }
+}
+
+fn encode_segment(segment: &str) -> String {
+    // Mirrors JS encodeURIComponent for the characters that can appear in a
+    // provider/model id. Path segments here are slugs (no whitespace), so a
+    // conservative encode of the reserved path delimiters is sufficient.
+    segment
+        .chars()
+        .flat_map(|c| match c {
+            '/' => "%2F".chars().collect::<Vec<_>>(),
+            '?' => "%3F".chars().collect(),
+            '#' => "%23".chars().collect(),
+            ' ' => "%20".chars().collect(),
+            other => vec![other],
+        })
+        .collect()
+}
+
+fn as_number(value: Option<&serde_json::Value>) -> Option<f64> {
+    let n = value?.as_f64()?;
+    n.is_finite().then_some(n)
+}
+
+fn to_array(value: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
+    match value {
+        Some(serde_json::Value::Array(items)) => items.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn providers_array(body: &serde_json::Value) -> Vec<serde_json::Value> {
+    match body {
+        serde_json::Value::Array(items) => items.clone(),
+        other => to_array(other.get("providers")),
+    }
+}
+
+fn field_equals(value: &serde_json::Value, keys: &[&str], expected: &str) -> bool {
+    keys.iter()
+        .any(|key| value.get(*key).and_then(serde_json::Value::as_str) == Some(expected))
+}
+
+fn pricing_from_model(model: &serde_json::Value) -> Option<PricingEntry> {
+    let input = as_number(model.get("inputCostPerMtok"))?;
+    let output = as_number(model.get("outputCostPerMtok"))?;
+    Some(PricingEntry { input, output })
+}

--- a/crates/pops-ai/src/record.rs
+++ b/crates/pops-ai/src/record.rs
@@ -1,0 +1,121 @@
+//! The canonical wire shape for a single AI inference event.
+//!
+//! This is the Rust mirror of `@pops/ai-telemetry`'s `InferenceRecordSchema`
+//! (zod). The field casing (`serde(rename_all = "camelCase")`) and the status
+//! enum (`serde(rename_all = "kebab-case")`) are load-bearing: they MUST
+//! serialize to the exact JSON the TS `POST /ai-usage/record` ingest accepts.
+//! The cross-language golden-fixture test (`tests/contract.rs`) pins this.
+
+use serde::{Deserialize, Serialize};
+
+/// Terminal status of a wrapped inference call. Serializes kebab-case to match
+/// the TS `z.enum(['success','error','timeout','budget-blocked'])`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum InferenceStatus {
+    Success,
+    Error,
+    Timeout,
+    BudgetBlocked,
+}
+
+/// One row per Claude call — the cross-pillar telemetry record.
+///
+/// PII discipline mirrors the TS schema: `context_id` is an opaque,
+/// low-cardinality key and `metadata` is caller-supplied and must be PII-free.
+/// Optional fields are omitted from the JSON when `None`
+/// (`skip_serializing_if`) so the wire matches zod's `.optional()` exactly —
+/// absent rather than `null`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceRecord {
+    pub provider: String,
+    pub model: String,
+    /// Free-form; each pillar owns its operation vocabulary.
+    pub operation: String,
+    /// The caller's pillar id (validated against KNOWN_MODULES server-side).
+    pub domain: String,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub cost_usd: f64,
+    pub latency_ms: u32,
+    pub status: InferenceStatus,
+    /// Stored as 0|1 server-side.
+    pub cached: bool,
+    /// Opaque low-cardinality FK to the originating row; no whitespace.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub context_id: Option<String>,
+    /// Merged into `metadata.prompt_version` server-side.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub prompt_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error_message: Option<String>,
+    /// Caller-supplied, PII-free; the server caps the serialized JSON length.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Identity + provenance carried onto every emitted [`InferenceRecord`] — the
+/// Rust mirror of TS `InferenceContext`. The measurement fields
+/// (`status`/tokens/cost/latency/cached) are filled in by the wrapper; this
+/// struct is what the caller supplies.
+#[derive(Debug, Clone, Default)]
+pub struct InferenceContext {
+    pub provider: String,
+    pub model: String,
+    pub operation: String,
+    pub domain: String,
+    pub context_id: Option<String>,
+    pub prompt_version: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    /// Reserved for the future pre-call budget gate (telemetry-only in v1):
+    /// carried through but not enforced.
+    pub cost_cap_usd: Option<f64>,
+}
+
+impl InferenceContext {
+    /// Materializes a full [`InferenceRecord`] from this context plus the
+    /// measured outcome. Mirrors the TS `buildBaseRecord` + spread on emit.
+    pub fn into_record(
+        &self,
+        status: InferenceStatus,
+        input_tokens: u32,
+        output_tokens: u32,
+        cost_usd: f64,
+        latency_ms: u32,
+        error_message: Option<String>,
+    ) -> InferenceRecord {
+        InferenceRecord {
+            provider: self.provider.clone(),
+            model: self.model.clone(),
+            operation: self.operation.clone(),
+            domain: self.domain.clone(),
+            input_tokens,
+            output_tokens,
+            cost_usd,
+            latency_ms,
+            status,
+            cached: false,
+            context_id: self.context_id.clone(),
+            prompt_version: self.prompt_version.clone(),
+            error_message,
+            metadata: self.metadata.clone(),
+        }
+    }
+}
+
+/// Token usage handed back by a wrapped non-streaming call, or extracted from a
+/// stream's terminal event. Mirrors TS `CallResult.usage`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+/// What a wrapped non-streaming Claude call hands back — the response plus its
+/// token usage. Mirrors TS `CallResult<T>`.
+#[derive(Debug, Clone)]
+pub struct CallResult<T> {
+    pub response: T,
+    pub usage: Usage,
+}

--- a/crates/pops-ai/src/sink.rs
+++ b/crates/pops-ai/src/sink.rs
@@ -1,0 +1,86 @@
+//! The fire-and-forget report sink — the Rust mirror of TS
+//! `report-sink.ts` (`createEnvReportSink` / `reportInference`).
+
+use async_trait::async_trait;
+
+use crate::record::InferenceRecord;
+
+/// Path the record is POSTed to on the ai pillar. Matches TS `RECORD_PATH`.
+const RECORD_PATH: &str = "/ai-usage/record";
+
+/// A fire-and-forget sink for a finished inference record. By contract it must
+/// never panic and never propagate an error into the caller — telemetry can
+/// never break a Claude call. Mirrors TS `ReportInferenceFn`.
+#[async_trait]
+pub trait ReportSink: Send + Sync {
+    async fn report(&self, record: InferenceRecord);
+}
+
+/// Reads an environment variable, treating an empty string as unset (mirrors
+/// the JS `process.env.X ?? undefined` falsy-empty behavior closely enough for
+/// the URL/token resolution).
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|value| !value.is_empty())
+}
+
+/// An env-driven sink that POSTs an [`InferenceRecord`] to the ai pillar's
+/// internal `/ai-usage/record` ingest.
+///
+/// Resolution mirrors TS exactly: the base URL is `AI_API_URL` FIRST (so it
+/// never collides with a service's self-pointing `POPS_API_URL`), then
+/// `POPS_API_URL`; the token is `POPS_API_INTERNAL_TOKEN`. When no base URL
+/// resolves, [`report`](ReportSink::report) is a silent no-op. A non-2xx
+/// response or a transport failure is swallowed — best-effort by contract.
+pub struct EnvHttpSink {
+    base_url: Option<String>,
+    token: Option<String>,
+    client: reqwest::Client,
+}
+
+impl EnvHttpSink {
+    /// Builds a sink from the ambient environment. Never fails: a missing URL
+    /// simply yields a no-op sink.
+    pub fn from_env() -> Self {
+        Self {
+            base_url: env_nonempty("AI_API_URL").or_else(|| env_nonempty("POPS_API_URL")),
+            token: env_nonempty("POPS_API_INTERNAL_TOKEN"),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Builds a sink with explicit configuration (for tests / non-env wiring).
+    /// A `None` base URL yields a no-op sink, matching `from_env`.
+    pub fn new(base_url: Option<String>, token: Option<String>) -> Self {
+        Self {
+            base_url,
+            token,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Whether this sink will actually attempt a POST. `false` for the no-op
+    /// (no base URL) case — useful for tests asserting the dev/browser no-op.
+    pub fn is_active(&self) -> bool {
+        self.base_url.is_some()
+    }
+}
+
+#[async_trait]
+impl ReportSink for EnvHttpSink {
+    async fn report(&self, record: InferenceRecord) {
+        let Some(base_url) = &self.base_url else {
+            return;
+        };
+        let base = base_url.strip_suffix('/').unwrap_or(base_url);
+        let mut request = self
+            .client
+            .post(format!("{base}{RECORD_PATH}"))
+            .json(&record);
+        if let Some(token) = &self.token {
+            request = request.header("x-pops-internal-token", token);
+        }
+        // Best-effort by contract: drop any transport error on the floor so a
+        // failing sink can never propagate into (or panic) a caller.
+        let _ = request.send().await;
+    }
+}

--- a/crates/pops-ai/tests/contract.rs
+++ b/crates/pops-ai/tests/contract.rs
@@ -1,0 +1,306 @@
+//! Cross-language golden-fixture parity tests for `pops-ai`.
+//!
+//! `tests/fixtures/record.json` is the SHARED wire fixture: this test asserts
+//! the Rust [`InferenceRecord`] round-trips it byte-for-byte, while the TS side
+//! (`packages/ai-telemetry/src/__tests__/record-fixture.test.ts`) asserts the
+//! SAME bytes are `InferenceRecordSchema.parse`-clean. Together they pin one
+//! wire across both languages — any camelCase / kebab-case-enum drift fails here.
+
+use std::sync::Arc;
+
+use futures::stream::{self, StreamExt};
+use pops_ai::{
+    call_with_logging, call_with_logging_stream, compute_cost_usd, CallDeps, CallResult,
+    EnvHttpSink, InferenceContext, InferenceRecord, InferenceStatus, LookupPricing, PricingEntry,
+    ReportSink, Usage,
+};
+
+const FIXTURE: &str = include_str!("fixtures/record.json");
+
+/// The golden fixture deserializes into an `InferenceRecord` and serializes
+/// back to the EXACT same bytes — camelCase keys, kebab-case status, optionals
+/// present. This is the cross-language wire pin.
+#[test]
+fn golden_fixture_round_trips_byte_for_byte() {
+    let trimmed = FIXTURE.trim_end();
+    let record: InferenceRecord = serde_json::from_str(trimmed).expect("fixture deserializes");
+
+    assert_eq!(record.provider, "anthropic");
+    assert_eq!(record.status, InferenceStatus::BudgetBlocked);
+    assert!(record.cached);
+    assert_eq!(record.context_id.as_deref(), Some("import_batch:42"));
+    assert_eq!(record.prompt_version.as_deref(), Some("v3"));
+
+    let reserialized = serde_json::to_string(&record).expect("record serializes");
+    assert_eq!(
+        reserialized, trimmed,
+        "Rust serialization must match the shared TS-accepted fixture byte-for-byte"
+    );
+}
+
+/// Every status value maps to the kebab-case string the TS `z.enum` accepts.
+#[test]
+fn status_enum_serializes_kebab_case() {
+    let cases = [
+        (InferenceStatus::Success, "\"success\""),
+        (InferenceStatus::Error, "\"error\""),
+        (InferenceStatus::Timeout, "\"timeout\""),
+        (InferenceStatus::BudgetBlocked, "\"budget-blocked\""),
+    ];
+    for (status, expected) in cases {
+        assert_eq!(serde_json::to_string(&status).unwrap(), expected);
+        let back: InferenceStatus = serde_json::from_str(expected).unwrap();
+        assert_eq!(back, status);
+    }
+}
+
+/// Optional fields are OMITTED (not `null`) when `None`, matching zod
+/// `.optional()` — a `null` would be rejected by the TS schema.
+#[test]
+fn absent_optionals_are_omitted_not_null() {
+    let record = InferenceRecord {
+        provider: "anthropic".into(),
+        model: "claude-haiku-4-5".into(),
+        operation: "categorize".into(),
+        domain: "finance".into(),
+        input_tokens: 10,
+        output_tokens: 5,
+        cost_usd: 0.001,
+        latency_ms: 120,
+        status: InferenceStatus::Success,
+        cached: false,
+        context_id: None,
+        prompt_version: None,
+        error_message: None,
+        metadata: None,
+    };
+    let json = serde_json::to_string(&record).unwrap();
+    assert!(
+        !json.contains("contextId"),
+        "absent contextId must be omitted: {json}"
+    );
+    assert!(
+        !json.contains("null"),
+        "no field should serialize to null: {json}"
+    );
+    assert!(json.contains("\"cached\":false"));
+}
+
+/// `compute_cost_usd` matches the TS arithmetic exactly.
+#[test]
+fn compute_cost_matches_ts_formula() {
+    let pricing = PricingEntry {
+        input: 1.0,
+        output: 5.0,
+    };
+    let result = compute_cost_usd(1_000_000, 200_000, Some(&pricing));
+    assert!((result.cost_usd - (1.0 + 1.0)).abs() < 1e-12);
+    assert!(!result.missing);
+
+    let missing = compute_cost_usd(10, 10, None);
+    assert_eq!(missing.cost_usd, 0.0);
+    assert!(missing.missing);
+}
+
+/// `EnvHttpSink` is a no-op when no base URL is configured — it never panics,
+/// mirroring the TS browser/dev/vitest no-op.
+#[tokio::test]
+async fn env_http_sink_is_noop_without_base_url() {
+    let sink = EnvHttpSink::new(None, None);
+    assert!(!sink.is_active());
+    // Must not panic even with no URL.
+    sink.report(sample_record()).await;
+}
+
+#[tokio::test]
+async fn env_http_sink_active_with_base_url() {
+    let sink = EnvHttpSink::new(Some("http://ai-api:3008".into()), Some("tok".into()));
+    assert!(sink.is_active());
+}
+
+/// A recording sink that captures every reported record for assertions.
+#[derive(Default, Clone)]
+struct RecordingSink {
+    records: Arc<std::sync::Mutex<Vec<InferenceRecord>>>,
+}
+
+#[async_trait::async_trait]
+impl ReportSink for RecordingSink {
+    async fn report(&self, record: InferenceRecord) {
+        self.records.lock().unwrap().push(record);
+    }
+}
+
+struct FixedPricing(Option<PricingEntry>);
+
+#[async_trait::async_trait]
+impl LookupPricing for FixedPricing {
+    async fn lookup(&self, _provider: &str, _model: &str) -> Option<PricingEntry> {
+        self.0
+    }
+}
+
+fn sample_record() -> InferenceRecord {
+    serde_json::from_str(FIXTURE.trim_end()).unwrap()
+}
+
+fn ctx() -> InferenceContext {
+    InferenceContext {
+        provider: "anthropic".into(),
+        model: "claude-haiku-4-5".into(),
+        operation: "ego.chat".into(),
+        domain: "cerebrum".into(),
+        ..Default::default()
+    }
+}
+
+/// `call_with_logging` returns the response and fires a success report with the
+/// computed cost — off the hot path, never blocking the return.
+#[tokio::test]
+async fn call_with_logging_reports_success() {
+    let sink = RecordingSink::default();
+    let deps = CallDeps {
+        sink: Arc::new(sink.clone()),
+        lookup_pricing: Arc::new(FixedPricing(Some(PricingEntry {
+            input: 3.0,
+            output: 15.0,
+        }))),
+    };
+
+    let response = call_with_logging(ctx(), deps, || async {
+        Ok(CallResult {
+            response: 42_u32,
+            usage: Usage {
+                input_tokens: 1_000_000,
+                output_tokens: 1_000_000,
+            },
+        })
+    })
+    .await
+    .expect("call succeeds");
+    assert_eq!(response, 42);
+
+    let record = await_one_record(&sink).await;
+    assert_eq!(record.status, InferenceStatus::Success);
+    assert_eq!(record.input_tokens, 1_000_000);
+    assert!((record.cost_usd - 18.0).abs() < 1e-9);
+}
+
+/// On a failing call, an error report (tokens 0, status error) is fired BEFORE
+/// the error propagates — telemetry is never lost even though the caller errors.
+#[tokio::test]
+async fn call_with_logging_reports_error_then_propagates() {
+    let sink = RecordingSink::default();
+    let deps = CallDeps {
+        sink: Arc::new(sink.clone()),
+        lookup_pricing: Arc::new(FixedPricing(None)),
+    };
+
+    let result: anyhow::Result<u32> = call_with_logging(ctx(), deps, || async {
+        Err(anyhow::anyhow!("provider 529 overloaded"))
+    })
+    .await;
+    assert!(result.is_err());
+
+    let record = await_one_record(&sink).await;
+    assert_eq!(record.status, InferenceStatus::Error);
+    assert_eq!(record.input_tokens, 0);
+    assert_eq!(
+        record.error_message.as_deref(),
+        Some("provider 529 overloaded")
+    );
+}
+
+/// The streaming wrapper re-yields every item in order, then fires a success
+/// report whose usage is extracted from the terminal event.
+#[tokio::test]
+async fn stream_passthrough_reports_terminal_usage() {
+    let sink = RecordingSink::default();
+    let deps = CallDeps {
+        sink: Arc::new(sink.clone()),
+        lookup_pricing: Arc::new(FixedPricing(Some(PricingEntry {
+            input: 1.0,
+            output: 1.0,
+        }))),
+    };
+
+    let events = stream::iter(vec![
+        StreamEvent::Delta("hel".into()),
+        StreamEvent::Delta("lo".into()),
+        StreamEvent::Done {
+            tokens_in: 12,
+            tokens_out: 8,
+        },
+    ]);
+
+    let wrapped = call_with_logging_stream(ctx(), deps, events, |event| match event {
+        StreamEvent::Done {
+            tokens_in,
+            tokens_out,
+        } => Some(Usage {
+            input_tokens: *tokens_in,
+            output_tokens: *tokens_out,
+        }),
+        StreamEvent::Delta(_) => None,
+    });
+
+    let collected: Vec<StreamEvent> = wrapped.collect().await;
+    assert_eq!(collected.len(), 3, "every event re-yielded in order");
+    let deltas: Vec<&str> = collected
+        .iter()
+        .filter_map(|event| match event {
+            StreamEvent::Delta(text) => Some(text.as_str()),
+            StreamEvent::Done { .. } => None,
+        })
+        .collect();
+    assert_eq!(
+        deltas,
+        ["hel", "lo"],
+        "delta payloads re-yielded verbatim, in order"
+    );
+    assert!(matches!(collected[2], StreamEvent::Done { .. }));
+
+    let record = await_one_record(&sink).await;
+    assert_eq!(record.status, InferenceStatus::Success);
+    assert_eq!(record.input_tokens, 12);
+    assert_eq!(record.output_tokens, 8);
+}
+
+/// When no terminal usage event is seen, the stream still reports success with
+/// tokens 0 (the TS "usage unavailable" path).
+#[tokio::test]
+async fn stream_without_usage_reports_zero() {
+    let sink = RecordingSink::default();
+    let deps = CallDeps {
+        sink: Arc::new(sink.clone()),
+        lookup_pricing: Arc::new(FixedPricing(None)),
+    };
+
+    let events = stream::iter(vec![StreamEvent::Delta("partial".into())]);
+    let wrapped = call_with_logging_stream(ctx(), deps, events, |_event| None);
+    let collected: Vec<StreamEvent> = wrapped.collect().await;
+    assert_eq!(collected.len(), 1);
+
+    let record = await_one_record(&sink).await;
+    assert_eq!(record.status, InferenceStatus::Success);
+    assert_eq!(record.input_tokens, 0);
+    assert_eq!(record.output_tokens, 0);
+}
+
+#[derive(Debug, Clone)]
+enum StreamEvent {
+    Delta(String),
+    Done { tokens_in: u32, tokens_out: u32 },
+}
+
+/// Polls the recording sink until the fire-and-forget `tokio::spawn` report has
+/// landed. Yields to the runtime rather than sleeping a fixed duration.
+async fn await_one_record(sink: &RecordingSink) -> InferenceRecord {
+    for _ in 0..1000 {
+        if let Some(record) = sink.records.lock().unwrap().first().cloned() {
+            return record;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("no record reported within the spawn budget");
+}

--- a/crates/pops-ai/tests/fixtures/record.json
+++ b/crates/pops-ai/tests/fixtures/record.json
@@ -1,0 +1,1 @@
+{"provider":"anthropic","model":"claude-haiku-4-5","operation":"imports.categorize","domain":"finance","inputTokens":1280,"outputTokens":640,"costUsd":0.0048,"latencyMs":742,"status":"budget-blocked","cached":true,"contextId":"import_batch:42","promptVersion":"v3","errorMessage":"upstream 529 overloaded","metadata":{"backfilled_from":"food","prompt_version":"v3"}}

--- a/crates/pops-settings/Cargo.toml
+++ b/crates/pops-settings/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pops-settings"
+version = "0.1.0"
+# A direct member of the `crates/` cargo workspace (a sibling of `pops-ai` and
+# of the `pillars/contacts` crate). 1:1 Rust mirror of the TS
+# `@pops/pillar-settings` federated RU+reset settings surface — the byte-
+# identical `/settings/*` wire contract every pillar serves
+# (`docs/plans/02-settings-federation.md` §4.4/§4.6, US-S6). Standalone
+# library: it has no in-tree consumer yet (the contacts Rust pillar will mount
+# it), so it ships compiled + tested-but-unused, with a golden-fixture parity
+# test pinning the wire bytes against the TS schema.
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "POPS settings — Rust mirror of @pops/pillar-settings's federated RU+reset wire contract."
+
+[lib]
+name = "pops_settings"
+path = "src/lib.rs"
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+utoipa = { workspace = true }

--- a/crates/pops-settings/src/error.rs
+++ b/crates/pops-settings/src/error.rs
@@ -1,0 +1,28 @@
+//! Settings surface errors — the Rust mirror of TS `errors.ts`.
+
+use std::fmt;
+
+/// Raised when a write/reset addresses a key the pillar never declared in its
+/// settings manifest. Keys are a fixed declared set (no create verb), so an
+/// undeclared write is a client error — the mounting pillar maps this to a 400.
+/// Carries the offending keys for the response body. Mirror of TS
+/// `UnknownSettingKeyError`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownSettingKeyError {
+    pub keys: Vec<String>,
+}
+
+impl UnknownSettingKeyError {
+    /// Constructs the error from the offending keys.
+    pub fn new(keys: Vec<String>) -> Self {
+        Self { keys }
+    }
+}
+
+impl fmt::Display for UnknownSettingKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown setting key(s): {}", self.keys.join(", "))
+    }
+}
+
+impl std::error::Error for UnknownSettingKeyError {}

--- a/crates/pops-settings/src/handlers.rs
+++ b/crates/pops-settings/src/handlers.rs
@@ -1,0 +1,334 @@
+//! The pure RU+reset handler logic — the Rust mirror of TS `handlers.ts`.
+//!
+//! Each method gates the principal, runs the [`service`](crate::service), and
+//! redacts sensitive values on READ paths only. The mounting pillar wraps these
+//! in its axum adapter (principal extraction + error mapping). There is no
+//! create or delete handler — only read, update, reset, and the internal-only
+//! `ensure` seed. WRITE/RESET paths reject keys outside the declared set
+//! ([`UnknownSettingKeyError`]) so a batch write can never become a backdoor
+//! create; READ paths stay lenient (an undeclared key is simply absent).
+
+use std::collections::BTreeMap;
+
+use crate::error::UnknownSettingKeyError;
+use crate::manifest::KeyDefaults;
+use crate::redact::{redact_sensitive, redact_sensitive_map};
+use crate::service::{
+    ensure, get_bulk, get_or_null, list_effective, reset_setting, reset_settings, set_bulk,
+    set_raw, ResetResult, SettingsStore,
+};
+use crate::wire::Setting;
+
+/// The identity gate injected by the mounting pillar. Runs the same
+/// authorization check the pillar's REST middleware uses and returns `Err` when
+/// the principal lacks the scope. The principal and denial types are
+/// associated (one gate authorizes one principal type) so [`SettingsHandlers`]
+/// stays a two-parameter generic. Mirror of TS `SettingsGate<Principal>` (which
+/// throws rather than returns).
+pub trait SettingsGate {
+    /// The principal type this gate authorizes (e.g. the pillar's session).
+    type Principal;
+    /// The error the pillar's middleware raises on denial (e.g. its
+    /// `UnauthorizedError`). Surfaced verbatim to the caller.
+    type Denied;
+
+    /// Authorize `principal` for `scope` (e.g. `"finance.settings.get"`).
+    fn check(&self, principal: &Self::Principal, scope: &str) -> Result<(), Self::Denied>;
+}
+
+/// A handler failure: either the injected gate denied the principal, or a
+/// write/reset addressed an undeclared key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HandlerError<Denied> {
+    /// The gate rejected the principal; carries the pillar's own denial value.
+    Denied(Denied),
+    /// A write/reset addressed keys outside the declared set.
+    UnknownKey(UnknownSettingKeyError),
+}
+
+impl<Denied> From<UnknownSettingKeyError> for HandlerError<Denied> {
+    fn from(err: UnknownSettingKeyError) -> Self {
+        HandlerError::UnknownKey(err)
+    }
+}
+
+/// The injected, pillar-agnostic RU+reset handlers bound to one store, key
+/// authority, scope prefix, and identity gate. READ paths
+/// (`list`/`get`/`get_many`) redact sensitive keys to the `__redacted__`
+/// sentinel; UPDATE/RESET paths persist and return real values. Mirror of TS
+/// `makeSettingsHandlers`.
+pub struct SettingsHandlers<S, G> {
+    store: S,
+    key_defaults: KeyDefaults,
+    scope_prefix: String,
+    gate: G,
+}
+
+impl<S, G> SettingsHandlers<S, G>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    /// Builds the handlers. `scope_prefix` is the gate prefix, e.g.
+    /// `"finance.settings"`; each proc gates `"<prefix>.<proc>"`.
+    pub fn new(
+        store: S,
+        key_defaults: KeyDefaults,
+        scope_prefix: impl Into<String>,
+        gate: G,
+    ) -> Self {
+        Self {
+            store,
+            key_defaults,
+            scope_prefix: scope_prefix.into(),
+            gate,
+        }
+    }
+
+    fn scope(&self, proc: &str) -> String {
+        format!("{}.{proc}", self.scope_prefix)
+    }
+
+    fn assert_declared(&self, keys: &[String]) -> Result<(), UnknownSettingKeyError> {
+        let unknown: Vec<String> = keys
+            .iter()
+            .filter(|key| !self.key_defaults.is_declared(key))
+            .cloned()
+            .collect();
+        if unknown.is_empty() {
+            Ok(())
+        } else {
+            Err(UnknownSettingKeyError::new(unknown))
+        }
+    }
+
+    fn gate(&self, principal: &G::Principal, proc: &str) -> Result<(), HandlerError<G::Denied>> {
+        self.gate
+            .check(principal, &self.scope(proc))
+            .map_err(HandlerError::Denied)
+    }
+
+    /// `list` — every declared key's effective value (sensitive redacted).
+    pub fn list(&self, principal: &G::Principal) -> Result<Vec<Setting>, HandlerError<G::Denied>> {
+        self.gate(principal, "list")?;
+        Ok(redact_sensitive(
+            &list_effective(&self.store, &self.key_defaults),
+            &self.key_defaults.sensitive,
+        ))
+    }
+
+    /// `get` — a single setting, `None` on unset (sensitive redacted).
+    pub fn get(
+        &self,
+        principal: &G::Principal,
+        key: &str,
+    ) -> Result<Option<Setting>, HandlerError<G::Denied>> {
+        self.gate(principal, "get")?;
+        let Some(row) = get_or_null(&self.store, key) else {
+            return Ok(None);
+        };
+        Ok(redact_sensitive(&[row], &self.key_defaults.sensitive)
+            .into_iter()
+            .next())
+    }
+
+    /// `get_many` — batch-read (missing omitted, sensitive redacted).
+    pub fn get_many(
+        &self,
+        principal: &G::Principal,
+        keys: &[String],
+    ) -> Result<BTreeMap<String, String>, HandlerError<G::Denied>> {
+        self.gate(principal, "getMany")?;
+        Ok(redact_sensitive_map(
+            &get_bulk(&self.store, keys),
+            &self.key_defaults.sensitive,
+        ))
+    }
+
+    /// `set` — upsert a single declared setting (rejects undeclared keys).
+    pub fn set(
+        &mut self,
+        principal: &G::Principal,
+        key: &str,
+        value: &str,
+    ) -> Result<Setting, HandlerError<G::Denied>> {
+        self.gate(principal, "set")?;
+        self.assert_declared(&[key.to_string()])?;
+        Ok(set_raw(&mut self.store, key, value))
+    }
+
+    /// `set_many` — transactional batch write (rejects any undeclared key).
+    pub fn set_many(
+        &mut self,
+        principal: &G::Principal,
+        entries: &[Setting],
+    ) -> Result<BTreeMap<String, String>, HandlerError<G::Denied>> {
+        self.gate(principal, "setMany")?;
+        let keys: Vec<String> = entries.iter().map(|entry| entry.key.clone()).collect();
+        self.assert_declared(&keys)?;
+        Ok(set_bulk(&mut self.store, entries))
+    }
+
+    /// `reset_key` — reset one declared key to its default (rejects undeclared).
+    pub fn reset_key(
+        &mut self,
+        principal: &G::Principal,
+        key: &str,
+    ) -> Result<Setting, HandlerError<G::Denied>> {
+        self.gate(principal, "resetKey")?;
+        self.assert_declared(&[key.to_string()])?;
+        Ok(reset_setting(&mut self.store, key, &self.key_defaults))
+    }
+
+    /// `reset` — reset declared keys to defaults (omit ⇒ reset all).
+    pub fn reset(
+        &mut self,
+        principal: &G::Principal,
+        keys: Option<&[String]>,
+    ) -> Result<ResetResult, HandlerError<G::Denied>> {
+        self.gate(principal, "reset")?;
+        Ok(reset_settings(&mut self.store, keys, &self.key_defaults))
+    }
+
+    /// `ensure` — internal-only write-once seed.
+    pub fn ensure(
+        &mut self,
+        principal: &G::Principal,
+        key: &str,
+        value: &str,
+    ) -> Result<Setting, HandlerError<G::Denied>> {
+        self.gate(principal, "ensure")?;
+        Ok(ensure(&mut self.store, key, value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{
+        derive_key_set, DeclaredSettingsField, DeclaredSettingsGroup, DeclaredSettingsManifest,
+    };
+    use crate::redact::REDACTED;
+    use crate::service::MemoryStore;
+
+    /// A gate that allows everything — for the happy-path assertions.
+    struct AllowAll;
+    impl SettingsGate for AllowAll {
+        type Principal = &'static str;
+        type Denied = ();
+        fn check(&self, _principal: &&'static str, _scope: &str) -> Result<(), ()> {
+            Ok(())
+        }
+    }
+
+    /// A gate that denies a single named scope, so the test can assert the
+    /// dotted `<prefix>.<proc>` scope string.
+    struct DenyScope {
+        deny: &'static str,
+    }
+    impl SettingsGate for DenyScope {
+        type Principal = &'static str;
+        type Denied = String;
+        fn check(&self, _principal: &&'static str, scope: &str) -> Result<(), String> {
+            if scope == self.deny {
+                Err(format!("denied: {scope}"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn kd() -> KeyDefaults {
+        derive_key_set(&[DeclaredSettingsManifest {
+            groups: vec![DeclaredSettingsGroup {
+                fields: vec![
+                    DeclaredSettingsField::new("theme").with_default("light"),
+                    DeclaredSettingsField::new("token").sensitive(),
+                ],
+            }],
+        }])
+    }
+
+    #[test]
+    fn list_redacts_sensitive_values() {
+        let mut store = MemoryStore::new();
+        store.set("token", "super-secret");
+        let handlers = SettingsHandlers::new(store, kd(), "finance.settings", AllowAll);
+        let rows = handlers.list(&"admin").unwrap();
+        let token = rows.iter().find(|s| s.key == "token").unwrap();
+        assert_eq!(token.value, REDACTED);
+        let theme = rows.iter().find(|s| s.key == "theme").unwrap();
+        assert_eq!(theme.value, "light");
+    }
+
+    #[test]
+    fn get_redacts_a_single_sensitive_value() {
+        let mut store = MemoryStore::new();
+        store.set("token", "secret");
+        let handlers = SettingsHandlers::new(store, kd(), "finance.settings", AllowAll);
+        let row = handlers.get(&"admin", "token").unwrap().unwrap();
+        assert_eq!(row.value, REDACTED);
+    }
+
+    #[test]
+    fn get_many_redacts_sensitive_values() {
+        let mut store = MemoryStore::new();
+        store.set("token", "secret");
+        store.set("theme", "dark");
+        let handlers = SettingsHandlers::new(store, kd(), "finance.settings", AllowAll);
+        let out = handlers
+            .get_many(&"admin", &["token".to_string(), "theme".to_string()])
+            .unwrap();
+        assert_eq!(out["token"], REDACTED);
+        assert_eq!(out["theme"], "dark");
+    }
+
+    #[test]
+    fn set_rejects_undeclared_key() {
+        let mut handlers =
+            SettingsHandlers::new(MemoryStore::new(), kd(), "finance.settings", AllowAll);
+        let err = handlers.set(&"admin", "not-declared", "v").unwrap_err();
+        assert_eq!(
+            err,
+            HandlerError::UnknownKey(UnknownSettingKeyError::new(
+                vec!["not-declared".to_string()]
+            ))
+        );
+    }
+
+    #[test]
+    fn set_persists_real_value_never_redacted() {
+        let mut handlers =
+            SettingsHandlers::new(MemoryStore::new(), kd(), "finance.settings", AllowAll);
+        let written = handlers.set(&"admin", "token", "plaintext").unwrap();
+        assert_eq!(written.value, "plaintext", "writes are never redacted");
+    }
+
+    #[test]
+    fn gate_denial_gates_the_dotted_scope() {
+        let gate = DenyScope {
+            deny: "finance.settings.set",
+        };
+        let mut handlers =
+            SettingsHandlers::new(MemoryStore::new(), kd(), "finance.settings", gate);
+        assert!(handlers.list(&"admin").is_ok());
+        let err = handlers.set(&"admin", "theme", "dark").unwrap_err();
+        assert_eq!(
+            err,
+            HandlerError::Denied("denied: finance.settings.set".to_string())
+        );
+    }
+
+    #[test]
+    fn reset_does_not_reject_unknown_keys() {
+        let mut handlers =
+            SettingsHandlers::new(MemoryStore::new(), kd(), "finance.settings", AllowAll);
+        let result = handlers
+            .reset(
+                &"admin",
+                Some(&["theme".to_string(), "unknown".to_string()]),
+            )
+            .unwrap();
+        assert_eq!(result.reset, ["theme"]);
+    }
+}

--- a/crates/pops-settings/src/lib.rs
+++ b/crates/pops-settings/src/lib.rs
@@ -1,0 +1,53 @@
+//! `pops-settings` — the Rust mirror of the TS `@pops/pillar-settings` package.
+//!
+//! It provides the federated Read/Update/Reset settings surface every pillar
+//! serves byte-identically (`docs/plans/02-settings-federation.md` §4.4/§4.6,
+//! US-S6): the wire types ([`Setting`] and the per-route response bodies), the
+//! storage-agnostic RU+reset+seed [`service`] over an injected
+//! [`SettingsStore`], read-side sensitive redaction ([`redact_sensitive`]) to a
+//! fixed `__redacted__` sentinel, manifest → key-authority derivation
+//! ([`derive_key_set`]), the gated, pillar-agnostic [`SettingsHandlers`], and
+//! the axum [`settings_router`] whose utoipa `operation_id`s are pinned to the
+//! DOT-form (`settings.get`, `settings.set`, …).
+//!
+//! Protocol is READ + UPDATE + RESET only. There is no create verb and no
+//! delete verb — keys are a fixed declared set per pillar; DELETE is a reset
+//! alias. The `ensure` write-once seed is internal-only.
+//!
+//! Every map output is a [`std::collections::BTreeMap`] so the serialized key
+//! order is deterministic and sorted. HTTP JSON object key order is not
+//! semantically significant; sorted order is chosen so the Rust and TS sides
+//! produce comparable bytes.
+//!
+//! Parity with the TS schema is pinned by `tests/contract.rs`, which
+//! round-trips a shared golden fixture (`tests/fixtures/settings.json`,
+//! sorted-key JSON) the TS `contract-fixture` test also accepts.
+//!
+//! This is a standalone library crate: it has no in-tree consumer yet (the
+//! contacts Rust pillar will mount it), so it ships compiled + tested-but-unused.
+
+mod error;
+mod handlers;
+mod manifest;
+pub mod openapi;
+mod redact;
+mod routes;
+mod service;
+mod wire;
+
+pub use error::UnknownSettingKeyError;
+pub use handlers::{HandlerError, SettingsGate, SettingsHandlers};
+pub use manifest::{
+    derive_key_set, DeclaredSettingsField, DeclaredSettingsGroup, DeclaredSettingsManifest,
+    KeyDefaults,
+};
+pub use redact::{redact_sensitive, redact_sensitive_map, REDACTED};
+pub use routes::{settings_router, SettingsState};
+pub use service::{
+    ensure, get_bulk, get_or_null, list_effective, reset_setting, reset_settings, set_bulk,
+    set_raw, MemoryStore, ResetResult, SettingsStore,
+};
+pub use wire::{
+    EnsureResponse, GetManyRequest, GetResponse, ListResponse, MutationResponse, ResetRequest,
+    ResetResponse, SetManyRequest, Setting, SettingValueBody, SettingsMapResponse,
+};

--- a/crates/pops-settings/src/manifest.rs
+++ b/crates/pops-settings/src/manifest.rs
@@ -1,0 +1,164 @@
+//! Manifest → key authority derivation — the Rust mirror of TS
+//! `manifest-keys.ts`.
+//!
+//! A pillar's settings manifest is the single authority for its declared keys
+//! (no central enum). [`derive_key_set`] flattens the manifest descriptors into
+//! the [`KeyDefaults`] the service and handlers gate on: the ordered declared
+//! keys, the key→default map (only keys with an explicit default), and the
+//! sensitive-key set (redacted on read).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A single declared settings field — the structural subset read here. Mirror
+/// of TS `DeclaredSettingsField`.
+#[derive(Debug, Clone)]
+pub struct DeclaredSettingsField {
+    pub key: String,
+    pub default: Option<String>,
+    pub sensitive: bool,
+}
+
+impl DeclaredSettingsField {
+    /// A plain field with no default and not sensitive.
+    pub fn new(key: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            default: None,
+            sensitive: false,
+        }
+    }
+
+    /// Sets the manifest default for this field.
+    pub fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.default = Some(default.into());
+        self
+    }
+
+    /// Marks this field sensitive (redacted on read).
+    pub fn sensitive(mut self) -> Self {
+        self.sensitive = true;
+        self
+    }
+}
+
+/// A group of declared fields within a manifest descriptor. Mirror of TS
+/// `DeclaredSettingsGroup`.
+#[derive(Debug, Clone, Default)]
+pub struct DeclaredSettingsGroup {
+    pub fields: Vec<DeclaredSettingsField>,
+}
+
+/// The structural subset of a settings manifest descriptor read here. Mirror of
+/// TS `DeclaredSettingsManifest`.
+#[derive(Debug, Clone, Default)]
+pub struct DeclaredSettingsManifest {
+    pub groups: Vec<DeclaredSettingsGroup>,
+}
+
+/// The resolved key authority for one pillar: the ordered declared keys, the
+/// key→default map (only keys with an explicit manifest default), and the
+/// sensitive-key set (redacted on read). Mirror of TS `KeyDefaults`.
+#[derive(Debug, Clone, Default)]
+pub struct KeyDefaults {
+    /// Declared keys in manifest declaration order. Order is load-bearing for
+    /// `list`/`reset` outputs.
+    pub keys: Vec<String>,
+    /// Sorted key→default map; only keys with an explicit manifest default.
+    pub defaults: BTreeMap<String, String>,
+    /// Sorted set of sensitive keys (redacted on read).
+    pub sensitive: BTreeSet<String>,
+}
+
+impl KeyDefaults {
+    /// Whether `key` is one of this pillar's declared keys.
+    pub fn is_declared(&self, key: &str) -> bool {
+        self.keys.iter().any(|k| k == key)
+    }
+
+    /// The resolved default for `key` (manifest default, else the empty
+    /// string), matching TS `kd.defaults[key] ?? ''`.
+    pub fn default_for(&self, key: &str) -> String {
+        self.defaults.get(key).cloned().unwrap_or_default()
+    }
+}
+
+/// Flattens a pillar's manifest descriptors into its [`KeyDefaults`]. Iterates
+/// every group's fields in declaration order, collecting keys, explicit
+/// defaults, and sensitive flags. Mirror of TS `deriveKeySet`.
+pub fn derive_key_set(manifests: &[DeclaredSettingsManifest]) -> KeyDefaults {
+    let mut kd = KeyDefaults::default();
+    for manifest in manifests {
+        for group in &manifest.groups {
+            for field in &group.fields {
+                kd.keys.push(field.key.clone());
+                if let Some(default) = &field.default {
+                    kd.defaults.insert(field.key.clone(), default.clone());
+                }
+                if field.sensitive {
+                    kd.sensitive.insert(field.key.clone());
+                }
+            }
+        }
+    }
+    kd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(fields: Vec<DeclaredSettingsField>) -> DeclaredSettingsManifest {
+        DeclaredSettingsManifest {
+            groups: vec![DeclaredSettingsGroup { fields }],
+        }
+    }
+
+    #[test]
+    fn collects_keys_in_declaration_order() {
+        let kd = derive_key_set(&[manifest(vec![
+            DeclaredSettingsField::new("b"),
+            DeclaredSettingsField::new("a"),
+            DeclaredSettingsField::new("c"),
+        ])]);
+        assert_eq!(kd.keys, ["b", "a", "c"]);
+    }
+
+    #[test]
+    fn collects_only_explicit_defaults() {
+        let kd = derive_key_set(&[manifest(vec![
+            DeclaredSettingsField::new("a").with_default("da"),
+            DeclaredSettingsField::new("b"),
+        ])]);
+        assert_eq!(kd.defaults.get("a").map(String::as_str), Some("da"));
+        assert!(!kd.defaults.contains_key("b"));
+        assert_eq!(kd.default_for("b"), "");
+    }
+
+    #[test]
+    fn collects_sensitive_flags() {
+        let kd = derive_key_set(&[manifest(vec![
+            DeclaredSettingsField::new("token").sensitive(),
+            DeclaredSettingsField::new("url"),
+        ])]);
+        assert!(kd.sensitive.contains("token"));
+        assert!(!kd.sensitive.contains("url"));
+    }
+
+    #[test]
+    fn flattens_multiple_manifests_and_groups() {
+        let kd = derive_key_set(&[
+            DeclaredSettingsManifest {
+                groups: vec![
+                    DeclaredSettingsGroup {
+                        fields: vec![DeclaredSettingsField::new("a")],
+                    },
+                    DeclaredSettingsGroup {
+                        fields: vec![DeclaredSettingsField::new("b")],
+                    },
+                ],
+            },
+            manifest(vec![DeclaredSettingsField::new("c")]),
+        ]);
+        assert_eq!(kd.keys, ["a", "b", "c"]);
+    }
+}

--- a/crates/pops-settings/src/openapi.rs
+++ b/crates/pops-settings/src/openapi.rs
@@ -1,0 +1,247 @@
+//! OpenAPI document generation for the settings surface, pinned to **OpenAPI
+//! 3.0.3**.
+//!
+//! Mirrors the contacts pillar's emission: utoipa 5 emits OpenAPI 3.1 by
+//! default, but the repo's client generator (`@hey-api/openapi-ts`) targets
+//! 3.0, so a deterministic post-process pass rewrites the serialized document
+//! to a 3.0.3 shape (`type: [..,"null"]` → `nullable: true`; 3.1 `examples`
+//! array → 3.0 singular `example`).
+//!
+//! The document documents the DOT-form `settings.*` operationIds — the polyglot
+//! parity pin against the TS ts-rest projection.
+
+use serde_json::{Map, Value};
+use utoipa::OpenApi;
+
+use crate::wire::{
+    EnsureResponse, GetManyRequest, GetResponse, ListResponse, MutationResponse, ResetRequest,
+    ResetResponse, SetManyRequest, Setting, SettingValueBody, SettingsMapResponse,
+};
+
+/// The settings OpenAPI surface. Documents the federated RU+reset routes with
+/// DOTTED `settings.*` operationIds (`settings.list`, `settings.get`,
+/// `settings.getMany`, `settings.set`, `settings.setMany`, `settings.resetKey`,
+/// `settings.reset`, and the internal `settings.ensure`).
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "POPS Settings",
+        description = "Federated RU+reset settings surface — Rust mirror of @pops/pillar-settings."
+    ),
+    paths(
+        crate::routes::list,
+        crate::routes::get_one,
+        crate::routes::get_many,
+        crate::routes::set,
+        crate::routes::set_many,
+        crate::routes::reset_key,
+        crate::routes::reset,
+        crate::routes::ensure,
+    ),
+    components(schemas(
+        Setting,
+        ListResponse,
+        GetResponse,
+        GetManyRequest,
+        SettingsMapResponse,
+        SettingValueBody,
+        SetManyRequest,
+        ResetRequest,
+        ResetResponse,
+        MutationResponse,
+        EnsureResponse,
+    ))
+)]
+pub struct ApiDoc;
+
+/// The OpenAPI version string every emitted/served document is pinned to.
+pub const OPENAPI_VERSION: &str = "3.0.3";
+
+/// Render the OpenAPI document as a 3.0.3 `serde_json::Value`.
+pub fn openapi_30_value() -> Value {
+    let mut doc =
+        serde_json::to_value(ApiDoc::openapi()).expect("utoipa OpenApi serializes to a JSON value");
+    downgrade_to_30(&mut doc);
+    doc
+}
+
+/// Render the 3.0.3 document as deterministic pretty JSON with a trailing
+/// newline (so a committed copy would be diff-stable across regenerations).
+pub fn openapi_30_json() -> String {
+    let value = openapi_30_value();
+    let mut json =
+        serde_json::to_string_pretty(&value).expect("3.0 OpenAPI value serializes to pretty JSON");
+    json.push('\n');
+    json
+}
+
+/// Force the top-level `openapi` field to 3.0.3 and recursively rewrite the
+/// schema tree to the 3.0 dialect.
+fn downgrade_to_30(doc: &mut Value) {
+    if let Value::Object(map) = doc {
+        map.insert(
+            "openapi".to_string(),
+            Value::String(OPENAPI_VERSION.to_string()),
+        );
+    }
+    rewrite_schema_node(doc);
+}
+
+/// Recursively convert 3.1-only schema constructs to their 3.0 equivalents.
+fn rewrite_schema_node(node: &mut Value) {
+    match node {
+        Value::Object(map) => {
+            rewrite_nullable_type_union(map);
+            rewrite_nullable_composition(map);
+            rewrite_examples_to_example(map);
+            for value in map.values_mut() {
+                rewrite_schema_node(value);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                rewrite_schema_node(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// `type: ["string", "null"]` → `type: "string"` + `nullable: true`.
+fn rewrite_nullable_type_union(map: &mut Map<String, Value>) {
+    let Some(Value::Array(variants)) = map.get("type") else {
+        return;
+    };
+    let has_null = variants
+        .iter()
+        .any(|v| v == &Value::String("null".to_string()));
+    if !has_null {
+        return;
+    }
+    let concrete: Vec<Value> = variants
+        .iter()
+        .filter(|v| *v != &Value::String("null".to_string()))
+        .cloned()
+        .collect();
+    if let [single] = concrete.as_slice() {
+        map.insert("type".to_string(), single.clone());
+        map.insert("nullable".to_string(), Value::Bool(true));
+    }
+}
+
+/// 3.1 `Option<Object>` emits as `oneOf: [{type:"null"}, {$ref}]` (or
+/// `anyOf`). 3.0 has no `null` type, so drop the null member and set
+/// `nullable: true`. When exactly one member remains, inline it: a `$ref`
+/// cannot carry a sibling `nullable` in 3.0, so wrap it as `allOf: [{$ref}]`;
+/// any other single member is hoisted in place.
+fn rewrite_nullable_composition(map: &mut Map<String, Value>) {
+    for keyword in ["oneOf", "anyOf"] {
+        let Some(Value::Array(members)) = map.get(keyword) else {
+            continue;
+        };
+        let is_null = |v: &Value| v.get("type") == Some(&Value::String("null".to_string()));
+        if !members.iter().any(is_null) {
+            continue;
+        }
+        let concrete: Vec<Value> = members.iter().filter(|v| !is_null(v)).cloned().collect();
+        map.remove(keyword);
+        map.insert("nullable".to_string(), Value::Bool(true));
+        match concrete.as_slice() {
+            [single] if single.get("$ref").is_some() => {
+                map.insert("allOf".to_string(), Value::Array(vec![single.clone()]));
+            }
+            [single] => {
+                if let Value::Object(inner) = single {
+                    for (k, v) in inner {
+                        map.entry(k.clone()).or_insert_with(|| v.clone());
+                    }
+                }
+            }
+            _ => {
+                map.insert(keyword.to_string(), Value::Array(concrete));
+            }
+        }
+        return;
+    }
+}
+
+/// `examples: [x, …]` → `example: x` (3.0 schema objects carry a singular
+/// `example`, not the 3.1 `examples` array).
+fn rewrite_examples_to_example(map: &mut Map<String, Value>) {
+    let Some(Value::Array(examples)) = map.get("examples") else {
+        return;
+    };
+    if let Some(first) = examples.first().cloned() {
+        map.insert("example".to_string(), first);
+    }
+    map.remove("examples");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emitted_document_is_openapi_30() {
+        let value = openapi_30_value();
+        let version = value
+            .get("openapi")
+            .and_then(Value::as_str)
+            .expect("openapi field is a string");
+        assert_eq!(version, OPENAPI_VERSION);
+    }
+
+    #[test]
+    fn json_output_is_stable_and_newline_terminated() {
+        let first = openapi_30_json();
+        let second = openapi_30_json();
+        assert_eq!(first, second, "emission must be deterministic");
+        assert!(first.ends_with('\n'), "emitted JSON ends with a newline");
+    }
+
+    #[test]
+    fn no_31_style_nullable_type_union_remains() {
+        let json = openapi_30_json();
+        assert!(
+            !json.contains("\"null\""),
+            "3.0 documents express nullability via the `nullable` keyword"
+        );
+    }
+
+    #[test]
+    fn nullable_union_is_rewritten_to_30_keyword() {
+        let mut node = serde_json::json!({ "type": ["string", "null"] });
+        rewrite_schema_node(&mut node);
+        assert_eq!(node["type"], serde_json::json!("string"));
+        assert_eq!(node["nullable"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn nullable_oneof_ref_is_rewritten_to_allof_plus_nullable() {
+        let mut node = serde_json::json!({
+            "oneOf": [{ "type": "null" }, { "$ref": "#/components/schemas/Setting" }]
+        });
+        rewrite_schema_node(&mut node);
+        assert_eq!(node["nullable"], serde_json::json!(true));
+        assert!(
+            node.get("oneOf").is_none(),
+            "the null union must be removed"
+        );
+        assert_eq!(
+            node["allOf"],
+            serde_json::json!([{ "$ref": "#/components/schemas/Setting" }]),
+            "a single $ref member is wrapped in allOf so nullable has no $ref sibling"
+        );
+    }
+
+    #[test]
+    fn get_response_data_is_nullable_in_30() {
+        let doc = openapi_30_value();
+        let data = &doc["components"]["schemas"]["GetResponse"]["properties"]["data"];
+        assert_eq!(
+            data["nullable"],
+            serde_json::json!(true),
+            "GET /settings/:key returns a nullable setting; got {data}"
+        );
+    }
+}

--- a/crates/pops-settings/src/redact.rs
+++ b/crates/pops-settings/src/redact.rs
@@ -1,0 +1,98 @@
+//! Read-side sensitive-value redaction — the Rust mirror of TS `redact.ts`.
+//!
+//! Sensitive keys read back as a fixed [`REDACTED`] sentinel; writes are never
+//! passed through here, so the stored value stays intact and only outbound
+//! reads are masked. This matches OD-8 in `docs/plans/02-settings-federation.md`:
+//! the shell renders a field holding the sentinel as an empty password input
+//! and only sends edited fields, so a no-op save never persists the sentinel
+//! over the real secret.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::wire::Setting;
+
+/// Fixed sentinel a sensitive value reads back as. Byte-identical to the TS
+/// `REDACTED` constant.
+pub const REDACTED: &str = "__redacted__";
+
+/// Masks sensitive values for READ paths only. Returns a new vec; rows whose
+/// key is in `sensitive` have their value replaced by [`REDACTED`]. Writes are
+/// never passed through this.
+pub fn redact_sensitive(rows: &[Setting], sensitive: &BTreeSet<String>) -> Vec<Setting> {
+    rows.iter()
+        .map(|row| {
+            if sensitive.contains(&row.key) {
+                Setting::new(row.key.clone(), REDACTED)
+            } else {
+                row.clone()
+            }
+        })
+        .collect()
+}
+
+/// Redacts the values of a key→value map for READ paths. Returns a new sorted
+/// map; keys in `sensitive` map to [`REDACTED`].
+pub fn redact_sensitive_map(
+    settings: &BTreeMap<String, String>,
+    sensitive: &BTreeSet<String>,
+) -> BTreeMap<String, String> {
+    settings
+        .iter()
+        .map(|(key, value)| {
+            if sensitive.contains(key) {
+                (key.clone(), REDACTED.to_string())
+            } else {
+                (key.clone(), value.clone())
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sensitive_set(keys: &[&str]) -> BTreeSet<String> {
+        keys.iter().map(|k| (*k).to_string()).collect()
+    }
+
+    #[test]
+    fn masks_sensitive_rows_and_leaves_others_intact() {
+        let sensitive = sensitive_set(&["plex_token", "finance.apiToken"]);
+        let rows = vec![
+            Setting::new("plex_url", "http://plex.local"),
+            Setting::new("plex_token", "super-secret-ciphertext"),
+            Setting::new("finance.apiToken", "tok_live_123"),
+        ];
+        let out = redact_sensitive(&rows, &sensitive);
+        assert_eq!(out[0], Setting::new("plex_url", "http://plex.local"));
+        assert_eq!(out[1], Setting::new("plex_token", REDACTED));
+        assert_eq!(out[2], Setting::new("finance.apiToken", REDACTED));
+    }
+
+    #[test]
+    fn does_not_mutate_input_rows() {
+        let sensitive = sensitive_set(&["plex_token"]);
+        let rows = vec![Setting::new("plex_token", "secret")];
+        let _ = redact_sensitive(&rows, &sensitive);
+        assert_eq!(rows[0].value, "secret");
+    }
+
+    #[test]
+    fn empty_rows_round_trip_unchanged() {
+        let sensitive = sensitive_set(&["plex_token"]);
+        assert!(redact_sensitive(&[], &sensitive).is_empty());
+    }
+
+    #[test]
+    fn masks_sensitive_entries_in_a_map() {
+        let sensitive = sensitive_set(&["secret"]);
+        let mut input = BTreeMap::new();
+        input.insert("public".to_string(), "v".to_string());
+        input.insert("secret".to_string(), "hidden".to_string());
+        let out = redact_sensitive_map(&input, &sensitive);
+        assert_eq!(out["public"], "v");
+        assert_eq!(out["secret"], REDACTED);
+        assert_eq!(input["secret"], "hidden", "input map is not mutated");
+    }
+}

--- a/crates/pops-settings/src/routes.rs
+++ b/crates/pops-settings/src/routes.rs
@@ -1,0 +1,282 @@
+//! Axum routes for the federated RU+reset settings surface, with the utoipa
+//! `operation_id` pinned to the DOT-form on every path.
+//!
+//! Every `#[utoipa::path]` pins `operation_id` to the DOTTED `settings.<proc>`
+//! string (`settings.list`, `settings.get`, `settings.getMany`,
+//! `settings.set`, `settings.setMany`, `settings.resetKey`, `settings.reset`,
+//! and the internal `settings.ensure`). This is load-bearing (mustFix #2 /
+//! crossPlanConflict #1 in `docs/plans/02-settings-federation.md`): the ts-rest
+//! projection emits the same dot-form ids, so the contacts pillar's generated
+//! hey-api client derives identical method names to every TS pillar and the
+//! single contacts OpenAPI doc never mixes two operationId styles. utoipa's
+//! default id is the fn name (which cannot contain a dot), hence the explicit
+//! override on each route.
+//!
+//! The handler bodies are intentionally thin: the crate ships standalone (no
+//! in-tree DB/identity wiring yet — the contacts pillar supplies that when it
+//! mounts the surface), so these document the wire shape and pin the
+//! operationIds. The persistence-bearing logic lives in
+//! [`SettingsHandlers`](crate::handlers::SettingsHandlers).
+
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+
+use crate::handlers::{HandlerError, SettingsGate, SettingsHandlers};
+use crate::service::SettingsStore;
+use crate::wire::{
+    EnsureResponse, GetManyRequest, GetResponse, ListResponse, MutationResponse, ResetRequest,
+    ResetResponse, SetManyRequest, SettingValueBody, SettingsMapResponse,
+};
+
+/// The shared state a mounting pillar supplies: the bound [`SettingsHandlers`]
+/// plus the principal to gate each request against. The pillar's real adapter
+/// extracts the principal per request; this standalone shape carries one so the
+/// handlers compile and document the wire end to end.
+pub struct SettingsState<S, G>
+where
+    G: SettingsGate,
+{
+    /// The bound handlers (store + key authority + scope prefix + gate).
+    pub handlers: Arc<Mutex<SettingsHandlers<S, G>>>,
+    /// The principal each route gates against.
+    pub principal: G::Principal,
+}
+
+impl<S, G> Clone for SettingsState<S, G>
+where
+    G: SettingsGate,
+    G::Principal: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handlers: Arc::clone(&self.handlers),
+            principal: self.principal.clone(),
+        }
+    }
+}
+
+/// Mounts the RU+reset routes onto a router sharing a [`SettingsState`].
+///
+/// The paths are byte-identical to the TS contract (`contract.ts`): `list`
+/// (`GET /settings`), `get` (`GET /settings/:key`), `getMany`
+/// (`POST /settings/get-many`), `set` (`PUT /settings/:key`), `setMany`
+/// (`POST /settings/set-many`), `resetKey` (`POST /settings/:key/reset`),
+/// `reset` (`POST /settings/reset`), and the internal `ensure`
+/// (`POST /settings/:key/ensure`). There is deliberately NO create and NO
+/// delete route — DELETE is an alias for reset.
+pub fn settings_router<S, G>() -> Router<SettingsState<S, G>>
+where
+    S: SettingsStore + Send + 'static,
+    G: SettingsGate + Send + 'static,
+    G::Principal: Clone + Send + Sync + 'static,
+    G::Denied: Send + 'static,
+{
+    Router::new()
+        .route("/settings", get(list::<S, G>))
+        .route("/settings/get-many", post(get_many::<S, G>))
+        .route("/settings/set-many", post(set_many::<S, G>))
+        .route("/settings/reset", post(reset::<S, G>))
+        .route("/settings/:key", get(get_one::<S, G>).put(set::<S, G>))
+        .route("/settings/:key/reset", post(reset_key::<S, G>))
+        .route("/settings/:key/ensure", post(ensure::<S, G>))
+}
+
+/// Maps a handler failure to an HTTP status: a gate denial is `401`, an
+/// undeclared key is `400`.
+fn status_for<D>(err: &HandlerError<D>) -> StatusCode {
+    match err {
+        HandlerError::Denied(_) => StatusCode::UNAUTHORIZED,
+        HandlerError::UnknownKey(_) => StatusCode::BAD_REQUEST,
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/settings",
+    operation_id = "settings.list",
+    responses((status = 200, description = "Effective value for every declared key (sensitive redacted)", body = ListResponse))
+)]
+pub async fn list<S, G>(
+    State(state): State<SettingsState<S, G>>,
+) -> Result<Json<ListResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let handlers = state.handlers.lock().expect("settings handlers lock");
+    let data = handlers
+        .list(&state.principal)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(ListResponse { data }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/settings/{key}",
+    operation_id = "settings.get",
+    params(("key" = String, Path, description = "Declared setting key")),
+    responses((status = 200, description = "A single setting (null on unset; sensitive redacted)", body = GetResponse))
+)]
+pub async fn get_one<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Path(key): Path<String>,
+) -> Result<Json<GetResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let handlers = state.handlers.lock().expect("settings handlers lock");
+    let data = handlers
+        .get(&state.principal, &key)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(GetResponse { data }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/get-many",
+    operation_id = "settings.getMany",
+    request_body = GetManyRequest,
+    responses((status = 200, description = "Batch-read settings by key (missing omitted; sensitive redacted)", body = SettingsMapResponse))
+)]
+pub async fn get_many<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Json(body): Json<GetManyRequest>,
+) -> Result<Json<SettingsMapResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let handlers = state.handlers.lock().expect("settings handlers lock");
+    let settings = handlers
+        .get_many(&state.principal, &body.keys)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(SettingsMapResponse { settings }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/settings/{key}",
+    operation_id = "settings.set",
+    params(("key" = String, Path, description = "Declared setting key")),
+    request_body = SettingValueBody,
+    responses((status = 200, description = "Upsert a single declared setting", body = MutationResponse))
+)]
+pub async fn set<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Path(key): Path<String>,
+    Json(body): Json<SettingValueBody>,
+) -> Result<Json<MutationResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let mut handlers = state.handlers.lock().expect("settings handlers lock");
+    let data = handlers
+        .set(&state.principal, &key, &body.value)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(MutationResponse {
+        data,
+        message: "Setting saved".to_string(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/set-many",
+    operation_id = "settings.setMany",
+    request_body = SetManyRequest,
+    responses((status = 200, description = "Transactional batch write (all-or-nothing); returns the written mirror", body = SettingsMapResponse))
+)]
+pub async fn set_many<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Json(body): Json<SetManyRequest>,
+) -> Result<Json<SettingsMapResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let mut handlers = state.handlers.lock().expect("settings handlers lock");
+    let settings = handlers
+        .set_many(&state.principal, &body.entries)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(SettingsMapResponse { settings }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/{key}/reset",
+    operation_id = "settings.resetKey",
+    params(("key" = String, Path, description = "Declared setting key")),
+    responses((status = 200, description = "Reset a single setting to its manifest default", body = MutationResponse))
+)]
+pub async fn reset_key<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Path(key): Path<String>,
+) -> Result<Json<MutationResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let mut handlers = state.handlers.lock().expect("settings handlers lock");
+    let data = handlers
+        .reset_key(&state.principal, &key)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(MutationResponse {
+        data,
+        message: "Setting reset to default".to_string(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/reset",
+    operation_id = "settings.reset",
+    request_body = ResetRequest,
+    responses((status = 200, description = "Reset declared keys to defaults (omit keys ⇒ reset all)", body = ResetResponse))
+)]
+pub async fn reset<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Json(body): Json<ResetRequest>,
+) -> Result<Json<ResetResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let mut handlers = state.handlers.lock().expect("settings handlers lock");
+    let result = handlers
+        .reset(&state.principal, body.keys.as_deref())
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(ResetResponse {
+        reset: result.reset,
+        settings: result.settings,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/{key}/ensure",
+    operation_id = "settings.ensure",
+    params(("key" = String, Path, description = "Declared setting key")),
+    request_body = SettingValueBody,
+    responses((status = 200, description = "Internal-only write-once seed (encryption seed / client id)", body = EnsureResponse))
+)]
+pub async fn ensure<S, G>(
+    State(state): State<SettingsState<S, G>>,
+    Path(key): Path<String>,
+    Json(body): Json<SettingValueBody>,
+) -> Result<Json<EnsureResponse>, StatusCode>
+where
+    S: SettingsStore,
+    G: SettingsGate,
+{
+    let mut handlers = state.handlers.lock().expect("settings handlers lock");
+    let data = handlers
+        .ensure(&state.principal, &key, &body.value)
+        .map_err(|e| status_for(&e))?;
+    Ok(Json(EnsureResponse { data }))
+}

--- a/crates/pops-settings/src/service.rs
+++ b/crates/pops-settings/src/service.rs
@@ -1,0 +1,341 @@
+//! The storage-agnostic RU+reset+seed service — the Rust mirror of TS
+//! `service.ts`.
+//!
+//! The TS module is a set of pure functions over an injected drizzle handle;
+//! the Rust mirror is the same logic over an injected [`SettingsStore`] trait,
+//! so the crate binds to no specific database (the contacts pillar will supply
+//! a sqlx-backed store). Every map output is a [`BTreeMap`] so the result is
+//! deterministic and sorted.
+//!
+//! Protocol is READ + UPDATE + RESET only — there is no create verb and no
+//! delete verb. The `ensure` write-once seed is internal-only.
+
+use std::collections::BTreeMap;
+
+use crate::manifest::KeyDefaults;
+use crate::wire::Setting;
+
+/// The per-pillar key/value persistence the service operates over. The mounting
+/// pillar supplies the storage; the crate never opens a database itself. By
+/// contract a store only ever holds that pillar's declared keys (there is no
+/// owner/namespace column). Mirror of the injected drizzle `SettingsDb` handle.
+pub trait SettingsStore {
+    /// Read one stored override; `None` when the key has no row (the caller
+    /// applies the manifest default). Does NOT resolve the default itself.
+    fn get(&self, key: &str) -> Option<String>;
+
+    /// Batch-read stored overrides by key. Missing keys are omitted. Duplicate
+    /// input keys are de-duped by the [`BTreeMap`] result.
+    fn get_bulk(&self, keys: &[String]) -> BTreeMap<String, String>;
+
+    /// Upsert a single setting (UPDATE). The value is stored verbatim — writes
+    /// are never redacted.
+    fn set(&mut self, key: &str, value: &str);
+
+    /// Transactional batch write (UPDATE) — every entry lands or none do.
+    fn set_bulk(&mut self, entries: &[Setting]);
+
+    /// Delete a stored override (idempotent — no-op when absent).
+    fn delete(&mut self, key: &str);
+
+    /// Write-once seed: insert only if absent, returning the value that is now
+    /// stored (the existing one wins on a race). Mirror of TS
+    /// `ON CONFLICT DO NOTHING` + re-read.
+    fn ensure(&mut self, key: &str, value: &str) -> String;
+}
+
+/// Read one stored override as a [`Setting`]; `None` when unset. Mirror of TS
+/// `getOrNull`.
+pub fn get_or_null<S: SettingsStore>(store: &S, key: &str) -> Option<Setting> {
+    store.get(key).map(|value| Setting::new(key, value))
+}
+
+/// Batch-read stored overrides by key (missing omitted). Mirror of TS
+/// `getBulk`.
+pub fn get_bulk<S: SettingsStore>(store: &S, keys: &[String]) -> BTreeMap<String, String> {
+    if keys.is_empty() {
+        return BTreeMap::new();
+    }
+    store.get_bulk(keys)
+}
+
+/// The effective value set: every declared key resolved to its stored override,
+/// else its manifest default, else the empty string — in declared order. Mirror
+/// of TS `listEffective`.
+pub fn list_effective<S: SettingsStore>(store: &S, kd: &KeyDefaults) -> Vec<Setting> {
+    let overrides = store.get_bulk(&kd.keys);
+    kd.keys
+        .iter()
+        .map(|key| {
+            let value = overrides
+                .get(key)
+                .cloned()
+                .unwrap_or_else(|| kd.default_for(key));
+            Setting::new(key.clone(), value)
+        })
+        .collect()
+}
+
+/// Upsert a single setting and return the persisted row. Mirror of TS
+/// `setRaw`.
+pub fn set_raw<S: SettingsStore>(store: &mut S, key: &str, value: &str) -> Setting {
+    store.set(key, value);
+    Setting::new(key, value)
+}
+
+/// Transactional batch write; returns a sorted mirror of the written entries.
+/// Mirror of TS `setBulk`.
+pub fn set_bulk<S: SettingsStore>(store: &mut S, entries: &[Setting]) -> BTreeMap<String, String> {
+    if entries.is_empty() {
+        return BTreeMap::new();
+    }
+    store.set_bulk(entries);
+    entries
+        .iter()
+        .map(|entry| (entry.key.clone(), entry.value.clone()))
+        .collect()
+}
+
+/// Write-once seed for values that must stay stable for the install's lifetime
+/// (encryption seed, generated client id). INTERNAL-ONLY. Mirror of TS
+/// `ensure`.
+pub fn ensure<S: SettingsStore>(store: &mut S, key: &str, value: &str) -> Setting {
+    let stored = store.ensure(key, value);
+    Setting::new(key, stored)
+}
+
+/// RESET a single declared key to its manifest default by deleting any stored
+/// override (idempotent — no error on miss). Returns the resolved default the
+/// next read would observe. Mirror of TS `resetSetting`.
+pub fn reset_setting<S: SettingsStore>(store: &mut S, key: &str, kd: &KeyDefaults) -> Setting {
+    store.delete(key);
+    Setting::new(key, kd.default_for(key))
+}
+
+/// The outcome of a batch reset: the keys reset and their resolved defaults.
+/// Mirror of TS `ResetResult`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResetResult {
+    /// Reset keys in declared/sorted order.
+    pub reset: Vec<String>,
+    /// Sorted key→default map for the reset keys.
+    pub settings: BTreeMap<String, String>,
+}
+
+/// RESET declared keys to their manifest defaults. `keys` omitted (or empty)
+/// resets ALL declared keys; otherwise only the supplied keys that are actually
+/// declared (unknown keys are ignored, never written). Mirror of TS
+/// `resetSettings`.
+pub fn reset_settings<S: SettingsStore>(
+    store: &mut S,
+    keys: Option<&[String]>,
+    kd: &KeyDefaults,
+) -> ResetResult {
+    let target: Vec<String> = match keys {
+        Some(supplied) if !supplied.is_empty() => supplied
+            .iter()
+            .filter(|key| kd.is_declared(key))
+            .cloned()
+            .collect(),
+        _ => kd.keys.clone(),
+    };
+
+    for key in &target {
+        store.delete(key);
+    }
+
+    let settings = target
+        .iter()
+        .map(|key| (key.clone(), kd.default_for(key)))
+        .collect();
+    ResetResult {
+        reset: target,
+        settings,
+    }
+}
+
+/// An in-memory [`SettingsStore`] — the test/non-DB binding, mirroring the role
+/// of the TS in-memory better-sqlite3 test handle. Backed by a [`BTreeMap`] so
+/// iteration is deterministic.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryStore {
+    rows: BTreeMap<String, String>,
+}
+
+impl MemoryStore {
+    /// An empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl SettingsStore for MemoryStore {
+    fn get(&self, key: &str) -> Option<String> {
+        self.rows.get(key).cloned()
+    }
+
+    fn get_bulk(&self, keys: &[String]) -> BTreeMap<String, String> {
+        keys.iter()
+            .filter_map(|key| self.rows.get(key).map(|value| (key.clone(), value.clone())))
+            .collect()
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        self.rows.insert(key.to_string(), value.to_string());
+    }
+
+    fn set_bulk(&mut self, entries: &[Setting]) {
+        for entry in entries {
+            self.rows.insert(entry.key.clone(), entry.value.clone());
+        }
+    }
+
+    fn delete(&mut self, key: &str) {
+        self.rows.remove(key);
+    }
+
+    fn ensure(&mut self, key: &str, value: &str) -> String {
+        self.rows
+            .entry(key.to_string())
+            .or_insert_with(|| value.to_string())
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{
+        derive_key_set, DeclaredSettingsField, DeclaredSettingsGroup, DeclaredSettingsManifest,
+    };
+
+    fn kd_abc() -> KeyDefaults {
+        derive_key_set(&[DeclaredSettingsManifest {
+            groups: vec![DeclaredSettingsGroup {
+                fields: vec![
+                    DeclaredSettingsField::new("a").with_default("da"),
+                    DeclaredSettingsField::new("b").with_default("db"),
+                    DeclaredSettingsField::new("c"),
+                ],
+            }],
+        }])
+    }
+
+    #[test]
+    fn get_or_null_returns_none_when_unset() {
+        let store = MemoryStore::new();
+        assert_eq!(get_or_null(&store, "a"), None);
+    }
+
+    #[test]
+    fn set_raw_then_get_returns_the_row() {
+        let mut store = MemoryStore::new();
+        assert_eq!(set_raw(&mut store, "a", "v"), Setting::new("a", "v"));
+        assert_eq!(get_or_null(&store, "a"), Some(Setting::new("a", "v")));
+    }
+
+    #[test]
+    fn get_bulk_omits_missing_and_dedupes() {
+        let mut store = MemoryStore::new();
+        set_raw(&mut store, "a", "va");
+        let keys = vec!["a".to_string(), "a".to_string(), "missing".to_string()];
+        let out = get_bulk(&store, &keys);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out["a"], "va");
+    }
+
+    #[test]
+    fn list_effective_resolves_override_then_default_then_empty() {
+        let mut store = MemoryStore::new();
+        set_raw(&mut store, "a", "override");
+        let out = list_effective(&store, &kd_abc());
+        assert_eq!(
+            out,
+            vec![
+                Setting::new("a", "override"),
+                Setting::new("b", "db"),
+                Setting::new("c", ""),
+            ]
+        );
+    }
+
+    #[test]
+    fn set_bulk_is_all_or_nothing_mirror() {
+        let mut store = MemoryStore::new();
+        let entries = vec![Setting::new("a", "1"), Setting::new("b", "2")];
+        let mirror = set_bulk(&mut store, &entries);
+        assert_eq!(mirror["a"], "1");
+        assert_eq!(mirror["b"], "2");
+        assert_eq!(store.get("a").as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn ensure_is_write_once() {
+        let mut store = MemoryStore::new();
+        assert_eq!(ensure(&mut store, "seed", "first").value, "first");
+        assert_eq!(
+            ensure(&mut store, "seed", "second").value,
+            "first",
+            "the first write wins; ensure never overwrites"
+        );
+    }
+
+    #[test]
+    fn reset_setting_deletes_override_and_returns_default() {
+        let mut store = MemoryStore::new();
+        set_raw(&mut store, "a", "override");
+        assert_eq!(
+            reset_setting(&mut store, "a", &kd_abc()),
+            Setting::new("a", "da")
+        );
+        assert_eq!(get_or_null(&store, "a"), None);
+    }
+
+    #[test]
+    fn reset_setting_is_idempotent_and_empty_default_when_undeclared_default() {
+        let mut store = MemoryStore::new();
+        let kd = kd_abc();
+        assert_eq!(reset_setting(&mut store, "a", &kd), Setting::new("a", "da"));
+        set_raw(&mut store, "c", "x");
+        assert_eq!(reset_setting(&mut store, "c", &kd), Setting::new("c", ""));
+    }
+
+    #[test]
+    fn reset_settings_resets_only_supplied_declared_keys() {
+        let mut store = MemoryStore::new();
+        set_raw(&mut store, "a", "oa");
+        set_raw(&mut store, "b", "ob");
+        let result = reset_settings(&mut store, Some(&["a".to_string()]), &kd_abc());
+        assert_eq!(result.reset, ["a"]);
+        assert_eq!(result.settings["a"], "da");
+        assert_eq!(get_or_null(&store, "a"), None);
+        assert_eq!(store.get("b").as_deref(), Some("ob"));
+    }
+
+    #[test]
+    fn reset_settings_resets_all_when_keys_omitted_or_empty() {
+        let kd = kd_abc();
+        for keys in [None, Some(Vec::new())] {
+            let mut store = MemoryStore::new();
+            set_raw(&mut store, "a", "oa");
+            let result = reset_settings(&mut store, keys.as_deref(), &kd);
+            assert_eq!(result.reset, ["a", "b", "c"]);
+            assert_eq!(result.settings["a"], "da");
+            assert_eq!(result.settings["b"], "db");
+            assert_eq!(result.settings["c"], "");
+        }
+    }
+
+    #[test]
+    fn reset_settings_ignores_unknown_keys() {
+        let mut store = MemoryStore::new();
+        set_raw(&mut store, "a", "oa");
+        let result = reset_settings(
+            &mut store,
+            Some(&["a".to_string(), "not-declared".to_string()]),
+            &kd_abc(),
+        );
+        assert_eq!(result.reset, ["a"]);
+        assert!(!result.settings.contains_key("not-declared"));
+    }
+}

--- a/crates/pops-settings/src/wire.rs
+++ b/crates/pops-settings/src/wire.rs
@@ -1,0 +1,112 @@
+//! The canonical wire shapes for the federated RU+reset settings surface.
+//!
+//! These are the Rust mirror of `@pops/pillar-settings`'s ts-rest contract
+//! response/request bodies (`contract.ts`). Every map output is a
+//! [`BTreeMap`] so the serialized key order is deterministic and sorted,
+//! matching the sorted-key JSON the shared golden fixture pins. HTTP JSON
+//! object key order is not semantically significant; sorted order is chosen so
+//! the Rust and TS sides produce comparable bytes.
+//!
+//! The cross-language golden-fixture test (`tests/contract.rs`) pins these
+//! shapes against the same fixture the TS `contract-fixture` test accepts.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A single persisted setting on the wire — `{ key, value }`. Mirror of the TS
+/// `SettingSchema`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct Setting {
+    pub key: String,
+    pub value: String,
+}
+
+impl Setting {
+    /// Convenience constructor used by the service and tests.
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// `GET /settings` response — the effective value for every declared key
+/// (sensitive redacted). Mirror of TS `{ data: SettingSchema[] }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct ListResponse {
+    pub data: Vec<Setting>,
+}
+
+/// `GET /settings/:key` response — a single setting, `null` when unset
+/// (sensitive redacted). Mirror of TS `{ data: SettingSchema | null }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct GetResponse {
+    pub data: Option<Setting>,
+}
+
+/// `POST /settings/get-many` request — batch-read keys. Mirror of TS
+/// `{ keys: string[] }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct GetManyRequest {
+    pub keys: Vec<String>,
+}
+
+/// `POST /settings/get-many` response — a sorted key→value map (missing keys
+/// omitted, sensitive redacted). Mirror of TS `{ settings: Record<string,
+/// string> }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct SettingsMapResponse {
+    pub settings: BTreeMap<String, String>,
+}
+
+/// `PUT /settings/:key` request body — the new value. Mirror of TS
+/// `{ value: string }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct SettingValueBody {
+    pub value: String,
+}
+
+/// `POST /settings/set-many` request — a transactional batch write. Mirror of
+/// TS `{ entries: SettingSchema[] }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct SetManyRequest {
+    pub entries: Vec<Setting>,
+}
+
+/// `POST /settings/reset` request — reset declared keys to defaults. `keys`
+/// omitted (or empty) resets ALL declared keys. Mirror of TS
+/// `{ keys?: string[] }`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, ToSchema)]
+pub struct ResetRequest {
+    /// Absent (or empty) ⇒ reset every declared key. Serialized only when
+    /// present, matching zod `.optional()`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub keys: Option<Vec<String>>,
+}
+
+/// Single-write/reset response — the resulting setting plus a human-readable
+/// message. Mirror of TS `{ data: SettingSchema, message: string }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct MutationResponse {
+    pub data: Setting,
+    pub message: String,
+}
+
+/// `POST /settings/:key/ensure` (internal) response — the seeded setting.
+/// Mirror of TS `{ data: SettingSchema }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct EnsureResponse {
+    pub data: Setting,
+}
+
+/// `POST /settings/reset` response — the reset keys (in declared/sorted order)
+/// and their resolved defaults. Mirror of TS
+/// `{ reset: string[], settings: Record<string, string> }`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct ResetResponse {
+    pub reset: Vec<String>,
+    pub settings: BTreeMap<String, String>,
+}

--- a/crates/pops-settings/tests/contract.rs
+++ b/crates/pops-settings/tests/contract.rs
@@ -1,0 +1,219 @@
+//! Cross-language golden-fixture parity tests for `pops-settings`.
+//!
+//! `tests/fixtures/settings.json` is the SHARED wire fixture: this test asserts
+//! every Rust wire type round-trips its section, while the TS side
+//! (`packages/pillar-settings/src/__tests__/contract-fixture.test.ts`) asserts
+//! the SAME fixture is contract-schema-clean. Together they pin one federated
+//! RU+reset wire across both languages.
+//!
+//! The fixture is authored in SORTED-key order. `serde_json::Map` is a
+//! `BTreeMap` here (no `preserve_order` feature), so re-serializing a parsed
+//! `Value` always emits sorted keys; the Rust wire structs declare their fields
+//! in alphabetical order and use `BTreeMap` for every map output, so a typed
+//! round-trip is byte-identical to the canonical sorted section. HTTP JSON
+//! object key order is not semantically significant; sorted order is the
+//! deterministic choice that lets the Rust and TS bytes be compared directly.
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+
+use pops_settings::{
+    GetResponse, ListResponse, MutationResponse, ResetResponse, Setting, SettingsMapResponse,
+    REDACTED,
+};
+
+const FIXTURE: &str = include_str!("fixtures/settings.json");
+
+/// Parse the shared fixture into its section map.
+fn sections() -> serde_json::Map<String, Value> {
+    serde_json::from_str::<Value>(FIXTURE)
+        .expect("fixture is valid JSON")
+        .as_object()
+        .expect("fixture is a JSON object of named sections")
+        .clone()
+}
+
+/// The canonical (sorted-key, compact) serialization of one fixture section —
+/// the bytes a byte-identical typed round-trip must reproduce.
+fn canonical(section: &str) -> String {
+    let value = sections()
+        .get(section)
+        .unwrap_or_else(|| panic!("fixture is missing section `{section}`"))
+        .clone();
+    serde_json::to_string(&value).expect("section re-serializes")
+}
+
+/// Deserialize a fixture section into `T`, re-serialize, and assert the bytes
+/// equal the canonical sorted form. This is the per-type wire pin.
+fn assert_round_trips<T: DeserializeOwned + Serialize>(section: &str) {
+    let canonical = canonical(section);
+    let typed: T = serde_json::from_str(&canonical)
+        .unwrap_or_else(|e| panic!("section `{section}` deserializes into the wire type: {e}"));
+    let reserialized = serde_json::to_string(&typed).expect("typed value re-serializes");
+    assert_eq!(
+        reserialized, canonical,
+        "section `{section}` must round-trip byte-for-byte against the shared sorted fixture"
+    );
+}
+
+#[test]
+fn setting_round_trips_byte_for_byte() {
+    assert_round_trips::<Setting>("setting");
+}
+
+#[test]
+fn list_response_round_trips_byte_for_byte() {
+    assert_round_trips::<ListResponse>("listResponse");
+}
+
+#[test]
+fn get_response_round_trips_byte_for_byte() {
+    assert_round_trips::<GetResponse>("getResponse");
+}
+
+#[test]
+fn get_response_null_round_trips_byte_for_byte() {
+    assert_round_trips::<GetResponse>("getResponseNull");
+}
+
+#[test]
+fn settings_map_response_round_trips_byte_for_byte() {
+    assert_round_trips::<SettingsMapResponse>("settingsMapResponse");
+}
+
+#[test]
+fn reset_response_round_trips_byte_for_byte() {
+    assert_round_trips::<ResetResponse>("resetResponse");
+}
+
+#[test]
+fn mutation_response_round_trips_byte_for_byte() {
+    assert_round_trips::<MutationResponse>("mutationResponse");
+}
+
+/// The unset single-read is the JSON `null`, NOT an omitted field or `{}` — the
+/// TS contract types `data` as `SettingSchema | null`.
+#[test]
+fn unset_get_is_explicit_null() {
+    let response: GetResponse = serde_json::from_str(&canonical("getResponseNull")).unwrap();
+    assert!(response.data.is_none());
+    assert_eq!(
+        serde_json::to_string(&response).unwrap(),
+        r#"{"data":null}"#
+    );
+}
+
+/// Sensitive values read back as the fixed `__redacted__` sentinel, byte-equal
+/// to the TS `REDACTED` constant — the read-side masking contract (OD-8).
+#[test]
+fn redaction_sentinel_is_byte_identical_to_ts() {
+    assert_eq!(REDACTED, "__redacted__");
+    let list: ListResponse = serde_json::from_str(&canonical("listResponse")).unwrap();
+    let masked = list
+        .data
+        .iter()
+        .find(|s| s.key == "finance.apiToken")
+        .expect("the sensitive key is present in the list");
+    assert_eq!(
+        masked.value, REDACTED,
+        "a sensitive value reads back as the shared sentinel"
+    );
+}
+
+/// Maps serialize in sorted key order (BTreeMap), so the fixture's map sections
+/// are already canonical — re-sorting them is a no-op.
+#[test]
+fn map_outputs_are_sorted() {
+    let map: SettingsMapResponse = serde_json::from_str(&canonical("settingsMapResponse")).unwrap();
+    let keys: Vec<&String> = map.settings.keys().collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "BTreeMap output is sorted-key deterministic");
+}
+
+/// The emitted OpenAPI document pins the DOT-form `settings.*` operationIds the
+/// TS ts-rest projection also emits, and carries NO create or delete verb.
+#[test]
+fn openapi_operation_ids_are_dot_form_and_complete() {
+    let doc = pops_settings::openapi::openapi_30_value();
+    let mut ids = std::collections::BTreeSet::new();
+    for methods in doc["paths"].as_object().expect("paths object").values() {
+        for op in methods.as_object().expect("method map").values() {
+            if let Some(id) = op.get("operationId").and_then(Value::as_str) {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+
+    for required in [
+        "settings.list",
+        "settings.get",
+        "settings.getMany",
+        "settings.set",
+        "settings.setMany",
+        "settings.resetKey",
+        "settings.reset",
+    ] {
+        assert!(
+            ids.contains(required),
+            "the document must carry the DOTTED operationId `{required}`; present: {ids:?}"
+        );
+    }
+
+    for id in &ids {
+        assert!(
+            id.contains('.'),
+            "operationId `{id}` is not dotted — hey-api would derive the wrong method name"
+        );
+        assert!(
+            id.starts_with("settings."),
+            "every settings operationId is namespaced `settings.<proc>`; got `{id}`"
+        );
+    }
+
+    for forbidden in ["settings.create", "settings.delete"] {
+        assert!(
+            !ids.contains(forbidden),
+            "the RU+reset surface has no `{forbidden}` verb"
+        );
+    }
+}
+
+/// The router wires the whole surface into a real axum `Router` once a store, a
+/// gate, and a principal are supplied — proving the generic bounds of
+/// `settings_router` / `SettingsState` line up end to end (not just that the
+/// handlers compile in isolation).
+#[test]
+fn settings_router_binds_into_a_real_axum_app() {
+    use std::sync::{Arc, Mutex};
+
+    use pops_settings::{
+        derive_key_set, settings_router, DeclaredSettingsField, DeclaredSettingsGroup,
+        DeclaredSettingsManifest, MemoryStore, SettingsGate, SettingsHandlers, SettingsState,
+    };
+
+    struct AllowAll;
+    impl SettingsGate for AllowAll {
+        type Principal = String;
+        type Denied = ();
+        fn check(&self, _principal: &String, _scope: &str) -> Result<(), ()> {
+            Ok(())
+        }
+    }
+
+    let kd = derive_key_set(&[DeclaredSettingsManifest {
+        groups: vec![DeclaredSettingsGroup {
+            fields: vec![DeclaredSettingsField::new("theme").with_default("light")],
+        }],
+    }]);
+    let handlers = SettingsHandlers::new(MemoryStore::new(), kd, "contacts.settings", AllowAll);
+    let state = SettingsState {
+        handlers: Arc::new(Mutex::new(handlers)),
+        principal: "admin".to_string(),
+    };
+
+    let app: axum::Router = settings_router::<MemoryStore, AllowAll>().with_state(state);
+    // Binding `with_state` to a unit router collapses the generic surface into a
+    // concrete `Router<()>`; reaching this line means the full mount type-checks.
+    let _ = app;
+}

--- a/crates/pops-settings/tests/fixtures/settings.json
+++ b/crates/pops-settings/tests/fixtures/settings.json
@@ -1,0 +1,23 @@
+{
+  "getResponse": { "data": { "key": "theme", "value": "dark" } },
+  "getResponseNull": { "data": null },
+  "listResponse": {
+    "data": [
+      { "key": "core.appName", "value": "POPS" },
+      { "key": "finance.apiToken", "value": "__redacted__" },
+      { "key": "theme", "value": "dark" }
+    ]
+  },
+  "mutationResponse": {
+    "data": { "key": "theme", "value": "dark" },
+    "message": "Setting saved"
+  },
+  "resetResponse": {
+    "reset": ["core.appName", "finance.apiToken", "theme"],
+    "settings": { "core.appName": "POPS", "finance.apiToken": "", "theme": "light" }
+  },
+  "setting": { "key": "theme", "value": "dark" },
+  "settingsMapResponse": {
+    "settings": { "core.appName": "POPS", "finance.apiToken": "__redacted__", "theme": "dark" }
+  }
+}

--- a/packages/ai-telemetry/src/__tests__/fixtures/record.json
+++ b/packages/ai-telemetry/src/__tests__/fixtures/record.json
@@ -1,0 +1,1 @@
+{"provider":"anthropic","model":"claude-haiku-4-5","operation":"imports.categorize","domain":"finance","inputTokens":1280,"outputTokens":640,"costUsd":0.0048,"latencyMs":742,"status":"budget-blocked","cached":true,"contextId":"import_batch:42","promptVersion":"v3","errorMessage":"upstream 529 overloaded","metadata":{"backfilled_from":"food","prompt_version":"v3"}}

--- a/packages/ai-telemetry/src/__tests__/record-fixture.test.ts
+++ b/packages/ai-telemetry/src/__tests__/record-fixture.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { InferenceRecordSchema } from '../record-schema.js';
+
+/**
+ * Cross-language golden-fixture parity test.
+ *
+ * `fixtures/record.json` is the SHARED wire fixture — byte-identical to
+ * `crates/pops-ai/tests/fixtures/record.json`. The Rust contract test asserts
+ * its `InferenceRecord` round-trips these exact bytes; here we assert the TS
+ * schema (a) accepts the same bytes and (b) re-serializes (compact) back to
+ * them. Together they pin ONE wire across both languages: any camelCase /
+ * kebab-case-enum / field-order drift fails on one side or the other.
+ */
+const fixturePath = fileURLToPath(new URL('./fixtures/record.json', import.meta.url));
+const fixtureBytes = readFileSync(fixturePath, 'utf8').trimEnd();
+
+describe('InferenceRecord golden fixture (Rust ↔ TS parity)', () => {
+  it('parses the shared fixture clean', () => {
+    const parsed = InferenceRecordSchema.safeParse(JSON.parse(fixtureBytes));
+    expect(parsed.success).toBe(true);
+  });
+
+  it('round-trips to the same compact bytes the Rust crate serializes', () => {
+    const record = InferenceRecordSchema.parse(JSON.parse(fixtureBytes));
+    // zod builds the output object in schema-declaration order, which matches
+    // the fixture's key order (the Rust struct field order). Compact
+    // JSON.stringify must therefore reproduce the fixture byte-for-byte.
+    expect(JSON.stringify(record)).toBe(fixtureBytes);
+  });
+
+  it('pins the widened status + camelCase token keys the wire carries', () => {
+    const record = InferenceRecordSchema.parse(JSON.parse(fixtureBytes));
+    expect(record.status).toBe('budget-blocked');
+    expect(record.inputTokens).toBe(1280);
+    expect(record.outputTokens).toBe(640);
+    expect(record.contextId).toBe('import_batch:42');
+  });
+});

--- a/packages/pillar-settings/src/__tests__/contract-fixture.test.ts
+++ b/packages/pillar-settings/src/__tests__/contract-fixture.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { makeSettingsContract } from '../contract.js';
+import { REDACTED } from '../redact.js';
+import fixture from './settings.fixture.json' with { type: 'json' };
+
+/**
+ * Cross-language golden-fixture parity test.
+ *
+ * `settings.fixture.json` is the SHARED wire fixture — byte-identical to
+ * `crates/pops-settings/tests/fixtures/settings.json`. The Rust contract test
+ * asserts each section round-trips its typed wire struct byte-for-byte; this
+ * test asserts the SAME fixture is contract-schema-clean on the TS side.
+ * Together they pin one federated RU+reset wire across both languages.
+ *
+ * This side is deliberately tolerant of compact JSON and key order (zod
+ * `.parse` ignores both) — the byte-level pin lives on the Rust side, where
+ * `serde_json` re-emits sorted keys. What this test guards is that every
+ * section the Rust types accept is ALSO valid under the authoritative ts-rest
+ * contract schemas, so neither language can drift the shape unilaterally.
+ */
+const errors = { 401: z.object({ message: z.string() }) };
+const contract = makeSettingsContract(['theme', 'core.appName', 'finance.apiToken'], errors);
+
+/** Pull a route's 200-response schema off the built contract. */
+function okResponse(route: keyof typeof contract): z.ZodType {
+  return (contract[route].responses as Record<number, z.ZodType>)[200];
+}
+
+describe('shared settings wire fixture', () => {
+  it('validates `setting` against the SettingSchema element', () => {
+    const SettingSchema = z.object({ key: z.string(), value: z.string() });
+    expect(() => SettingSchema.parse(fixture.setting)).not.toThrow();
+  });
+
+  it('validates `listResponse` against the list 200 response', () => {
+    expect(() => okResponse('list').parse(fixture.listResponse)).not.toThrow();
+  });
+
+  it('validates `getResponse` and the explicit-null `getResponseNull`', () => {
+    expect(() => okResponse('get').parse(fixture.getResponse)).not.toThrow();
+    expect(() => okResponse('get').parse(fixture.getResponseNull)).not.toThrow();
+    expect(fixture.getResponseNull.data).toBeNull();
+  });
+
+  it('validates `settingsMapResponse` against the get-many 200 response', () => {
+    expect(() => okResponse('getMany').parse(fixture.settingsMapResponse)).not.toThrow();
+  });
+
+  it('validates `resetResponse` against the reset 200 response', () => {
+    expect(() => okResponse('reset').parse(fixture.resetResponse)).not.toThrow();
+  });
+
+  it('validates `mutationResponse` against the set 200 response', () => {
+    expect(() => okResponse('set').parse(fixture.mutationResponse)).not.toThrow();
+  });
+
+  it('carries the `__redacted__` sentinel byte-identical to the Rust REDACTED constant', () => {
+    expect(REDACTED).toBe('__redacted__');
+    const masked = fixture.listResponse.data.find((s) => s.key === 'finance.apiToken');
+    expect(masked?.value).toBe(REDACTED);
+    expect(fixture.settingsMapResponse.settings['finance.apiToken']).toBe(REDACTED);
+  });
+
+  it('exposes no create or delete verb (parity with the Rust operationId set)', () => {
+    expect(contract).not.toHaveProperty('create');
+    expect(contract).not.toHaveProperty('delete');
+    expect(Object.keys(contract).toSorted()).toEqual(
+      ['ensure', 'get', 'getMany', 'list', 'reset', 'resetKey', 'set', 'setMany'].toSorted()
+    );
+  });
+});

--- a/packages/pillar-settings/src/__tests__/settings.fixture.json
+++ b/packages/pillar-settings/src/__tests__/settings.fixture.json
@@ -1,0 +1,23 @@
+{
+  "getResponse": { "data": { "key": "theme", "value": "dark" } },
+  "getResponseNull": { "data": null },
+  "listResponse": {
+    "data": [
+      { "key": "core.appName", "value": "POPS" },
+      { "key": "finance.apiToken", "value": "__redacted__" },
+      { "key": "theme", "value": "dark" }
+    ]
+  },
+  "mutationResponse": {
+    "data": { "key": "theme", "value": "dark" },
+    "message": "Setting saved"
+  },
+  "resetResponse": {
+    "reset": ["core.appName", "finance.apiToken", "theme"],
+    "settings": { "core.appName": "POPS", "finance.apiToken": "", "theme": "light" }
+  },
+  "setting": { "key": "theme", "value": "dark" },
+  "settingsMapResponse": {
+    "settings": { "core.appName": "POPS", "finance.apiToken": "__redacted__", "theme": "dark" }
+  }
+}


### PR DESCRIPTION
Adds two standalone Rust library crates to the `crates/` workspace, each a 1:1 mirror of an existing TS package's HTTP wire contract, pinned cross-language by a shared golden fixture. Neither is wired into a consumer yet (the contacts Rust pillar will adopt both) — they ship compiled + tested-but-unused.

## `crates/pops-ai` (already on this branch)
Rust mirror of `@pops/ai-telemetry`'s inference-record wire contract: `InferenceRecord` (serde camelCase, kebab-case status enum), the `call_with_logging` wrappers, cost math, the `ReportSink` trait + best-effort `EnvHttpSink`, and the HTTP pricing adapter. Parity pinned by `tests/contract.rs` round-tripping `tests/fixtures/record.json` byte-for-byte against the TS-accepted shape.

## `crates/pops-settings` (this change)
Rust mirror of `@pops/pillar-settings`'s federated RU+reset settings surface (`docs/plans/02-settings-federation.md` §4.4/§4.6, US-S6):

- **Wire types** (`Setting` + per-route bodies) byte-identical to the ts-rest contract. Every map output is a `BTreeMap` (sorted, deterministic) — HTTP JSON object key order is not semantically significant.
- **Surface:** get / get-many / set / set-many / reset (single `resetKey` + batch `reset`) / list, plus the internal-only `ensure` write-once seed. **No create verb, no delete verb** (DELETE = reset alias).
- **Read-side redaction** to the `__redacted__` sentinel (byte-identical to TS `REDACTED`); writes are never redacted.
- **Storage-agnostic** service over an injected `SettingsStore` trait (+ an in-memory store for tests); manifest→key-authority derivation (`derive_key_set`); a gated, pillar-agnostic `SettingsHandlers`; and an axum `settings_router`.
- **utoipa `operation_id` pinned to the DOT-form** — `settings.list/get/getMany/set/setMany/resetKey/reset` (+ `settings.ensure`), NOT camelCase — so the contacts pillar's generated hey-api client derives identical method names to every TS pillar (mustFix #2 / crossPlanConflict #1). OpenAPI emitted as 3.0.3 (3.1→3.0 downgrade pass, incl. `Option<Object>` `oneOf`-null → `nullable` + `allOf`).

## Cross-language parity approach
Each crate round-trips a **shared sorted-key JSON fixture** in `tests/contract.rs`; the same fixture is mirrored on the TS side with a matching, compact-/key-order-tolerant test (`record-fixture.test.ts` for ai-telemetry; new `contract-fixture.test.ts` for pillar-settings) that validates it against the authoritative zod/ts-rest schemas. Either language drifting the wire shape fails its side.

## Standalone
Both crates are workspace members with no in-tree consumer; the contacts pillar mounts them later. `crates/Cargo.lock` is committed. Also adds `crates/*/tests/fixtures/*.json` to the oxfmt ignore set so the byte-locked Rust parity fixtures stay compact and the repo-wide format gate passes.

## Verification (all green locally)
- Rust: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-targets`, `cargo test --all` — including both crates' parity tests and the contacts OpenAPI drift gate (no drift).
- TS: `turbo typecheck test --filter=@pops/pillar-settings --filter=@pops/ai-telemetry` green; `pnpm lint` (oxlint --type-aware) exit 0; `oxfmt --check` clean repo-wide.