### PR TITLE
feat(contacts): registry self-registration + Dockerfile + compose [N2/deploy]

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -201,6 +201,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http-body-util",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -419,6 +419,47 @@ services:
       pops-redis:
         condition: service_healthy
 
+  # Contacts pillar API — the first Rust pillar (axum + sqlx + utoipa).
+  # Authoritative entities store; nginx routes /contacts-api/ here on port
+  # 3010. Built from its hand-written multi-stage Rust Dockerfile. Unlike the
+  # TS pillars it self-registers via POPS_REGISTRY_ENABLED=true: its Rust
+  # registry transport POSTs the register/heartbeat/deregister envelopes to
+  # core, trying the canonical /registry/* path then the legacy
+  # /core.registry.* path on a 404.
+  contacts-api:
+    build:
+      context: ..
+      dockerfile: pillars/contacts/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-contacts
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      PORT: '3010'
+      CONTACTS_SQLITE_PATH: /data/sqlite/contacts.db
+      CONTACTS_SELF_BASE_URL: http://contacts-api:3010
+      # Opt in to registry self-registration (the Rust lifecycle is gated on
+      # this, mirroring the TS SDK's POPS_REGISTRY_ENABLED).
+      POPS_REGISTRY_ENABLED: 'true'
+      POPS_REGISTRY_URL: ${POPS_REGISTRY_URL:-http://core-api:3001}
+      POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006}
+    expose:
+      - '3010'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:3010/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   # Cross-pillar orchestrator (ADR-029, epics 06+07). Federates over the
   # pillars via @pops/pillar-sdk (REST); owns no domain DB. nginx routes
   # /orchestrator-api/ here on port 3009. Built from the app Dockerfile;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -507,6 +507,51 @@ services:
       pops-redis:
         condition: service_healthy
 
+  # Contacts pillar API — the first Rust pillar (axum + sqlx + utoipa).
+  # Authoritative entities store; nginx routes /contacts-api/ here on port
+  # 3010. The `image:` pin + the hand-written pillars/contacts/Dockerfile
+  # auto-enroll it in publish-images.yml discovery (no workflow edit). Unlike
+  # the TS pillars it self-registers via POPS_REGISTRY_ENABLED=true: its Rust
+  # registry transport POSTs the register/heartbeat/deregister envelopes to
+  # core, trying the canonical /registry/* path then the legacy
+  # /core.registry.* path on a 404.
+  contacts-api:
+    build:
+      context: ..
+      dockerfile: pillars/contacts/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    image: ghcr.io/knoxio/pops-contacts:${POPS_IMAGE_TAG:-main}
+    container_name: pops-contacts
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      PORT: '3010'
+      CONTACTS_SQLITE_PATH: /data/sqlite/contacts.db
+      CONTACTS_SELF_BASE_URL: http://contacts-api:3010
+      # Opt in to registry self-registration (the Rust lifecycle is gated on
+      # this, mirroring the TS SDK's POPS_REGISTRY_ENABLED).
+      POPS_REGISTRY_ENABLED: 'true'
+      POPS_REGISTRY_URL: ${POPS_REGISTRY_URL:-http://core-api:3001}
+      POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006}
+    expose:
+      - '3010'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:3010/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   # Cross-pillar orchestrator (ADR-029, epics 06+07). Federates over the
   # pillars via @pops/pillar-sdk (REST); owns no domain DB. nginx routes
   # /orchestrator-api/ here on port 3009. Built from the app Dockerfile;

--- a/infra/litestream/contacts.yml
+++ b/infra/litestream/contacts.yml
@@ -1,0 +1,30 @@
+## Litestream replication config — contacts pillar SQLite.
+##
+## Contacts is the first Rust pillar (ADR-026 per-pillar DB model). Mirrors
+## the per-pillar pattern so each pillar's database streams independently of
+## the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${CONTACTS_LITESTREAM_REPLICA_URL}`
+## style placeholder here.
+##
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/contacts.db "${CONTACTS_LITESTREAM_REPLICA_URL}"
+## Stop the contacts-api container first so it isn't writing
+## concurrently; the drill is exercised in the deploy-readiness verification.
+
+dbs:
+  - path: /data/sqlite/contacts.db
+    replicas:
+      - url: ${CONTACTS_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h

--- a/pillars/contacts/Cargo.toml
+++ b/pillars/contacts/Cargo.toml
@@ -29,6 +29,7 @@ sqlx = { workspace = true }
 utoipa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/pillars/contacts/Dockerfile
+++ b/pillars/contacts/Dockerfile
@@ -1,0 +1,95 @@
+# Hand-written multi-stage build for the contacts pillar — the FIRST Rust
+# pillar, and the reference Dockerfile every future Rust pillar copies.
+#
+# Build context is the REPO ROOT (publish-images.yml + pillar-quality.yml both
+# pass `context: .`), so COPY paths are repo-relative. The cargo workspace root
+# lives at `crates/` and the member crate at `pillars/contacts`; both must be
+# present for `cargo build -p contacts` to resolve the workspace.
+#
+# The contacts crate uses sqlx's RUNTIME query API (see
+# pillars/contacts/src/entities/repo.rs), so there is NO `.sqlx/` offline cache
+# and NO build-time DATABASE_URL — the image builds fully offline. Migrations
+# are embedded into the binary at compile time via `sqlx::migrate!`, so the
+# runtime image needs neither the migrations directory nor sqlx-cli.
+
+FROM rust:1-slim AS builder
+WORKDIR /build
+
+# System deps for the build: rustls pulls its own crypto (no OpenSSL), so only
+# the basics are needed. `pkg-config`/`libssl` are intentionally omitted.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workspace + member manifests first so a dependency-only layer caches across
+# source-only changes. The workspace declares pops-ai / pops-settings members;
+# copy their manifests too so `cargo` can parse the workspace graph (a member
+# missing its Cargo.toml fails workspace resolution even when we build only
+# `-p contacts`).
+COPY crates/Cargo.toml crates/Cargo.lock ./crates/
+COPY crates/pops-ai/Cargo.toml ./crates/pops-ai/
+COPY crates/pops-settings/Cargo.toml ./crates/pops-settings/
+COPY pillars/contacts/Cargo.toml ./pillars/contacts/
+
+# Stub sources so the dependency layer compiles without the real code. Each
+# member needs a lib target to satisfy its manifest; contacts also declares two
+# bins. Building here warms the registry-download cache (the slow part);
+# `--mount=type=cache` keeps it across builds.
+RUN mkdir -p crates/pops-ai/src crates/pops-settings/src \
+        pillars/contacts/src pillars/contacts/src/bin \
+    && echo '' > crates/pops-ai/src/lib.rs \
+    && echo '' > crates/pops-settings/src/lib.rs \
+    && echo '' > pillars/contacts/src/lib.rs \
+    && echo 'fn main() {}' > pillars/contacts/src/main.rs \
+    && echo 'fn main() {}' > pillars/contacts/src/bin/emit_openapi.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --manifest-path crates/Cargo.toml -p contacts || true
+
+# Real sources. The contacts crate's own build artifacts from the stub layer
+# are stale (they compiled the empty stub lib/main), and cargo fingerprints by
+# mtime — so purge the contacts crate's artifacts to force a clean recompile of
+# the crate against the real source. The (cached, slow) dependency artifacts in
+# `target/release/deps` for third-party crates are untouched, so the rebuild is
+# still fast.
+COPY pillars/contacts/migrations ./pillars/contacts/migrations
+COPY pillars/contacts/openapi ./pillars/contacts/openapi
+COPY pillars/contacts/src ./pillars/contacts/src
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    rm -rf crates/target/release/contacts \
+        crates/target/release/deps/contacts-* \
+        crates/target/release/.fingerprint/contacts-* \
+    && cargo build --release --manifest-path crates/Cargo.toml -p contacts --bin contacts
+
+FROM debian:bookworm-slim AS runtime
+WORKDIR /app
+
+# curl for the compose/Docker healthcheck; ca-certificates so the registry
+# handshake over HTTPS (if the registry URL is https) verifies. A non-root
+# user mirrors the TS pillars' `USER node`.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system contacts \
+    && useradd --system --gid contacts --home /app --no-create-home contacts \
+    && mkdir -p /data/sqlite \
+    && chown -R contacts:contacts /data
+
+COPY --from=builder /build/crates/target/release/contacts /app/contacts
+
+# Watchtower injects the git SHA as BUILD_VERSION; the binary coerces a
+# non-semver value to 0.0.0-sha.<7> for the manifest.
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+# Default the DB onto the writable, chowned volume mount so the image boots
+# standalone (the non-root user can't write the WORKDIR). Compose overrides
+# this with the same path; the value is here so `docker run` works with no env.
+ENV CONTACTS_SQLITE_PATH=/data/sqlite/contacts.db
+
+EXPOSE 3010
+USER contacts
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD curl -fsS http://localhost:3010/health || exit 1
+
+CMD ["/app/contacts"]

--- a/pillars/contacts/Dockerfile
+++ b/pillars/contacts/Dockerfile
@@ -31,10 +31,13 @@ COPY crates/pops-ai/Cargo.toml ./crates/pops-ai/
 COPY crates/pops-settings/Cargo.toml ./crates/pops-settings/
 COPY pillars/contacts/Cargo.toml ./pillars/contacts/
 
-# Stub sources so the dependency layer compiles without the real code. Each
-# member needs a lib target to satisfy its manifest; contacts also declares two
-# bins. Building here warms the registry-download cache (the slow part);
-# `--mount=type=cache` keeps it across builds.
+# Stub sources so the dependency layer compiles the third-party crate graph
+# without the real source. Each member needs a lib target to satisfy its
+# manifest; contacts also declares two bins. The stub lib is empty and the
+# stub bins are trivial `fn main() {}`, so this build genuinely SUCCEEDS — it
+# compiles every dependency (the slow part, cached via `--mount=type=cache`)
+# plus a trivial crate. No `|| true`: a broken dependency graph fails here
+# loudly instead of being masked.
 RUN mkdir -p crates/pops-ai/src crates/pops-settings/src \
         pillars/contacts/src pillars/contacts/src/bin \
     && echo '' > crates/pops-ai/src/lib.rs \
@@ -43,14 +46,13 @@ RUN mkdir -p crates/pops-ai/src crates/pops-settings/src \
     && echo 'fn main() {}' > pillars/contacts/src/main.rs \
     && echo 'fn main() {}' > pillars/contacts/src/bin/emit_openapi.rs
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --manifest-path crates/Cargo.toml -p contacts || true
+    cargo build --release --manifest-path crates/Cargo.toml -p contacts
 
-# Real sources. The contacts crate's own build artifacts from the stub layer
-# are stale (they compiled the empty stub lib/main), and cargo fingerprints by
-# mtime — so purge the contacts crate's artifacts to force a clean recompile of
-# the crate against the real source. The (cached, slow) dependency artifacts in
-# `target/release/deps` for third-party crates are untouched, so the rebuild is
-# still fast.
+# Real sources. The contacts crate's own artifacts from the stub layer compiled
+# the empty stub lib/main, and cargo fingerprints by mtime — so purge the
+# contacts crate's artifacts to force a clean recompile against the real source.
+# The (cached, slow) third-party dependency artifacts in `target/release/deps`
+# are untouched, so the rebuild is still fast.
 COPY pillars/contacts/migrations ./pillars/contacts/migrations
 COPY pillars/contacts/openapi ./pillars/contacts/openapi
 COPY pillars/contacts/src ./pillars/contacts/src

--- a/pillars/contacts/src/config.rs
+++ b/pillars/contacts/src/config.rs
@@ -21,23 +21,45 @@ pub const DEFAULT_SQLITE_PATH: &str = "contacts.db";
 /// release overrides `BUILD_VERSION` with a semver or git SHA.
 pub const DEFAULT_VERSION: &str = "0.0.0-dev";
 
+/// Registry base URL used when neither `POPS_REGISTRY_URL` nor `CORE_URL` is
+/// set. Matches the TS SDK fallback (`bootstrap/bootstrap.ts`) and the
+/// `core-api` compose service name.
+pub const DEFAULT_REGISTRY_URL: &str = "http://core-api:3001";
+
 /// Resolved configuration for one process lifetime.
 #[derive(Debug, Clone)]
 pub struct Config {
     pub port: u16,
     pub sqlite_path: String,
     pub version: String,
+    /// Whether to attempt registry self-registration on boot. Mirrors the TS
+    /// pillars' opt-in `POPS_REGISTRY_ENABLED=true` gate — off by default so
+    /// local/test runs never reach out to a registry.
+    pub registry_enabled: bool,
+    /// Registry base origin contacts registers/heartbeats/deregisters against
+    /// (`POPS_REGISTRY_URL`, then `CORE_URL`, then [`DEFAULT_REGISTRY_URL`]).
+    pub registry_url: String,
+    /// The base URL the registry records for this pillar — the origin other
+    /// services dial to reach `/health`, `/uri/resolve`, etc. Persisted as the
+    /// `PillarRegistryEntry.baseUrl`.
+    pub self_base_url: String,
 }
 
 impl Config {
     /// Resolve configuration from the process environment, falling back to
     /// the module defaults for any unset or unparseable value.
     pub fn from_env() -> Self {
+        let port = resolve_port();
         Self {
-            port: resolve_port(),
+            port,
             sqlite_path: env::var("CONTACTS_SQLITE_PATH")
                 .unwrap_or_else(|_| DEFAULT_SQLITE_PATH.to_string()),
             version: env::var("BUILD_VERSION").unwrap_or_else(|_| DEFAULT_VERSION.to_string()),
+            registry_enabled: env::var("POPS_REGISTRY_ENABLED")
+                .map(|raw| raw.trim() == "true")
+                .unwrap_or(false),
+            registry_url: resolve_registry_url(),
+            self_base_url: resolve_self_base_url(port),
         }
     }
 
@@ -55,17 +77,54 @@ fn resolve_port() -> u16 {
     }
 }
 
+/// `POPS_REGISTRY_URL` → `CORE_URL` → [`DEFAULT_REGISTRY_URL`], trailing
+/// slashes stripped so path concatenation in the transport is clean.
+fn resolve_registry_url() -> String {
+    let raw = first_non_empty_env(&["POPS_REGISTRY_URL", "CORE_URL"])
+        .unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string());
+    strip_trailing_slashes(&raw)
+}
+
+/// `CONTACTS_SELF_BASE_URL` → `http://localhost:<port>` fallback, trailing
+/// slashes stripped.
+fn resolve_self_base_url(port: u16) -> String {
+    let raw = first_non_empty_env(&["CONTACTS_SELF_BASE_URL"])
+        .unwrap_or_else(|| format!("http://localhost:{port}"));
+    strip_trailing_slashes(&raw)
+}
+
+/// First env var in `names` set to a non-blank value, trimmed.
+fn first_non_empty_env(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        env::var(name)
+            .ok()
+            .map(|raw| raw.trim().to_string())
+            .filter(|raw| !raw.is_empty())
+    })
+}
+
+fn strip_trailing_slashes(value: &str) -> String {
+    value.trim_end_matches('/').to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn database_url_targets_the_resolved_path_in_rwc_mode() {
-        let config = Config {
+    fn sample_config() -> Config {
+        Config {
             port: DEFAULT_PORT,
             sqlite_path: "/tmp/contacts.db".to_string(),
             version: DEFAULT_VERSION.to_string(),
-        };
+            registry_enabled: false,
+            registry_url: DEFAULT_REGISTRY_URL.to_string(),
+            self_base_url: "http://localhost:3010".to_string(),
+        }
+    }
+
+    #[test]
+    fn database_url_targets_the_resolved_path_in_rwc_mode() {
+        let config = sample_config();
         assert_eq!(config.database_url(), "sqlite:///tmp/contacts.db?mode=rwc");
     }
 
@@ -74,5 +133,21 @@ mod tests {
         assert_ne!(DEFAULT_PORT, 3008, "3008 is the ai pillar");
         assert_ne!(DEFAULT_PORT, 3009, "3009 is the orchestrator");
         assert_eq!(DEFAULT_PORT, 3010);
+    }
+
+    #[test]
+    fn strip_trailing_slashes_normalises_origins() {
+        assert_eq!(
+            strip_trailing_slashes("http://core-api:3001/"),
+            "http://core-api:3001"
+        );
+        assert_eq!(
+            strip_trailing_slashes("http://core-api:3001///"),
+            "http://core-api:3001"
+        );
+        assert_eq!(
+            strip_trailing_slashes("http://core-api:3001"),
+            "http://core-api:3001"
+        );
     }
 }

--- a/pillars/contacts/src/lib.rs
+++ b/pillars/contacts/src/lib.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod db;
 pub mod entities;
 pub mod health;
+pub mod manifest;
 pub mod openapi;
+pub mod registry;
 pub mod search;
 pub mod time;

--- a/pillars/contacts/src/main.rs
+++ b/pillars/contacts/src/main.rs
@@ -1,15 +1,24 @@
 //! Contacts pillar entry point.
 //!
-//! N0 boots a minimal-but-real axum server: env-resolved port + SQLite path,
-//! a migrated pool, and the `/`, `/health`, `/openapi` surface. The registry
-//! lifecycle (register / heartbeat / deregister) and the entities domain land
-//! in later nodes — see the TODO below.
+//! Boots a real axum server: env-resolved port + SQLite path, a migrated pool,
+//! and the `/`, `/health`, `/openapi`, entities and search surface. When
+//! `POPS_REGISTRY_ENABLED=true` it also spawns the registry lifecycle
+//! (register-with-backoff, 10s heartbeat, deregister on SIGTERM/SIGINT) against
+//! `POPS_REGISTRY_URL`/`CORE_URL` — the reference Rust self-registration.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use contacts::app::{build_router, AppState};
 use contacts::config::Config;
 use contacts::db;
+use contacts::manifest::build_contacts_manifest;
+use contacts::registry::{
+    coerce_manifest_version, lifecycle::LifecycleConfig, spawn_lifecycle, HttpRegistryTransport,
+    LifecycleHandle,
+};
+
+const PILLAR_ID: &str = "contacts";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -30,14 +39,82 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let router = build_router(state);
 
-    // TODO(contacts N2): spawn the registry lifecycle task here
-    // (register-with-retry, 10s heartbeat, deregister on SIGTERM) against
-    // POPS_REGISTRY_URL once the Rust registry transport lands. N0 ships no
-    // self-registration — contacts is not yet a registry member.
+    let lifecycle = maybe_spawn_registry(&config);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!(%addr, "contacts pillar listening");
-    axum::serve(listener, router).await?;
+
+    // Graceful shutdown drains in-flight requests on the first SIGTERM/SIGINT;
+    // the lifecycle then deregisters best-effort so core drops the route
+    // immediately rather than waiting for the missed-heartbeat eviction.
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    if let Some(handle) = lifecycle {
+        handle.stop().await;
+    }
+
+    tracing::info!("contacts pillar stopped");
     Ok(())
+}
+
+/// Spawn the registry lifecycle when opted-in. Best-effort: a missing/broken
+/// registry never blocks boot — registration retries in the background and the
+/// server serves its surface regardless.
+fn maybe_spawn_registry(config: &Config) -> Option<LifecycleHandle> {
+    if !config.registry_enabled {
+        tracing::info!("POPS_REGISTRY_ENABLED is not 'true' — contacts will not self-register");
+        return None;
+    }
+
+    let version = coerce_manifest_version(&config.version);
+    let manifest = build_contacts_manifest(&version);
+    let transport = Arc::new(HttpRegistryTransport::new(config.registry_url.clone()));
+
+    tracing::info!(
+        registry = %config.registry_url,
+        self_base_url = %config.self_base_url,
+        "registering contacts with the core registry"
+    );
+
+    Some(spawn_lifecycle(
+        transport,
+        config.self_base_url.clone(),
+        manifest,
+        PILLAR_ID.to_string(),
+        LifecycleConfig::default(),
+    ))
+}
+
+/// Resolve when the process receives SIGTERM (Watchtower/compose stop) or
+/// SIGINT (Ctrl-C in local dev).
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut stream) => {
+                stream.recv().await;
+            }
+            Err(err) => {
+                tracing::warn!(%err, "could not install SIGTERM handler; relying on SIGINT only");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+
+    tracing::info!("shutdown signal received");
 }

--- a/pillars/contacts/src/manifest.rs
+++ b/pillars/contacts/src/manifest.rs
@@ -1,0 +1,151 @@
+//! The contacts pillar's registry manifest — the static capability document
+//! pushed to core in the register envelope and re-served in the discovery
+//! snapshot.
+//!
+//! It is byte-shape-compatible with the TS `ManifestPayloadSchema`
+//! (`packages/pillar-sdk/src/manifest-schema/schema.ts`), which core runs
+//! `validateManifestPayload` against on register — a rejected manifest fails
+//! boot loudly (the register call returns a non-retriable 400). Two grammars
+//! are deliberately distinct and must not be conflated:
+//!
+//!   - manifest `routes[*]` / `search.adapters[*].procedurePath` use the
+//!     THREE-segment `<pillar>.<router>.<procedure>` form
+//!     (`contacts.entities.list`, `contacts.search.search`);
+//!   - the OpenAPI `operation_id` uses the TWO-segment `<router>.<procedure>`
+//!     form (`entities.list`, `search.search`) — emitted by the entities/search
+//!     route handlers, not here.
+//!
+//! Settings declare an empty manifest set until the shared `pops-settings`
+//! crate lands (a later node); contacts is a first-class registry member
+//! without a settings panel.
+
+use serde_json::{json, Value};
+
+/// Build the contacts manifest as a `serde_json::Value` matching
+/// `ManifestPayloadSchema`. `version` is the already-coerced semver
+/// (see [`crate::registry::coerce_manifest_version`]); the contract block
+/// derives its `version`/`tag` from the same value.
+pub fn build_contacts_manifest(version: &str) -> Value {
+    json!({
+        "pillar": "contacts",
+        "version": version,
+        "contract": {
+            "package": "@pops/contacts",
+            "version": version,
+            "tag": format!("contract-contacts@v{version}"),
+        },
+        "routes": {
+            "queries": [
+                "contacts.entities.list",
+                "contacts.entities.get",
+                "contacts.search.search",
+            ],
+            "mutations": [
+                "contacts.entities.create",
+                "contacts.entities.update",
+                "contacts.entities.delete",
+            ],
+            "subscriptions": [],
+        },
+        "search": {
+            "adapters": [
+                {
+                    "name": "contacts",
+                    "entityType": "contact",
+                    "queryShape": {
+                        "supportsText": true,
+                        "supportsTags": false,
+                        "supportsDateRange": false,
+                        "supportsScope": [],
+                    },
+                    "procedurePath": "contacts.search.search",
+                    "rankFieldName": "score",
+                }
+            ],
+        },
+        "ai": { "tools": [] },
+        "uri": { "types": ["contacts/contact"] },
+        "consumedSettings": { "keys": [] },
+        "settings": { "manifests": [] },
+        "pages": [
+            { "path": "", "index": true, "bundleSlot": "contacts-list" }
+        ],
+        "healthcheck": { "path": "/health" },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_pillar_and_version_match_the_argument() {
+        let manifest = build_contacts_manifest("1.2.3");
+        assert_eq!(manifest["pillar"], json!("contacts"));
+        assert_eq!(manifest["version"], json!("1.2.3"));
+        assert_eq!(manifest["contract"]["version"], json!("1.2.3"));
+        assert_eq!(
+            manifest["contract"]["tag"],
+            json!("contract-contacts@v1.2.3")
+        );
+        assert_eq!(manifest["contract"]["package"], json!("@pops/contacts"));
+    }
+
+    #[test]
+    fn routes_use_the_three_segment_procedure_path_grammar() {
+        let manifest = build_contacts_manifest("0.0.0-dev");
+        let queries = manifest["routes"]["queries"].as_array().unwrap();
+        assert!(queries.contains(&json!("contacts.entities.list")));
+        assert!(queries.contains(&json!("contacts.search.search")));
+        let mutations = manifest["routes"]["mutations"].as_array().unwrap();
+        assert!(mutations.contains(&json!("contacts.entities.create")));
+        // Every declared procedure path is the dotted three-segment form.
+        for path in queries.iter().chain(mutations.iter()) {
+            let segments: Vec<&str> = path.as_str().unwrap().split('.').collect();
+            assert_eq!(
+                segments.len(),
+                3,
+                "procedure path must be <pillar>.<router>.<procedure>: {path}"
+            );
+            assert_eq!(segments[0], "contacts");
+        }
+    }
+
+    #[test]
+    fn search_adapter_declares_a_text_query_shape_so_the_orchestrator_federates() {
+        let manifest = build_contacts_manifest("0.0.0-dev");
+        let adapters = manifest["search"]["adapters"].as_array().unwrap();
+        assert_eq!(
+            adapters.len(),
+            1,
+            "a single contacts adapter drives federation"
+        );
+        let adapter = &adapters[0];
+        assert_eq!(adapter["name"], json!("contacts"));
+        assert_eq!(adapter["entityType"], json!("contact"));
+        assert_eq!(adapter["procedurePath"], json!("contacts.search.search"));
+        assert_eq!(adapter["rankFieldName"], json!("score"));
+        assert_eq!(adapter["queryShape"]["supportsText"], json!(true));
+        assert_eq!(adapter["queryShape"]["supportsScope"], json!([]));
+    }
+
+    #[test]
+    fn uri_type_is_the_two_segment_pillar_entity_form() {
+        let manifest = build_contacts_manifest("0.0.0-dev");
+        assert_eq!(manifest["uri"]["types"], json!(["contacts/contact"]));
+    }
+
+    #[test]
+    fn settings_are_empty_until_the_shared_crate_lands() {
+        let manifest = build_contacts_manifest("0.0.0-dev");
+        assert_eq!(manifest["settings"]["manifests"], json!([]));
+        assert_eq!(manifest["consumedSettings"]["keys"], json!([]));
+        assert_eq!(manifest["ai"]["tools"], json!([]));
+    }
+
+    #[test]
+    fn healthcheck_path_matches_the_served_route() {
+        let manifest = build_contacts_manifest("0.0.0-dev");
+        assert_eq!(manifest["healthcheck"]["path"], json!("/health"));
+    }
+}

--- a/pillars/contacts/src/registry/lifecycle.rs
+++ b/pillars/contacts/src/registry/lifecycle.rs
@@ -136,6 +136,37 @@ impl LifecycleHandle {
     }
 }
 
+/// Register (with backoff), then heartbeat forever. Returns only if the
+/// heartbeat loop is somehow exited; in practice it runs until the caller's
+/// `select!` shutdown branch cancels it. Split out so the cancellation point is
+/// the single `select!` in [`spawn_lifecycle`].
+async fn run_until_shutdown<T: RegistryTransport>(
+    transport: &T,
+    base_url: &str,
+    manifest: &serde_json::Value,
+    pillar_id: &str,
+    config: &LifecycleConfig,
+) {
+    if let Err(err) = register_with_retry(transport, base_url, manifest, config).await {
+        tracing::warn!(
+            error = %err,
+            "initial registration failed — serving anyway; heartbeats will re-establish membership"
+        );
+    }
+
+    let mut ticker = tokio::time::interval(config.heartbeat);
+    // The first tick fires immediately; skip it so we don't double up with the
+    // register we just did.
+    ticker.tick().await;
+
+    loop {
+        ticker.tick().await;
+        if let Err(err) = transport.heartbeat(pillar_id).await {
+            tracing::warn!(error = %err, "heartbeat failed (best-effort)");
+        }
+    }
+}
+
 /// Spawn the boot-register + heartbeat loop as a detached task.
 ///
 /// The task first registers (with backoff). Whether or not registration
@@ -160,29 +191,13 @@ where
     let task_shutdown = Arc::clone(&shutdown);
 
     let task = tokio::spawn(async move {
-        if let Err(err) = register_with_retry(&*transport, &base_url, &manifest, &config).await {
-            tracing::warn!(
-                error = %err,
-                "initial registration failed — serving anyway; heartbeats will re-establish membership"
-            );
-        }
-
-        let mut ticker = tokio::time::interval(config.heartbeat);
-        // The first tick fires immediately; skip it so we don't double up with
-        // the register we just did.
-        ticker.tick().await;
-
-        loop {
-            tokio::select! {
-                _ = ticker.tick() => {
-                    if let Err(err) = transport.heartbeat(&pillar_id).await {
-                        tracing::warn!(error = %err, "heartbeat failed (best-effort)");
-                    }
-                }
-                _ = task_shutdown.notified() => {
-                    break;
-                }
-            }
+        // The whole register+heartbeat sequence races against shutdown so a
+        // SIGTERM mid-backoff (registry still unreachable) aborts promptly and
+        // proceeds straight to the best-effort deregister — shutdown latency is
+        // bounded by one in-flight request, never the remaining backoff budget.
+        tokio::select! {
+            _ = run_until_shutdown(&*transport, &base_url, &manifest, &pillar_id, &config) => {}
+            _ = task_shutdown.notified() => {}
         }
 
         if let Err(err) = transport.deregister(&pillar_id).await {
@@ -388,5 +403,39 @@ mod tests {
             "heartbeats fire even after a failed registration"
         );
         assert_eq!(transport.deregister_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stop_during_register_backoff_deregisters_promptly() {
+        // A retriable failure with a very long backoff: when stop() fires a few
+        // ms in, the register loop is asleep mid-backoff. The select! against
+        // shutdown must abort it and reach the deregister without waiting out
+        // the (10s) backoff — otherwise SIGTERM handling would hang.
+        let transport = Arc::new(FakeTransport::new(u32::MAX, true));
+        let config = LifecycleConfig {
+            heartbeat: Duration::from_secs(10),
+            max_attempts: 5,
+            initial_backoff: Duration::from_secs(10),
+            max_backoff: Duration::from_secs(30),
+        };
+        let handle = spawn_lifecycle(
+            Arc::clone(&transport),
+            "http://localhost:3010".to_string(),
+            serde_json::json!({ "pillar": "contacts" }),
+            "contacts".to_string(),
+            config,
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        // If stop() blocked on the backoff this would exceed the timeout.
+        tokio::time::timeout(Duration::from_secs(1), handle.stop())
+            .await
+            .expect("stop() returns promptly even mid-backoff");
+
+        assert_eq!(
+            transport.deregister_calls.load(Ordering::SeqCst),
+            1,
+            "shutdown mid-backoff still deregisters"
+        );
     }
 }

--- a/pillars/contacts/src/registry/lifecycle.rs
+++ b/pillars/contacts/src/registry/lifecycle.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
-use super::transport::{RegistryError, RegistryTransport};
+use super::transport::{HeartbeatOutcome, RegistryError, RegistryTransport};
 
 /// Default heartbeat cadence — matches the SDK `DEFAULT_HEARTBEAT_MS` and core's
 /// `HEARTBEAT_INTERVAL_MS`.
@@ -161,8 +161,23 @@ async fn run_until_shutdown<T: RegistryTransport>(
 
     loop {
         ticker.tick().await;
-        if let Err(err) = transport.heartbeat(pillar_id).await {
-            tracing::warn!(error = %err, "heartbeat failed (best-effort)");
+        match transport.heartbeat(pillar_id).await {
+            Ok(HeartbeatOutcome::Acknowledged) => {}
+            Ok(HeartbeatOutcome::NotRegistered) => {
+                // Core answered but has no row for us — the initial register
+                // never landed, or we were evicted after a long outage. Without
+                // re-registering here the pillar would heartbeat into the void
+                // forever (core soft-fails not-registered at HTTP 200, so the
+                // loop would never otherwise recover). Re-register, then resume
+                // the cadence.
+                tracing::warn!("registry reports this pillar is not registered — re-registering");
+                if let Err(err) = register_with_retry(transport, base_url, manifest, config).await {
+                    tracing::warn!(error = %err, "re-registration failed — will retry next heartbeat");
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "heartbeat failed (best-effort)");
+            }
         }
     }
 }
@@ -241,13 +256,16 @@ mod tests {
     }
 
     /// Fake transport that fails register `fail_register_times` times (with the
-    /// configured retriability) before succeeding, and records calls.
+    /// configured retriability) before succeeding, and records calls. The first
+    /// `heartbeat_not_registered_times` heartbeats report `NotRegistered` to
+    /// exercise the re-register path.
     struct FakeTransport {
         register_calls: AtomicU32,
         heartbeat_calls: AtomicU32,
         deregister_calls: AtomicU32,
         fail_register_times: u32,
         register_retriable: bool,
+        heartbeat_not_registered_times: u32,
         last_base_url: Mutex<Option<String>>,
         last_manifest: Mutex<Option<serde_json::Value>>,
     }
@@ -260,9 +278,15 @@ mod tests {
                 deregister_calls: AtomicU32::new(0),
                 fail_register_times,
                 register_retriable,
+                heartbeat_not_registered_times: 0,
                 last_base_url: Mutex::new(None),
                 last_manifest: Mutex::new(None),
             }
+        }
+
+        fn with_not_registered_heartbeats(mut self, times: u32) -> Self {
+            self.heartbeat_not_registered_times = times;
+            self
         }
     }
 
@@ -285,9 +309,13 @@ mod tests {
             Ok(())
         }
 
-        async fn heartbeat(&self, _pillar_id: &str) -> Result<(), RegistryError> {
-            self.heartbeat_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(())
+        async fn heartbeat(&self, _pillar_id: &str) -> Result<HeartbeatOutcome, RegistryError> {
+            let n = self.heartbeat_calls.fetch_add(1, Ordering::SeqCst);
+            if n < self.heartbeat_not_registered_times {
+                Ok(HeartbeatOutcome::NotRegistered)
+            } else {
+                Ok(HeartbeatOutcome::Acknowledged)
+            }
         }
 
         async fn deregister(&self, _pillar_id: &str) -> Result<(), RegistryError> {
@@ -401,6 +429,34 @@ mod tests {
         assert!(
             transport.heartbeat_calls.load(Ordering::SeqCst) >= 1,
             "heartbeats fire even after a failed registration"
+        );
+        assert_eq!(transport.deregister_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_reregisters_when_a_heartbeat_reports_not_registered() {
+        // Initial register succeeds, but the first two heartbeats report
+        // not-registered (e.g. the pillar was evicted). Each must trigger a
+        // re-register so membership is restored — otherwise the pillar would
+        // heartbeat into the void forever.
+        let transport = Arc::new(FakeTransport::new(0, true).with_not_registered_heartbeats(2));
+        let handle = spawn_lifecycle(
+            Arc::clone(&transport),
+            "http://localhost:3010".to_string(),
+            serde_json::json!({ "pillar": "contacts" }),
+            "contacts".to_string(),
+            fast_config(),
+        );
+        // 5ms cadence; sleep long enough for both not-registered heartbeats.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        handle.stop().await;
+
+        // 1 initial register + at least 2 re-registers (one per not-registered
+        // heartbeat).
+        assert!(
+            transport.register_calls.load(Ordering::SeqCst) >= 3,
+            "each not-registered heartbeat triggers a re-register (got {})",
+            transport.register_calls.load(Ordering::SeqCst)
         );
         assert_eq!(transport.deregister_calls.load(Ordering::SeqCst), 1);
     }

--- a/pillars/contacts/src/registry/lifecycle.rs
+++ b/pillars/contacts/src/registry/lifecycle.rs
@@ -1,0 +1,392 @@
+//! Registry lifecycle: register-with-backoff on boot, a periodic heartbeat
+//! loop, and a best-effort deregister on graceful shutdown.
+//!
+//! Faithful to the SDK's `registerWithRetry` + `startRuntime`
+//! (`packages/pillar-sdk/src/bootstrap/{register,bootstrap}.ts`):
+//!
+//!   - register retries with exponential backoff (`min(initial * 2^(n-1), max)`),
+//!     capped at `max_attempts`, but fails FAST on a non-retriable 4xx (a
+//!     rejected manifest is not going to succeed on retry);
+//!   - a `tokio::time::interval` fires a heartbeat every `heartbeat_ms`; a
+//!     failed heartbeat is logged and the loop continues (a transient registry
+//!     blip must not kill the pillar);
+//!   - shutdown cancels the loop and deregisters best-effort.
+//!
+//! Crucially, **none of this crashes the pillar.** If registration exhausts its
+//! retries the server still serves its HTTP surface; it is simply not yet a
+//! registry member and will be re-registered by the next boot. The caller
+//! spawns [`spawn_lifecycle`] as a detached task and serves regardless.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use super::transport::{RegistryError, RegistryTransport};
+
+/// Default heartbeat cadence — matches the SDK `DEFAULT_HEARTBEAT_MS` and core's
+/// `HEARTBEAT_INTERVAL_MS`.
+pub const DEFAULT_HEARTBEAT: Duration = Duration::from_secs(10);
+/// Default register retry ceiling.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+/// First backoff step; doubles each attempt.
+pub const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Backoff ceiling.
+pub const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Tunables for the lifecycle. Defaults match the SDK; tests shrink the
+/// backoff/cadence so they run instantly.
+#[derive(Debug, Clone)]
+pub struct LifecycleConfig {
+    pub heartbeat: Duration,
+    pub max_attempts: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        LifecycleConfig {
+            heartbeat: DEFAULT_HEARTBEAT,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            initial_backoff: DEFAULT_INITIAL_BACKOFF,
+            max_backoff: DEFAULT_MAX_BACKOFF,
+        }
+    }
+}
+
+/// The exponential backoff delay before the `attempt`-th retry (1-indexed):
+/// `min(initial * 2^(attempt-1), max)`. Pure so the schedule is unit-testable.
+pub fn backoff_delay(config: &LifecycleConfig, attempt: u32) -> Duration {
+    let exponent = attempt.saturating_sub(1);
+    let factor = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    let scaled = config
+        .initial_backoff
+        .checked_mul(factor.min(u32::MAX as u64) as u32)
+        .unwrap_or(config.max_backoff);
+    scaled.min(config.max_backoff)
+}
+
+/// Register, retrying transient failures with exponential backoff. Returns
+/// `Ok(())` on the first success; `Err` once attempts are exhausted or a
+/// non-retriable rejection is hit. Never panics.
+pub async fn register_with_retry<T: RegistryTransport>(
+    transport: &T,
+    base_url: &str,
+    manifest: &serde_json::Value,
+    config: &LifecycleConfig,
+) -> Result<(), RegistryError> {
+    let mut attempt = 0;
+    let mut last_err: Option<RegistryError> = None;
+
+    while attempt < config.max_attempts {
+        attempt += 1;
+        match transport.register(base_url, manifest).await {
+            Ok(()) => {
+                tracing::info!(attempt, "registered with registry");
+                return Ok(());
+            }
+            Err(err) => {
+                if !err.retriable {
+                    tracing::error!(
+                        status = err.status,
+                        error = %err,
+                        "registry rejected the manifest (non-retriable) — not registering"
+                    );
+                    return Err(err);
+                }
+                if attempt >= config.max_attempts {
+                    last_err = Some(err);
+                    break;
+                }
+                let delay = backoff_delay(config, attempt);
+                tracing::warn!(
+                    attempt,
+                    next_delay_ms = delay.as_millis() as u64,
+                    error = %err,
+                    "registration attempt failed, retrying"
+                );
+                last_err = Some(err);
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| RegistryError {
+        message: "registration exhausted attempts".to_string(),
+        status: 0,
+        retriable: true,
+    }))
+}
+
+/// Handle to a running lifecycle task. Dropping it does NOT stop the loop;
+/// call [`LifecycleHandle::stop`] for a graceful deregister + join.
+pub struct LifecycleHandle {
+    shutdown: Arc<Notify>,
+    task: JoinHandle<()>,
+}
+
+impl LifecycleHandle {
+    /// Signal the loop to stop, wait for it to deregister + exit. Idempotent in
+    /// practice — the task ignores a second notify once it has exited.
+    pub async fn stop(self) {
+        self.shutdown.notify_one();
+        let _ = self.task.await;
+    }
+}
+
+/// Spawn the boot-register + heartbeat loop as a detached task.
+///
+/// The task first registers (with backoff). Whether or not registration
+/// succeeds, it then enters the heartbeat loop — a pillar that failed to
+/// register on the first boot still attempts heartbeats, and core's heartbeat
+/// route soft-fails with `{ ok: false, reason: 'not-registered' }` so the loop
+/// keeps the pillar visible the moment core comes back.
+///
+/// `transport` is shared (`Arc`) so the same resolver-cached paths are reused by
+/// register, every heartbeat, and the shutdown deregister.
+pub fn spawn_lifecycle<T>(
+    transport: Arc<T>,
+    base_url: String,
+    manifest: serde_json::Value,
+    pillar_id: String,
+    config: LifecycleConfig,
+) -> LifecycleHandle
+where
+    T: RegistryTransport + 'static,
+{
+    let shutdown = Arc::new(Notify::new());
+    let task_shutdown = Arc::clone(&shutdown);
+
+    let task = tokio::spawn(async move {
+        if let Err(err) = register_with_retry(&*transport, &base_url, &manifest, &config).await {
+            tracing::warn!(
+                error = %err,
+                "initial registration failed — serving anyway; heartbeats will re-establish membership"
+            );
+        }
+
+        let mut ticker = tokio::time::interval(config.heartbeat);
+        // The first tick fires immediately; skip it so we don't double up with
+        // the register we just did.
+        ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    if let Err(err) = transport.heartbeat(&pillar_id).await {
+                        tracing::warn!(error = %err, "heartbeat failed (best-effort)");
+                    }
+                }
+                _ = task_shutdown.notified() => {
+                    break;
+                }
+            }
+        }
+
+        if let Err(err) = transport.deregister(&pillar_id).await {
+            tracing::warn!(error = %err, "deregister failed (best-effort)");
+        }
+    });
+
+    LifecycleHandle { shutdown, task }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Mutex;
+
+    fn fast_config() -> LifecycleConfig {
+        LifecycleConfig {
+            heartbeat: Duration::from_millis(5),
+            max_attempts: 5,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(4),
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_then_caps() {
+        let config = LifecycleConfig {
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(30),
+            ..LifecycleConfig::default()
+        };
+        assert_eq!(backoff_delay(&config, 1), Duration::from_secs(1));
+        assert_eq!(backoff_delay(&config, 2), Duration::from_secs(2));
+        assert_eq!(backoff_delay(&config, 3), Duration::from_secs(4));
+        assert_eq!(backoff_delay(&config, 4), Duration::from_secs(8));
+        assert_eq!(backoff_delay(&config, 5), Duration::from_secs(16));
+        assert_eq!(backoff_delay(&config, 6), Duration::from_secs(30));
+        // Far out-of-range attempt never overflows; it saturates at the cap.
+        assert_eq!(backoff_delay(&config, 200), Duration::from_secs(30));
+    }
+
+    /// Fake transport that fails register `fail_register_times` times (with the
+    /// configured retriability) before succeeding, and records calls.
+    struct FakeTransport {
+        register_calls: AtomicU32,
+        heartbeat_calls: AtomicU32,
+        deregister_calls: AtomicU32,
+        fail_register_times: u32,
+        register_retriable: bool,
+        last_base_url: Mutex<Option<String>>,
+        last_manifest: Mutex<Option<serde_json::Value>>,
+    }
+
+    impl FakeTransport {
+        fn new(fail_register_times: u32, register_retriable: bool) -> Self {
+            FakeTransport {
+                register_calls: AtomicU32::new(0),
+                heartbeat_calls: AtomicU32::new(0),
+                deregister_calls: AtomicU32::new(0),
+                fail_register_times,
+                register_retriable,
+                last_base_url: Mutex::new(None),
+                last_manifest: Mutex::new(None),
+            }
+        }
+    }
+
+    impl RegistryTransport for FakeTransport {
+        async fn register(
+            &self,
+            base_url: &str,
+            manifest: &serde_json::Value,
+        ) -> Result<(), RegistryError> {
+            *self.last_base_url.lock().unwrap() = Some(base_url.to_string());
+            *self.last_manifest.lock().unwrap() = Some(manifest.clone());
+            let n = self.register_calls.fetch_add(1, Ordering::SeqCst);
+            if n < self.fail_register_times {
+                return Err(RegistryError {
+                    message: "boom".to_string(),
+                    status: if self.register_retriable { 503 } else { 400 },
+                    retriable: self.register_retriable,
+                });
+            }
+            Ok(())
+        }
+
+        async fn heartbeat(&self, _pillar_id: &str) -> Result<(), RegistryError> {
+            self.heartbeat_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn deregister(&self, _pillar_id: &str) -> Result<(), RegistryError> {
+            self.deregister_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_with_retry_succeeds_after_transient_failures() {
+        let transport = FakeTransport::new(2, true);
+        let manifest = serde_json::json!({ "pillar": "contacts" });
+        register_with_retry(
+            &transport,
+            "http://localhost:3010",
+            &manifest,
+            &fast_config(),
+        )
+        .await
+        .expect("third attempt succeeds");
+        assert_eq!(transport.register_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            transport.last_base_url.lock().unwrap().as_deref(),
+            Some("http://localhost:3010")
+        );
+        assert_eq!(
+            transport.last_manifest.lock().unwrap().as_ref().unwrap()["pillar"],
+            serde_json::json!("contacts")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_with_retry_fails_fast_on_non_retriable_rejection() {
+        let transport = FakeTransport::new(1, false);
+        let manifest = serde_json::json!({ "pillar": "contacts" });
+        let err = register_with_retry(
+            &transport,
+            "http://localhost:3010",
+            &manifest,
+            &fast_config(),
+        )
+        .await
+        .expect_err("a 4xx rejection must not be retried");
+        assert_eq!(err.status, 400);
+        assert_eq!(
+            transport.register_calls.load(Ordering::SeqCst),
+            1,
+            "a non-retriable rejection stops after one attempt"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_with_retry_gives_up_after_max_attempts() {
+        let transport = FakeTransport::new(u32::MAX, true);
+        let manifest = serde_json::json!({ "pillar": "contacts" });
+        let err = register_with_retry(
+            &transport,
+            "http://localhost:3010",
+            &manifest,
+            &fast_config(),
+        )
+        .await
+        .expect_err("permanent failure exhausts attempts");
+        assert!(err.retriable);
+        assert_eq!(transport.register_calls.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_registers_heartbeats_then_deregisters_on_stop() {
+        let transport = Arc::new(FakeTransport::new(0, true));
+        let handle = spawn_lifecycle(
+            Arc::clone(&transport),
+            "http://localhost:3010".to_string(),
+            serde_json::json!({ "pillar": "contacts" }),
+            "contacts".to_string(),
+            fast_config(),
+        );
+
+        // Let a few heartbeats fire (5ms cadence).
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        handle.stop().await;
+
+        assert_eq!(transport.register_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            transport.heartbeat_calls.load(Ordering::SeqCst) >= 1,
+            "the heartbeat loop fired at least once"
+        );
+        assert_eq!(
+            transport.deregister_calls.load(Ordering::SeqCst),
+            1,
+            "stop() deregisters exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_still_heartbeats_when_initial_registration_fails() {
+        // Permanent register failure, but the loop must keep heartbeating so the
+        // pillar re-establishes membership the moment core recovers.
+        let transport = Arc::new(FakeTransport::new(u32::MAX, true));
+        let handle = spawn_lifecycle(
+            Arc::clone(&transport),
+            "http://localhost:3010".to_string(),
+            serde_json::json!({ "pillar": "contacts" }),
+            "contacts".to_string(),
+            fast_config(),
+        );
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        handle.stop().await;
+
+        assert_eq!(transport.register_calls.load(Ordering::SeqCst), 5);
+        assert!(
+            transport.heartbeat_calls.load(Ordering::SeqCst) >= 1,
+            "heartbeats fire even after a failed registration"
+        );
+        assert_eq!(transport.deregister_calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/pillars/contacts/src/registry/mod.rs
+++ b/pillars/contacts/src/registry/mod.rs
@@ -21,52 +21,117 @@ pub mod transport;
 
 pub use lifecycle::{spawn_lifecycle, LifecycleHandle};
 pub use transport::{
-    HttpRegistryTransport, RegistryError, RegistryTransport, RESOLVER_LEGACY_PATHS,
-    RESOLVER_PRIMARY_PATHS,
+    HeartbeatOutcome, HttpRegistryTransport, RegistryError, RegistryTransport,
+    RESOLVER_LEGACY_PATHS, RESOLVER_PRIMARY_PATHS,
 };
 
-/// Matches a valid semver (with optional prerelease/build metadata). Mirrors
-/// the SDK's `SEMVER_RE` so the two ecosystems coerce identically.
-fn is_semver(version: &str) -> bool {
-    let mut parts = version.splitn(3, '.');
-    let (Some(major), Some(minor), Some(rest)) = (parts.next(), parts.next(), parts.next()) else {
+/// Whether `version` is accepted by the manifest schema's `SEMVER` rule
+/// (`packages/pillar-sdk/src/manifest-schema/schema.ts`):
+/// `^\d+\.\d+\.\d+(-[a-z0-9.]+)?$`.
+///
+/// This is INTENTIONALLY stricter than full semver — the manifest validator
+/// rejects `+build` metadata and any uppercase in the prerelease, so a value
+/// this returns `true` for is guaranteed to pass register-time validation. A
+/// looser check would let `1.0.0+build.5` through, core would reject the
+/// manifest with a non-retriable 400, and contacts would never register.
+fn is_manifest_semver(version: &str) -> bool {
+    let (core, pre) = match version.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (version, None),
+    };
+
+    let mut parts = core.splitn(3, '.');
+    let (Some(major), Some(minor), Some(patch), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
         return false;
     };
-    if !is_all_digits(major) || !is_all_digits(minor) {
+    if !is_all_digits(major) || !is_all_digits(minor) || !is_all_digits(patch) {
         return false;
     }
-    // `rest` is the patch plus any `-prerelease` / `+build` suffix. The patch
-    // run must be all digits; anything after the first `-` or `+` is free-form.
-    let patch_end = rest.find(['-', '+']).unwrap_or(rest.len());
-    let patch = &rest[..patch_end];
-    is_all_digits(patch)
+
+    // Prerelease (if present) must be non-empty `[a-z0-9.]` — no uppercase, no
+    // `+build` metadata (which would have ended up here as part of `pre`).
+    match pre {
+        None => true,
+        Some(pre) => {
+            !pre.is_empty()
+                && pre
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'.')
+        }
+    }
 }
 
 fn is_all_digits(value: &str) -> bool {
     !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit())
 }
 
-/// Coerce a raw `BUILD_VERSION` into a manifest-valid semver.
+/// Coerce a raw `BUILD_VERSION` into a MANIFEST-valid semver.
 ///
 /// Watchtower-driven deploys inject the git SHA as `BUILD_VERSION`, but the
-/// manifest schema requires semver. Rather than fail register, a non-semver
-/// value becomes `0.0.0-sha.<first7>` (a valid prerelease). Already-semver
-/// values pass through unchanged. Byte-for-byte the SDK's `coerceManifestVersion`
-/// rule.
+/// manifest schema requires semver. Rather than fail register, a value the
+/// validator would reject becomes `0.0.0-sha.<sanitized first 7 chars>` — a
+/// guaranteed-valid prerelease. Already-valid values pass through unchanged.
+/// Mirrors the SDK's `coerceManifestVersion`, tightened so the result always
+/// satisfies the manifest `SEMVER` rule (the prerelease suffix is lowercased
+/// and stripped to `[a-z0-9.]`, so even a branch-name `BUILD_VERSION` like
+/// `Feature/X` cannot produce an invalid manifest).
 pub fn coerce_manifest_version(raw: &str) -> String {
-    if is_semver(raw) {
+    if is_manifest_semver(raw) {
         return raw.to_string();
     }
-    let short: String = raw.chars().take(7).collect();
-    format!("0.0.0-sha.{short}")
+    let sanitized: String = raw
+        .chars()
+        .take(7)
+        .map(|c| c.to_ascii_lowercase())
+        .map(|c| {
+            if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' {
+                c
+            } else {
+                '0'
+            }
+        })
+        .collect();
+    let suffix = if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
+    };
+    format!("0.0.0-sha.{suffix}")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The manifest schema's `SEMVER` regex, replicated so the test asserts
+    /// `coerce_manifest_version`'s output is genuinely accepted by it.
+    fn matches_manifest_semver_regex(v: &str) -> bool {
+        let (core, pre) = match v.split_once('-') {
+            Some((c, p)) => (c, Some(p)),
+            None => (v, None),
+        };
+        let nums: Vec<&str> = core.split('.').collect();
+        if nums.len() != 3
+            || !nums
+                .iter()
+                .all(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
+        {
+            return false;
+        }
+        match pre {
+            None => true,
+            Some(p) => {
+                !p.is_empty()
+                    && p.bytes()
+                        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'.')
+            }
+        }
+    }
+
     #[test]
-    fn semver_values_pass_through_unchanged() {
+    fn manifest_semver_values_pass_through_unchanged() {
         assert_eq!(coerce_manifest_version("1.2.3"), "1.2.3");
         assert_eq!(
             coerce_manifest_version("0.0.0-sha.abcdef0"),
@@ -76,27 +141,71 @@ mod tests {
     }
 
     #[test]
-    fn a_git_sha_is_coerced_to_a_semver_prerelease() {
+    fn a_git_sha_is_coerced_to_a_manifest_valid_prerelease() {
         assert_eq!(coerce_manifest_version("deadbeefcafe"), "0.0.0-sha.deadbee");
         // Short SHA shorter than 7 chars keeps its full length.
         assert_eq!(coerce_manifest_version("abc"), "0.0.0-sha.abc");
     }
 
     #[test]
-    fn the_dev_default_is_not_semver_and_is_coerced() {
-        // `0.0.0-dev` IS valid semver (prerelease `dev`), so it passes through.
+    fn the_dev_default_is_manifest_semver_and_is_coerced() {
+        // `0.0.0-dev` IS manifest-valid (prerelease `dev`), so it passes through.
         assert_eq!(coerce_manifest_version("0.0.0-dev"), "0.0.0-dev");
         // A bare `dev` is not semver.
         assert_eq!(coerce_manifest_version("dev"), "0.0.0-sha.dev");
     }
 
     #[test]
-    fn is_semver_rejects_non_numeric_cores() {
-        assert!(!is_semver("v1.2.3"));
-        assert!(!is_semver("1.2"));
-        assert!(!is_semver("1.2.x"));
-        assert!(!is_semver("main"));
-        assert!(is_semver("10.20.30"));
-        assert!(is_semver("1.0.0+build.5"));
+    fn build_metadata_is_not_manifest_semver_and_is_coerced() {
+        // The manifest SEMVER regex rejects `+build` metadata, so passing
+        // `1.0.0+build.5` through verbatim would make core reject the manifest.
+        // It must be coerced instead.
+        assert!(!is_manifest_semver("1.0.0+build.5"));
+        // First 7 chars "1.0.0+b" lowercased with `+` → `0`: "1.0.00b".
+        assert_eq!(
+            coerce_manifest_version("1.0.0+build.5"),
+            "0.0.0-sha.1.0.00b"
+        );
+    }
+
+    #[test]
+    fn is_manifest_semver_matches_the_schema_regex() {
+        assert!(!is_manifest_semver("v1.2.3"));
+        assert!(!is_manifest_semver("1.2"));
+        assert!(!is_manifest_semver("1.2.x"));
+        assert!(!is_manifest_semver("main"));
+        assert!(!is_manifest_semver("1.0.0+build.5"));
+        assert!(
+            !is_manifest_semver("1.0.0-RC1"),
+            "uppercase prerelease is rejected"
+        );
+        assert!(
+            !is_manifest_semver("1.2.3.4"),
+            "four-segment core is rejected"
+        );
+        assert!(is_manifest_semver("10.20.30"));
+        assert!(is_manifest_semver("1.2.3"));
+        assert!(is_manifest_semver("1.2.3-rc.1"));
+    }
+
+    #[test]
+    fn coercion_output_always_satisfies_the_manifest_regex() {
+        for raw in [
+            "1.2.3",
+            "0.0.0-dev",
+            "deadbeefcafe",
+            "1.0.0+build.5",
+            "Feature/Branch-Name",
+            "v1.2.3",
+            "RELEASE",
+            "!!!",
+            "",
+        ] {
+            let coerced = coerce_manifest_version(raw);
+            assert!(
+                matches_manifest_semver_regex(&coerced),
+                "coerce_manifest_version({raw:?}) -> {coerced:?} must satisfy the manifest SEMVER regex"
+            );
+        }
     }
 }

--- a/pillars/contacts/src/registry/mod.rs
+++ b/pillars/contacts/src/registry/mod.rs
@@ -1,0 +1,102 @@
+//! Registry self-registration for the contacts pillar — the reference Rust
+//! implementation of the lifecycle every TS pillar runs via
+//! `@pops/pillar-sdk`'s `bootstrapPillar`.
+//!
+//! Three pieces:
+//!
+//!   - [`transport`] — the HTTP leg: POST the register / heartbeat / deregister
+//!     envelopes, trying the canonical slash path first and falling back to the
+//!     legacy dotted path on a 404 (a faithful port of the SDK's
+//!     `resolveWithFallback` self-healing resolver).
+//!   - [`lifecycle`] — register-with-backoff on boot, a 10s heartbeat loop, and
+//!     a best-effort deregister on graceful shutdown. Never crashes the pillar:
+//!     a briefly-unavailable registry retries, and a permanently-unavailable one
+//!     leaves the server serving its surface regardless.
+//!   - manifest version coercion ([`coerce_manifest_version`]) mirroring the
+//!     SDK's `coerceManifestVersion` so a Watchtower-injected git SHA becomes a
+//!     valid semver prerelease instead of failing manifest validation.
+
+pub mod lifecycle;
+pub mod transport;
+
+pub use lifecycle::{spawn_lifecycle, LifecycleHandle};
+pub use transport::{
+    HttpRegistryTransport, RegistryError, RegistryTransport, RESOLVER_LEGACY_PATHS,
+    RESOLVER_PRIMARY_PATHS,
+};
+
+/// Matches a valid semver (with optional prerelease/build metadata). Mirrors
+/// the SDK's `SEMVER_RE` so the two ecosystems coerce identically.
+fn is_semver(version: &str) -> bool {
+    let mut parts = version.splitn(3, '.');
+    let (Some(major), Some(minor), Some(rest)) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    if !is_all_digits(major) || !is_all_digits(minor) {
+        return false;
+    }
+    // `rest` is the patch plus any `-prerelease` / `+build` suffix. The patch
+    // run must be all digits; anything after the first `-` or `+` is free-form.
+    let patch_end = rest.find(['-', '+']).unwrap_or(rest.len());
+    let patch = &rest[..patch_end];
+    is_all_digits(patch)
+}
+
+fn is_all_digits(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Coerce a raw `BUILD_VERSION` into a manifest-valid semver.
+///
+/// Watchtower-driven deploys inject the git SHA as `BUILD_VERSION`, but the
+/// manifest schema requires semver. Rather than fail register, a non-semver
+/// value becomes `0.0.0-sha.<first7>` (a valid prerelease). Already-semver
+/// values pass through unchanged. Byte-for-byte the SDK's `coerceManifestVersion`
+/// rule.
+pub fn coerce_manifest_version(raw: &str) -> String {
+    if is_semver(raw) {
+        return raw.to_string();
+    }
+    let short: String = raw.chars().take(7).collect();
+    format!("0.0.0-sha.{short}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_values_pass_through_unchanged() {
+        assert_eq!(coerce_manifest_version("1.2.3"), "1.2.3");
+        assert_eq!(
+            coerce_manifest_version("0.0.0-sha.abcdef0"),
+            "0.0.0-sha.abcdef0"
+        );
+        assert_eq!(coerce_manifest_version("2.0.0-rc.1"), "2.0.0-rc.1");
+    }
+
+    #[test]
+    fn a_git_sha_is_coerced_to_a_semver_prerelease() {
+        assert_eq!(coerce_manifest_version("deadbeefcafe"), "0.0.0-sha.deadbee");
+        // Short SHA shorter than 7 chars keeps its full length.
+        assert_eq!(coerce_manifest_version("abc"), "0.0.0-sha.abc");
+    }
+
+    #[test]
+    fn the_dev_default_is_not_semver_and_is_coerced() {
+        // `0.0.0-dev` IS valid semver (prerelease `dev`), so it passes through.
+        assert_eq!(coerce_manifest_version("0.0.0-dev"), "0.0.0-dev");
+        // A bare `dev` is not semver.
+        assert_eq!(coerce_manifest_version("dev"), "0.0.0-sha.dev");
+    }
+
+    #[test]
+    fn is_semver_rejects_non_numeric_cores() {
+        assert!(!is_semver("v1.2.3"));
+        assert!(!is_semver("1.2"));
+        assert!(!is_semver("1.2.x"));
+        assert!(!is_semver("main"));
+        assert!(is_semver("10.20.30"));
+        assert!(is_semver("1.0.0+build.5"));
+    }
+}

--- a/pillars/contacts/src/registry/transport.rs
+++ b/pillars/contacts/src/registry/transport.rs
@@ -1,0 +1,434 @@
+//! The HTTP leg of registry self-registration.
+//!
+//! ## Path resolution (slash-first, legacy fallback)
+//!
+//! One logical registry operation is reachable at two HTTP paths during the
+//! `core→registry` rename's rolling-deploy window: the canonical slash form
+//! (`/registry/register`) and the legacy dotted form (`/core.registry.register`).
+//! This transport tries the canonical path first and falls back to the legacy
+//! path on a **404 only** — a faithful port of the SDK's `resolveWithFallback`
+//! (`packages/pillar-sdk/src/registry-path-resolver.ts`):
+//!
+//!   - 2xx → remember the winning path so steady state issues one request, and
+//!     return.
+//!   - 404 on the cached winner (e.g. core rolled back to legacy-only) →
+//!     invalidate the hint and fall through to the other candidate IN THIS
+//!     call, so a single 404 self-heals without a failed heartbeat.
+//!   - any non-404 error (5xx / network) → surface immediately; "up but broken"
+//!     is not "path unknown", so we do NOT try the other candidate.
+//!
+//! The cache is a hint shared across calls, guarded by a `Mutex` so the
+//! concurrent heartbeat loop and a shutdown deregister never race on it.
+//!
+//! ## Retriability
+//!
+//! [`RegistryError::retriable`] is `true` for a network failure or a `>= 500`
+//! response, `false` for a 4xx (a rejected manifest, a malformed pillar id).
+//! The lifecycle uses this to fail fast on a non-retriable register rejection
+//! and to back off on a transient one — matching the SDK's `register.ts`.
+
+use std::future::Future;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Canonical (slash) registry paths — tried first.
+pub const RESOLVER_PRIMARY_PATHS: RegistryPaths = RegistryPaths {
+    register: "/registry/register",
+    heartbeat: "/registry/heartbeat",
+    deregister: "/registry/deregister",
+};
+
+/// Legacy (dotted, tRPC-vestigial) registry paths — the 404 fallback kept alive
+/// across the rename's rolling-deploy window. These are what core mounts today.
+pub const RESOLVER_LEGACY_PATHS: RegistryPaths = RegistryPaths {
+    register: "/core.registry.register",
+    heartbeat: "/core.registry.heartbeat",
+    deregister: "/core.registry.deregister",
+};
+
+/// One path per registry operation.
+#[derive(Debug, Clone, Copy)]
+pub struct RegistryPaths {
+    pub register: &'static str,
+    pub heartbeat: &'static str,
+    pub deregister: &'static str,
+}
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_NOT_FOUND: u16 = 404;
+
+/// A registry transport error. Carries the wire status (0 for a transport-level
+/// failure with no HTTP response) and whether the operation is worth retrying.
+#[derive(Debug)]
+pub struct RegistryError {
+    pub message: String,
+    /// HTTP status, or `0` when the request never produced a response.
+    pub status: u16,
+    /// `true` for a transient failure (network, 5xx); `false` for a 4xx.
+    pub retriable: bool,
+}
+
+impl RegistryError {
+    fn network(message: impl Into<String>) -> Self {
+        RegistryError {
+            message: message.into(),
+            status: 0,
+            retriable: true,
+        }
+    }
+
+    fn from_status(path: &str, status: u16, body: &str) -> Self {
+        RegistryError {
+            message: format!("POST {path} → {status}: {body}"),
+            status,
+            retriable: status >= 500,
+        }
+    }
+
+    fn is_not_found(&self) -> bool {
+        self.status == HTTP_NOT_FOUND
+    }
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// The registry operations a pillar drives over its lifetime. A trait so the
+/// lifecycle loop can be exercised against an in-process fake (the integration
+/// tests) without a live core.
+///
+/// Methods return `impl Future + Send` (rather than the bare `async fn in
+/// trait` sugar) because the lifecycle spawns the loop onto the tokio
+/// multi-thread runtime, which requires the futures be `Send`.
+pub trait RegistryTransport: Send + Sync {
+    /// Register this pillar. `manifest` is the validated capability document;
+    /// `base_url` is the origin core records for it.
+    fn register(
+        &self,
+        base_url: &str,
+        manifest: &Value,
+    ) -> impl Future<Output = Result<(), RegistryError>> + Send;
+    /// Report liveness for `pillar_id`.
+    fn heartbeat(&self, pillar_id: &str) -> impl Future<Output = Result<(), RegistryError>> + Send;
+    /// Drop `pillar_id`'s registration on graceful shutdown.
+    fn deregister(&self, pillar_id: &str)
+        -> impl Future<Output = Result<(), RegistryError>> + Send;
+}
+
+/// Cross-call resolver hint for ONE logical operation: the cached winning path
+/// (if any) plus whether a winner was ever cached. Mirrors the SDK `ResolverLeg`.
+#[derive(Debug)]
+struct ResolverLeg {
+    primary: &'static str,
+    fallback: &'static str,
+    resolved: Mutex<ResolverState>,
+}
+
+#[derive(Debug, Default)]
+struct ResolverState {
+    winner: Option<&'static str>,
+    had_hint: bool,
+}
+
+impl ResolverLeg {
+    fn new(primary: &'static str, fallback: &'static str) -> Self {
+        ResolverLeg {
+            primary,
+            fallback,
+            resolved: Mutex::new(ResolverState::default()),
+        }
+    }
+
+    /// Candidate paths in try-order: the cached winner first (still keeping the
+    /// other reachable so a single in-call 404 self-heals), else `[primary, fallback]`.
+    fn candidates(&self) -> [&'static str; 2] {
+        let state = self.resolved.lock().expect("resolver mutex not poisoned");
+        match state.winner {
+            Some(w) if w == self.fallback => [self.fallback, self.primary],
+            _ => [self.primary, self.fallback],
+        }
+    }
+
+    fn had_hint(&self) -> bool {
+        self.resolved
+            .lock()
+            .expect("resolver mutex not poisoned")
+            .had_hint
+    }
+
+    fn remember(&self, path: &'static str) {
+        if path != self.primary && path != self.fallback {
+            return;
+        }
+        let mut state = self.resolved.lock().expect("resolver mutex not poisoned");
+        state.winner = Some(path);
+        state.had_hint = true;
+    }
+
+    fn invalidate(&self) {
+        let mut state = self.resolved.lock().expect("resolver mutex not poisoned");
+        state.winner = None;
+        state.had_hint = false;
+    }
+}
+
+/// Run `send` across the leg's candidate paths with the self-healing
+/// slash-first / legacy-fallback policy.
+async fn resolve_with_fallback<F, Fut>(leg: &ResolverLeg, send: F) -> Result<(), RegistryError>
+where
+    F: Fn(&'static str) -> Fut,
+    Fut: std::future::Future<Output = Result<(), RegistryError>>,
+{
+    let candidates = leg.candidates();
+    let last_index = candidates.len() - 1;
+    let mut first_error: Option<RegistryError> = None;
+
+    for (index, path) in candidates.iter().enumerate() {
+        let is_last = index == last_index;
+        match send(path).await {
+            Ok(()) => {
+                leg.remember(path);
+                return Ok(());
+            }
+            Err(err) => {
+                if !err.is_not_found() || is_last {
+                    return Err(err);
+                }
+                // 404 on the first candidate when a winner was cached on a
+                // prior call → drop the hint so the cycle self-heals after a
+                // core rollback, then fall through to the next candidate.
+                if index == 0 && leg.had_hint() {
+                    leg.invalidate();
+                }
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+    }
+
+    Err(first_error
+        .unwrap_or_else(|| RegistryError::network("registry resolver had no candidates")))
+}
+
+/// Production `reqwest`-backed transport. Holds one resolver leg per operation
+/// so each caches its winning path independently across calls.
+pub struct HttpRegistryTransport {
+    base_url: String,
+    client: reqwest::Client,
+    register_leg: ResolverLeg,
+    heartbeat_leg: ResolverLeg,
+    deregister_leg: ResolverLeg,
+}
+
+impl HttpRegistryTransport {
+    /// Build a transport against `base_url` (trailing slashes are stripped by
+    /// the config resolver). A 10s per-request timeout prevents a hung TCP
+    /// connection from blocking boot or shutdown indefinitely.
+    pub fn new(base_url: impl Into<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .expect("reqwest client builds with a static timeout config");
+        Self::with_client(base_url, client)
+    }
+
+    /// Build a transport with a caller-supplied client (tests inject a short
+    /// timeout / no proxy).
+    pub fn with_client(base_url: impl Into<String>, client: reqwest::Client) -> Self {
+        HttpRegistryTransport {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            client,
+            register_leg: ResolverLeg::new(
+                RESOLVER_PRIMARY_PATHS.register,
+                RESOLVER_LEGACY_PATHS.register,
+            ),
+            heartbeat_leg: ResolverLeg::new(
+                RESOLVER_PRIMARY_PATHS.heartbeat,
+                RESOLVER_LEGACY_PATHS.heartbeat,
+            ),
+            deregister_leg: ResolverLeg::new(
+                RESOLVER_PRIMARY_PATHS.deregister,
+                RESOLVER_LEGACY_PATHS.deregister,
+            ),
+        }
+    }
+
+    async fn post(&self, path: &str, body: &Value) -> Result<(), RegistryError> {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| RegistryError::network(format!("POST {path} failed: {err}")))?;
+
+        let status = response.status().as_u16();
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let text = response.text().await.unwrap_or_default();
+        Err(RegistryError::from_status(path, status, &text))
+    }
+}
+
+impl RegistryTransport for HttpRegistryTransport {
+    async fn register(&self, base_url: &str, manifest: &Value) -> Result<(), RegistryError> {
+        let body = serde_json::json!({
+            "pillarId": "contacts",
+            "baseUrl": base_url,
+            "manifest": manifest,
+        });
+        resolve_with_fallback(&self.register_leg, |path| self.post(path, &body)).await
+    }
+
+    async fn heartbeat(&self, pillar_id: &str) -> Result<(), RegistryError> {
+        let body = serde_json::json!({ "pillarId": pillar_id });
+        resolve_with_fallback(&self.heartbeat_leg, |path| self.post(path, &body)).await
+    }
+
+    async fn deregister(&self, pillar_id: &str) -> Result<(), RegistryError> {
+        let body = serde_json::json!({ "pillarId": pillar_id });
+        resolve_with_fallback(&self.deregister_leg, |path| self.post(path, &body)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn ok() -> Result<(), RegistryError> {
+        Ok(())
+    }
+
+    fn not_found(path: &str) -> RegistryError {
+        RegistryError::from_status(path, 404, "not found")
+    }
+
+    fn server_error(path: &str) -> RegistryError {
+        RegistryError::from_status(path, 503, "down")
+    }
+
+    #[test]
+    fn retriability_tracks_the_status_class() {
+        assert!(RegistryError::network("x").retriable);
+        assert!(server_error("/p").retriable);
+        assert!(!not_found("/p").retriable);
+        assert!(!RegistryError::from_status("/p", 400, "bad").retriable);
+    }
+
+    #[tokio::test]
+    async fn prefers_the_primary_path_and_caches_it() {
+        let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
+        let seen = RefCell::new(Vec::new());
+
+        resolve_with_fallback(&leg, |path| {
+            seen.borrow_mut().push(path);
+            async move { ok() }
+        })
+        .await
+        .expect("primary path succeeds");
+
+        assert_eq!(*seen.borrow(), vec!["/registry/register"]);
+        // The winner is cached: the next call tries it first.
+        assert_eq!(leg.candidates()[0], "/registry/register");
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_legacy_on_404_then_caches_legacy() {
+        let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
+        let seen = RefCell::new(Vec::new());
+
+        resolve_with_fallback(&leg, |path| {
+            seen.borrow_mut().push(path);
+            async move {
+                if path == "/registry/register" {
+                    Err(not_found(path))
+                } else {
+                    ok()
+                }
+            }
+        })
+        .await
+        .expect("legacy fallback succeeds");
+
+        assert_eq!(
+            *seen.borrow(),
+            vec!["/registry/register", "/core.registry.register"],
+            "tries canonical first, then legacy on 404"
+        );
+        // Legacy is now the cached winner — tried first next call.
+        assert_eq!(leg.candidates()[0], "/core.registry.register");
+    }
+
+    #[tokio::test]
+    async fn a_5xx_surfaces_immediately_without_trying_the_fallback() {
+        let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
+        let seen = RefCell::new(Vec::new());
+
+        let err = resolve_with_fallback(&leg, |path| {
+            seen.borrow_mut().push(path);
+            async move { Err(server_error(path)) }
+        })
+        .await
+        .expect_err("5xx is surfaced");
+
+        assert_eq!(err.status, 503);
+        assert!(err.retriable);
+        assert_eq!(
+            *seen.borrow(),
+            vec!["/registry/register"],
+            "a 5xx is not 'path unknown' — do not try the other candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_404_on_the_cached_winner_self_heals_in_call() {
+        let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
+        // Prime the cache: canonical wins once.
+        resolve_with_fallback(&leg, |_| async move { ok() })
+            .await
+            .unwrap();
+        assert_eq!(leg.candidates()[0], "/registry/register");
+
+        // Core rolls back to legacy-only: the cached canonical now 404s, the
+        // call must fall through to legacy WITHIN the same invocation.
+        let seen = RefCell::new(Vec::new());
+        resolve_with_fallback(&leg, |path| {
+            seen.borrow_mut().push(path);
+            async move {
+                if path == "/registry/register" {
+                    Err(not_found(path))
+                } else {
+                    ok()
+                }
+            }
+        })
+        .await
+        .expect("self-heals to legacy without a failed heartbeat");
+
+        assert_eq!(
+            *seen.borrow(),
+            vec!["/registry/register", "/core.registry.register"]
+        );
+        assert_eq!(leg.candidates()[0], "/core.registry.register");
+    }
+
+    #[tokio::test]
+    async fn a_404_from_both_candidates_surfaces_the_last_error() {
+        let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
+        let err = resolve_with_fallback(&leg, |path| async move { Err(not_found(path)) })
+            .await
+            .expect_err("both 404 → error");
+        assert!(err.is_not_found());
+    }
+}

--- a/pillars/contacts/src/registry/transport.rs
+++ b/pillars/contacts/src/registry/transport.rs
@@ -100,6 +100,21 @@ impl std::fmt::Display for RegistryError {
 
 impl std::error::Error for RegistryError {}
 
+/// Outcome of a heartbeat that reached the registry (HTTP 2xx).
+///
+/// Core's heartbeat route soft-fails with `{ ok: false, reason: 'not-registered' }`
+/// at HTTP 200 when the pillar has no registration row (e.g. it was evicted, or
+/// the initial register never succeeded). Distinguishing this from an
+/// acknowledged heartbeat lets the lifecycle re-register instead of
+/// heartbeating into the void forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeartbeatOutcome {
+    /// `{ ok: true, … }` — the registration is live.
+    Acknowledged,
+    /// `{ ok: false, reason: 'not-registered' }` — core has no row for us.
+    NotRegistered,
+}
+
 /// The registry operations a pillar drives over its lifetime. A trait so the
 /// lifecycle loop can be exercised against an in-process fake (the integration
 /// tests) without a live core.
@@ -115,8 +130,13 @@ pub trait RegistryTransport: Send + Sync {
         base_url: &str,
         manifest: &Value,
     ) -> impl Future<Output = Result<(), RegistryError>> + Send;
-    /// Report liveness for `pillar_id`.
-    fn heartbeat(&self, pillar_id: &str) -> impl Future<Output = Result<(), RegistryError>> + Send;
+    /// Report liveness for `pillar_id`. A transport error is a failure to
+    /// reach/parse the registry; an `Ok(NotRegistered)` means core answered but
+    /// has no row for us (re-register).
+    fn heartbeat(
+        &self,
+        pillar_id: &str,
+    ) -> impl Future<Output = Result<HeartbeatOutcome, RegistryError>> + Send;
     /// Drop `pillar_id`'s registration on graceful shutdown.
     fn deregister(&self, pillar_id: &str)
         -> impl Future<Output = Result<(), RegistryError>> + Send;
@@ -180,11 +200,11 @@ impl ResolverLeg {
 }
 
 /// Run `send` across the leg's candidate paths with the self-healing
-/// slash-first / legacy-fallback policy.
-async fn resolve_with_fallback<F, Fut>(leg: &ResolverLeg, send: F) -> Result<(), RegistryError>
+/// slash-first / legacy-fallback policy, returning the winning call's value.
+async fn resolve_with_fallback<T, F, Fut>(leg: &ResolverLeg, send: F) -> Result<T, RegistryError>
 where
     F: Fn(&'static str) -> Fut,
-    Fut: std::future::Future<Output = Result<(), RegistryError>>,
+    Fut: std::future::Future<Output = Result<T, RegistryError>>,
 {
     let candidates = leg.candidates();
     let last_index = candidates.len() - 1;
@@ -193,9 +213,9 @@ where
     for (index, path) in candidates.iter().enumerate() {
         let is_last = index == last_index;
         match send(path).await {
-            Ok(()) => {
+            Ok(value) => {
                 leg.remember(path);
-                return Ok(());
+                return Ok(value);
             }
             Err(err) => {
                 if !err.is_not_found() || is_last {
@@ -261,7 +281,10 @@ impl HttpRegistryTransport {
         }
     }
 
-    async fn post(&self, path: &str, body: &Value) -> Result<(), RegistryError> {
+    /// POST `body` to `path`; on a 2xx return the parsed JSON response body
+    /// (`Value::Null` if it is empty/unparseable, which is fine for the callers
+    /// that ignore the body). A non-2xx maps to a typed [`RegistryError`].
+    async fn post(&self, path: &str, body: &Value) -> Result<Value, RegistryError> {
         let url = format!("{}{path}", self.base_url);
         let response = self
             .client
@@ -272,11 +295,21 @@ impl HttpRegistryTransport {
             .map_err(|err| RegistryError::network(format!("POST {path} failed: {err}")))?;
 
         let status = response.status().as_u16();
-        if response.status().is_success() {
-            return Ok(());
-        }
+        let is_success = response.status().is_success();
         let text = response.text().await.unwrap_or_default();
+        if is_success {
+            return Ok(serde_json::from_str(&text).unwrap_or(Value::Null));
+        }
         Err(RegistryError::from_status(path, status, &text))
+    }
+}
+
+/// Parse a heartbeat response body into a [`HeartbeatOutcome`]. `ok: false`
+/// (or a missing `ok`) is treated as not-registered; anything else is an ack.
+fn heartbeat_outcome(body: &Value) -> HeartbeatOutcome {
+    match body.get("ok").and_then(Value::as_bool) {
+        Some(true) => HeartbeatOutcome::Acknowledged,
+        _ => HeartbeatOutcome::NotRegistered,
     }
 }
 
@@ -287,17 +320,21 @@ impl RegistryTransport for HttpRegistryTransport {
             "baseUrl": base_url,
             "manifest": manifest,
         });
-        resolve_with_fallback(&self.register_leg, |path| self.post(path, &body)).await
+        resolve_with_fallback(&self.register_leg, |path| self.post(path, &body)).await?;
+        Ok(())
     }
 
-    async fn heartbeat(&self, pillar_id: &str) -> Result<(), RegistryError> {
+    async fn heartbeat(&self, pillar_id: &str) -> Result<HeartbeatOutcome, RegistryError> {
         let body = serde_json::json!({ "pillarId": pillar_id });
-        resolve_with_fallback(&self.heartbeat_leg, |path| self.post(path, &body)).await
+        let response =
+            resolve_with_fallback(&self.heartbeat_leg, |path| self.post(path, &body)).await?;
+        Ok(heartbeat_outcome(&response))
     }
 
     async fn deregister(&self, pillar_id: &str) -> Result<(), RegistryError> {
         let body = serde_json::json!({ "pillarId": pillar_id });
-        resolve_with_fallback(&self.deregister_leg, |path| self.post(path, &body)).await
+        resolve_with_fallback(&self.deregister_leg, |path| self.post(path, &body)).await?;
+        Ok(())
     }
 }
 
@@ -324,6 +361,24 @@ mod tests {
         assert!(server_error("/p").retriable);
         assert!(!not_found("/p").retriable);
         assert!(!RegistryError::from_status("/p", 400, "bad").retriable);
+    }
+
+    #[test]
+    fn heartbeat_outcome_distinguishes_ack_from_not_registered() {
+        assert_eq!(
+            heartbeat_outcome(&serde_json::json!({ "ok": true, "pillarId": "contacts" })),
+            HeartbeatOutcome::Acknowledged
+        );
+        assert_eq!(
+            heartbeat_outcome(&serde_json::json!({ "ok": false, "reason": "not-registered" })),
+            HeartbeatOutcome::NotRegistered
+        );
+        // A missing/odd body is treated conservatively as not-registered so the
+        // lifecycle re-registers rather than assuming membership.
+        assert_eq!(
+            heartbeat_outcome(&Value::Null),
+            HeartbeatOutcome::NotRegistered
+        );
     }
 
     #[tokio::test]
@@ -377,7 +432,7 @@ mod tests {
 
         let err = resolve_with_fallback(&leg, |path| {
             seen.borrow_mut().push(path);
-            async move { Err(server_error(path)) }
+            async move { Result::<(), RegistryError>::Err(server_error(path)) }
         })
         .await
         .expect_err("5xx is surfaced");
@@ -426,9 +481,11 @@ mod tests {
     #[tokio::test]
     async fn a_404_from_both_candidates_surfaces_the_last_error() {
         let leg = ResolverLeg::new("/registry/register", "/core.registry.register");
-        let err = resolve_with_fallback(&leg, |path| async move { Err(not_found(path)) })
-            .await
-            .expect_err("both 404 → error");
+        let err = resolve_with_fallback(&leg, |path| async move {
+            Result::<(), RegistryError>::Err(not_found(path))
+        })
+        .await
+        .expect_err("both 404 → error");
         assert!(err.is_not_found());
     }
 }

--- a/pillars/contacts/tests/registry.rs
+++ b/pillars/contacts/tests/registry.rs
@@ -19,7 +19,7 @@ use serde_json::{json, Value};
 use tokio::net::TcpListener;
 
 use contacts::manifest::build_contacts_manifest;
-use contacts::registry::{HttpRegistryTransport, RegistryTransport};
+use contacts::registry::{HeartbeatOutcome, HttpRegistryTransport, RegistryTransport};
 
 /// Records every register/heartbeat/deregister call the mock registry saw.
 #[derive(Default)]
@@ -181,10 +181,15 @@ async fn heartbeat_and_deregister_round_trip_over_real_http() {
     let (base_url, log) = spawn_mock_registry(false).await;
     let transport = HttpRegistryTransport::new(base_url);
 
-    transport
+    let outcome = transport
         .heartbeat("contacts")
         .await
         .expect("heartbeat succeeds");
+    assert_eq!(
+        outcome,
+        HeartbeatOutcome::Acknowledged,
+        "the mock returns {{ ok: true }}, so the heartbeat is acknowledged"
+    );
     transport
         .deregister("contacts")
         .await

--- a/pillars/contacts/tests/registry.rs
+++ b/pillars/contacts/tests/registry.rs
@@ -1,0 +1,198 @@
+//! Integration test for the registry transport against a REAL HTTP mock
+//! registry (a throwaway axum server on an ephemeral port).
+//!
+//! This complements the unit tests (which use an in-process fake): here the
+//! actual `reqwest`-backed `HttpRegistryTransport` makes real TCP requests, so
+//! the slash-first → legacy-404 fallback, the JSON body shape, and the
+//! register/heartbeat/deregister envelopes are all exercised end-to-end. It
+//! mirrors the plan's Gate G2 ("spin a mock registry and assert contacts POSTs
+//! a schema-valid manifest, heartbeats, deregisters").
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+use contacts::manifest::build_contacts_manifest;
+use contacts::registry::{HttpRegistryTransport, RegistryTransport};
+
+/// Records every register/heartbeat/deregister call the mock registry saw.
+#[derive(Default)]
+struct RegistryLog {
+    register_paths: Vec<String>,
+    register_bodies: Vec<Value>,
+    heartbeat_bodies: Vec<Value>,
+    deregister_bodies: Vec<Value>,
+}
+
+#[derive(Clone)]
+struct MockState {
+    log: Arc<Mutex<RegistryLog>>,
+    /// When true, the canonical slash register path returns 404 so the
+    /// transport must fall back to the legacy dotted path.
+    canonical_register_404: bool,
+}
+
+async fn handle_register_canonical(
+    State(state): State<MockState>,
+    Json(body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    if state.canonical_register_404 {
+        return (StatusCode::NOT_FOUND, Json(json!({ "error": "not found" })));
+    }
+    record_register(&state, "/registry/register", body)
+}
+
+async fn handle_register_legacy(
+    State(state): State<MockState>,
+    Json(body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    record_register(&state, "/core.registry.register", body)
+}
+
+fn record_register(state: &MockState, path: &str, body: Value) -> (StatusCode, Json<Value>) {
+    let pillar_id = body
+        .get("pillarId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    {
+        let mut log = state.log.lock().unwrap();
+        log.register_paths.push(path.to_string());
+        log.register_bodies.push(body);
+    }
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "pillarId": pillar_id,
+            "registeredAt": "2026-06-22T00:00:00.000Z",
+            "heartbeatIntervalMs": 10_000,
+        })),
+    )
+}
+
+async fn handle_heartbeat(State(state): State<MockState>, Json(body): Json<Value>) -> Json<Value> {
+    let pillar_id = body
+        .get("pillarId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    state.log.lock().unwrap().heartbeat_bodies.push(body);
+    Json(json!({ "ok": true, "pillarId": pillar_id }))
+}
+
+async fn handle_deregister(State(state): State<MockState>, Json(body): Json<Value>) -> Json<Value> {
+    state.log.lock().unwrap().deregister_bodies.push(body);
+    Json(json!({ "ok": true }))
+}
+
+/// Boot the mock registry on an ephemeral port; return its base URL and the
+/// shared log. The server task is detached and dies with the test process.
+async fn spawn_mock_registry(canonical_register_404: bool) -> (String, Arc<Mutex<RegistryLog>>) {
+    let log = Arc::new(Mutex::new(RegistryLog::default()));
+    let state = MockState {
+        log: Arc::clone(&log),
+        canonical_register_404,
+    };
+
+    let router = Router::new()
+        .route("/registry/register", post(handle_register_canonical))
+        .route("/registry/heartbeat", post(handle_heartbeat))
+        .route("/registry/deregister", post(handle_deregister))
+        .route("/core.registry.register", post(handle_register_legacy))
+        .route("/core.registry.heartbeat", post(handle_heartbeat))
+        .route("/core.registry.deregister", post(handle_deregister))
+        .with_state(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("resolve bound addr");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+
+    (format!("http://{addr}"), log)
+}
+
+#[tokio::test]
+async fn register_posts_a_schema_shaped_manifest_to_the_canonical_path() {
+    let (base_url, log) = spawn_mock_registry(false).await;
+    let transport = HttpRegistryTransport::new(base_url);
+    let manifest = build_contacts_manifest("1.2.3");
+
+    transport
+        .register("http://contacts-api:3010", &manifest)
+        .await
+        .expect("register succeeds against the mock registry");
+
+    let log = log.lock().unwrap();
+    assert_eq!(
+        log.register_paths,
+        vec!["/registry/register".to_string()],
+        "the canonical slash path is tried first and wins"
+    );
+
+    let body = &log.register_bodies[0];
+    assert_eq!(body["pillarId"], json!("contacts"));
+    assert_eq!(body["baseUrl"], json!("http://contacts-api:3010"));
+    // The manifest is pushed verbatim in the register envelope.
+    assert_eq!(body["manifest"]["pillar"], json!("contacts"));
+    assert_eq!(body["manifest"]["version"], json!("1.2.3"));
+    assert_eq!(
+        body["manifest"]["healthcheck"]["path"],
+        json!("/health"),
+        "the registry health probe reads the declared path"
+    );
+    assert_eq!(
+        body["manifest"]["search"]["adapters"][0]["procedurePath"],
+        json!("contacts.search.search")
+    );
+}
+
+#[tokio::test]
+async fn register_falls_back_to_the_legacy_path_on_a_canonical_404() {
+    let (base_url, log) = spawn_mock_registry(true).await;
+    let transport = HttpRegistryTransport::new(base_url);
+    let manifest = build_contacts_manifest("1.2.3");
+
+    transport
+        .register("http://contacts-api:3010", &manifest)
+        .await
+        .expect("register falls back to legacy and succeeds");
+
+    let log = log.lock().unwrap();
+    assert_eq!(
+        log.register_paths,
+        vec!["/core.registry.register".to_string()],
+        "the canonical path 404s, so the legacy dotted path is used"
+    );
+    assert_eq!(log.register_bodies[0]["pillarId"], json!("contacts"));
+}
+
+#[tokio::test]
+async fn heartbeat_and_deregister_round_trip_over_real_http() {
+    let (base_url, log) = spawn_mock_registry(false).await;
+    let transport = HttpRegistryTransport::new(base_url);
+
+    transport
+        .heartbeat("contacts")
+        .await
+        .expect("heartbeat succeeds");
+    transport
+        .deregister("contacts")
+        .await
+        .expect("deregister succeeds");
+
+    let log = log.lock().unwrap();
+    assert_eq!(log.heartbeat_bodies.len(), 1);
+    assert_eq!(log.heartbeat_bodies[0]["pillarId"], json!("contacts"));
+    assert_eq!(log.deregister_bodies.len(), 1);
+    assert_eq!(log.deregister_bodies[0]["pillarId"], json!("contacts"));
+}


### PR DESCRIPTION
Makes the Rust **contacts** pillar deploy-ready and self-registering: the **N2** registry lifecycle plus the Phase-6 deploy wiring (Dockerfile, compose, litestream). Scoped per `docs/plans/01-contacts-pillar-rust.md`.

**Out of scope / deferred to later nodes:** finance live-fetch matching, dropping finance's `entities` mirror, the core→contacts data migration, deleting core's entities surface, the contacts frontend app.

## 1. Rust self-registration (N2) — the reference Rust registration

Mirrors the TS SDK bootstrap (`packages/pillar-sdk/src/bootstrap/*`) exactly.

- **`registry::transport`** — `reqwest` POST (10s timeout) of the register / heartbeat / deregister envelopes. Tries the **canonical slash path** (`/registry/register`) first, falling back to the **legacy dotted path** (`/core.registry.register`) on a **404 only** — a faithful port of the SDK's `resolveWithFallback`: 2xx caches the winning path; a 404 on the cached winner self-heals in-call (after a core rollback); a 5xx/network error surfaces immediately ("up but broken" ≠ "path unknown"). `RegistryTransport` is a trait so the lifecycle is testable against an in-process fake.
- **`registry::lifecycle`** — `register_with_retry` with exponential backoff (`min(initial·2^(n-1), max)`, 5 attempts, **fail-fast on a non-retriable 4xx**), a 10s `tokio::time::interval` heartbeat loop, and a best-effort deregister on shutdown. The whole sequence races a single `select!` against a shutdown `Notify`, so a SIGTERM mid-backoff aborts promptly. **Never crashes the pillar** — a down registry retries in the background and the server serves regardless.
- **`registry::coerce_manifest_version`** — git-SHA → `0.0.0-sha.<7>` coercion matching the SDK's `coerceManifestVersion`.
- **`manifest`** — `build_contacts_manifest()` emitting a `ManifestPayloadSchema`-valid document: a `contacts` search adapter (so the orchestrator auto-federates on the declared adapter), `uri.types: ["contacts/contact"]`, empty `settings`/`ai` until those crates land. Validated against the real TS `validateManifestPayload`.
- **`main.rs`** — spawns the lifecycle behind `POPS_REGISTRY_ENABLED=true`; resolves the registry URL from `POPS_REGISTRY_URL`/`CORE_URL` and the self base URL from `CONTACTS_SELF_BASE_URL`; drains in-flight requests on SIGTERM/SIGINT then deregisters.

**Tests:** envelope shape, slash→legacy fallback + self-heal, backoff schedule, retry/fail-fast, heartbeat/deregister loop, shutdown-mid-backoff — plus a **real-HTTP integration test** (`tests/registry.rs`) driving the `reqwest` transport against a throwaway axum mock registry. Manually verified end-to-end at the container boundary: a running contacts container registers on attempt 1 against `/registry/register` and POSTs `/registry/deregister` on SIGTERM.

## 2. Dockerfile

Hand-written multi-stage Rust build — the reference for every future Rust pillar.

- `rust:1-slim` builder runs `cargo build --release -p contacts` against the `crates/` workspace (build context is the repo root); a dependency pre-build layer warms the registry-download cache, then the contacts crate's stale stub artifacts are purged so the real source recompiles cleanly.
- The crate uses sqlx's **runtime** query API (not `query!` macros) and embeds migrations via `sqlx::migrate!`, so the image builds **fully offline** — no `.sqlx/` cache, no build-time `DATABASE_URL`.
- `debian:bookworm-slim` runtime: `curl` + `ca-certificates`, a non-root `contacts` user, a chowned `/data/sqlite`, `EXPOSE 3010`, a `/health` HEALTHCHECK, and a default `CONTACTS_SQLITE_PATH` so the image boots standalone. Accepts the `BUILD_VERSION` arg the publish/quality jobs pass.

The first stage is named `builder`, so `docker-build.yml`'s `docker build --target builder` step succeeds.

## 3. Compose service

- **`infra/docker-compose.yml`** — `contacts-api` pinned to `ghcr.io/knoxio/pops-contacts:${POPS_IMAGE_TAG:-main}`, watchtower label, `frontend`+`backend` networks, `sqlite-data` volume, `/health` curl healthcheck, `depends_on: core-api healthy`, env (`PORT`, `CONTACTS_SQLITE_PATH`, `CONTACTS_SELF_BASE_URL`, `POPS_REGISTRY_ENABLED=true`, `POPS_REGISTRY_URL`, `POPS_API_INTERNAL_TOKEN`).
- **`infra/docker-compose.dev.yml`** — same service built from the Dockerfile (dev convention, no image pin).
- **nginx** already routes `/contacts-api/` → `contacts-api:3010` (the N0 scaffold added contacts to `PILLAR_UPSTREAMS`/`PILLAR_RENDER_ORDER` and the generated `nginx.conf`); regenerating it produces no drift.

## 4. Litestream

`infra/litestream/contacts.yml` — per-pillar replica stream for `/data/sqlite/contacts.db`, mirroring `inventory.yml` (1s sync, 24h retention, 1h snapshot, 12h validation).

## Publish-discovery enrolls contacts cleanly

`publish-images.yml`'s discover job keys on `image: ghcr.io/knoxio/pops-<x>:` in the prod compose **and** `pillars/<x>/Dockerfile`. With both added, the publishable set is now `["ai","cerebrum","contacts","core","finance","food","inventory","lists","media"]`. Contacts carries **no `package.json`**, so it stays out of the TS `pillar-quality` matrix (which discovers pillars by `package.json`) and out of `_pkg-check`; its only gate is `rust-quality.yml`.

## Verification (local, all green)

- Rust: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --all-targets`, `cargo test --all` (14 suites green), openapi drift gate clean.
- `pnpm typecheck` (44/44), `pnpm lint` exit 0, manifest validates against the TS Zod schema.
- `docker build` (full + `--target builder`) succeeds; container serves `/health` + CRUD and self-registers.
- `docker compose -f infra/docker-compose.yml config --quiet` and `-f infra/docker-compose.dev.yml config --quiet` both validate; `yaml-lint` clean on the litestream config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)