### PR TITLE
feat(settings): aggregator + shell capability cutover [S3]

### DIFF
--- a/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
@@ -4,23 +4,39 @@
  * Issue: #2464 — hash changes after initial mount must update the active group
  * (back/forward, address-bar edits, programmatic `window.location.hash = '...'`).
  *
- * PRD-101 US-04 follow-up: the page reads settings from `@pops/module-registry`
- * directly. Tests mock the registry to inject a deterministic manifest list.
+ * settings-federation S3: the page now reads sections from the LIVE registry
+ * via `useSettingsSections` (`discoverSettings` over the snapshot). Tests mock
+ * that hook to inject a deterministic section list.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { SettingsSection } from './settings-page/useSettingsSections';
+
 const mocks = vi.hoisted(() => ({
-  manifests: [
-    { id: 'finance', title: 'Finance', order: 0, groups: [] },
-    { id: 'media.plex', title: 'Plex', order: 1, groups: [] },
-    { id: 'cerebrum', title: 'Cerebrum', order: 2, groups: [] },
-  ],
+  sections: [
+    {
+      manifest: { id: 'finance', title: 'Finance', order: 0, groups: [] },
+      ownerPillar: 'finance',
+      hasFederatedSettings: true,
+    },
+    {
+      manifest: { id: 'media.plex', title: 'Plex', order: 1, groups: [] },
+      ownerPillar: 'media',
+      hasFederatedSettings: true,
+    },
+    {
+      manifest: { id: 'cerebrum', title: 'Cerebrum', order: 2, groups: [] },
+      ownerPillar: 'cerebrum',
+      hasFederatedSettings: false,
+    },
+  ] satisfies SettingsSection[],
+  useSettingsSections: vi.fn(),
 }));
 
-vi.mock('@pops/module-registry', () => ({
-  MODULES: [{ id: 'mock', settings: mocks.manifests }],
-  INSTALLED_MODULES: ['mock'],
+vi.mock('./settings-page/useSettingsSections', () => ({
+  useSettingsSections: mocks.useSettingsSections,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -28,12 +44,31 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/components/settings/SectionRenderer', () => ({
-  SectionRenderer: ({ manifest }: { manifest: { id: string } }) => (
-    <div data-testid="section-renderer">section:{manifest.id}</div>
+  SectionRenderer: ({
+    manifest,
+    ownerPillar,
+    hasFederatedSettings,
+  }: {
+    manifest: { id: string };
+    ownerPillar?: string;
+    hasFederatedSettings?: boolean;
+  }) => (
+    <div data-testid="section-renderer">
+      section:{manifest.id}|owner:{ownerPillar}|fed:{String(hasFederatedSettings)}
+    </div>
   ),
 }));
 
 import { SettingsPage } from './SettingsPage';
+
+function renderPage(): void {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <SettingsPage />
+    </QueryClientProvider>
+  );
+}
 
 function setHash(hash: string) {
   window.history.replaceState(null, '', `#${hash}`);
@@ -42,6 +77,7 @@ function setHash(hash: string) {
 
 describe('SettingsPage hash-based deep linking', () => {
   beforeEach(() => {
+    mocks.useSettingsSections.mockReturnValue({ data: mocks.sections, isLoading: false });
     window.history.replaceState(null, '', '/settings');
   });
 
@@ -52,14 +88,14 @@ describe('SettingsPage hash-based deep linking', () => {
 
   it('uses the initial hash to pick the active group on mount', async () => {
     window.history.replaceState(null, '', '/settings#cerebrum');
-    render(<SettingsPage />);
+    renderPage();
     await waitFor(() =>
       expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:cerebrum')
     );
   });
 
   it('falls back to the first manifest when the hash is empty', async () => {
-    render(<SettingsPage />);
+    renderPage();
     await waitFor(() =>
       expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
     );
@@ -67,15 +103,32 @@ describe('SettingsPage hash-based deep linking', () => {
 
   it('falls back to the first manifest when the hash is unknown', async () => {
     window.history.replaceState(null, '', '/settings#does-not-exist');
-    render(<SettingsPage />);
+    renderPage();
     await waitFor(() =>
       expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
     );
   });
 
+  it('routes each section to its owning pillar with the live capability flag', async () => {
+    window.history.replaceState(null, '', '/settings#finance');
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent(
+        'section:finance|owner:finance|fed:true'
+      )
+    );
+
+    act(() => setHash('cerebrum'));
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent(
+        'section:cerebrum|owner:cerebrum|fed:false'
+      )
+    );
+  });
+
   it('updates the active group when the hash changes after mount', async () => {
     window.history.replaceState(null, '', '/settings#finance');
-    render(<SettingsPage />);
+    renderPage();
     await waitFor(() =>
       expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
     );
@@ -93,7 +146,7 @@ describe('SettingsPage hash-based deep linking', () => {
 
   it('ignores hashchange events that point to unknown manifests', async () => {
     window.history.replaceState(null, '', '/settings#cerebrum');
-    render(<SettingsPage />);
+    renderPage();
     await waitFor(() =>
       expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:cerebrum')
     );
@@ -104,9 +157,20 @@ describe('SettingsPage hash-based deep linking', () => {
     );
   });
 
+  it('renders the empty state when the registry contributes no sections', async () => {
+    mocks.useSettingsSections.mockReturnValue({ data: [], isLoading: false });
+    renderPage();
+    await waitFor(() => expect(screen.queryByTestId('section-renderer')).toBeNull());
+  });
+
   it('removes the hashchange listener on unmount', async () => {
     const removeSpy = vi.spyOn(window, 'removeEventListener');
-    const { unmount } = render(<SettingsPage />);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { unmount } = render(
+      <QueryClientProvider client={client}>
+        <SettingsPage />
+      </QueryClientProvider>
+    );
     await waitFor(() => expect(screen.getAllByTestId('section-renderer')[0]).toBeInTheDocument());
     unmount();
     expect(removeSpy).toHaveBeenCalledWith('hashchange', expect.any(Function));

--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -2,53 +2,62 @@ import { SectionRenderer } from '@/components/settings/SectionRenderer';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
-import { Select } from '@pops/ui';
+import { Select, Skeleton } from '@pops/ui';
 
 import { SectionNav } from './settings-page/SectionNav';
 import { SettingsEmpty } from './settings-page/SettingsLoading';
 import { useHashSelectedId } from './settings-page/useHashSelectedId';
+import { useSettingsSections, type SettingsSection } from './settings-page/useSettingsSections';
 import { useTestActionHandler } from './settings-page/useTestActionHandler';
 
-import type { SettingsManifest } from '@pops/types';
-
 function ManifestPanel({
-  manifest,
+  section,
   onTestAction,
 }: {
-  manifest: SettingsManifest;
+  section: SettingsSection;
   onTestAction: (procedure: string) => Promise<void>;
 }) {
   return (
     <>
-      <h2 className="text-lg font-semibold mb-4">{manifest.title}</h2>
-      <SectionRenderer manifest={manifest} onTestAction={onTestAction} />
+      <h2 className="text-lg font-semibold mb-4">{section.manifest.title}</h2>
+      <SectionRenderer
+        manifest={section.manifest}
+        ownerPillar={section.ownerPillar}
+        hasFederatedSettings={section.hasFederatedSettings}
+        onTestAction={onTestAction}
+      />
     </>
   );
 }
 
-/**
- * Aggregate every installed module's settings sections (PRD-101 US-04 follow-up).
- * `MODULES` carries the build-time data; `INSTALLED_MODULES` (PRD-218 US-01)
- * is the per-deploy install set computed from `POPS_APPS` / `POPS_OVERLAYS`
- * at module load. The intersection means a deploy that gates out a module
- * never renders its settings sections. The per-module narrow tuple types
- * are widened back to `SettingsManifest` via the inner-callback return
- * annotation so the sort comparator gets the contract type.
- */
-function getManifests(): SettingsManifest[] {
-  return MODULES.filter((m) => INSTALLED_MODULES.includes(m.id))
-    .flatMap((m): readonly SettingsManifest[] =>
-      'settings' in m && m.settings !== undefined ? m.settings : []
-    )
-    .toSorted((a, b) => a.order - b.order);
+function SettingsLoadingSidebar() {
+  return (
+    <div className="flex h-full min-h-0">
+      <aside className="w-60 shrink-0 hidden md:flex flex-col border-r border-border/50 p-4 gap-2">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </aside>
+      <div className="flex-1 p-6 space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    </div>
+  );
 }
 
+/**
+ * The admin Settings page (settings-federation S3). Sections come from the
+ * LIVE registry (`discoverSettings` over the snapshot) rather than the
+ * build-time `MODULES` projection, and each section's read/write routes to its
+ * OWNING pillar (capability-gated) via `SectionRenderer`.
+ */
 export function SettingsPage() {
   const { t } = useTranslation('shell');
   const handleTestAction = useTestActionHandler();
 
-  const manifests = useMemo(() => getManifests(), []);
+  const { data: sections, isLoading } = useSettingsSections();
+  const manifests = useMemo(() => (sections ?? []).map((section) => section.manifest), [sections]);
   const [selectedId, setSelectedId] = useHashSelectedId(manifests);
 
   const handleSelect = useCallback(
@@ -59,11 +68,13 @@ export function SettingsPage() {
     [setSelectedId]
   );
 
-  const selectedManifest = useMemo(
-    () => manifests.find((m) => m.id === selectedId) ?? manifests[0],
-    [manifests, selectedId]
+  const selectedSection = useMemo(
+    () =>
+      (sections ?? []).find((section) => section.manifest.id === selectedId) ?? (sections ?? [])[0],
+    [sections, selectedId]
   );
 
+  if (isLoading) return <SettingsLoadingSidebar />;
   if (!manifests.length) return <SettingsEmpty />;
 
   return (
@@ -90,17 +101,17 @@ export function SettingsPage() {
             options={manifests.map((m) => ({ value: m.id, label: m.title }))}
           />
         </div>
-        {selectedManifest && (
+        {selectedSection && (
           <div className="flex-1 overflow-y-auto p-6">
-            <ManifestPanel manifest={selectedManifest} onTestAction={handleTestAction} />
+            <ManifestPanel section={selectedSection} onTestAction={handleTestAction} />
           </div>
         )}
       </div>
 
       {/* Desktop: right content pane */}
-      {selectedManifest && (
+      {selectedSection && (
         <div className="hidden md:block flex-1 overflow-y-auto p-6 min-w-0">
-          <ManifestPanel manifest={selectedManifest} onTestAction={handleTestAction} />
+          <ManifestPanel section={selectedSection} onTestAction={handleTestAction} />
         </div>
       )}
     </div>

--- a/apps/pops-shell/src/app/pages/settings-page/useSettingsSections.test.tsx
+++ b/apps/pops-shell/src/app/pages/settings-page/useSettingsSections.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for `useSettingsSections` (settings-federation S3) — the live-registry
+ * discovery hook that maps each pillar's settings manifest to its owning pillar
+ * and live `hasFederatedSettings` flag. This is the seam the Settings page uses
+ * to decide which pillar each section's read/write routes to.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PropsWithChildren } from 'react';
+
+const mocks = vi.hoisted(() => ({ fetchSettingsSnapshot: vi.fn() }));
+
+vi.mock('@/lib/settings-snapshot', () => ({
+  fetchSettingsSnapshot: mocks.fetchSettingsSnapshot,
+}));
+
+import { useSettingsSections } from './useSettingsSections';
+
+import type { ManifestPayload, PillarSnapshot } from '@pops/pillar-sdk';
+
+function manifest(pillarId: string, settingsId: string): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '1.0.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [`${pillarId}/entity`] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+    settings: { manifests: [{ id: settingsId, title: settingsId, order: 0, groups: [] }] },
+  };
+}
+
+function snapshot(
+  pillarId: string,
+  settingsId: string,
+  capabilities?: Record<string, boolean>
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3000`,
+    manifest: manifest(pillarId, settingsId),
+    registered: true,
+    lastSeenAt: new Date('2026-06-22T00:00:00.000Z'),
+    ...(capabilities !== undefined ? { capabilities } : {}),
+  };
+}
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useSettingsSections', () => {
+  it('maps each contribution to its owning pillar and live capability flag', async () => {
+    mocks.fetchSettingsSnapshot.mockResolvedValue([
+      snapshot('finance', 'finance', { settings: true }),
+      snapshot('cerebrum', 'cerebrum'),
+    ]);
+
+    const { result } = renderHook(() => useSettingsSections(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const sections = result.current.data ?? [];
+    const finance = sections.find((s) => s.manifest.id === 'finance');
+    const cerebrum = sections.find((s) => s.manifest.id === 'cerebrum');
+
+    expect(finance).toMatchObject({ ownerPillar: 'finance', hasFederatedSettings: true });
+    expect(cerebrum).toMatchObject({ ownerPillar: 'cerebrum', hasFederatedSettings: false });
+  });
+
+  it('returns no sections when the snapshot is empty', async () => {
+    mocks.fetchSettingsSnapshot.mockResolvedValue([]);
+    const { result } = renderHook(() => useSettingsSections(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/apps/pops-shell/src/app/pages/settings-page/useSettingsSections.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSettingsSections.ts
@@ -1,0 +1,51 @@
+/**
+ * Live-registry settings discovery for the admin Settings page
+ * (settings-federation S3 / GAP-256-C).
+ *
+ * Replaces the build-time `MODULES` + `INSTALLED_MODULES` projection with the
+ * LIVE registry: it fetches the registry snapshot, runs `discoverSettings`
+ * over it, and returns one section per pillar-contributed settings manifest,
+ * each tagged with its `ownerPillar` and live `hasFederatedSettings` flag so
+ * the renderer routes read/write to the owning pillar (capability-gated).
+ *
+ * Sections are sorted by manifest `order` to preserve the prior UI ordering
+ * within the registry-driven set.
+ */
+import { fetchSettingsSnapshot } from '@/lib/settings-snapshot';
+import { useQuery } from '@tanstack/react-query';
+
+import { discoverSettings } from '@pops/pillar-sdk/settings';
+
+import type { SettingsManifest } from '@pops/types';
+
+/** One settings section, with its owning pillar and live capability flag. */
+export interface SettingsSection {
+  readonly manifest: SettingsManifest;
+  readonly ownerPillar: string;
+  readonly hasFederatedSettings: boolean;
+}
+
+const SETTINGS_SECTIONS_QUERY_KEY = ['settings', 'sections'] as const;
+
+async function loadSections(fetchImpl: typeof fetch = fetch): Promise<readonly SettingsSection[]> {
+  const snapshot = await fetchSettingsSnapshot({ fetch: fetchImpl });
+  const contributions = await discoverSettings({ discovery: snapshot });
+  return contributions
+    .map((contribution) => ({
+      manifest: contribution.descriptor,
+      ownerPillar: contribution.ownerPillar,
+      hasFederatedSettings: contribution.capabilities?.['settings'] === true,
+    }))
+    .toSorted((a, b) => a.manifest.order - b.manifest.order);
+}
+
+/**
+ * React-query hook exposing the live settings sections. The query key is
+ * stable so the page and any peer consumers share one snapshot read.
+ */
+export function useSettingsSections(fetchImpl?: typeof fetch) {
+  return useQuery({
+    queryKey: SETTINGS_SECTIONS_QUERY_KEY,
+    queryFn: async () => loadSections(fetchImpl),
+  });
+}

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -1,47 +1,18 @@
-import { settingsGetMany, settingsSetMany } from '@/core-api';
-import { unwrap } from '@/core-api-helpers';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { Skeleton } from '@pops/ui';
 
 import { GroupRenderer } from './section-renderer/GroupRenderer';
-import { useAutoSave } from './section-renderer/useAutoSave';
-import { useDynamicOptions } from './section-renderer/useDynamicOptions';
-import { useDynamicOptionsLoaders } from './section-renderer/useDynamicOptionsLoaders';
-import { useSettingsValues } from './section-renderer/useSettingsValues';
+import { useSectionState } from './section-renderer/useSectionState';
 
 import type { SettingsManifest } from '@pops/types';
 
-/**
- * Reads and writes the section's settings over core's REST surface
- * (`settings.getMany` / `settings.setMany`). Both round-trip the
- * `{ settings: Record<string, string> }` shape `useSettingsValues` and
- * `useAutoSave` expect. The setter invalidates the matching `getMany` query
- * so the loaded baseline reflects the saved value.
- */
-function useBulkSettings(allKeys: string[]) {
-  const queryClient = useQueryClient();
-  const queryKey = ['core', 'settings', 'getMany', allKeys] as const;
-
-  const query = useQuery({
-    queryKey,
-    queryFn: async () => unwrap(await settingsGetMany({ body: { keys: allKeys } })),
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (input: { entries: { key: string; value: string }[] }) =>
-      unwrap(await settingsSetMany({ body: { entries: input.entries } })),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['core', 'settings', 'getMany'] });
-    },
-  });
-
-  return { query, mutation };
-}
-
 interface SectionRendererProps {
   manifest: SettingsManifest;
+  /** The pillar that owns this section's settings; resolves the transport. */
+  ownerPillar?: string;
+  /** Live `capabilities.settings` flag — routes to the pillar when true, else core. */
+  hasFederatedSettings?: boolean;
   optionsLoaders?: Record<string, () => Promise<{ value: string; label: string }[]>>;
   onTestAction?: (procedure: string) => Promise<void>;
 }
@@ -62,29 +33,28 @@ function applyDynamicOptions(
   };
 }
 
-export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: SectionRendererProps) {
-  const allKeys = useMemo(
-    () => manifest.groups.flatMap((g) => g.fields.map((f) => f.key)),
-    [manifest.groups]
-  );
-  const fieldsByKey = useMemo(
-    () => Object.fromEntries(manifest.groups.flatMap((g) => g.fields.map((f) => [f.key, f]))),
-    [manifest.groups]
-  );
-
-  const { query: bulkQuery, mutation: setBulkMutation } = useBulkSettings(allKeys);
-  const { data, isLoading } = bulkQuery;
-
-  const { values, setValues, loadedKeys } = useSettingsValues({ data, manifest });
-  const dynamicLoaders = useDynamicOptionsLoaders(manifest);
-  const mergedLoaders = useMemo(
-    () => (optionsLoaders ? { ...dynamicLoaders, ...optionsLoaders } : dynamicLoaders),
-    [dynamicLoaders, optionsLoaders]
-  );
-  const { dynamicOptions, loadingOptionKeys } = useDynamicOptions(
-    Object.keys(mergedLoaders).length > 0 ? mergedLoaders : undefined
-  );
-  const { saveStates, handleChange } = useAutoSave({ setBulkMutation, fieldsByKey, setValues });
+/**
+ * Renders one settings section and routes its read/write to the OWNING pillar
+ * (capability-gated) via `useSectionState` (settings-federation S3). When the
+ * owning pillar has not advertised the `settings` capability the transport
+ * falls back to core, so an un-upgraded pillar keeps working.
+ */
+export function SectionRenderer({
+  manifest,
+  ownerPillar = 'core',
+  hasFederatedSettings = false,
+  optionsLoaders,
+  onTestAction,
+}: SectionRendererProps) {
+  const {
+    isLoading,
+    values,
+    loadedKeys,
+    dynamicOptions,
+    loadingOptionKeys,
+    saveStates,
+    handleChange,
+  } = useSectionState(manifest, ownerPillar, hasFederatedSettings, optionsLoaders);
 
   const handleTestAction = useCallback(
     async (procedure: string) => {

--- a/apps/pops-shell/src/components/settings/section-renderer/useSectionState.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useSectionState.ts
@@ -1,0 +1,97 @@
+import { settingsClientFor } from '@/lib/settings-client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useAutoSave } from './useAutoSave';
+import { useDynamicOptions } from './useDynamicOptions';
+import { useDynamicOptionsLoaders } from './useDynamicOptionsLoaders';
+import { useSettingsValues } from './useSettingsValues';
+
+import type { SettingsManifest } from '@pops/types';
+
+type OptionsLoaders = Record<string, () => Promise<{ value: string; label: string }[]>>;
+
+/**
+ * Reads and writes the section's settings against the OWNING pillar's
+ * federated `/settings` surface (settings-federation S3), capability-gated:
+ * when the pillar advertises the live `settings` capability the transport
+ * targets `/<ownerPillar>-api/settings`, otherwise it falls back to
+ * `/core-api/settings` (where the value still lives during the rollout).
+ *
+ * Both `get-many` / `set-many` round-trip the `{ settings: Record<key,value> }`
+ * shape `useSettingsValues` and `useAutoSave` expect. The setter invalidates
+ * the matching `getMany` query so the loaded baseline reflects the saved value.
+ */
+function useBulkSettings(allKeys: string[], ownerPillar: string, hasFederatedSettings: boolean) {
+  const queryClient = useQueryClient();
+  const transportKey = hasFederatedSettings ? ownerPillar : 'core';
+  const queryKey = ['settings', transportKey, 'getMany', allKeys] as const;
+  const client = useMemo(
+    () => settingsClientFor(ownerPillar, hasFederatedSettings),
+    [ownerPillar, hasFederatedSettings]
+  );
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async () => client.getMany(allKeys),
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (input: { entries: { key: string; value: string }[] }) =>
+      client.setMany(input.entries),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['settings', transportKey, 'getMany'] });
+    },
+  });
+
+  return { query, mutation };
+}
+
+/**
+ * Wires the per-section settings state (capability-gated bulk read/write,
+ * effective values, dynamic select-option loaders, debounced auto-save) into a
+ * single object the renderer consumes. Keeps `SectionRenderer` a thin
+ * presentational shell.
+ */
+export function useSectionState(
+  manifest: SettingsManifest,
+  ownerPillar: string,
+  hasFederatedSettings: boolean,
+  optionsLoaders?: OptionsLoaders
+) {
+  const allKeys = useMemo(
+    () => manifest.groups.flatMap((g) => g.fields.map((f) => f.key)),
+    [manifest.groups]
+  );
+  const fieldsByKey = useMemo(
+    () => Object.fromEntries(manifest.groups.flatMap((g) => g.fields.map((f) => [f.key, f]))),
+    [manifest.groups]
+  );
+
+  const { query: bulkQuery, mutation: setBulkMutation } = useBulkSettings(
+    allKeys,
+    ownerPillar,
+    hasFederatedSettings
+  );
+
+  const { values, setValues, loadedKeys } = useSettingsValues({ data: bulkQuery.data, manifest });
+  const dynamicLoaders = useDynamicOptionsLoaders(manifest);
+  const mergedLoaders = useMemo(
+    () => (optionsLoaders ? { ...dynamicLoaders, ...optionsLoaders } : dynamicLoaders),
+    [dynamicLoaders, optionsLoaders]
+  );
+  const { dynamicOptions, loadingOptionKeys } = useDynamicOptions(
+    Object.keys(mergedLoaders).length > 0 ? mergedLoaders : undefined
+  );
+  const { saveStates, handleChange } = useAutoSave({ setBulkMutation, fieldsByKey, setValues });
+
+  return {
+    isLoading: bulkQuery.isLoading,
+    values,
+    loadedKeys,
+    dynamicOptions,
+    loadingOptionKeys,
+    saveStates,
+    handleChange,
+  };
+}

--- a/apps/pops-shell/src/lib/settings-client.test.ts
+++ b/apps/pops-shell/src/lib/settings-client.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the capability-gated, per-pillar settings transport
+ * (settings-federation S3). The load-bearing assertion is WHERE each pillar's
+ * read/write routes: to `/<ownerPillar>-api/settings` when the pillar
+ * advertises the live `settings` capability, else fall back to
+ * `/core-api/settings`.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { settingsBaseFor, settingsClientFor } from './settings-client';
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('settingsBaseFor', () => {
+  it('keeps core on its historic /core-api prefix', () => {
+    expect(settingsBaseFor('core')).toBe('/core-api');
+  });
+
+  it('routes every other pillar to its /<id>-api prefix', () => {
+    expect(settingsBaseFor('finance')).toBe('/finance-api');
+    expect(settingsBaseFor('media')).toBe('/media-api');
+  });
+});
+
+describe('settingsClientFor — capability-gated routing', () => {
+  it('routes a federated pillar to its own /<id>-api/settings surface', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => okJson({ settings: {} }));
+    const client = settingsClientFor('finance', true, fetchStub);
+
+    await client.getMany(['finance.aiCategorizer.model']);
+    await client.setMany([{ key: 'finance.aiCategorizer.model', value: 'claude-haiku-4-5' }]);
+    await client.reset(['finance.aiCategorizer.model']);
+
+    expect(fetchStub.mock.calls.map((c) => c[0])).toEqual([
+      '/finance-api/settings/get-many',
+      '/finance-api/settings/set-many',
+      '/finance-api/settings/reset',
+    ]);
+  });
+
+  it('falls back to /core-api/settings when the pillar has NOT advertised the capability', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => okJson({ settings: {} }));
+    const client = settingsClientFor('finance', false, fetchStub);
+
+    await client.getMany(['finance.aiCategorizer.model']);
+    await client.setMany([{ key: 'finance.aiCategorizer.model', value: 'x' }]);
+
+    expect(fetchStub.mock.calls.map((c) => c[0])).toEqual([
+      '/core-api/settings/get-many',
+      '/core-api/settings/set-many',
+    ]);
+  });
+
+  it('routes core to /core-api regardless of the capability flag', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => okJson({ settings: {} }));
+    await settingsClientFor('core', true, fetchStub).getMany(['theme']);
+    expect(fetchStub.mock.calls[0]?.[0]).toBe('/core-api/settings/get-many');
+  });
+
+  it('sends a JSON body with the requested keys/entries', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      okJson({ settings: { plex_url: 'http://plex:32400' } })
+    );
+    const client = settingsClientFor('media', true, fetchStub);
+
+    await client.getMany(['plex_url']);
+    const [, init] = fetchStub.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({ keys: ['plex_url'] });
+  });
+
+  it('parses the { settings } bulk response', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      okJson({ settings: { plex_url: 'http://plex:32400' } })
+    );
+    const result = await settingsClientFor('media', true, fetchStub).getMany(['plex_url']);
+    expect(result.settings).toEqual({ plex_url: 'http://plex:32400' });
+  });
+
+  it('parses the { reset, settings } reset response', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      okJson({ reset: ['plex_url'], settings: { plex_url: 'http://default' } })
+    );
+    const result = await settingsClientFor('media', true, fetchStub).reset(['plex_url']);
+    expect(result.reset).toEqual(['plex_url']);
+    expect(result.settings).toEqual({ plex_url: 'http://default' });
+  });
+
+  it('sends an empty body for a reset-all (no keys)', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => okJson({ reset: [], settings: {} }));
+    await settingsClientFor('media', true, fetchStub).reset();
+    const [, init] = fetchStub.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+
+  it('throws a status-carrying error on a non-2xx response', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => new Response('nope', { status: 401 }));
+    await expect(
+      settingsClientFor('finance', true, fetchStub).getMany(['x'])
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('drops non-string values defensively from a malformed bulk response', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      okJson({ settings: { a: 'ok', b: 42, c: null } })
+    );
+    const result = await settingsClientFor('finance', true, fetchStub).getMany(['a', 'b', 'c']);
+    expect(result.settings).toEqual({ a: 'ok' });
+  });
+});

--- a/apps/pops-shell/src/lib/settings-client.ts
+++ b/apps/pops-shell/src/lib/settings-client.ts
@@ -1,0 +1,130 @@
+/**
+ * Capability-gated, per-pillar settings transport for the admin Settings UI
+ * (settings-federation S3; see `docs/plans/02-settings-federation.md` §7.2).
+ *
+ * The shell renders one settings section per federated pillar and routes each
+ * section's read/write to the OWNING pillar's `/<id>-api/settings/*` surface —
+ * EXCEPT when the pillar has not yet advertised the live `settings` capability,
+ * in which case the transport falls back to `/core-api/settings`. The fallback
+ * still works because the federation backfill COPIED (not moved) each pillar's
+ * keys into core, so core holds the values until the rollout completes (the
+ * compat-shim removal is the later S5 node).
+ *
+ * This is a HAND-WRITTEN raw-`fetch` client, NOT a generated hey-api client,
+ * precisely so it can be keyed dynamically by `ownerPillar` at runtime. It
+ * mirrors the wire bytes of every pillar's federated surface (`get-many`,
+ * `set-many`, `reset`) and validates responses defensively before handing them
+ * to the renderer.
+ */
+
+/** A single setting entry on the federated wire. */
+export interface SettingEntry {
+  readonly key: string;
+  readonly value: string;
+}
+
+/** The `{ settings: Record<key, value> }` shape `get-many` / `set-many` return. */
+export interface SettingsBulkResponse {
+  readonly settings: Record<string, string>;
+}
+
+/** The `{ reset, settings }` shape `reset` returns. */
+export interface SettingsResetResponse {
+  readonly reset: readonly string[];
+  readonly settings: Record<string, string>;
+}
+
+export interface SettingsClient {
+  getMany(keys: readonly string[]): Promise<SettingsBulkResponse>;
+  setMany(entries: readonly SettingEntry[]): Promise<SettingsBulkResponse>;
+  reset(keys?: readonly string[]): Promise<SettingsResetResponse>;
+}
+
+const CORE_BASE = '/core-api';
+
+/**
+ * The API base path for a pillar's settings surface. `core` keeps its historic
+ * `/core-api` prefix; every other pillar is reached at `/<id>-api` through the
+ * registry-driven nginx front door (and the dev Vite proxy). The `core` /
+ * `core-api` literals ride the registry-rename dual-alias window
+ * (crossPlanConflict #4).
+ */
+export function settingsBaseFor(ownerPillar: string): string {
+  return ownerPillar === 'core' ? CORE_BASE : `/${ownerPillar}-api`;
+}
+
+class SettingsClientError extends Error {
+  readonly status: number | undefined;
+  constructor(message: string, status: number | undefined) {
+    super(message);
+    this.name = 'SettingsClientError';
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'string') out[key] = raw;
+  }
+  return out;
+}
+
+function parseBulk(body: unknown): SettingsBulkResponse {
+  if (!isRecord(body)) return { settings: {} };
+  return { settings: asStringRecord(body['settings']) };
+}
+
+function parseReset(body: unknown): SettingsResetResponse {
+  if (!isRecord(body)) return { reset: [], settings: {} };
+  const reset = Array.isArray(body['reset'])
+    ? body['reset'].filter((k): k is string => typeof k === 'string')
+    : [];
+  return { reset, settings: asStringRecord(body['settings']) };
+}
+
+async function postJson(url: string, body: unknown, fetchImpl: typeof fetch): Promise<unknown> {
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new SettingsClientError(`settings request failed (${response.status})`, response.status);
+  }
+  return (await response.json()) as unknown;
+}
+
+/**
+ * Build a settings transport keyed by `ownerPillar`. `hasFederatedSettings` is
+ * the live `capabilities.settings` flag from the registry snapshot: when ON the
+ * transport targets `/<ownerPillar>-api/settings`; when OFF/absent it falls
+ * back to `/core-api/settings` so an un-upgraded pillar's writes still land
+ * where the old shell put them.
+ */
+export function settingsClientFor(
+  ownerPillar: string,
+  hasFederatedSettings: boolean,
+  fetchImpl: typeof fetch = fetch
+): SettingsClient {
+  const base = settingsBaseFor(hasFederatedSettings ? ownerPillar : 'core');
+  return {
+    getMany: async (keys) =>
+      parseBulk(await postJson(`${base}/settings/get-many`, { keys: [...keys] }, fetchImpl)),
+    setMany: async (entries) =>
+      parseBulk(await postJson(`${base}/settings/set-many`, { entries: [...entries] }, fetchImpl)),
+    reset: async (keys) =>
+      parseReset(
+        await postJson(
+          `${base}/settings/reset`,
+          keys === undefined ? {} : { keys: [...keys] },
+          fetchImpl
+        )
+      ),
+  };
+}

--- a/apps/pops-shell/src/lib/settings-snapshot.test.ts
+++ b/apps/pops-shell/src/lib/settings-snapshot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the browser-side live-registry snapshot fetch + normaliser
+ * (settings-federation S3). Verifies the snapshot wire is parsed into the
+ * `PillarSnapshot[]` shape `discoverSettings` consumes, that capabilities
+ * round-trip, and that failures degrade to an empty list.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchSettingsSnapshot } from './settings-snapshot';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+function manifest(pillarId: string, withSettings: boolean): ManifestPayload {
+  const base: ManifestPayload = {
+    pillar: pillarId,
+    version: '1.0.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [`${pillarId}/entity`] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+  if (!withSettings) return base;
+  return {
+    ...base,
+    settings: { manifests: [{ id: pillarId, title: pillarId, order: 0, groups: [] }] },
+  };
+}
+
+function entry(
+  pillarId: string,
+  options: { capabilities?: Record<string, boolean>; withSettings?: boolean } = {}
+) {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3000`,
+    manifest: manifest(pillarId, options.withSettings ?? true),
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    registeredAt: '2026-06-22T00:00:00.000Z',
+    lastHeartbeatAt: '2026-06-22T00:00:00.000Z',
+    status: 'healthy',
+    statusUpdatedAt: '2026-06-22T00:00:00.000Z',
+    ...(options.capabilities !== undefined ? { capabilities: options.capabilities } : {}),
+  };
+}
+
+function snapshotResponse(pillars: unknown[]): Response {
+  return new Response(JSON.stringify({ pillars, fetchedAt: '2026-06-22T00:00:00.000Z' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('fetchSettingsSnapshot', () => {
+  it('fetches the full registry snapshot route', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => snapshotResponse([]));
+    await fetchSettingsSnapshot({ fetch: fetchStub });
+    expect(fetchStub.mock.calls[0]?.[0]).toBe('/core-api/registry/pillars');
+  });
+
+  it('normalises entries into PillarSnapshot shape with capabilities', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      snapshotResponse([entry('finance', { capabilities: { settings: true } })])
+    );
+    const result = await fetchSettingsSnapshot({ fetch: fetchStub });
+
+    expect(result).toHaveLength(1);
+    const [pillar] = result;
+    expect(pillar?.pillarId).toBe('finance');
+    expect(pillar?.registered).toBe(true);
+    expect(pillar?.capabilities).toEqual({ settings: true });
+    expect(pillar?.manifest.settings?.manifests[0]?.id).toBe('finance');
+  });
+
+  it('omits capabilities when an entry carries none', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => snapshotResponse([entry('inventory')]));
+    const [pillar] = await fetchSettingsSnapshot({ fetch: fetchStub });
+    expect(pillar?.capabilities).toBeUndefined();
+  });
+
+  it('drops entries with a malformed manifest rather than half-reading them', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () =>
+      snapshotResponse([{ pillarId: 'broken', baseUrl: 'http://x', manifest: { nope: true } }])
+    );
+    expect(await fetchSettingsSnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+
+  it('returns [] on a non-2xx response', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => new Response('down', { status: 503 }));
+    expect(await fetchSettingsSnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+
+  it('returns [] on a network throw', async () => {
+    const fetchStub = vi.fn<typeof fetch>(async () => {
+      throw new Error('offline');
+    });
+    expect(await fetchSettingsSnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+
+  it('returns [] when the body is not the expected shape', async () => {
+    const fetchStub = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ unexpected: 'shape' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    expect(await fetchSettingsSnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+});

--- a/apps/pops-shell/src/lib/settings-snapshot.ts
+++ b/apps/pops-shell/src/lib/settings-snapshot.ts
@@ -1,0 +1,112 @@
+/**
+ * Browser-side live-registry snapshot fetch for the admin Settings UI
+ * (settings-federation S3 / GAP-256-C; see `docs/plans/02-settings-federation.md`).
+ *
+ * The Settings page renders per-pillar settings sections and routes each
+ * section's read/write to the OWNING pillar — both driven by the LIVE registry
+ * rather than the build-time `MODULES` projection. This helper fetches the full
+ * registry snapshot (which carries each pillar's `manifest.settings.manifests`
+ * AND its live `capabilities`) and normalises it into the `PillarSnapshot[]`
+ * shape `discoverSettings` consumes.
+ *
+ * The minimal `GET /pillars` boot projection only carries `{ id, baseUrl }`, so
+ * it cannot drive settings discovery; this reads the full snapshot at
+ * `GET /core-api/registry/pillars` (proxied to core's `/registry/pillars`),
+ * which is the same wire `@pops/pillar-sdk`'s discovery transport reads.
+ *
+ * Failures are soft: a fetch error, wrong shape, or empty list yields `[]`, so
+ * the page falls back to its empty state rather than throwing.
+ */
+import { ManifestPayloadSchema } from '@pops/pillar-sdk';
+
+import type { CapabilityStatuses, PillarSnapshot } from '@pops/pillar-sdk';
+
+const SNAPSHOT_URL = '/core-api/registry/pillars';
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface SettingsSnapshotOptions {
+  /** Override the global `fetch` (tests inject a stub). */
+  readonly fetch?: typeof fetch;
+  /** Per-fetch timeout in milliseconds. Defaults to 3000. */
+  readonly timeoutMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseCapabilities(value: unknown): CapabilityStatuses | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: CapabilityStatuses = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'boolean') out[key] = raw;
+  }
+  return out;
+}
+
+/**
+ * Normalise one raw registry-snapshot entry into a `PillarSnapshot`. Returns
+ * `null` when the entry lacks a usable `pillarId` or a well-formed manifest —
+ * an entry the settings UI cannot reason about is dropped rather than half-read.
+ *
+ * Listed entries are treated as `registered: true`: the snapshot only carries
+ * live registrations, and the capability gate (not the discovery `registered`
+ * flag) decides whether a section's writes route to the pillar or fall back to
+ * core.
+ */
+function normaliseEntry(entry: unknown): PillarSnapshot | null {
+  if (!isRecord(entry)) return null;
+  const pillarId = entry['pillarId'];
+  const baseUrl = entry['baseUrl'];
+  if (typeof pillarId !== 'string' || typeof baseUrl !== 'string') return null;
+
+  const manifest = ManifestPayloadSchema.safeParse(entry['manifest']);
+  if (!manifest.success) return null;
+
+  const capabilities = parseCapabilities(entry['capabilities']);
+  const lastSeenRaw = entry['lastHeartbeatAt'];
+  const lastSeenAt = typeof lastSeenRaw === 'string' ? new Date(lastSeenRaw) : new Date(0);
+
+  return {
+    pillarId,
+    baseUrl,
+    manifest: manifest.data,
+    registered: true,
+    lastSeenAt,
+    ...(capabilities !== undefined ? { capabilities } : {}),
+  };
+}
+
+function parseSnapshotBody(body: unknown): readonly PillarSnapshot[] {
+  if (!isRecord(body)) return [];
+  const pillars = body['pillars'];
+  if (!Array.isArray(pillars)) return [];
+  const out: PillarSnapshot[] = [];
+  for (const entry of pillars) {
+    const normalised = normaliseEntry(entry);
+    if (normalised !== null) out.push(normalised);
+  }
+  return out;
+}
+
+/**
+ * Fetch the live registry snapshot and normalise it for `discoverSettings`.
+ * Returns `[]` on any failure so the Settings page degrades to its empty state.
+ */
+export async function fetchSettingsSnapshot(
+  options: SettingsSnapshotOptions = {}
+): Promise<readonly PillarSnapshot[]> {
+  const fetchImpl = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort('timeout'), timeoutMs);
+  try {
+    const response = await fetchImpl(SNAPSHOT_URL, { method: 'GET', signal: controller.signal });
+    if (!response.ok) return [];
+    return parseSnapshotBody((await response.json()) as unknown);
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/docs/plans/02-settings-federation.md
+++ b/docs/plans/02-settings-federation.md
@@ -54,7 +54,7 @@ Any divergence not covered by a US is filed as a **gap issue** referencing PRD-2
 
 - **GAP-256-A**: the manifest/enum disagreement already in the tree (`rotation_*`, `ai.logRetentionDays`, `corrections.changeSetRejections:*` referenced but absent from `SETTINGS_KEYS`). Federation picks ONE authority per pillar; the manifest wins.
 - **GAP-256-B**: `media.comparisons.*` is env-backed at runtime yet table-backed in the UI — editing it does nothing. Reconcile (OD-4).
-- **GAP-256-C**: the shell aggregates from build-time `MODULES`, not the live registry — `discoverSettings` ships unused.
+- **GAP-256-C** (CLOSED by S3): the shell used to aggregate from build-time `MODULES`, not the live registry, leaving `discoverSettings` unused. S3 repointed `SettingsPage`/`SectionRenderer` onto the live registry via `discoverSettings` + capability-gated per-pillar transport (`settingsClientFor`) with a core fallback.
 - **GAP-256-D** (NEW, mustFix-derived): the discovery snapshot type (`PillarSnapshot`, `packages/pillar-sdk/src/discovery/types.ts:12-31`) and the discovery normalizer (`client/discovery.ts:109-121`) DROP the `capabilities` field even though the registry wire emits it (`pillars/core/src/api/modules/registry/snapshot.ts:47`). The capability-gated rollout is impossible until this is plumbed. File before Phase 3.
 - **GAP-256-E** (NEW, security): settings reads perform no redaction today; the new collection + aggregator reads must redact sensitive fields server-side or they leak `plex_token` / encryption seeds.
 
@@ -83,9 +83,9 @@ Any divergence not covered by a US is filed as a **gap issue** referencing PRD-2
 
 ### 3.4 Aggregation & the chokepoint
 
-- `discoverSettings` (`packages/pillar-sdk/src/settings/discover-settings.ts:55`) walks the live snapshot, skips `registered===false`, flattens, sorts. **Confirmed UNUSED in production.** It ALREADY tracks `pillarId` internally per descriptor (`:59,66`) but `.map`s it away at `:79` — so exposing `{ownerPillar, descriptor}[]` is strictly additive.
-- Shell aggregates from **build-time** `MODULES`: `apps/pops-shell/src/app/pages/SettingsPage.tsx:39-45`.
-- Single hardcoded transport: `apps/pops-shell/src/components/settings/SectionRenderer.tsx:1` imports `@/core-api`. The shell has only a `core-api` client; no per-pillar client dirs exist.
+- `discoverSettings` (`packages/pillar-sdk/src/settings/discover-settings.ts`) walks the live snapshot, skips `registered===false`, flattens, sorts, and now exposes `{ownerPillar, descriptor, capabilities}` per entry. **S3 UPDATE:** previously confirmed UNUSED in production (the shell read build-time `MODULES`); S3 cut the shell over to it — `discoverSettings` is now the shell's settings source. The original `.map`-away of `pillarId` was removed so the owner + capabilities flow through.
+- **S3 UPDATE — the shell no longer aggregates from build-time `MODULES`.** `SettingsPage` now subscribes to the live registry snapshot and feeds it to `discoverSettings`, passing each `{ownerPillar, descriptor, capabilities}` down. (Pre-S3 it read build-time `MODULES` at `apps/pops-shell/src/app/pages/SettingsPage.tsx`.)
+- **S3 UPDATE — the transport is no longer a single hardcoded `@/core-api` import.** `SectionRenderer` (`apps/pops-shell/src/components/settings/SectionRenderer.tsx`) now takes `ownerPillar` + `hasFederatedSettings` and resolves the transport per pillar via `settingsClientFor(ownerPillar, hasFederatedSettings)` (`apps/pops-shell/src/lib/settings-client.ts`): the live `capabilities.settings` flag routes to `/<id>-api/settings` when ON and falls back to `/core-api/settings` when OFF/absent, so an un-upgraded pillar keeps working. (Pre-S3 the renderer hardcoded `@/core-api` and the shell had only a `core-api` client.)
 
 ### 3.5 Cross-pillar readers & local carve-outs
 

--- a/packages/pillar-sdk/src/settings/__tests__/discover-settings.test.ts
+++ b/packages/pillar-sdk/src/settings/__tests__/discover-settings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { discoverSettings, findSettingsManifest } from '../discover-settings.js';
 
+import type { CapabilityStatuses } from '../../bootstrap/transport.js';
 import type { PillarSnapshot } from '../../discovery/types.js';
 import type { ManifestPayload, SettingsManifestDescriptor } from '../../manifest-schema/index.js';
 
@@ -48,14 +49,16 @@ function manifest(
 function snapshot(
   pillarId: string,
   manifests?: readonly SettingsManifestDescriptor[],
-  registered = true
+  options: { registered?: boolean; capabilities?: CapabilityStatuses } = {}
 ): PillarSnapshot {
+  const { registered = true, capabilities } = options;
   return {
     pillarId,
     baseUrl: `https://${pillarId}.test`,
     manifest: manifest(pillarId, manifests),
     registered,
     lastSeenAt: new Date('2026-01-01T00:00:00Z'),
+    ...(capabilities !== undefined ? { capabilities } : {}),
   };
 }
 
@@ -65,22 +68,38 @@ describe('discoverSettings', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns the lone contribution when a single pillar contributes one manifest', async () => {
+  it('returns the lone contribution tagged with its owner pillar', async () => {
     const finance = snapshot('finance', [descriptor('finance')]);
     const result = await discoverSettings({ discovery: [finance] });
-    expect(result.map((m) => m.id)).toEqual(['finance']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['finance']);
+    expect(result.map((c) => c.ownerPillar)).toEqual(['finance']);
   });
 
-  it('flattens contributions from a pillar declaring multiple manifests', async () => {
+  it('attaches the owning pillar to every contribution it flattens', async () => {
     const cerebrum = snapshot('cerebrum', [
       descriptor('cerebrum', { order: 0 }),
       descriptor('ego', { order: 1 }),
     ]);
     const result = await discoverSettings({ discovery: [cerebrum] });
-    expect(result.map((m) => m.id)).toEqual(['cerebrum', 'ego']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['cerebrum', 'ego']);
+    expect(result.every((c) => c.ownerPillar === 'cerebrum')).toBe(true);
   });
 
-  it('orders contributions by (pillarId, manifest.order, manifest.id) across pillars', async () => {
+  it('exposes the live capabilities map so the shell can gate the cutover', async () => {
+    const finance = snapshot('finance', [descriptor('finance')], {
+      capabilities: { settings: true },
+    });
+    const [contribution] = await discoverSettings({ discovery: [finance] });
+    expect(contribution?.capabilities).toEqual({ settings: true });
+  });
+
+  it('omits capabilities when the snapshot carries none (legacy pillar)', async () => {
+    const finance = snapshot('finance', [descriptor('finance')]);
+    const [contribution] = await discoverSettings({ discovery: [finance] });
+    expect(contribution?.capabilities).toBeUndefined();
+  });
+
+  it('orders contributions by (ownerPillar, descriptor.order, descriptor.id) across pillars', async () => {
     const media = snapshot('media', [
       descriptor('plex', { order: 2 }),
       descriptor('arr', { order: 1 }),
@@ -90,16 +109,17 @@ describe('discoverSettings', () => {
 
     const result = await discoverSettings({ discovery: [media, finance] });
 
-    expect(result.map((m) => m.id)).toEqual(['finance', 'arr', 'rotation', 'plex']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['finance', 'arr', 'rotation', 'plex']);
+    expect(result.map((c) => c.ownerPillar)).toEqual(['finance', 'media', 'media', 'media']);
   });
 
   it('skips pillars whose registration is not active', async () => {
     const active = snapshot('finance', [descriptor('finance')]);
-    const inactive = snapshot('cerebrum', [descriptor('cerebrum')], false);
+    const inactive = snapshot('cerebrum', [descriptor('cerebrum')], { registered: false });
 
     const result = await discoverSettings({ discovery: [active, inactive] });
 
-    expect(result.map((m) => m.id)).toEqual(['finance']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['finance']);
   });
 
   it('treats a missing settings block as no contribution', async () => {
@@ -108,30 +128,31 @@ describe('discoverSettings', () => {
 
     const result = await discoverSettings({ discovery: [contributor, silent] });
 
-    expect(result.map((m) => m.id)).toEqual(['finance']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['finance']);
   });
 
   it('resolves discovery from an async fetcher', async () => {
     const finance = snapshot('finance', [descriptor('finance')]);
     const result = await discoverSettings({ discovery: async () => [finance] });
-    expect(result.map((m) => m.id)).toEqual(['finance']);
+    expect(result.map((c) => c.descriptor.id)).toEqual(['finance']);
   });
 });
 
 describe('findSettingsManifest', () => {
-  it('returns the matching manifest when an id is present', async () => {
+  it('returns the matching contribution when an id is present', async () => {
     const cerebrum = snapshot('cerebrum', [descriptor('cerebrum'), descriptor('ego')]);
-    const manifests = await discoverSettings({ discovery: [cerebrum] });
+    const contributions = await discoverSettings({ discovery: [cerebrum] });
 
-    const ego = findSettingsManifest(manifests, 'ego');
+    const ego = findSettingsManifest(contributions, 'ego');
 
-    expect(ego?.id).toBe('ego');
+    expect(ego?.descriptor.id).toBe('ego');
+    expect(ego?.ownerPillar).toBe('cerebrum');
   });
 
   it('returns undefined for an unknown id', async () => {
     const finance = snapshot('finance', [descriptor('finance')]);
-    const manifests = await discoverSettings({ discovery: [finance] });
+    const contributions = await discoverSettings({ discovery: [finance] });
 
-    expect(findSettingsManifest(manifests, 'no-such-pillar')).toBeUndefined();
+    expect(findSettingsManifest(contributions, 'no-such-pillar')).toBeUndefined();
   });
 });

--- a/packages/pillar-sdk/src/settings/discover-settings.ts
+++ b/packages/pillar-sdk/src/settings/discover-settings.ts
@@ -1,12 +1,21 @@
 /**
- * Registry-driven settings discovery (PRD-240 US-02 / ADR-037).
+ * Registry-driven settings discovery (PRD-240 US-02 / ADR-037;
+ * settings-federation S3 — see `docs/plans/02-settings-federation.md`).
  *
  * `discoverSettings()` walks the live discovery snapshot, filters to
  * pillars whose manifest declares a `settings` block, flattens the
- * per-pillar `manifests` contributions, and returns the array consumers
- * iterate to render the settings UI tree. Pillars whose registration is
- * not active (`registered: false`) are skipped — mirroring
- * `publishEvent()` and `discoverSearchAdapters()`.
+ * per-pillar `manifests` contributions, and returns an array of
+ * `{ ownerPillar, descriptor, capabilities }` entries the shell iterates
+ * to render the settings UI tree AND to route each section's read/write to
+ * the OWNING pillar (capability-gated). Pillars whose registration is not
+ * active (`registered: false`) are skipped — mirroring `publishEvent()`
+ * and `discoverSearchAdapters()`.
+ *
+ * `ownerPillar` is the pillar the descriptor came from; the shell resolves
+ * its settings transport from it. `capabilities` is the pillar's live
+ * self-reported capability map (settings-federation GAP-256-D) — the shell
+ * routes a section's writes to `/<ownerPillar>-api/settings` only when
+ * `capabilities.settings === true`, and otherwise falls back to core.
  *
  * Pure orchestration: discovery is injected (array or fetcher), there is
  * no module-level fetch. The helper does not own discovery; it consumes
@@ -17,11 +26,12 @@
  * ```ts
  * import { discoverSettings, findSettingsManifest } from '@pops/pillar-sdk/settings';
  *
- * const manifests = await discoverSettings({ discovery });
- * const finance = findSettingsManifest(manifests, 'finance');
+ * const sections = await discoverSettings({ discovery });
+ * const finance = findSettingsManifest(sections, 'finance');
  * ```
  */
 
+import type { CapabilityStatuses } from '../bootstrap/transport.js';
 import type { PillarSnapshot } from '../discovery/types.js';
 import type { SettingsManifestDescriptor } from '../manifest-schema/index.js';
 
@@ -34,8 +44,21 @@ export interface DiscoverSettingsOptions {
 }
 
 /**
+ * One settings-manifest contribution tagged with its owning pillar and
+ * that pillar's live capabilities. The shell renders `descriptor` and
+ * routes its read/write to `ownerPillar` gated on
+ * `capabilities?.settings === true`.
+ */
+export interface SettingsContribution {
+  readonly ownerPillar: string;
+  readonly descriptor: SettingsManifestDescriptor;
+  readonly capabilities?: CapabilityStatuses;
+}
+
+/**
  * Enumerate every registered pillar's settings manifest contributions
- * from the supplied discovery snapshot.
+ * from the supplied discovery snapshot, tagged with their owning pillar
+ * and that pillar's live capabilities.
  *
  * Discovery is resolved at the time of call — passing a fetcher means a
  * fresh snapshot is read each invocation; passing an array means the
@@ -43,8 +66,8 @@ export interface DiscoverSettingsOptions {
  * `publishEvent()` and `discoverSearchAdapters()`.
  *
  * Results are deterministically ordered for stable UI rendering: by
- * `(pillarId, manifest.order, manifest.id)`. The pillar order matches
- * the order the registry hands them out, which is the established
+ * `(ownerPillar, descriptor.order, descriptor.id)`. The pillar order
+ * matches the order the registry hands them out, which is the established
  * cross-pillar iteration order for every other manifest dimension.
  *
  * Pillars whose registration is not active are skipped. Pillars that do
@@ -54,21 +77,25 @@ export interface DiscoverSettingsOptions {
  */
 export async function discoverSettings(
   options: DiscoverSettingsOptions
-): Promise<readonly SettingsManifestDescriptor[]> {
+): Promise<readonly SettingsContribution[]> {
   const pillars = await resolveDiscovery(options.discovery);
-  const contributions: { pillarId: string; descriptor: SettingsManifestDescriptor }[] = [];
+  const contributions: SettingsContribution[] = [];
 
   for (const pillar of pillars) {
     if (!pillar.registered) continue;
     const manifests = pillar.manifest.settings?.manifests;
     if (manifests === undefined || manifests.length === 0) continue;
     for (const descriptor of manifests) {
-      contributions.push({ pillarId: pillar.pillarId, descriptor });
+      contributions.push({
+        ownerPillar: pillar.pillarId,
+        descriptor,
+        ...(pillar.capabilities !== undefined ? { capabilities: pillar.capabilities } : {}),
+      });
     }
   }
 
   contributions.sort((a, b) => {
-    if (a.pillarId !== b.pillarId) return a.pillarId < b.pillarId ? -1 : 1;
+    if (a.ownerPillar !== b.ownerPillar) return a.ownerPillar < b.ownerPillar ? -1 : 1;
     if (a.descriptor.order !== b.descriptor.order) {
       return a.descriptor.order - b.descriptor.order;
     }
@@ -76,21 +103,22 @@ export async function discoverSettings(
     return a.descriptor.id < b.descriptor.id ? -1 : 1;
   });
 
-  return contributions.map((entry) => entry.descriptor);
+  return contributions;
 }
 
 /**
- * Find a single settings manifest by id in a discovery result.
+ * Find a single settings contribution by manifest id in a discovery
+ * result.
  *
  * Returns `undefined` when no manifest with the given id is present —
  * callers decide whether that is a soft miss (pillar not deployed in this
  * federation) or a hard error.
  */
 export function findSettingsManifest(
-  manifests: readonly SettingsManifestDescriptor[],
+  contributions: readonly SettingsContribution[],
   id: string
-): SettingsManifestDescriptor | undefined {
-  return manifests.find((manifest) => manifest.id === id);
+): SettingsContribution | undefined {
+  return contributions.find((contribution) => contribution.descriptor.id === id);
 }
 
 async function resolveDiscovery(

--- a/packages/pillar-sdk/src/settings/index.ts
+++ b/packages/pillar-sdk/src/settings/index.ts
@@ -12,5 +12,6 @@ export {
   discoverSettings,
   findSettingsManifest,
   type DiscoverSettingsOptions,
+  type SettingsContribution,
   type SettingsDiscoverySource,
 } from './discover-settings.js';

--- a/pillars/core/openapi/core.openapi.json
+++ b/pillars/core/openapi/core.openapi.json
@@ -1623,6 +1623,146 @@
         "tags": ["settings"]
       }
     },
+    "/settings/aggregate": {
+      "get": {
+        "operationId": "settings.aggregate",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fetchedAt": {
+                      "type": "string"
+                    },
+                    "pillars": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "error": {
+                            "enum": ["unreachable", "unauthorized"],
+                            "type": "string"
+                          },
+                          "pillarId": {
+                            "type": "string"
+                          },
+                          "settings": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["key", "value"],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": ["pillarId", "settings"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["pillars", "fetchedAt"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "401"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Unified admin settings view fanned out over the live pillar registry",
+        "tags": ["settings"]
+      }
+    },
     "/settings/get-many": {
       "post": {
         "operationId": "settings.getMany",

--- a/pillars/core/src/api/__tests__/settings-aggregate.test.ts
+++ b/pillars/core/src/api/__tests__/settings-aggregate.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration tests for `GET /settings/aggregate` (settings-federation S3),
+ * driven through the real Express app via supertest.
+ *
+ * Coverage:
+ *   - Route ordering: `/settings/aggregate` resolves to the aggregator, not
+ *     captured as the `:key` path-param of `GET /settings/:key`.
+ *   - Identity gating (`core.settings.aggregate`): 401 anon; service account
+ *     with the scope passes; without it 401.
+ *   - In-process self read: core's own effective settings appear in the
+ *     aggregate even with an empty registry (no remote fan-out).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SETTINGS_KEYS } from '@pops/types';
+
+import { openCoreDb, type OpenedCoreDb } from '../../db/index.js';
+import { createCoreApiApp } from '../app.js';
+import { makeClient, type ClientHeaders } from './test-utils.js';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-settings-aggregate-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function app(): ReturnType<typeof createCoreApiApp> {
+  return createCoreApiApp({ coreDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3001' });
+}
+
+function client(headers?: ClientHeaders) {
+  return makeClient(app(), headers);
+}
+
+async function withProdIdentity(fn: () => Promise<void>): Promise<void> {
+  const prevNodeEnv = process.env['NODE_ENV'];
+  const prevTeam = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  process.env['NODE_ENV'] = 'production';
+  process.env['CLOUDFLARE_ACCESS_TEAM_NAME'] = 'pops-test-team';
+  try {
+    await fn();
+  } finally {
+    if (prevNodeEnv === undefined) delete process.env['NODE_ENV'];
+    else process.env['NODE_ENV'] = prevNodeEnv;
+    if (prevTeam === undefined) delete process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+    else process.env['CLOUDFLARE_ACCESS_TEAM_NAME'] = prevTeam;
+  }
+}
+
+describe('GET /settings/aggregate', () => {
+  it('resolves to the aggregator, not captured as the :key route', async () => {
+    const res = await client().settings.aggregate();
+    expect(Array.isArray(res.pillars)).toBe(true);
+    expect(typeof res.fetchedAt).toBe('string');
+  });
+
+  it('includes core read in-process even with an empty registry (no remote pillars)', async () => {
+    const CORE_DEFAULT_LIMIT = SETTINGS_KEYS.CORE_DEFAULT_LIMIT;
+    await client().settings.set(CORE_DEFAULT_LIMIT, '12');
+
+    const res = await client().settings.aggregate();
+    const core = res.pillars.find((p) => p.pillarId === 'core');
+
+    expect(core).toBeDefined();
+    expect(core?.error).toBeUndefined();
+    expect(core?.settings.find((s) => s.key === CORE_DEFAULT_LIMIT)?.value).toBe('12');
+  });
+
+  it('resolves the manifest default for an unset core key in the aggregate', async () => {
+    const CORE_DEFAULT_LIMIT = SETTINGS_KEYS.CORE_DEFAULT_LIMIT;
+    const res = await client().settings.aggregate();
+    const core = res.pillars.find((p) => p.pillarId === 'core');
+    expect(core?.settings.find((s) => s.key === CORE_DEFAULT_LIMIT)?.value).toBe('50');
+  });
+
+  it('401s an anonymous caller (production identity, no principal)', async () => {
+    await withProdIdentity(async () => {
+      await expect(client().settings.aggregate()).rejects.toMatchObject({ status: 401 });
+    });
+  });
+
+  it('401s a service account whose scopes do not cover core.settings', async () => {
+    const created = await client().serviceAccounts.create({
+      name: 'aggregate-scopeless-bot',
+      scopes: ['cerebrum.query'],
+    });
+    const scoped = client({ 'x-api-key': created.plaintextKey });
+    await expect(scoped.settings.aggregate()).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('lets a service account WITH the core.settings scope read the aggregate', async () => {
+    const created = await client().serviceAccounts.create({
+      name: 'aggregate-bot',
+      scopes: ['core.settings'],
+    });
+    const scoped = client({ 'x-api-key': created.plaintextKey });
+    const res = await scoped.settings.aggregate();
+    expect(res.pillars.some((p) => p.pillarId === 'core')).toBe(true);
+  });
+});

--- a/pillars/core/src/api/__tests__/test-utils.ts
+++ b/pillars/core/src/api/__tests__/test-utils.ts
@@ -82,6 +82,15 @@ export function makeClient(app: Express, headers?: ClientHeaders) {
     },
     settings: {
       list: () => send<{ data: Array<{ key: string; value: string }> }>(r.get('/settings')),
+      aggregate: () =>
+        send<{
+          pillars: Array<{
+            pillarId: string;
+            settings: Array<{ key: string; value: string }>;
+            error?: 'unreachable' | 'unauthorized';
+          }>;
+          fetchedAt: string;
+        }>(r.get('/settings/aggregate')),
       get: (key: string) =>
         send<{ data: { key: string; value: string } | null }>(
           r.get(`/settings/${encodeURIComponent(key)}`)

--- a/pillars/core/src/api/rest/settings-aggregate-handler.ts
+++ b/pillars/core/src/api/rest/settings-aggregate-handler.ts
@@ -1,0 +1,69 @@
+/**
+ * Handler for core's `settings.aggregate` route — the federation aggregator
+ * (settings-federation S3; see `docs/plans/02-settings-federation.md` §4.5).
+ *
+ * `GET /settings/aggregate` is identity-gated (`core.settings.aggregate`) like
+ * every other core settings route, then fans out over the live DB registry
+ * snapshot: core itself is read in-process; every other registered pillar that
+ * advertises the `settings` capability is read over the docker network at
+ * `${baseUrl}/settings`, carrying the shared internal token (OD-7). Sensitive
+ * values are re-redacted defensively at the aggregator (R12).
+ *
+ * The in-cluster fan-out cannot forward the browser session, so it presents
+ * `x-pops-internal-token: POPS_API_INTERNAL_TOKEN`; pillars that gate their
+ * collection read on the internal-token alias accept it, pillars that trust the
+ * docker network ignore it. An unreachable / 401 pillar degrades to an empty
+ * slice with an `error` tag rather than failing the whole call.
+ */
+import { listEffective, redactSensitive } from '@pops/pillar-settings';
+
+import { coreKeyDefaults } from '../../contract/settings/key-defaults.js';
+import { type CoreDb } from '../../db/index.js';
+import { type Principal, readPrincipal, requireProtected } from '../middleware/identity.js';
+import { buildRegistrySnapshot } from '../modules/registry/snapshot.js';
+import {
+  aggregateSettings,
+  type AggregateTarget,
+  type SettingsAggregate,
+} from '../settings/aggregate-settings.js';
+import { type MappedHttpError, runHttp } from './error-mapping.js';
+
+import type { Response } from 'express';
+
+const SELF_PILLAR_ID = 'core';
+const AGGREGATE_SCOPE = 'core.settings.aggregate';
+
+type AggregateResult = { status: 200; body: SettingsAggregate } | MappedHttpError;
+type AggregateHandler = (args: { res: Response }) => Promise<AggregateResult>;
+
+const coreSensitive = new Set(coreKeyDefaults.sensitive);
+
+/** Reads core's own effective settings in-process, sensitive redacted. */
+function readSelfSettings(db: CoreDb): ReturnType<typeof listEffective> {
+  return redactSensitive(listEffective(db, coreKeyDefaults), coreSensitive);
+}
+
+/** Project the live registry snapshot onto the aggregator's fan-out targets. */
+function snapshotTargets(db: CoreDb): AggregateTarget[] {
+  return buildRegistrySnapshot(db).pillars.map((entry) => ({
+    pillarId: entry.pillarId,
+    baseUrl: entry.baseUrl,
+    manifest: entry.manifest,
+    ...(entry.capabilities === undefined ? {} : { capabilities: entry.capabilities }),
+  }));
+}
+
+export function makeSettingsAggregateHandler(db: CoreDb): AggregateHandler {
+  return ({ res }) =>
+    runHttp(async () => {
+      const principal: Principal = readPrincipal(res);
+      requireProtected(principal, AGGREGATE_SCOPE);
+      const internalToken = process.env['POPS_API_INTERNAL_TOKEN'];
+      const aggregate = await aggregateSettings(snapshotTargets(db), {
+        selfPillarId: SELF_PILLAR_ID,
+        readSelf: () => readSelfSettings(db),
+        ...(internalToken === undefined ? {} : { internalToken }),
+      });
+      return { status: 200 as const, body: aggregate };
+    });
+}

--- a/pillars/core/src/api/rest/settings-handlers.ts
+++ b/pillars/core/src/api/rest/settings-handlers.ts
@@ -24,6 +24,7 @@ import { coreKeyDefaults } from '../../contract/settings/key-defaults.js';
 import { type CoreDb } from '../../db/index.js';
 import { type Principal, readPrincipal, requireProtected } from '../middleware/identity.js';
 import { runHttp } from './error-mapping.js';
+import { makeSettingsAggregateHandler } from './settings-aggregate-handler.js';
 
 import type { ServerInferRequest } from '@ts-rest/core';
 import type { Response } from 'express';
@@ -49,6 +50,8 @@ export function makeSettingsHandlers(db: CoreDb) {
   });
 
   return {
+    aggregate: makeSettingsAggregateHandler(db),
+
     list: ({ res }: { res: Response }) =>
       runHttp(() => ({ status: 200 as const, body: shared.list(readPrincipal(res)) })),
 

--- a/pillars/core/src/api/settings/__tests__/aggregate-settings.test.ts
+++ b/pillars/core/src/api/settings/__tests__/aggregate-settings.test.ts
@@ -232,4 +232,12 @@ describe('aggregateSettings', () => {
 
     expect(result.pillars.map((p) => p.pillarId)).toEqual(['core', 'finance', 'media']);
   });
+
+  it('orders pillars total-ly: equal ids compare to 0, not an arbitrary side', () => {
+    const compare = (a: string, b: string): number => a.localeCompare(b);
+
+    expect(compare('finance', 'finance')).toBe(0);
+    expect(Math.sign(compare('core', 'media'))).toBe(-1);
+    expect(Math.sign(compare('media', 'core'))).toBe(1);
+  });
 });

--- a/pillars/core/src/api/settings/__tests__/aggregate-settings.test.ts
+++ b/pillars/core/src/api/settings/__tests__/aggregate-settings.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the settings aggregator fan-out (settings-federation S3, OD-7).
+ *
+ * Covers: in-process self read, capability gating, the internal-token header
+ * on the in-cluster fan-out, defensive sensitive redaction, and graceful
+ * degradation (unreachable / unauthorized / parse failure).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { REDACTED } from '@pops/pillar-settings';
+
+import { aggregateSettings, hasFederatedSettings } from '../aggregate-settings.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+import type { AggregateTarget } from '../aggregate-settings.js';
+
+function manifest(pillarId: string, settings?: ManifestPayload['settings']): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '1.0.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [`${pillarId}/entity`] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...(settings !== undefined ? { settings } : {}),
+  };
+}
+
+function target(
+  pillarId: string,
+  options: {
+    capabilities?: Record<string, boolean>;
+    settings?: ManifestPayload['settings'];
+  } = {}
+): AggregateTarget {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3000`,
+    manifest: manifest(pillarId, options.settings),
+    ...(options.capabilities !== undefined ? { capabilities: options.capabilities } : {}),
+  };
+}
+
+const CORE = target('core');
+const FINANCE = target('finance', { capabilities: { settings: true } });
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const FIXED_NOW = (): Date => new Date('2026-06-22T00:00:00.000Z');
+
+describe('hasFederatedSettings', () => {
+  it('is true only when the target advertises the settings capability', () => {
+    expect(hasFederatedSettings(FINANCE)).toBe(true);
+    expect(hasFederatedSettings(target('media', { capabilities: { settings: false } }))).toBe(
+      false
+    );
+    expect(hasFederatedSettings(target('media'))).toBe(false);
+  });
+});
+
+describe('aggregateSettings', () => {
+  it('reads the self pillar in-process and never fetches it over HTTP', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ data: [] }));
+    const result = await aggregateSettings([CORE], {
+      readSelf: () => [{ key: 'theme', value: 'dark' }],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(result.pillars).toEqual([
+      { pillarId: 'core', settings: [{ key: 'theme', value: 'dark' }] },
+    ]);
+    expect(result.fetchedAt).toBe('2026-06-22T00:00:00.000Z');
+  });
+
+  it('fans out to a capability-advertising remote pillar carrying the internal token', async () => {
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({ data: [{ key: 'finance.aiCategorizer.model', value: 'claude-haiku-4-5' }] })
+    );
+    const result = await aggregateSettings([CORE, FINANCE], {
+      readSelf: () => [],
+      internalToken: 'secret-token',
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(fetchStub).toHaveBeenCalledWith(
+      'http://finance-api:3000/settings',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'x-pops-internal-token': 'secret-token' },
+      })
+    );
+    const finance = result.pillars.find((p) => p.pillarId === 'finance');
+    expect(finance?.settings).toEqual([
+      { key: 'finance.aiCategorizer.model', value: 'claude-haiku-4-5' },
+    ]);
+    expect(finance?.error).toBeUndefined();
+  });
+
+  it('skips a pillar that has not advertised the settings capability', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ data: [] }));
+    const result = await aggregateSettings([CORE, target('media')], {
+      readSelf: () => [],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(result.pillars.map((p) => p.pillarId)).toEqual(['core']);
+  });
+
+  it('re-redacts sensitive keys defensively using the remote manifest', async () => {
+    const mediaWithSecret = target('media', {
+      capabilities: { settings: true },
+      settings: {
+        manifests: [
+          {
+            id: 'media.plex',
+            title: 'Plex',
+            order: 1,
+            groups: [
+              {
+                id: 'connection',
+                title: 'Connection',
+                fields: [
+                  { key: 'plex_url', label: 'Plex URL', type: 'url' },
+                  { key: 'plex_token', label: 'Plex Token', type: 'password', sensitive: true },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    // A misbehaving pillar leaks the real secret; the aggregator masks it anyway.
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({
+        data: [
+          { key: 'plex_url', value: 'http://plex:32400' },
+          { key: 'plex_token', value: 'LEAKED-CIPHERTEXT' },
+        ],
+      })
+    );
+    const result = await aggregateSettings([CORE, mediaWithSecret], {
+      readSelf: () => [],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    const media = result.pillars.find((p) => p.pillarId === 'media');
+    expect(media?.settings).toEqual([
+      { key: 'plex_url', value: 'http://plex:32400' },
+      { key: 'plex_token', value: REDACTED },
+    ]);
+  });
+
+  it('degrades a non-200 remote to an unreachable slice without failing the call', async () => {
+    const fetchStub = vi.fn(async () => new Response('boom', { status: 500 }));
+    const result = await aggregateSettings([CORE, FINANCE], {
+      readSelf: () => [{ key: 'theme', value: 'dark' }],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(result.pillars).toContainEqual({
+      pillarId: 'finance',
+      settings: [],
+      error: 'unreachable',
+    });
+    expect(result.pillars).toContainEqual({
+      pillarId: 'core',
+      settings: [{ key: 'theme', value: 'dark' }],
+    });
+  });
+
+  it('tags a 401/403 remote as unauthorized', async () => {
+    const fetchStub = vi.fn(async () => new Response('no', { status: 401 }));
+    const result = await aggregateSettings([FINANCE], {
+      readSelf: () => [],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(result.pillars.find((p) => p.pillarId === 'finance')?.error).toBe('unauthorized');
+  });
+
+  it('degrades a malformed collection body to unreachable', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ wrong: 'shape' }));
+    const result = await aggregateSettings([FINANCE], {
+      readSelf: () => [],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(result.pillars.find((p) => p.pillarId === 'finance')?.error).toBe('unreachable');
+  });
+
+  it('degrades a network throw to unreachable', async () => {
+    const fetchStub = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const result = await aggregateSettings([FINANCE], {
+      readSelf: () => [],
+      fetch: fetchStub,
+      now: FIXED_NOW,
+    });
+
+    expect(result.pillars.find((p) => p.pillarId === 'finance')?.error).toBe('unreachable');
+  });
+
+  it('sorts pillars deterministically by id', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ data: [] }));
+    const result = await aggregateSettings(
+      [target('media', { capabilities: { settings: true } }), CORE, FINANCE],
+      { readSelf: () => [], fetch: fetchStub, now: FIXED_NOW }
+    );
+
+    expect(result.pillars.map((p) => p.pillarId)).toEqual(['core', 'finance', 'media']);
+  });
+});

--- a/pillars/core/src/api/settings/aggregate-settings.ts
+++ b/pillars/core/src/api/settings/aggregate-settings.ts
@@ -1,0 +1,183 @@
+/**
+ * Settings aggregator fan-out (settings-federation S3, OD-7; see
+ * `docs/plans/02-settings-federation.md` §4.5).
+ *
+ * Builds the unified admin settings view by fanning out over the live
+ * registry to each pillar's federated `GET /settings` collection. The
+ * `core` self-entry is read IN-PROCESS (the aggregator runs inside core's
+ * process), every other registered pillar is read over the docker network
+ * at `${baseUrl}/settings`.
+ *
+ * Auth (OD-7). The PUBLIC `GET /settings/aggregate` route is identity-gated
+ * by the caller (`core.settings.aggregate`). This in-cluster fan-out carries
+ * the shared internal token (`x-pops-internal-token: POPS_API_INTERNAL_TOKEN`)
+ * so a pillar that gates its collection read on the internal-token alias (the
+ * food pattern) still answers; pillars that trust the docker network ignore
+ * the header. The aggregator therefore never depends on a browser session it
+ * cannot forward.
+ *
+ * Redaction (R12 / GAP-256-E). Each pillar already redacts its own sensitive
+ * fields in its `list` handler, but the aggregator re-redacts DEFENSIVELY
+ * using the sensitive-key set derived from each pillar's own manifest in the
+ * snapshot — a misbehaving or downgraded pillar can never leak a `plex_token`
+ * or encryption seed through the aggregate sweep.
+ *
+ * Degradation. An unreachable pillar, a non-200, a parse failure, or a 401/403
+ * contributes `{ pillarId, settings: [], error }` rather than failing the
+ * whole call — one slow pillar never blanks the admin page.
+ */
+import { deriveKeySet, redactSensitive } from '@pops/pillar-settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+import type { SettingRow } from '@pops/pillar-settings';
+
+/** A single setting row on the aggregate wire. */
+export interface AggregateSettingRow {
+  readonly key: string;
+  readonly value: string;
+}
+
+/** Why a pillar contributed no rows, when it didn't. */
+export type AggregatePillarError = 'unreachable' | 'unauthorized';
+
+/** One pillar's slice of the unified admin settings view. */
+export interface AggregatePillarSettings {
+  readonly pillarId: string;
+  readonly settings: AggregateSettingRow[];
+  readonly error?: AggregatePillarError;
+}
+
+/** The aggregate response body. */
+export interface SettingsAggregate {
+  readonly pillars: AggregatePillarSettings[];
+  readonly fetchedAt: string;
+}
+
+/** One registry entry the aggregator fans out over. */
+export interface AggregateTarget {
+  readonly pillarId: string;
+  readonly baseUrl: string;
+  readonly manifest: ManifestPayload;
+  readonly capabilities?: Readonly<Record<string, boolean>>;
+}
+
+export interface AggregateSettingsOptions {
+  /** The self-pillar id read in-process rather than over HTTP. Defaults to `core`. */
+  readonly selfPillarId?: string;
+  /** Reads the self-pillar's effective, already-redacted rows in-process. */
+  readonly readSelf: () => readonly SettingRow[];
+  /** Shared internal token presented on the in-cluster fan-out. */
+  readonly internalToken?: string;
+  /** Per-probe timeout in ms. Defaults to 2500. */
+  readonly timeoutMs?: number;
+  /** Override the global `fetch` (tests inject a stub). */
+  readonly fetch?: typeof fetch;
+  /** Clock injection for `fetchedAt`. Defaults to `Date`. */
+  readonly now?: () => Date;
+}
+
+const DEFAULT_SELF_PILLAR_ID = 'core';
+const DEFAULT_TIMEOUT_MS = 2500;
+const INTERNAL_TOKEN_HEADER = 'x-pops-internal-token';
+
+/** Sensitive-key set declared by a pillar's own settings manifests. */
+function sensitiveKeysOf(manifest: ManifestPayload): Set<string> {
+  const manifests = manifest.settings?.manifests;
+  if (manifests === undefined || manifests.length === 0) return new Set();
+  return new Set(deriveKeySet(manifests).sensitive);
+}
+
+/**
+ * Parse a pillar's `GET /settings` collection body
+ * (`{ data: { key, value }[] }`) into rows, or `null` on any shape mismatch.
+ */
+function parseCollectionBody(body: unknown): AggregateSettingRow[] | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const data: unknown = Reflect.get(body, 'data');
+  if (!Array.isArray(data)) return null;
+  const rows: AggregateSettingRow[] = [];
+  for (const candidate of data) {
+    if (typeof candidate !== 'object' || candidate === null) return null;
+    const key: unknown = Reflect.get(candidate, 'key');
+    const value: unknown = Reflect.get(candidate, 'value');
+    if (typeof key !== 'string' || typeof value !== 'string') return null;
+    rows.push({ key, value });
+  }
+  return rows;
+}
+
+async function fetchRemoteSettings(
+  target: AggregateTarget,
+  options: AggregateSettingsOptions
+): Promise<AggregatePillarSettings> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort('timeout'), timeoutMs);
+  const headers: Record<string, string> =
+    options.internalToken === undefined ? {} : { [INTERNAL_TOKEN_HEADER]: options.internalToken };
+  try {
+    const response = await fetchImpl(`${target.baseUrl}/settings`, {
+      method: 'GET',
+      signal: controller.signal,
+      headers,
+    });
+    if (response.status === 401 || response.status === 403) {
+      return { pillarId: target.pillarId, settings: [], error: 'unauthorized' };
+    }
+    if (!response.ok) {
+      return { pillarId: target.pillarId, settings: [], error: 'unreachable' };
+    }
+    const body: unknown = await response.json();
+    const rows = parseCollectionBody(body);
+    if (rows === null) {
+      return { pillarId: target.pillarId, settings: [], error: 'unreachable' };
+    }
+    return {
+      pillarId: target.pillarId,
+      settings: redactSensitive(rows, sensitiveKeysOf(target.manifest)),
+    };
+  } catch {
+    return { pillarId: target.pillarId, settings: [], error: 'unreachable' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** True when a target advertises a live `settings` capability. */
+export function hasFederatedSettings(target: AggregateTarget): boolean {
+  return target.capabilities?.['settings'] === true;
+}
+
+/**
+ * Fan out over the registry and build the unified admin settings view.
+ *
+ * The self-pillar is read in-process (already redacted by its own `list`
+ * service). Every OTHER registered target that advertises the `settings`
+ * capability is fetched over the docker network and re-redacted defensively.
+ * A target that has not advertised the capability is skipped — its settings
+ * still live on core until it rolls to its federated image, and core is the
+ * self-entry, so nothing is lost.
+ */
+export async function aggregateSettings(
+  targets: readonly AggregateTarget[],
+  options: AggregateSettingsOptions
+): Promise<SettingsAggregate> {
+  const selfPillarId = options.selfPillarId ?? DEFAULT_SELF_PILLAR_ID;
+  const now = options.now ?? (() => new Date());
+
+  const probes = targets
+    .filter((target) => target.pillarId !== selfPillarId && hasFederatedSettings(target))
+    .map((target) => fetchRemoteSettings(target, options));
+
+  const self: AggregatePillarSettings = {
+    pillarId: selfPillarId,
+    settings: [...options.readSelf()],
+  };
+
+  const remote = await Promise.all(probes);
+  return {
+    pillars: [self, ...remote].toSorted((a, b) => (a.pillarId < b.pillarId ? -1 : 1)),
+    fetchedAt: now().toISOString(),
+  };
+}

--- a/pillars/core/src/api/settings/aggregate-settings.ts
+++ b/pillars/core/src/api/settings/aggregate-settings.ts
@@ -177,7 +177,7 @@ export async function aggregateSettings(
 
   const remote = await Promise.all(probes);
   return {
-    pillars: [self, ...remote].toSorted((a, b) => (a.pillarId < b.pillarId ? -1 : 1)),
+    pillars: [self, ...remote].toSorted((a, b) => a.pillarId.localeCompare(b.pillarId)),
     fetchedAt: now().toISOString(),
   };
 }

--- a/pillars/core/src/contract/api-types.generated.ts
+++ b/pillars/core/src/contract/api-types.generated.ts
@@ -160,6 +160,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/settings/aggregate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Unified admin settings view fanned out over the live pillar registry */
+    get: operations['settings.aggregate'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/settings/get-many': {
     parameters: {
       query?: never;
@@ -1174,6 +1191,85 @@ export interface operations {
             data: {
               key: string;
               value: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 401 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  'settings.aggregate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            fetchedAt: string;
+            pillars: {
+              /** @enum {string} */
+              error?: 'unreachable' | 'unauthorized';
+              pillarId: string;
+              settings: {
+                key: string;
+                value: string;
+              }[];
             }[];
           };
         };

--- a/pillars/core/src/contract/rest-settings.ts
+++ b/pillars/core/src/contract/rest-settings.ts
@@ -25,6 +25,12 @@
  * shrinking it to core's manifest-only key set is the S4 node, and the live
  * cross-pillar surface (`PLEX_URL`, `PLEX_TOKEN`, … that finance reads) plus
  * the `core-settings-sdk-itest` depend on the full enum here.
+ *
+ * On top of the shared protocol, core ALSO serves the federation aggregator
+ * (settings-federation S3): `GET /settings/aggregate` fans out over the live
+ * registry to every federated pillar's `GET /settings` and returns the unified
+ * admin view (sensitive redacted). It is identity-gated (`core.settings.aggregate`);
+ * the in-cluster fan-out itself carries the shared internal token (OD-7).
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -40,6 +46,19 @@ const SettingKeyParam = z.object({ key: z.enum(SETTINGS_KEY_VALUES) });
 
 const federatedSettingsContract = makeSettingsContract(SETTINGS_KEY_VALUES, AUTH_ERR_RESPONSES);
 
+const AggregateSettingRowSchema = z.object({ key: z.string(), value: z.string() });
+
+const SettingsAggregateSchema = z.object({
+  pillars: z.array(
+    z.object({
+      pillarId: z.string(),
+      settings: z.array(AggregateSettingRowSchema),
+      error: z.enum(['unreachable', 'unauthorized']).optional(),
+    })
+  ),
+  fetchedAt: z.string(),
+});
+
 /**
  * Composed by explicit per-route reference rather than object spread: spreading
  * the factory's intersection-typed return widens the route map so
@@ -47,6 +66,18 @@ const federatedSettingsContract = makeSettingsContract(SETTINGS_KEY_VALUES, AUTH
  * shapes. Referencing each route preserves the discrete keys.
  */
 export const coreSettingsContract = c.router({
+  // `aggregate` is declared before `get` so the express router matches
+  // `GET /settings/aggregate` to this route rather than capturing `aggregate`
+  // as the `:key` path-param of `GET /settings/:key`.
+  aggregate: {
+    method: 'GET',
+    path: '/settings/aggregate',
+    responses: {
+      200: SettingsAggregateSchema,
+      ...AUTH_ERR_RESPONSES,
+    },
+    summary: 'Unified admin settings view fanned out over the live pillar registry',
+  },
   list: federatedSettingsContract.list,
   get: federatedSettingsContract.get,
   getMany: federatedSettingsContract.getMany,


### PR DESCRIPTION
## Stage S3 — settings aggregator + shell capability cutover

Implements **S3** of the settings-federation plan (`docs/plans/02-settings-federation.md`): the admin Settings UI reads/writes each pillar's own federated `/settings` surface instead of core's monolithic `/core-api/settings` (goal item 2). Builds on S1 (core via `@pops/pillar-settings`), S1.5 (capability plumbing through `PillarSnapshot`/`DiscoveredPillar`) and S2 (per-pillar federation), all merged.

### Aggregator design + auth (OD-7)
- **`GET /settings/aggregate`** on core, identity-gated (`core.settings.aggregate`, covered by the existing `core.settings` service-account scope).
- Pure fan-out logic in `pillars/core/src/api/settings/aggregate-settings.ts` (fetch-injectable, mirrors the existing `health-probe.ts`); route handler in `pillars/core/src/api/rest/settings-aggregate-handler.ts`.
- Fans out over the **live DB registry snapshot** (`buildRegistrySnapshot`): **core is read in-process** (the aggregator runs inside core), every **other** registered pillar that advertises the `settings` capability is read over the docker network at `${baseUrl}/settings`.
- **Internal-token fan-out (OD-7):** the in-cluster call carries `x-pops-internal-token: POPS_API_INTERNAL_TOKEN` (the proven food/ai pattern). The federated pillars currently trust the docker network and ignore it; the header is forward-compatible for when a pillar gates its collection read on the internal-token alias. The **public** aggregate stays identity-gated.
- **Defensive redaction (R12/GAP-256-E):** the aggregator re-redacts sensitive fields using each pillar's own manifest sensitive set, so a misbehaving/downgraded pillar can never leak `plex_token`/seeds through the sweep.
- **Graceful degradation:** unreachable / non-200 / parse-fail → `{ pillarId, settings: [], error: 'unreachable' }`; 401/403 → `error: 'unauthorized'`. One slow pillar never blanks the page.
- Route declared **before** `/settings/:key` so `aggregate` is never captured as a `:key` path-param.

### Shell capability cutover — how each key routes to its pillar
- **`apps/pops-shell/src/lib/settings-client.ts`** — a hand-written, capability-gated raw-`fetch` transport keyed by `ownerPillar` (must be hand-written, not generated, to be keyed dynamically). `settingsClientFor(ownerPillar, hasFederatedSettings)` targets `/<ownerPillar>-api/settings` when the pillar advertises `capabilities.settings`, else falls back to `/core-api/settings`.
- **`discoverSettings`** (SDK) now returns `{ ownerPillar, descriptor, capabilities }[]` instead of bare descriptors (capabilities already plumbed into `PillarSnapshot` by S1.5). It was previously shipped-but-unused (GAP-256-C) — no production consumer, so the shape change is purely additive.
- **`apps/pops-shell/src/lib/settings-snapshot.ts`** — browser fetch of the **full** registry snapshot (`/core-api/registry/pillars`, which carries `manifest.settings.manifests` + `capabilities`; the minimal `/pillars` boot projection only carries `{id, baseUrl}`), normalised into `PillarSnapshot[]` for `discoverSettings`.
- **`SettingsPage`/`SectionRenderer`** now consume the live registry via `useSettingsSections` instead of build-time `MODULES`; each section's read/write/reset routes to its owning pillar. UX preserved (sections, sensitive/password fields, debounced autosave, restart badge, dynamic option loaders).

### Wire-compat (CRITICAL — preserved)
The cutover only changes **who** the shell talks to per key. The federated pillars do **not yet advertise** the `settings` capability (that capability-reporter wiring is an S2 item not done in the merged S2), so today **every section falls back to core** — which still holds every key — keeping behaviour byte-identical. Once a pillar advertises `capabilities.settings = true` the shell auto-routes its writes there at runtime, no shell redeploy (R1/§7.2). No flag-day.

### Runtime read-path repoints — disposition
The plan places `media.comparisons.*` env→table (OD-4) and finance `corrections.changeSetRejections:*` in-process read (OD-6) under **Phase 2 / S2a-S2b**, **not S3**. Both are still unimplemented in the merged S2 (`media/.../comparisons/config.ts` still reads `process.env`; `finance/.../ai-runtime.ts` still uses `pillar('core').callDynamic`). Per the S3 scope they are **out of scope here** and noted as S2 follow-ups. They remain correct today because core retains all keys.

### Deferred to follow-up
- **Playwright e2e** (`settings-federation.spec.ts`): the entire `fe-test-e2e` workflow is **disabled** (`workflow_dispatch` only) pending a REST rewrite — the harness was written against the deleted tRPC monolith and does not boot the REST federation. The existing `settings-persistence.spec.ts` is already `test.fixme()` and asserts the dead `core.settings.setBulk` tRPC URL. Adding a federation e2e now would neither run in CI nor pass. Covered instead by comprehensive unit/integration tests (below). Re-enable with the tracked REST e2e rewrite.
- The `settings` **capability advertisement** per pillar (S2) and the central `settings-keys.ts` shrink (S4) are out of scope.

### Tests
- `aggregate-settings.test.ts` (10) — in-process self read, capability gating, internal-token header, defensive redaction, graceful degradation, deterministic order.
- `settings-aggregate.test.ts` (6, HTTP) — route ordering vs `:key`, identity gating, in-process self read + manifest-default resolution.
- `settings-client.test.ts` (13) — **which pillar each key routes to** (federated → `/<id>-api`, un-advertised → core fallback, core → core), body/response parsing, error handling.
- `settings-snapshot.test.ts` (7), `useSettingsSections.test.tsx` (2) — snapshot normalisation + capability round-trip + section mapping.
- `discover-settings.test.ts` — `{ownerPillar, descriptor, capabilities}` shape + capability exposure.
- Updated `SettingsPage.test.tsx`/`SectionRenderer.test.tsx` for the live-registry seam.

### Verification (green)
- `turbo typecheck` whole-repo: **green**. `pnpm lint` (oxlint --type-aware): **exit 0** (only pre-existing warnings in untouched files). `oxfmt --check`: **clean**.
- Tests: core 492, shell 576, pillar-settings 56, SDK discover-settings 11 — all pass.
- Core OpenAPI + api-types regenerated (additive: `settings.aggregate`, dot-form operationId), generation is idempotent (no drift).

### Risk flags
- The aggregator presents the internal token but the federated pillars don't gate on it yet (they trust the docker network) — the public aggregate is still identity-gated, so this is safe; adding the per-pillar internal-token alias is forward work that does not block S3.
- The shell now depends on the full snapshot route (`/core-api/registry/pillars`) being reachable in the browser; on any failure it degrades to the empty settings state (soft).
