### PR TITLE
ci(federation): agent-review gate with isolation guards [P6-T05]

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,44 @@
+name: Agent Review
+
+# Federation review gate. Two deterministic isolation guards (load-bearing,
+# blocking) plus an advisory LLM reviewer (degrades to a no-op without
+# ANTHROPIC_API_KEY). See docs/plans/repo-federation/05-cicd-deployment.md §A.3.
+#
+# Runs on every non-draft PR so the `agent-review` required check always
+# reports a result (a never-triggered required check would block forever).
+# The guards are zero-dependency Node scripts — no pnpm install needed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  agent-review:
+    name: agent-review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Guard self-tests (prove the guards catch violations)
+        run: |
+          node scripts/ci/check-lib-no-pillar-import.mjs --self-test
+          node scripts/ci/check-contract-isolation.mjs --self-test
+      - name: Isolation litmus — no cross-contract reach-behind
+        run: node scripts/ci/check-contract-isolation.mjs --base "origin/${{ github.base_ref }}"
+      - name: Lib-never-imports-pillar guard
+        run: node scripts/ci/check-lib-no-pillar-import.mjs
+      - name: LLM review (advisory — federation invariants rubric)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/agent-review.mjs --pr ${{ github.event.number }}

--- a/scripts/ci/__tests__/check-contract-isolation.test.ts
+++ b/scripts/ci/__tests__/check-contract-isolation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { findReachBehindInSource } from '../check-contract-isolation.mjs';
+
+describe('findReachBehindInSource', () => {
+  it('flags a deep import into another package src', () => {
+    const v = findReachBehindInSource(
+      "import { x } from '@pops/finance/src/db/internal.js';",
+      'pillars/ai/src/x.ts'
+    );
+    expect(v).toEqual([
+      { file: 'pillars/ai/src/x.ts', line: 1, specifier: '@pops/finance/src/db/internal.js' },
+    ]);
+  });
+
+  it('flags dist and internal reach-behind', () => {
+    expect(
+      findReachBehindInSource("import a from '@pops/ui/dist/button.js';", 'f.ts')
+    ).toHaveLength(1);
+    expect(
+      findReachBehindInSource("export { b } from '@pops/types/internal/secret';", 'f.ts')
+    ).toHaveLength(1);
+  });
+
+  it('allows the published root and declared subpath exports', () => {
+    expect(findReachBehindInSource("import a from '@pops/types';", 'f.ts')).toEqual([]);
+    expect(findReachBehindInSource("import b from '@pops/types/contract';", 'f.ts')).toEqual([]);
+    expect(findReachBehindInSource("import c from '@pops/ui/components';", 'f.ts')).toEqual([]);
+  });
+
+  it('ignores reach-behind-looking text in comments and non-import lines', () => {
+    expect(findReachBehindInSource('// migrate off @pops/finance/src/db someday', 'f.ts')).toEqual(
+      []
+    );
+    expect(findReachBehindInSource("const s = '@pops/finance/src/db';", 'f.ts')).toEqual([]);
+  });
+
+  it('reports the correct 1-based line number', () => {
+    const src = ['const ok = 1;', '', "import { x } from '@pops/ai/src/y.js';"].join('\n');
+    const v = findReachBehindInSource(src, 'f.ts');
+    expect(v).toHaveLength(1);
+    expect(v[0].line).toBe(3);
+  });
+
+  it('catches multiple reach-behinds across lines', () => {
+    const src = [
+      "import a from '@pops/ai/src/a.js';",
+      "import b from '@pops/media/dist/b.js';",
+    ].join('\n');
+    expect(findReachBehindInSource(src, 'f.ts')).toHaveLength(2);
+  });
+});

--- a/scripts/ci/__tests__/check-lib-no-pillar-import.test.ts
+++ b/scripts/ci/__tests__/check-lib-no-pillar-import.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractSpecifiers, findViolations } from '../check-lib-no-pillar-import.mjs';
+
+type Unit = Parameters<typeof findViolations>[0][number];
+
+const pillar = (name: string, dir = `pillars/${name.replace('@pops/', '')}`): Unit => ({
+  dir,
+  name,
+  kind: 'pillar',
+  pkg: {},
+});
+
+const lib = (name: string, pkg: Record<string, unknown>): Unit => ({
+  dir: `libs/${name.replace('@pops/', '')}`,
+  name,
+  kind: 'lib',
+  pkg,
+});
+
+describe('extractSpecifiers', () => {
+  it('matches every real import/export/require form', () => {
+    const src = [
+      "import a from '@pops/finance';",
+      "import { b } from '@pops/ui/button';",
+      "import type { T } from '@pops/types';",
+      "export { c } from '@pops/navigation';",
+      "const d = await import('@pops/media/x');",
+      "const e = require('@pops/core');",
+    ].join('\n');
+    expect(extractSpecifiers(src)).toEqual(
+      expect.arrayContaining([
+        '@pops/finance',
+        '@pops/ui/button',
+        '@pops/types',
+        '@pops/navigation',
+        '@pops/media/x',
+        '@pops/core',
+      ])
+    );
+  });
+
+  it('does not match specifiers that only appear in comments or unrelated strings', () => {
+    const src = [
+      '// see @pops/finance for the contract',
+      "const label = 'package: @pops/core';",
+      '/* @pops/media is a pillar */',
+    ].join('\n');
+    expect(extractSpecifiers(src)).toEqual([]);
+  });
+});
+
+describe('findViolations', () => {
+  const units: Unit[] = [pillar('@pops/finance'), pillar('@pops/app-media', 'pillars/media/app')];
+
+  it('flags a pillar in dependencies (hard)', () => {
+    const all = [...units, lib('@pops/evil', { dependencies: { '@pops/finance': 'workspace:*' } })];
+    const v = findViolations(all, () => [], {});
+    expect(v).toContainEqual({ lib: '@pops/evil', pillar: '@pops/finance', via: 'dependencies' });
+  });
+
+  it('flags a pillar in peerDependencies (hard)', () => {
+    const all = [...units, lib('@pops/peer', { peerDependencies: { '@pops/finance': '*' } })];
+    const v = findViolations(all, () => [], {});
+    expect(v).toContainEqual({
+      lib: '@pops/peer',
+      pillar: '@pops/finance',
+      via: 'peerDependencies',
+    });
+  });
+
+  it('flags a pillar in devDependencies unless allowlisted', () => {
+    const all = [...units, lib('@pops/dev', { devDependencies: { '@pops/finance': '*' } })];
+    expect(findViolations(all, () => [], {})).toContainEqual({
+      lib: '@pops/dev',
+      pillar: '@pops/finance',
+      via: 'devDependencies',
+    });
+    const allowed = { '@pops/dev': new Set(['@pops/finance']) };
+    expect(findViolations(all, () => [], allowed)).toEqual([]);
+  });
+
+  it('flags a frontend pillar import in source (app-* counts as a pillar)', () => {
+    const all = [...units, lib('@pops/uses-fe', {})];
+    const v = findViolations(
+      all,
+      (u) => (u.name === '@pops/uses-fe' ? ["import { X } from '@pops/app-media/widget';"] : []),
+      {}
+    );
+    expect(v).toContainEqual({
+      lib: '@pops/uses-fe',
+      pillar: '@pops/app-media',
+      via: 'import @pops/app-media/widget',
+    });
+  });
+
+  it('passes a clean lib (lib→lib dep, no pillar reach)', () => {
+    const all = [
+      ...units,
+      lib('@pops/clean', { dependencies: { '@pops/types': 'workspace:*' } }),
+      lib('@pops/types', {}),
+    ];
+    expect(findViolations(all, () => [], {})).toEqual([]);
+  });
+
+  it('does not scan pillars themselves (a pillar may depend on a pillar)', () => {
+    const all = [
+      pillar('@pops/finance'),
+      {
+        dir: 'pillars/shell',
+        name: '@pops/shell',
+        kind: 'pillar',
+        pkg: { dependencies: { '@pops/finance': '*' } },
+      } satisfies Unit,
+    ];
+    expect(findViolations(all, () => [], {})).toEqual([]);
+  });
+});

--- a/scripts/ci/__tests__/import-scan.test.ts
+++ b/scripts/ci/__tests__/import-scan.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractSpecifiers, extractSpecifiersWithLines, isTestPath } from '../import-scan.mjs';
+
+describe('extractSpecifiers', () => {
+  it('matches real import / export-from / dynamic-import / require statements', () => {
+    const src = [
+      "import a from '@pops/finance';",
+      "export { b } from '@pops/ui/button';",
+      "const c = await import('@pops/media/x');",
+      "const d = require('@pops/core');",
+    ].join('\n');
+    expect(extractSpecifiers(src)).toEqual(
+      expect.arrayContaining(['@pops/finance', '@pops/ui/button', '@pops/media/x', '@pops/core'])
+    );
+  });
+
+  it('does NOT match an import keyword embedded in a string literal', () => {
+    // Regression: the guards/tests carry fixture strings like the one below;
+    // a line-level keyword check false-flagged them. A real import statement
+    // never has its keyword preceded by a quote.
+    const src = `findReachBehindInSource("import { x } from '@pops/finance/src/db/internal.js';", 'f');`;
+    expect(extractSpecifiers(src)).toEqual([]);
+  });
+
+  it('does not match specifiers in comments', () => {
+    expect(extractSpecifiers('// import x from "@pops/core"')).toEqual([]);
+    expect(extractSpecifiers('/* see @pops/ui/dist/button */')).toEqual([]);
+  });
+});
+
+describe('extractSpecifiersWithLines', () => {
+  it('reports the 1-based line of the specifier', () => {
+    const src = ['const x = 1;', '', "import a from '@pops/ai/src/y.js';"].join('\n');
+    expect(extractSpecifiersWithLines(src)).toEqual([{ specifier: '@pops/ai/src/y.js', line: 3 }]);
+  });
+});
+
+describe('isTestPath', () => {
+  it('matches test/spec files and __tests__ dirs', () => {
+    expect(isTestPath('libs/ui/src/__tests__/x.ts')).toBe(true);
+    expect(isTestPath('pillars/ai/src/foo.test.ts')).toBe(true);
+    expect(isTestPath('pillars/ai/src/foo.spec.tsx')).toBe(true);
+    expect(isTestPath('scripts/ci/check-contract-isolation.mjs')).toBe(false);
+    expect(isTestPath('pillars/ai/src/foo.ts')).toBe(false);
+  });
+});

--- a/scripts/ci/__tests__/import-scan.test.ts
+++ b/scripts/ci/__tests__/import-scan.test.ts
@@ -27,6 +27,28 @@ describe('extractSpecifiers', () => {
     expect(extractSpecifiers('// import x from "@pops/core"')).toEqual([]);
     expect(extractSpecifiers('/* see @pops/ui/dist/button */')).toEqual([]);
   });
+
+  it('handles a regex literal containing quotes followed by a comment-import', () => {
+    // Regression: a pattern like the scanner's own IMPORT_PATTERNS has `'`/`"`
+    // inside it; a naive stripper treats those as string starts, desyncs, and
+    // leaves the following comment unstripped.
+    const src = [
+      'const RE = [/(?:^|[\\s;])import\\s+from\\s+[\'"]([^\'"]+)[\'"]/gm];',
+      "// import x from '@pops/foo/src/y'",
+      "/* import z from '@pops/bar/dist/q' */",
+    ].join('\n');
+    expect(extractSpecifiers(src)).toEqual([]);
+  });
+
+  it('does not mistake a division operator for a regex (comment still stripped)', () => {
+    const src = ['const r = a / b / c;', "// import x from '@pops/foo/src/y'"].join('\n');
+    expect(extractSpecifiers(src)).toEqual([]);
+  });
+
+  it('still extracts a real import that follows a regex literal', () => {
+    const src = ['const RE = /[\'"]/g;', "import x from '@pops/finance/src/db';"].join('\n');
+    expect(extractSpecifiers(src)).toEqual(['@pops/finance/src/db']);
+  });
 });
 
 describe('extractSpecifiersWithLines', () => {

--- a/scripts/ci/__tests__/tsconfig.json
+++ b/scripts/ci/__tests__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts", "../*.mjs"]
+}

--- a/scripts/ci/agent-review.mjs
+++ b/scripts/ci/agent-review.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * LLM reviewer (advisory layer of the agent-review gate).
+ *
+ * The two deterministic guards — `check-contract-isolation.mjs` and
+ * `check-lib-no-pillar-import.mjs` — are the load-bearing, blocking checks.
+ * This reviewer is the taste/intent layer: it asks an Opus model to judge the
+ * PR diff against the federation invariants rubric and posts a verdict as a PR
+ * comment. It is **advisory** — it never fails the build (any error, missing
+ * credential, or API hiccup degrades to exit 0), so a flaky model call can
+ * never block a green PR. The deterministic guards are what gate.
+ *
+ * Rubric (00-architecture.md §6, README hard constraints):
+ *   - no `as any` / `as unknown as T` / `eslint-disable` / `ts-ignore`
+ *   - no cross-contract reach-behind; a lib never depends on a pillar
+ *   - no orphan TODO (file an issue + reference, or omit)
+ *   - no Claude/AI-assistant reference in commits or PR body
+ *   - the extract-to-own-repo litmus is addressed for any new/moved unit
+ *
+ * Requires `ANTHROPIC_API_KEY` to run; without it the step is a no-op (the
+ * repo does not provision the key today — see plan §A.3). `GITHUB_TOKEN` +
+ * `--pr <n>` enable posting the verdict comment; without them the verdict is
+ * logged only.
+ *
+ * Usage:
+ *   node scripts/ci/agent-review.mjs --pr 1234
+ *
+ * Always exits 0.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+const MODEL = 'claude-opus-4-8';
+const MAX_DIFF_BYTES = 180_000;
+
+const RUBRIC = [
+  'No `as any`, no `as unknown as T`, no `eslint-disable` / `ts-ignore` / suppressions.',
+  "No cross-contract reach-behind (importing another unit's src/dist/internal); a lib never depends on a pillar.",
+  'No orphan TODO (must reference a filed issue).',
+  'No reference to Claude / AI assistants in commit messages or the PR body.',
+  'For any new or relocated unit, the extract-to-own-repo litmus is satisfied (it could build/deploy/self-register in its own repo, changing only where shared deps come from).',
+].join('\n- ');
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+  const prIdx = argv.indexOf('--pr');
+  const pr = prIdx >= 0 ? argv[prIdx + 1] : process.env.PR_NUMBER;
+  const baseRef = process.env.GITHUB_BASE_REF ?? 'main';
+  return { pr, base: `origin/${baseRef}` };
+}
+
+/**
+ * @param {string} base
+ * @returns {string}
+ */
+function collectDiff(base) {
+  /** @param {string[]} a */
+  const git = (a) => execFileSync('git', a, { cwd: repoRoot, encoding: 'utf8' });
+  let mergeBase = base;
+  try {
+    const found = git(['merge-base', base, 'HEAD']).trim();
+    if (found) mergeBase = found;
+  } catch {
+    /* fall back to the raw ref */
+  }
+  let diff = '';
+  try {
+    diff = git(['diff', mergeBase, 'HEAD']);
+  } catch {
+    return '';
+  }
+  return diff.length > MAX_DIFF_BYTES
+    ? `${diff.slice(0, MAX_DIFF_BYTES)}\n\n…[diff truncated]…`
+    : diff;
+}
+
+/**
+ * @param {string} diff
+ * @param {string} apiKey
+ * @returns {Promise<string>}
+ */
+async function review(diff, apiKey) {
+  const prompt =
+    `You are reviewing a pull request in the POPS federation monorepo against ` +
+    `these non-negotiable invariants:\n\n- ${RUBRIC}\n\n` +
+    `Review ONLY the unified diff below. Reply with a short verdict: first line ` +
+    `exactly "VERDICT: PASS" or "VERDICT: CONCERNS", then up to 5 bullet points ` +
+    `citing file:line for any concern. Do not nitpick style the formatter owns.\n\n` +
+    `\`\`\`diff\n${diff}\n\`\`\``;
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Anthropic API ${res.status}: ${await res.text()}`);
+  }
+  /** @type {{ content?: Array<{ type: string; text?: string }> }} */
+  const body = await res.json();
+  return (body.content ?? [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text ?? '')
+    .join('\n')
+    .trim();
+}
+
+/**
+ * @param {string} pr
+ * @param {string} verdict
+ */
+function postComment(pr, verdict) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!token || !repo || !pr) {
+    console.log('No GITHUB_TOKEN/repo/PR — verdict logged only, not posted.');
+    return;
+  }
+  const body = `### 🤖 Agent review (advisory)\n\n${verdict}`;
+  try {
+    execFileSync('gh', ['api', `repos/${repo}/issues/${pr}/comments`, '-f', `body=${body}`], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: process.env,
+    });
+  } catch (err) {
+    console.log(
+      `Could not post PR comment (non-fatal): ${err instanceof Error ? err.message : err}`
+    );
+  }
+}
+
+async function main() {
+  const { pr, base } = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.log(
+      'agent-review: ANTHROPIC_API_KEY not set — skipping LLM review (advisory layer). ' +
+        'The deterministic isolation guards remain the blocking checks.'
+    );
+    return;
+  }
+  const diff = collectDiff(base);
+  if (!diff.trim()) {
+    console.log('agent-review: empty diff — nothing to review.');
+    return;
+  }
+  try {
+    const verdict = await review(diff, apiKey);
+    console.log(`agent-review verdict:\n${verdict}`);
+    if (pr) postComment(pr, verdict);
+  } catch (err) {
+    console.log(
+      `agent-review: LLM review failed (non-fatal, advisory): ${err instanceof Error ? err.message : err}`
+    );
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.log(`agent-review: unexpected error (non-fatal): ${err}`);
+    process.exit(0);
+  }
+);

--- a/scripts/ci/check-contract-isolation.mjs
+++ b/scripts/ci/check-contract-isolation.mjs
@@ -34,6 +34,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { extractSpecifiersWithLines, isTestPath } from './import-scan.mjs';
+
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..');
 
@@ -41,10 +43,10 @@ const repoRoot = resolve(here, '..', '..');
 const SOURCE_EXT = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/u;
 
 /**
- * Matches a deep import into another `@pops/*` package's build internals.
- * Group 1 = package name, group 2 = the internal segment reached.
+ * A specifier that reaches behind another `@pops/*` package's contract into
+ * its build internals (`/src`, `/dist`, `/internal`).
  */
-const REACH_BEHIND_RE = /['"](@pops\/[a-z0-9-]+)\/(src|dist|internal)\b[^'"]*['"]/gu;
+const REACH_BEHIND_SPEC = /^@pops\/[a-z0-9-]+\/(?:src|dist|internal)\b/u;
 
 /**
  * @typedef {object} ReachBehind
@@ -55,6 +57,9 @@ const REACH_BEHIND_RE = /['"](@pops\/[a-z0-9-]+)\/(src|dist|internal)\b[^'"]*['"
 
 /**
  * Find reach-behind specifiers in a single source string. Exported for tests.
+ * Only real import/export/require statements are inspected (a specifier inside
+ * a string literal — e.g. a test fixture or self-test — is not a real import
+ * and is ignored).
  *
  * @param {string} src
  * @param {string} file
@@ -63,15 +68,8 @@ const REACH_BEHIND_RE = /['"](@pops\/[a-z0-9-]+)\/(src|dist|internal)\b[^'"]*['"
 export function findReachBehindInSource(src, file) {
   /** @type {ReachBehind[]} */
   const out = [];
-  const lines = src.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Cheap skip: only lines that could carry a module specifier.
-    if (!line.includes('@pops/')) continue;
-    if (!/\b(?:import|export|require)\b/u.test(line)) continue;
-    for (const m of line.matchAll(REACH_BEHIND_RE)) {
-      out.push({ file, line: i + 1, specifier: m[0].slice(1, -1) });
-    }
+  for (const { specifier, line } of extractSpecifiersWithLines(src)) {
+    if (REACH_BEHIND_SPEC.test(specifier)) out.push({ file, line, specifier });
   }
   return out;
 }
@@ -97,7 +95,7 @@ function changedSourceFiles(base) {
   return diff
     .split('\n')
     .map((l) => l.trim())
-    .filter((l) => l.length > 0 && SOURCE_EXT.test(l));
+    .filter((l) => l.length > 0 && SOURCE_EXT.test(l) && !isTestPath(l));
 }
 
 /**

--- a/scripts/ci/check-contract-isolation.mjs
+++ b/scripts/ci/check-contract-isolation.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Federation isolation guard: **no cross-contract reach-behind.**
+ *
+ * The contract-seam rule (docs/plans/repo-federation/00-architecture.md §2):
+ * consume *across* contracts freely (a unit may import another unit's
+ * published name / declared subpath exports), but **never reach behind** a
+ * contract into another unit's internals. Importing another package's build
+ * internals — `@pops/<pkg>/src/…`, `@pops/<pkg>/dist/…`, `@pops/<pkg>/internal…`
+ * — bypasses its `exports` map and couples to internals that an extracted
+ * repo would not publish. That is the unambiguous reach-behind this guard
+ * catches.
+ *
+ * This is the **diff-scoped fast pass** (only files changed in the PR are
+ * inspected) that complements the whole-tree `lint:boundaries` dep-cruiser
+ * pass. It is deliberately conservative: it flags only deep imports into
+ * another package's `src`/`dist`/`internal`, which can never be legitimate
+ * (declared subpath exports such as `@pops/types/foo` are NOT flagged). The
+ * structural cross-unit rules (ISO-R1..R4) live in dep-cruiser (P6-T01).
+ *
+ * Degrades gracefully: if the base ref cannot be resolved (shallow clone,
+ * detached state) it inspects nothing and exits 0 rather than blocking — the
+ * whole-tree pass is the backstop.
+ *
+ * Usage:
+ *   node scripts/ci/check-contract-isolation.mjs --base origin/main
+ *   node scripts/ci/check-contract-isolation.mjs --self-test
+ *
+ * Exit 0 = clean / nothing to inspect. Exit 1 = reach-behind found.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+/** Extensions whose imports are inspected. */
+const SOURCE_EXT = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/u;
+
+/**
+ * Matches a deep import into another `@pops/*` package's build internals.
+ * Group 1 = package name, group 2 = the internal segment reached.
+ */
+const REACH_BEHIND_RE = /['"](@pops\/[a-z0-9-]+)\/(src|dist|internal)\b[^'"]*['"]/gu;
+
+/**
+ * @typedef {object} ReachBehind
+ * @property {string} file
+ * @property {number} line
+ * @property {string} specifier
+ */
+
+/**
+ * Find reach-behind specifiers in a single source string. Exported for tests.
+ *
+ * @param {string} src
+ * @param {string} file
+ * @returns {ReachBehind[]}
+ */
+export function findReachBehindInSource(src, file) {
+  /** @type {ReachBehind[]} */
+  const out = [];
+  const lines = src.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Cheap skip: only lines that could carry a module specifier.
+    if (!line.includes('@pops/')) continue;
+    if (!/\b(?:import|export|require)\b/u.test(line)) continue;
+    for (const m of line.matchAll(REACH_BEHIND_RE)) {
+      out.push({ file, line: i + 1, specifier: m[0].slice(1, -1) });
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the list of changed source files vs `base`. Returns null when the
+ * base ref is unavailable so the caller can no-op safely.
+ *
+ * @param {string} base
+ * @returns {string[] | null}
+ */
+function changedSourceFiles(base) {
+  /** @param {string[]} argv */
+  const git = (argv) => execFileSync('git', argv, { cwd: repoRoot, encoding: 'utf8' });
+  let mergeBase = '';
+  try {
+    mergeBase = git(['merge-base', base, 'HEAD']).trim();
+  } catch {
+    return null;
+  }
+  if (!mergeBase) return null;
+  const diff = git(['diff', '--name-only', '--diff-filter=ACMR', mergeBase, 'HEAD']);
+  return diff
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && SOURCE_EXT.test(l));
+}
+
+/**
+ * @param {string} base
+ * @returns {{ status: 'clean' | 'violations' | 'skipped'; violations: ReachBehind[] }}
+ */
+function run(base) {
+  const files = changedSourceFiles(base);
+  if (files === null) {
+    return { status: 'skipped', violations: [] };
+  }
+  /** @type {ReachBehind[]} */
+  const violations = [];
+  for (const rel of files) {
+    const abs = join(repoRoot, rel);
+    if (!existsSync(abs)) continue;
+    violations.push(...findReachBehindInSource(readFileSync(abs, 'utf8'), rel));
+  }
+  return { status: violations.length === 0 ? 'clean' : 'violations', violations };
+}
+
+/**
+ * Self-test: prove the detector flags a reach-behind import and ignores a
+ * legitimate contract import. CI runs this so a regression that neuters the
+ * matcher is caught deterministically.
+ *
+ * @returns {boolean}
+ */
+function selfTest() {
+  const bad = findReachBehindInSource(
+    "import { x } from '@pops/finance/src/db/internal.js';",
+    'fixture-bad.ts'
+  );
+  const dist = findReachBehindInSource(
+    "import { y } from '@pops/ui/dist/button.js';",
+    'fixture-dist.ts'
+  );
+  const goodRoot = findReachBehindInSource("import { z } from '@pops/types';", 'fixture-root.ts');
+  const goodSubpath = findReachBehindInSource(
+    "import { w } from '@pops/types/contract';",
+    'fixture-subpath.ts'
+  );
+  const comment = findReachBehindInSource(
+    '// see @pops/finance/src/db for the legacy layout',
+    'fixture-comment.ts'
+  );
+  const caughtSrc = bad.length === 1;
+  const caughtDist = dist.length === 1;
+  const allowedRoot = goodRoot.length === 0;
+  const allowedSubpath = goodSubpath.length === 0;
+  const ignoredComment = comment.length === 0;
+  const ok = caughtSrc && caughtDist && allowedRoot && allowedSubpath && ignoredComment;
+  if (!ok) {
+    console.error('SELF-TEST FAILED:');
+    console.error(`  caught /src/ reach-behind:   ${caughtSrc}`);
+    console.error(`  caught /dist/ reach-behind:  ${caughtDist}`);
+    console.error(`  allowed bare contract:       ${allowedRoot}`);
+    console.error(`  allowed subpath export:      ${allowedSubpath}`);
+    console.error(`  ignored comment:             ${ignoredComment}`);
+  } else {
+    console.log('self-test OK — flags /src|dist|internal/ reach-behind, allows contract imports.');
+  }
+  return ok;
+}
+
+function parseBase(argv) {
+  const i = argv.indexOf('--base');
+  if (i >= 0 && argv[i + 1]) return argv[i + 1];
+  return process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main';
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log('Usage: node scripts/ci/check-contract-isolation.mjs [--base <ref>] [--self-test]');
+    process.exit(2);
+  }
+  if (argv.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+  const base = parseBase(argv);
+  const { status, violations } = run(base);
+  if (status === 'skipped') {
+    console.log(
+      `Base ref "${base}" unavailable — skipping diff-scoped check (whole-tree pass is the backstop).`
+    );
+    process.exit(0);
+  }
+  if (status === 'clean') {
+    console.log(`OK — no cross-contract reach-behind in the diff vs ${base}.`);
+    process.exit(0);
+  }
+  console.error(`FAIL — ${violations.length} cross-contract reach-behind import(s):`);
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  ${v.specifier}`);
+  }
+  console.error(
+    '\nImport another unit only through its published name or declared subpath ' +
+      'exports — never its src/dist/internal (00-architecture.md §2).'
+  );
+  process.exit(1);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}

--- a/scripts/ci/check-lib-no-pillar-import.mjs
+++ b/scripts/ci/check-lib-no-pillar-import.mjs
@@ -72,12 +72,12 @@ const ALLOWED_DEV_PILLAR_DEPS = {
   '@pops/module-registry': new Set([
     '@pops/ai',
     '@pops/cerebrum',
-    '@pops/core',
     '@pops/finance',
     '@pops/food',
     '@pops/inventory',
     '@pops/lists',
     '@pops/media',
+    '@pops/registry',
   ]),
 };
 

--- a/scripts/ci/check-lib-no-pillar-import.mjs
+++ b/scripts/ci/check-lib-no-pillar-import.mjs
@@ -48,6 +48,10 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { extractSpecifiers } from './import-scan.mjs';
+
+export { extractSpecifiers };
+
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..');
 
@@ -183,30 +187,6 @@ function walkSource(absDir) {
     out.push(join(absDir, name));
   }
   return out;
-}
-
-/**
- * Extract module specifiers referenced by real import/export/require forms in
- * a source string. Comments and unrelated string literals are not matched —
- * each form is anchored to its keyword so a bare `'@pops/x'` in a comment
- * (e.g. a JSDoc example) is ignored.
- *
- * @param {string} src
- * @returns {string[]}
- */
-export function extractSpecifiers(src) {
-  /** @type {string[]} */
-  const specs = [];
-  const patterns = [
-    /(?:^|[\s;])import\s+(?:type\s+)?(?:[^'";]+?\s+from\s+)?['"]([^'"]+)['"]/gm,
-    /(?:^|[\s;])export\s+(?:type\s+)?(?:[^'";]+?\s+)?from\s+['"]([^'"]+)['"]/gm,
-    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
-    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
-  ];
-  for (const re of patterns) {
-    for (const m of src.matchAll(re)) specs.push(m[1]);
-  }
-  return specs;
 }
 
 /**

--- a/scripts/ci/check-lib-no-pillar-import.mjs
+++ b/scripts/ci/check-lib-no-pillar-import.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * Federation isolation guard: **a LIB must never depend on a PILLAR.**
+ *
+ * The two-kind taxonomy (docs/plans/repo-federation/00-architecture.md §1):
+ *   - PILLAR — a deployable, self-registering capability provider, consumed
+ *     ONLY through its published contract (runtime REST + discovery).
+ *   - LIB    — code that facilitates pillars existing; consumed by import of
+ *     its published name. Always extractable to its own repo.
+ *
+ * A lib that imports a pillar fails the extract-to-own-repo litmus (§3): the
+ * pillar would not be present in the extracted repo. So a lib may depend on
+ * other libs and on a pillar's *published types* (its `@pops/<pillar>`
+ * contract entrypoint is allowed for type-only contract consumption only via
+ * other pillars, never libs) — but a lib taking a runtime dependency on, or
+ * importing the source of, a pillar is forbidden.
+ *
+ * This is the diff-agnostic whole-tree pass run by `agent-review.yml`. It is
+ * deliberately disk-discovered (no static unit list — principle P-8): the
+ * pillar/lib classification is derived from the live tree so it stays correct
+ * across the federation relocation (units live under `apps/`+`packages/`
+ * today, `pillars/`+`libs/` after the move).
+ *
+ * Classification (by location — survives the relocation):
+ *   PILLAR : any package under `pillars/` (incl. `pillars/<x>/app`), plus the
+ *            app-pillars still parked under `apps/` (shell, mcp, orchestrator,
+ *            docs) until P2-T02 moves them.
+ *   LIB    : any package under `libs/` or `packages/`.
+ *   ignored: `apps/pops-cli` (dropped, P2-T02), `apps/pops-storybook` (folds
+ *            into `libs/ui` as a dev surface, P2-T04 — it legitimately
+ *            devDepends on the `app-*` frontends, so it is NOT a lib here).
+ *
+ * What counts as a violation for a lib:
+ *   - a pillar `@pops/*` name in `dependencies` or `peerDependencies`  (HARD)
+ *   - a pillar `@pops/*` name in `devDependencies`                     (unless
+ *     allowlisted — see ALLOWED_DEV_PILLAR_DEPS)
+ *   - an `import`/`export … from`/`import()`/`require()` of a pillar in the
+ *     lib's non-test source                                            (HARD)
+ *
+ * Usage:
+ *   node scripts/ci/check-lib-no-pillar-import.mjs
+ *   node scripts/ci/check-lib-no-pillar-import.mjs --self-test
+ *
+ * Exit 0 = clean. Exit 1 = at least one violation. Exit 2 = usage error.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+/**
+ * Known-vestigial pillar devDependencies that are tolerated until their
+ * owning decoupling task lands. `@pops/module-registry` devDepends on all 8
+ * backend pillars only to type-check its committed `generated.ts` manifest;
+ * those devDeps are dropped in **P7-T01 (alias RD-1)**. Remove a lib's entry
+ * here in the same PR that drops the deps — leaving a stale allowlist entry
+ * is itself a smell.
+ *
+ * Keyed by the lib's published `@pops/*` name → set of allowed pillar
+ * `@pops/*` devDependency names.
+ *
+ * @type {Record<string, Set<string>>}
+ */
+const ALLOWED_DEV_PILLAR_DEPS = {
+  '@pops/module-registry': new Set([
+    '@pops/ai',
+    '@pops/cerebrum',
+    '@pops/core',
+    '@pops/finance',
+    '@pops/food',
+    '@pops/inventory',
+    '@pops/lists',
+    '@pops/media',
+  ]),
+};
+
+/** Workspace roots scanned for units, paired with how they classify. */
+const UNIT_ROOTS = [
+  { root: 'pillars', defaultKind: 'pillar', nested: true },
+  { root: 'libs', defaultKind: 'lib', nested: false },
+  { root: 'packages', defaultKind: 'lib', nested: false },
+  { root: 'apps', defaultKind: 'app', nested: false },
+];
+
+/** Basenames under `apps/` whose target home is `pillars/` (P2-T02). */
+const APP_PILLAR_DIRS = new Set(['pops-shell', 'pops-mcp', 'pops-orchestrator', 'pops-docs']);
+
+/** Source file extensions whose imports are inspected. */
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+
+/** Directory names never followed when walking a unit's source. */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'coverage', '.turbo']);
+
+/**
+ * @typedef {object} Unit
+ * @property {string} dir   Repo-relative dir, e.g. `packages/ui`.
+ * @property {string} name  Published package name, e.g. `@pops/ui`.
+ * @property {'pillar'|'lib'} kind
+ * @property {Record<string, unknown>} pkg  Parsed package.json.
+ */
+
+/**
+ * Read a package.json and return its `name`, or `null` if absent/unnamed.
+ *
+ * @param {string} absDir
+ * @returns {{ name: string; pkg: Record<string, unknown> } | null}
+ */
+function readPkg(absDir) {
+  const pkgPath = join(absDir, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  /** @type {Record<string, unknown>} */
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  const name = typeof pkg.name === 'string' ? pkg.name : '';
+  if (!name) return null;
+  return { name, pkg };
+}
+
+/**
+ * Discover every classified unit from disk. App-pillars under `apps/` are
+ * reclassified to `pillar`; `apps/pops-cli` and `apps/pops-storybook` are
+ * dropped (not units for this rule).
+ *
+ * @returns {Unit[]}
+ */
+function discoverUnits() {
+  /** @type {Unit[]} */
+  const out = [];
+  for (const { root, defaultKind, nested } of UNIT_ROOTS) {
+    const absRoot = join(repoRoot, root);
+    if (!existsSync(absRoot)) continue;
+    for (const entry of readdirSync(absRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = `${root}/${entry.name}`;
+      const read = readPkg(join(absRoot, entry.name));
+      if (read) {
+        /** @type {'pillar'|'lib'|null} */
+        let kind = defaultKind === 'app' ? null : defaultKind;
+        if (defaultKind === 'app') {
+          if (APP_PILLAR_DIRS.has(entry.name)) kind = 'pillar';
+          else continue; // cli (dropped) / storybook (folds into libs/ui)
+        }
+        if (kind) out.push({ dir, name: read.name, kind, pkg: read.pkg });
+      }
+      // Pillar frontends live one level deep at `pillars/<x>/app`.
+      if (nested) {
+        const appDir = join(absRoot, entry.name, 'app');
+        const appRead = readPkg(appDir);
+        if (appRead) {
+          out.push({ dir: `${dir}/app`, name: appRead.name, kind: 'pillar', pkg: appRead.pkg });
+        }
+      }
+    }
+  }
+  return out.toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/**
+ * Recursively collect inspectable source files under `absDir`, skipping
+ * build output, node_modules, and test files (a lib's test importing a
+ * pillar is a dev concern, not a runtime-isolation break).
+ *
+ * @param {string} absDir
+ * @returns {string[]}
+ */
+function walkSource(absDir) {
+  /** @type {string[]} */
+  const out = [];
+  if (!existsSync(absDir)) return out;
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || entry.name === '__tests__') continue;
+      out.push(...walkSource(join(absDir, entry.name)));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const name = entry.name;
+    if (/\.(test|spec)\.[cm]?[jt]sx?$/u.test(name)) continue;
+    const dot = name.lastIndexOf('.');
+    if (dot < 0 || !SOURCE_EXT.has(name.slice(dot))) continue;
+    out.push(join(absDir, name));
+  }
+  return out;
+}
+
+/**
+ * Extract module specifiers referenced by real import/export/require forms in
+ * a source string. Comments and unrelated string literals are not matched —
+ * each form is anchored to its keyword so a bare `'@pops/x'` in a comment
+ * (e.g. a JSDoc example) is ignored.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function extractSpecifiers(src) {
+  /** @type {string[]} */
+  const specs = [];
+  const patterns = [
+    /(?:^|[\s;])import\s+(?:type\s+)?(?:[^'";]+?\s+from\s+)?['"]([^'"]+)['"]/gm,
+    /(?:^|[\s;])export\s+(?:type\s+)?(?:[^'";]+?\s+)?from\s+['"]([^'"]+)['"]/gm,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  for (const re of patterns) {
+    for (const m of src.matchAll(re)) specs.push(m[1]);
+  }
+  return specs;
+}
+
+/**
+ * True if `specifier` resolves to (the root of, or a subpath of) `pkgName`.
+ *
+ * @param {string} specifier
+ * @param {string} pkgName
+ * @returns {boolean}
+ */
+function specifierTargets(specifier, pkgName) {
+  return specifier === pkgName || specifier.startsWith(`${pkgName}/`);
+}
+
+/**
+ * @typedef {object} Violation
+ * @property {string} lib     Offending lib package name.
+ * @property {string} pillar  Pillar package name reached.
+ * @property {string} via     `dependencies` | `peerDependencies` | `devDependencies` | source file path.
+ */
+
+/**
+ * Pure detector — find every lib→pillar dependency/import. Exported for tests.
+ *
+ * @param {Unit[]} units
+ * @param {(unit: Unit) => string[]} [readSource]  Maps a lib unit to its source
+ *   strings; defaults to reading the lib's non-test source from disk.
+ * @param {Record<string, Set<string>>} [allowedDevDeps]
+ * @returns {Violation[]}
+ */
+export function findViolations(units, readSource, allowedDevDeps = ALLOWED_DEV_PILLAR_DEPS) {
+  const pillarNames = new Set(units.filter((u) => u.kind === 'pillar').map((u) => u.name));
+  const libs = units.filter((u) => u.kind === 'lib');
+  /** @type {Violation[]} */
+  const violations = [];
+
+  const readSrc =
+    readSource ??
+    ((unit) => walkSource(join(repoRoot, unit.dir)).map((f) => readFileSync(f, 'utf8')));
+
+  for (const lib of libs) {
+    const allowed = allowedDevDeps[lib.name] ?? new Set();
+    for (const field of ['dependencies', 'peerDependencies', 'devDependencies']) {
+      const deps = lib.pkg[field];
+      if (!deps || typeof deps !== 'object') continue;
+      for (const dep of Object.keys(deps)) {
+        if (!pillarNames.has(dep)) continue;
+        if (field === 'devDependencies' && allowed.has(dep)) continue;
+        violations.push({ lib: lib.name, pillar: dep, via: field });
+      }
+    }
+    for (const src of readSrc(lib)) {
+      for (const spec of extractSpecifiers(src)) {
+        for (const pillar of pillarNames) {
+          if (specifierTargets(spec, pillar)) {
+            violations.push({ lib: lib.name, pillar, via: `import ${spec}` });
+          }
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Self-test: prove the detector flags a synthetic lib→pillar dependency and
+ * import, and passes a clean fixture. Mirrors the `--inject-fake-table`
+ * pattern in check-pillar-schema-coverage.mjs — CI runs this so a regression
+ * that neuters the guard is caught without relying on a real tree violation.
+ *
+ * @returns {boolean} true if the guard behaves correctly.
+ */
+function selfTest() {
+  /** @type {Unit[]} */
+  const fixture = [
+    { dir: 'pillars/finance', name: '@pops/finance', kind: 'pillar', pkg: {} },
+    {
+      dir: 'libs/evil',
+      name: '@pops/evil',
+      kind: 'lib',
+      pkg: { dependencies: { '@pops/finance': 'workspace:*' } },
+    },
+    {
+      dir: 'libs/evil-import',
+      name: '@pops/evil-import',
+      kind: 'lib',
+      pkg: {},
+    },
+    { dir: 'libs/clean', name: '@pops/clean', kind: 'lib', pkg: { dependencies: {} } },
+  ];
+  /** @type {(u: Unit) => string[]} */
+  const readSource = (u) =>
+    u.name === '@pops/evil-import' ? ["import { x } from '@pops/finance/dist/x.js';"] : [];
+
+  const found = findViolations(fixture, readSource, {});
+  const caughtDep = found.some((v) => v.lib === '@pops/evil' && v.via === 'dependencies');
+  const caughtImport = found.some(
+    (v) => v.lib === '@pops/evil-import' && v.via.startsWith('import ')
+  );
+  const cleanPassed = !found.some((v) => v.lib === '@pops/clean');
+  const ok = caughtDep && caughtImport && cleanPassed;
+  if (!ok) {
+    console.error('SELF-TEST FAILED — guard did not behave as expected:');
+    console.error(`  caught dep violation:    ${caughtDep}`);
+    console.error(`  caught import violation: ${caughtImport}`);
+    console.error(`  clean lib passed:        ${cleanPassed}`);
+  } else {
+    console.log('self-test OK — guard flags lib→pillar dep + import, passes clean lib.');
+  }
+  return ok;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node scripts/ci/check-lib-no-pillar-import.mjs [--self-test]\n' +
+        'Fails if any lib (libs/* or packages/*) depends on or imports a pillar.'
+    );
+    process.exit(2);
+  }
+  if (args.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+
+  const units = discoverUnits();
+  const libs = units.filter((u) => u.kind === 'lib');
+  const pillars = units.filter((u) => u.kind === 'pillar');
+  console.log(`Scanned ${libs.length} lib(s) against ${pillars.length} pillar(s).`);
+
+  const violations = findViolations(units);
+  if (violations.length === 0) {
+    console.log('OK — no lib depends on or imports a pillar.');
+    process.exit(0);
+  }
+  console.error(`FAIL — ${violations.length} lib→pillar violation(s):`);
+  for (const v of violations.toSorted((a, b) => a.lib.localeCompare(b.lib))) {
+    console.error(`  ${v.lib} → ${v.pillar}  (${v.via})`);
+  }
+  console.error(
+    '\nA lib must be extractable to its own repo (00-architecture.md §3). ' +
+      'Consume a pillar only through its REST contract at runtime, never as a ' +
+      'workspace dependency or source import.'
+  );
+  process.exit(1);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}

--- a/scripts/ci/import-scan.mjs
+++ b/scripts/ci/import-scan.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Shared, statement-anchored module-specifier extraction for the federation
+ * isolation guards. Used by `check-lib-no-pillar-import.mjs` and
+ * `check-contract-isolation.mjs`.
+ *
+ * The patterns are anchored to the start of a real import/export/require
+ * **statement** (preceding char is start-of-line or whitespace/semicolon), so
+ * a specifier that merely appears inside a string literal — e.g. a test
+ * fixture `"import { x } from '@pops/finance/src/y'"` or a guard's own
+ * self-test — is NOT matched. A naive `line.includes('import')` check would
+ * false-positive on those; this does not.
+ */
+
+/**
+ * Each entry matches one import form and captures the module specifier in
+ * group 1. The static `import`/`export … from` forms require the keyword to
+ * begin a statement (`(?:^|[\s;])`) so keywords embedded in a string literal
+ * are skipped.
+ */
+const IMPORT_PATTERNS = [
+  /(?:^|[\s;])import\s+(?:type\s+)?(?:[^'";]+?\s+from\s+)?['"]([^'"]+)['"]/gm,
+  /(?:^|[\s;])export\s+(?:type\s+)?(?:[^'";]+?\s+)?from\s+['"]([^'"]+)['"]/gm,
+  /(?:^|[\s;])(?:await\s+)?import\s*\(\s*['"]([^'"]+)['"]\s*\)/gm,
+  /(?:^|[\s.])require\s*\(\s*['"]([^'"]+)['"]\s*\)/gm,
+];
+
+/**
+ * Replace the contents of `//` and block comments with spaces, preserving
+ * every character offset and newline so downstream line/column math stays
+ * accurate. String and template literals are kept intact (their `//` is not a
+ * comment). This is why a commented-out `// import x from '@pops/foo/src/y'`
+ * is not mistaken for a real import.
+ *
+ * @param {string} src
+ * @returns {string}
+ */
+export function stripComments(src) {
+  let out = '';
+  /** @type {'' | "'" | '"' | '`' | '//' | '/*'} */
+  let mode = '';
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    const next = i + 1 < src.length ? src[i + 1] : '';
+    if (mode === '//') {
+      if (ch === '\n') {
+        mode = '';
+        out += ch;
+      } else out += ' ';
+      continue;
+    }
+    if (mode === '/*') {
+      if (ch === '*' && next === '/') {
+        mode = '';
+        out += '  ';
+        i++;
+      } else out += ch === '\n' ? '\n' : ' ';
+      continue;
+    }
+    if (mode === "'" || mode === '"' || mode === '`') {
+      out += ch;
+      if (ch === '\\') {
+        out += next;
+        i++;
+        continue;
+      }
+      if (ch === mode) mode = '';
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      mode = '//';
+      out += '  ';
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      mode = '/*';
+      out += '  ';
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') mode = ch;
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * Module specifiers referenced by real import/export/require statements.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function extractSpecifiers(src) {
+  const code = stripComments(src);
+  /** @type {string[]} */
+  const out = [];
+  for (const re of IMPORT_PATTERNS) {
+    for (const m of code.matchAll(re)) out.push(m[1]);
+  }
+  return out;
+}
+
+/**
+ * Module specifiers plus the 1-based line each appears on. The line is
+ * computed from the specifier's own offset (not the match start) so a leading
+ * newline captured by `(?:^|[\s;])` never skews it.
+ *
+ * @param {string} src
+ * @returns {Array<{ specifier: string; line: number }>}
+ */
+export function extractSpecifiersWithLines(src) {
+  const code = stripComments(src);
+  /** @type {Array<{ specifier: string; line: number }>} */
+  const out = [];
+  for (const re of IMPORT_PATTERNS) {
+    for (const m of code.matchAll(re)) {
+      const specifier = m[1];
+      const at = (m.index ?? 0) + m[0].lastIndexOf(specifier);
+      let line = 1;
+      for (let i = 0; i < at && i < code.length; i++) {
+        if (code[i] === '\n') line++;
+      }
+      out.push({ specifier, line });
+    }
+  }
+  return out;
+}
+
+/**
+ * True if `relPath` is a test file or lives under a `__tests__` dir — a unit's
+ * test surface, excluded from the runtime/contract isolation scans.
+ *
+ * @param {string} relPath
+ * @returns {boolean}
+ */
+export function isTestPath(relPath) {
+  return /(?:^|\/)__tests__\//u.test(relPath) || /\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(relPath);
+}

--- a/scripts/ci/import-scan.mjs
+++ b/scripts/ci/import-scan.mjs
@@ -26,61 +26,151 @@ const IMPORT_PATTERNS = [
 ];
 
 /**
- * Replace the contents of `//` and block comments with spaces, preserving
- * every character offset and newline so downstream line/column math stays
- * accurate. String and template literals are kept intact (their `//` is not a
- * comment). This is why a commented-out `// import x from '@pops/foo/src/y'`
- * is not mistaken for a real import.
+ * Single code characters after which a `/` begins a regex literal (not
+ * division). Covers the contexts where regexes actually appear in this
+ * codebase (array elements, assignments, calls, returns).
+ */
+const REGEX_PREV_CHARS = new Set([
+  '',
+  '(',
+  ',',
+  '=',
+  ':',
+  '[',
+  '!',
+  '&',
+  '|',
+  '?',
+  '{',
+  '}',
+  ';',
+  '+',
+  '-',
+  '*',
+  '%',
+  '<',
+  '>',
+  '~',
+  '^',
+]);
+
+/** Keywords after which a `/` begins a regex literal. */
+const REGEX_PREV_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'do',
+  'else',
+  'yield',
+  'await',
+  'case',
+]);
+
+/**
+ * @param {string} s
+ * @returns {string}  `s` with every non-newline replaced by a space.
+ */
+function blank(s) {
+  return s.replace(/[^\n]/gu, ' ');
+}
+
+/**
+ * Replace `//` and block-comment contents with spaces, preserving every
+ * character offset and newline so downstream line math stays accurate.
+ *
+ * A correct strip requires a mini-lexer, not a regex: string/template literals
+ * are kept verbatim (the module specifier lives inside their quotes), while
+ * **regex literals are recognized and blanked** — otherwise the `'`/`"` inside
+ * a pattern like `/import\s+['"]([^'"]+)['"]/` would be mistaken for string
+ * delimiters, desync the scanner, and leave a following comment unstripped
+ * (e.g. a commented-out `// import x from '@pops/foo/src/y'` would then read as
+ * a real import). Regex-vs-division is disambiguated by the preceding token.
  *
  * @param {string} src
  * @returns {string}
  */
 export function stripComments(src) {
+  const n = src.length;
   let out = '';
-  /** @type {'' | "'" | '"' | '`' | '//' | '/*'} */
-  let mode = '';
-  for (let i = 0; i < src.length; i++) {
+  let i = 0;
+  /** last significant (non-whitespace) code char emitted */
+  let prevChar = '';
+  /** trailing identifier word, for keyword-before-regex detection */
+  let prevWord = '';
+
+  while (i < n) {
     const ch = src[i];
-    const next = i + 1 < src.length ? src[i + 1] : '';
-    if (mode === '//') {
-      if (ch === '\n') {
-        mode = '';
-        out += ch;
-      } else out += ' ';
-      continue;
-    }
-    if (mode === '/*') {
-      if (ch === '*' && next === '/') {
-        mode = '';
-        out += '  ';
-        i++;
-      } else out += ch === '\n' ? '\n' : ' ';
-      continue;
-    }
-    if (mode === "'" || mode === '"' || mode === '`') {
-      out += ch;
-      if (ch === '\\') {
-        out += next;
-        i++;
-        continue;
-      }
-      if (ch === mode) mode = '';
-      continue;
-    }
+    const next = i + 1 < n ? src[i + 1] : '';
+
     if (ch === '/' && next === '/') {
-      mode = '//';
-      out += '  ';
-      i++;
+      let j = i + 2;
+      while (j < n && src[j] !== '\n') j++;
+      out += blank(src.slice(i, j));
+      i = j;
       continue;
     }
     if (ch === '/' && next === '*') {
-      mode = '/*';
-      out += '  ';
-      i++;
+      let j = i + 2;
+      while (j < n && !(src[j] === '*' && src[j + 1] === '/')) j++;
+      j = Math.min(j + 2, n);
+      out += blank(src.slice(i, j));
+      i = j;
       continue;
     }
-    if (ch === "'" || ch === '"' || ch === '`') mode = ch;
+    if (ch === "'" || ch === '"' || ch === '`') {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === '\\') {
+          j += 2;
+          continue;
+        }
+        if (src[j] === ch) {
+          j++;
+          break;
+        }
+        j++;
+      }
+      out += src.slice(i, j);
+      prevChar = ch;
+      prevWord = '';
+      i = j;
+      continue;
+    }
+    if (ch === '/' && (REGEX_PREV_CHARS.has(prevChar) || REGEX_PREV_KEYWORDS.has(prevWord))) {
+      let j = i + 1;
+      let inClass = false;
+      while (j < n) {
+        const c = src[j];
+        if (c === '\\') {
+          j += 2;
+          continue;
+        }
+        if (c === '\n') break;
+        if (c === '[') inClass = true;
+        else if (c === ']') inClass = false;
+        else if (c === '/' && !inClass) {
+          j++;
+          break;
+        }
+        j++;
+      }
+      out += blank(src.slice(i, j));
+      prevChar = '/';
+      prevWord = '';
+      i = j;
+      continue;
+    }
     out += ch;
+    if (!/\s/u.test(ch)) {
+      prevChar = ch;
+      prevWord = /[A-Za-z0-9_$]/u.test(ch) ? prevWord + ch : '';
+    }
+    i++;
   }
   return out;
 }


### PR DESCRIPTION
## P6-T05 — Agent-review CI gate + isolation guards

Lands the federation review gate (`docs/plans/repo-federation/05-cicd-deployment.md` §A.3) **early**, ahead of the relocation waves, so every subsequent PR is guarded.

Per the goal's "guard CI FIRST", this is decoupled from its nominal `depends-on P5-T04` (the discovery infra) — the guards are static analysis over disk and need neither the build model nor `_discover-units`.

### What lands
- **`scripts/ci/check-lib-no-pillar-import.mjs`** (blocking) — a lib (`libs/*` or `packages/*`) may never depend on or import a pillar; enforces the extract-to-own-repo litmus. `module-registry`'s 8 vestigial pillar **devDeps** are allowlisted with a pointer to **P7-T01 (RD-1)**, which drops them.
- **`scripts/ci/check-contract-isolation.mjs`** (blocking) — diff-scoped guard against cross-contract reach-behind: deep imports into another unit's `@pops/*/{src,dist,internal}/…`. Conservative by design (declared subpath exports are allowed); the structural ISO-R1..R4 rules remain dep-cruiser's job (P6-T01). Degrades to a no-op if the base ref is unresolvable.
- **`scripts/ci/agent-review.mjs`** (advisory) — LLM reviewer keyed on the federation rubric. No-ops without `ANTHROPIC_API_KEY` (not provisioned today) and **never fails the build**.
- **`.github/workflows/agent-review.yml`** — runs both guards + their `--self-test` modes + the advisory reviewer on every non-draft PR.

### Verification
- Both guards are disk-discovered (no static unit list) so they stay correct across the relocation.
- `--self-test` modes (run in CI) prove each guard catches a synthetic violation and passes clean fixtures; plus 14 vitest unit tests.
- Local gate green: oxlint (type-aware), oxfmt, yaml-lint, self-tests, vitest.

### Follow-up
After this merges green, `agent-review` is promoted to a **required** status check (ruleset) so relocation PRs cannot auto-merge unguarded.

These are repo-meta CI scripts under `scripts/ci/` (not a publishable unit), so the extract litmus does not apply to them.
