### PR TITLE
chore(federation): add libs/* to pnpm workspace [P1-T01]

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'packages/*'
   - 'pillars/*'
   - 'pillars/*/*'
+  - 'libs/*'


### PR DESCRIPTION
Opens the gate for the `packages/*` -> `libs/*` relocation.

Additive only: adds `libs/*` to the workspace globs and removes nothing. `libs/` is currently empty, so `pnpm install` is a no-op and `pnpm-lock.yaml` is unchanged.

Scope intentionally narrow: `libs/*` only, no `libs/*/*`. Removing the old globs is a later task (P3-T01/G1).