### PR TITLE
ci(federation): fe-quality/storybook watch pillars/*/app (close live gate hole) [P-ci-T-fe-fix]

### DIFF
--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/pops-shell/**"
-      - "packages/app-*/**"
+      - "pillars/*/app/**"
       # Every pillar's OpenAPI projection feeds the generated FE client.
       # Globbed from disk so a new pillar (or `lists`, previously omitted)
       # is covered without editing this list.
@@ -19,7 +19,7 @@ on:
   pull_request:
     paths:
       - "apps/pops-shell/**"
-      - "packages/app-*/**"
+      - "pillars/*/app/**"
       - "pillars/*/openapi/**"
       - "packages/db-types/**"
       - "packages/navigation/**"
@@ -43,7 +43,7 @@ jobs:
           filters: |
             shell:
               - 'apps/pops-shell/**'
-              - 'packages/app-*/**'
+              - 'pillars/*/app/**'
               - 'packages/db-types/**'
               # Glob every pillar's OpenAPI projection so the filter can't
               # drift from the trigger paths (previously omitted inventory

--- a/.github/workflows/storybook-quality.yml
+++ b/.github/workflows/storybook-quality.yml
@@ -5,13 +5,13 @@ on:
     branches: [main]
     paths:
       - "apps/pops-storybook/**"
-      - "packages/app-*/package.json"
+      - "pillars/*/app/package.json"
       - ".github/workflows/storybook-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
     paths:
       - "apps/pops-storybook/**"
-      - "packages/app-*/package.json"
+      - "pillars/*/app/package.json"
       - ".github/workflows/storybook-quality.yml"
       - ".github/workflows/_pkg-check.yml"
 
@@ -30,7 +30,7 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-storybook/**'
-              - 'packages/app-*/package.json'
+              - 'pillars/*/app/package.json'
               - '.github/workflows/storybook-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 


### PR DESCRIPTION
## What

The frontends already live at `pillars/*/app`, but `fe-quality.yml` and `storybook-quality.yml` still watched the **deleted** `packages/app-*/**` paths. Result: frontend changes silently skipped CI — a live gate hole.

This swaps the dead globs for `pillars/*/app`, surgically:

- **`fe-quality.yml`** — 3 occurrences (`on.push.paths`, `on.pull_request.paths`, and the `dorny/paths-filter` `shell:` filter): `packages/app-*/**` → `pillars/*/app/**`.
- **`storybook-quality.yml`** — 3 occurrences (`on.push.paths`, `on.pull_request.paths`, and the dorny `relevant:` filter): `packages/app-*/package.json` → `pillars/*/app/package.json`.

## Scope guard

Shell (`apps/pops-shell`) and lib (`packages/{db-types,navigation,pillar-sdk,types,ui}`) globs are **unchanged** — those units have not moved yet; their full retarget is P4-T04. The `pillars/*/openapi/**`, the build filter, and the `cd` paths are untouched.

## Verification

- `grep packages/app-\*` over both files → no matches (gate hole closed).
- `grep pillars/\*/app` → new globs present (3 + 3).
- `npx yaml-lint` on both files → successful (this is what CI's `workflows-quality` runs).

Diff: 6 lines, 6 insertions / 6 deletions.