### PR TITLE
fix(ci): scope pops-mcp Dockerfile pnpm install to @pops/mcp subgraph [P-ci-T-mcp-fix]

### DIFF
--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -10,7 +10,7 @@ COPY apps/pops-mcp/package.json ./apps/pops-mcp/
 
 # Install pnpm and all workspace dependencies
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
-    corepack enable && pnpm install --frozen-lockfile
+    corepack enable && pnpm install --frozen-lockfile --filter "@pops/mcp..."
 
 # Copy shared package sources
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/


### PR DESCRIPTION
## What

`apps/pops-mcp/Dockerfile` line 13 ran `pnpm install --frozen-lockfile` with **no** `--filter`, requesting a full-workspace frozen install. But the builder stage only COPYs the mcp subgraph manifests beforehand:

- workspace root files (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, etc.)
- `packages/pillar-sdk/package.json`
- `apps/pops-mcp/package.json`

A full-workspace frozen install is incorrect for this scoped build.

## Change

Scope the install to the `@pops/mcp` dependency subgraph:

```
corepack enable && pnpm install --frozen-lockfile --filter "@pops/mcp..."
```

The trailing `...` is pnpm filter syntax for "this package and its dependencies".

Only the one install line changes — COPY lines, build steps, and the `pnpm --filter @pops/mcp deploy` line are untouched. The file stays at `apps/pops-mcp/` (it moves to `pillars/mcp` in a later task).

This lands before the `push:main` image publish is re-enabled.

## Verification

- `grep -n 'pnpm install' apps/pops-mcp/Dockerfile` shows the `--filter "@pops/mcp..."` form.
- `docker build --target builder -f apps/pops-mcp/Dockerfile -t fed-test-mcp .` from repo root: **succeeds** (install, pillar-sdk build, mcp build, and deploy stages all pass).