### PR TITLE
feat(settings): advertise capabilities.settings per pillar [P2]

### DIFF
--- a/pillars/ai/src/api/__tests__/capability-reporter.test.ts
+++ b/pillars/ai/src/api/__tests__/capability-reporter.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Capability-reporter regression guard (P2 settings federation). The ai pillar
+ * must advertise `settings: true` on its registry heartbeat so the shell's
+ * live-registry settings discovery routes ai settings to ai's own federated
+ * `/settings/*` surface instead of the registry fallback. Drop this flag and
+ * the federated surface silently goes dormant.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildAiCapabilityReporter } from '../ai-manifest.js';
+
+describe('buildAiCapabilityReporter', () => {
+  it('reports settings: true so the shell routes settings to ai', () => {
+    expect(buildAiCapabilityReporter()()).toEqual({ settings: true });
+  });
+});

--- a/pillars/ai/src/api/ai-manifest.ts
+++ b/pillars/ai/src/api/ai-manifest.ts
@@ -14,7 +14,18 @@
  */
 import { aiConfigManifest } from '../contract/settings/ai-manifest.js';
 
+import type { CapabilityReporter } from '@pops/pillar-sdk/bootstrap';
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+/**
+ * Runtime capability heartbeat for ai. Advertises `settings: true` so the
+ * shell's live-registry settings discovery routes ai's settings reads and
+ * writes to ai's own federated `/settings/*` surface (capability-gated) rather
+ * than falling back to the registry pillar.
+ */
+export function buildAiCapabilityReporter(): CapabilityReporter {
+  return () => ({ settings: true });
+}
 
 export function buildAiManifest(version: string): ManifestPayload {
   return {

--- a/pillars/ai/src/api/server.ts
+++ b/pillars/ai/src/api/server.ts
@@ -11,7 +11,7 @@
 import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { openAiDb } from '../db/index.js';
-import { buildAiManifest } from './ai-manifest.js';
+import { buildAiCapabilityReporter, buildAiManifest } from './ai-manifest.js';
 import { resolveAiSqlitePath } from './ai-sqlite-path.js';
 import { createAiApiApp } from './app.js';
 import { startAlertsScheduler } from './modules/ai-alerts/scheduler.js';
@@ -53,6 +53,7 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
     manifest: buildAiManifest(version),
     baseUrl: selfBaseUrl,
+    capabilityReporter: buildAiCapabilityReporter(),
   });
 }
 

--- a/pillars/cerebrum/src/api/__tests__/manifest.test.ts
+++ b/pillars/cerebrum/src/api/__tests__/manifest.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import { cerebrumManifest, egoManifest } from '../../contract/settings/index.js';
-import { buildCerebrumManifest } from '../manifest.js';
+import { buildCerebrumCapabilityReporter, buildCerebrumManifest } from '../manifest.js';
 
 describe('buildCerebrumManifest', () => {
   it('produces a payload that validates against ManifestPayloadSchema', () => {
@@ -57,5 +57,22 @@ describe('buildCerebrumManifest', () => {
     const payload = buildCerebrumManifest('1.2.3');
     const result = validateManifestPayload(payload);
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('buildCerebrumCapabilityReporter (P2 settings federation)', () => {
+  it('reports settings: true so the shell routes settings to cerebrum', () => {
+    expect(buildCerebrumCapabilityReporter(true)()['settings']).toBe(true);
+  });
+
+  it('preserves the live vectorSearch status alongside settings', () => {
+    expect(buildCerebrumCapabilityReporter(true)()).toEqual({
+      vectorSearch: true,
+      settings: true,
+    });
+    expect(buildCerebrumCapabilityReporter(false)()).toEqual({
+      vectorSearch: false,
+      settings: true,
+    });
   });
 });

--- a/pillars/cerebrum/src/api/manifest.ts
+++ b/pillars/cerebrum/src/api/manifest.ts
@@ -9,7 +9,19 @@
  */
 import { cerebrumManifest, egoManifest } from '../contract/settings/index.js';
 
+import type { CapabilityReporter } from '@pops/pillar-sdk/bootstrap';
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+/**
+ * Runtime capability heartbeat for cerebrum. Reports the live
+ * `cerebrum.vectorSearch` status (whether sqlite-vec loaded on this
+ * connection) alongside `settings: true`, which advertises cerebrum's own
+ * federated `/settings/*` surface so the shell routes settings reads/writes to
+ * it (capability-gated) rather than falling back to the registry pillar.
+ */
+export function buildCerebrumCapabilityReporter(vecAvailable: boolean): CapabilityReporter {
+  return () => ({ vectorSearch: vecAvailable, settings: true });
+}
 
 export function buildCerebrumManifest(version: string): ManifestPayload {
   return {

--- a/pillars/cerebrum/src/api/server.ts
+++ b/pillars/cerebrum/src/api/server.ts
@@ -19,7 +19,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { openCerebrumDb } from '../db/index.js';
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
-import { buildCerebrumManifest } from './manifest.js';
+import { buildCerebrumCapabilityReporter, buildCerebrumManifest } from './manifest.js';
 import { AnthropicEgoLlm } from './modules/ego/llm.js';
 import { AnthropicGenerationLlm } from './modules/emit/llm.js';
 import { resolveEngramRoot } from './modules/engrams/instance.js';
@@ -97,11 +97,12 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
     manifest: buildCerebrumManifest(version),
     baseUrl: selfBaseUrl,
-    // Cerebrum owns the `cerebrum.vectorSearch` capability. Its live status is
-    // whether sqlite-vec loaded on this connection (probed once at open). The
-    // value is stable for the process lifetime, but reporting it per heartbeat
-    // keeps the contract uniform and lets a future hot-reload surface here.
-    capabilityReporter: () => ({ vectorSearch: cerebrumDb.vecAvailable }),
+    // Cerebrum's `vectorSearch` status is whether sqlite-vec loaded on this
+    // connection (probed once at open). The value is stable for the process
+    // lifetime, but reporting it per heartbeat keeps the contract uniform and
+    // lets a future hot-reload surface here. `settings: true` advertises the
+    // federated settings surface (P2 settings federation).
+    capabilityReporter: buildCerebrumCapabilityReporter(cerebrumDb.vecAvailable),
   });
 }
 

--- a/pillars/finance/src/api/__tests__/capability-reporter.test.ts
+++ b/pillars/finance/src/api/__tests__/capability-reporter.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Capability-reporter regression guard (P2 settings federation). The finance
+ * pillar must advertise `settings: true` on its registry heartbeat so the
+ * shell's live-registry settings discovery routes finance settings to
+ * finance's own federated `/settings/*` surface instead of the registry
+ * fallback. Drop this flag and the federated surface silently goes dormant.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildFinanceCapabilityReporter } from '../manifest.js';
+
+describe('buildFinanceCapabilityReporter', () => {
+  it('reports settings: true so the shell routes settings to finance', () => {
+    expect(buildFinanceCapabilityReporter()()).toEqual({ settings: true });
+  });
+});

--- a/pillars/finance/src/api/__tests__/corrections-ai.test.ts
+++ b/pillars/finance/src/api/__tests__/corrections-ai.test.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { getBulk } from '@pops/pillar-settings/service';
+
 import {
   openFinanceDb,
   transactionCorrectionsService,
@@ -37,8 +39,8 @@ function completerReturning(byOp: Record<string, string | null>): ClaudeComplete
 
 function memoryFeedbackStore(map: Map<string, string>): FeedbackStore {
   return {
-    load: (k) => Promise.resolve(map.get(k) ?? null),
-    persist: (k, v) => {
+    load: (_db, k) => Promise.resolve(map.get(k) ?? null),
+    persist: (_db, k, v) => {
       map.set(k, v);
       return Promise.resolve();
     },
@@ -317,7 +319,7 @@ describe('corrections.rejectChangeSet', () => {
     __setClaudeCompleterForTests(completerReturning({}));
     __setFeedbackStoreForTests({
       load: () => Promise.resolve(null),
-      persist: () => Promise.reject(new Error('core unavailable')),
+      persist: () => Promise.reject(new Error('settings write failed')),
     });
     const res = await client().corrections.rejectChangeSet({
       signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' },
@@ -327,5 +329,23 @@ describe('corrections.rejectChangeSet', () => {
       feedback: 'too broad',
     });
     expect(res.message).toBe('ChangeSet rejected');
+  });
+
+  it('default (in-process) store persists feedback into finance’s local settings table', async () => {
+    __setClaudeCompleterForTests(completerReturning({}));
+    // Use the real default store (no mock) so the reject writes through
+    // @pops/pillar-settings into THIS finance.db, not the registry pillar.
+    __setFeedbackStoreForTests(null);
+    await client().corrections.rejectChangeSet({
+      signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' },
+      changeSet: {
+        ops: [{ op: 'add', data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains' } }],
+      },
+      feedback: 'too broad',
+    });
+    const key = feedbackKey({ matchType: 'contains', normalizedPattern: 'WOOLWORTHS' });
+    const stored = getBulk(financeDb.db, [key])[key];
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored ?? '{}')).toMatchObject({ feedback: 'too broad' });
   });
 });

--- a/pillars/finance/src/api/manifest.ts
+++ b/pillars/finance/src/api/manifest.ts
@@ -10,6 +10,7 @@
  */
 import { financeManifest } from '../contract/settings/index.js';
 
+import type { CapabilityReporter } from '@pops/pillar-sdk/bootstrap';
 import type {
   ManifestPayload,
   NavConfigDescriptor,
@@ -17,6 +18,16 @@ import type {
 } from '@pops/pillar-sdk/manifest-schema';
 
 export const FINANCE_PILLAR_ID = 'finance' as const;
+
+/**
+ * Runtime capability heartbeat for finance. Advertises `settings: true` so the
+ * shell's live-registry settings discovery routes finance's settings reads and
+ * writes to finance's own federated `/settings/*` surface (capability-gated)
+ * rather than falling back to the registry pillar.
+ */
+export function buildFinanceCapabilityReporter(): CapabilityReporter {
+  return () => ({ settings: true });
+}
 
 const FINANCE_NAV: NavConfigDescriptor = {
   id: 'finance',

--- a/pillars/finance/src/api/modules/corrections/ai-feedback.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-feedback.ts
@@ -2,10 +2,11 @@ import { ChangeSetSchema, type ChangeSet } from '../../../contract/rest-correcti
 /**
  * Rejection-feedback persistence + AI interpretation. The store keys are
  * dynamic (`corrections.changeSetRejections:<matchType>:<pattern>`) and live in
- * core settings, reached via the injectable `FeedbackStore` (`ai-runtime.ts`).
+ * finance's LOCAL settings store, reached in-process via the injectable
+ * `FeedbackStore` (`ai-runtime.ts`).
  * Ported from the monolith `core/corrections/handlers/ai-inference.ts`.
  */
-import { transactionCorrectionsService } from '../../../db/index.js';
+import { type FinanceDb, transactionCorrectionsService } from '../../../db/index.js';
 import { getClaudeCompleter, getFeedbackStore } from './ai-runtime.js';
 import {
   AdaptedSignalSchema,
@@ -60,21 +61,27 @@ function parseFeedbackRecord(value: string): RejectedChangeSetFeedbackRecord | n
   };
 }
 
-export async function loadLatestRejectedFeedback(args: {
-  matchType: 'exact' | 'contains' | 'regex';
-  normalizedPattern: string;
-}): Promise<RejectedChangeSetFeedbackRecord | null> {
-  const raw = await getFeedbackStore().load(feedbackKey(args));
+export async function loadLatestRejectedFeedback(
+  db: FinanceDb,
+  args: {
+    matchType: 'exact' | 'contains' | 'regex';
+    normalizedPattern: string;
+  }
+): Promise<RejectedChangeSetFeedbackRecord | null> {
+  const raw = await getFeedbackStore().load(db, feedbackKey(args));
   return raw ? parseFeedbackRecord(raw) : null;
 }
 
-export async function persistRejectedChangeSetFeedback(args: {
-  signal: CorrectionSignal;
-  changeSet: ChangeSet;
-  feedback: string;
-  impactSummary: ChangeSetImpactSummary | null;
-  userEmail: string;
-}): Promise<void> {
+export async function persistRejectedChangeSetFeedback(
+  db: FinanceDb,
+  args: {
+    signal: CorrectionSignal;
+    changeSet: ChangeSet;
+    feedback: string;
+    impactSummary: ChangeSetImpactSummary | null;
+    userEmail: string;
+  }
+): Promise<void> {
   const normalizedPattern = normalizeDescription(args.signal.descriptionPattern);
   const record: RejectedChangeSetFeedbackRecord = {
     createdAt: new Date().toISOString(),
@@ -84,6 +91,7 @@ export async function persistRejectedChangeSetFeedback(args: {
     impactSummary: args.impactSummary,
   };
   await getFeedbackStore().persist(
+    db,
     feedbackKey({ matchType: args.signal.matchType, normalizedPattern }),
     JSON.stringify(record)
   );

--- a/pillars/finance/src/api/modules/corrections/ai-propose.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-propose.ts
@@ -31,9 +31,10 @@ interface FeedbackInfo {
 }
 
 async function resolveEffectiveSignal(
+  db: FinanceDb,
   signal: CorrectionSignal
 ): Promise<{ effectiveSignal: CorrectionSignal; feedback: FeedbackInfo | null }> {
-  const latest = await loadLatestRejectedFeedback({
+  const latest = await loadLatestRejectedFeedback(db, {
     matchType: signal.matchType,
     normalizedPattern: normalizeDescription(signal.descriptionPattern),
   });
@@ -85,7 +86,7 @@ export async function proposeChangeSetFromCorrectionSignal(
   db: FinanceDb,
   args: ProposeArgs
 ): Promise<ChangeSetProposal> {
-  const { effectiveSignal, feedback } = await resolveEffectiveSignal(args.signal);
+  const { effectiveSignal, feedback } = await resolveEffectiveSignal(db, args.signal);
   const normalizedPattern = normalizeDescription(effectiveSignal.descriptionPattern);
   const matchType = effectiveSignal.matchType;
   const existing = findExistingRule(db, matchType, normalizedPattern);

--- a/pillars/finance/src/api/modules/corrections/ai-runtime.ts
+++ b/pillars/finance/src/api/modules/corrections/ai-runtime.ts
@@ -1,20 +1,20 @@
 /**
  * Injectable runtime seams for the corrections AI cluster: the Claude text
- * completer and the cross-pillar rejection-feedback store. Both default to
- * real implementations (Anthropic via env key; core settings via the server
- * SDK, best-effort) and are swappable in tests so no test hits the network.
+ * completer and the rejection-feedback store. Both default to real
+ * implementations (Anthropic via env key; finance's LOCAL settings store
+ * in-process, best-effort) and are swappable in tests so no test hits the
+ * network.
  *
  * Mirrors the finance AI-categorizer's env-based key + the monolith's
- * best-effort feedback persistence (try/catch, degrade gracefully when core is
- * unavailable).
+ * best-effort feedback persistence (try/catch, degrade gracefully when the
+ * settings write fails).
  */
 import Anthropic from '@anthropic-ai/sdk';
-import { z } from 'zod';
 
 import { callWithLogging } from '@pops/ai-telemetry';
-import { isOk } from '@pops/pillar-sdk/client';
-import { pillar } from '@pops/pillar-sdk/server';
+import { getBulk, setBulk } from '@pops/pillar-settings/service';
 
+import { type FinanceDb } from '../../../db/index.js';
 import { ANTHROPIC_PROVIDER, FINANCE_DOMAIN, financeTelemetryDeps } from '../ai-telemetry-deps.js';
 
 const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
@@ -85,43 +85,30 @@ export function __setClaudeCompleterForTests(impl: ClaudeCompleter | null): void
 
 /**
  * Persistence for rejection feedback (dynamic `corrections.changeSetRejections:*`
- * keys). The default reaches core settings over the REST server SDK; both legs
- * are best-effort — a missing/unavailable core never throws into the AI flow.
+ * keys). The default reads/writes finance's LOCAL settings store in-process via
+ * the shared free-form bulk paths (these accept undeclared/dynamic keys); both
+ * legs are best-effort — a failed read/write never throws into the AI flow.
  */
 export interface FeedbackStore {
-  load(key: string): Promise<string | null>;
-  persist(key: string, value: string): Promise<void>;
+  load(db: FinanceDb, key: string): Promise<string | null>;
+  persist(db: FinanceDb, key: string, value: string): Promise<void>;
 }
 
-const SettingsManyResponseSchema = z.object({ settings: z.record(z.string(), z.string()) });
-
 const defaultFeedbackStore: FeedbackStore = {
-  async load(key) {
+  load(db, key) {
     try {
-      const result = await pillar('registry').callDynamic(
-        'settings',
-        'getMany',
-        { keys: [key] },
-        'query'
-      );
-      if (!isOk(result)) return null;
-      const parsed = SettingsManyResponseSchema.safeParse(result.value);
-      return parsed.success ? (parsed.data.settings[key] ?? null) : null;
+      return Promise.resolve(getBulk(db, [key])[key] ?? null);
     } catch {
-      return null;
+      return Promise.resolve(null);
     }
   },
-  async persist(key, value) {
+  persist(db, key, value) {
     try {
-      await pillar('registry').callDynamic(
-        'settings',
-        'setMany',
-        { entries: [{ key, value }] },
-        'mutation'
-      );
+      setBulk(db, [{ key, value }]);
     } catch {
-      // best-effort: the learning loop degrades silently when core is down.
+      // best-effort: the learning loop degrades silently when the write fails.
     }
+    return Promise.resolve();
   },
 };
 

--- a/pillars/finance/src/api/rest/corrections-ai-handlers.ts
+++ b/pillars/finance/src/api/rest/corrections-ai-handlers.ts
@@ -62,7 +62,7 @@ export function makeCorrectionsAiHandlers(db: FinanceDb) {
     rejectChangeSet: ({ body }: Req['rejectChangeSet']) =>
       runHttp(async () => {
         try {
-          await persistRejectedChangeSetFeedback({
+          await persistRejectedChangeSetFeedback(db, {
             signal: body.signal,
             changeSet: body.changeSet,
             feedback: body.feedback,

--- a/pillars/finance/src/api/server.ts
+++ b/pillars/finance/src/api/server.ts
@@ -19,7 +19,7 @@ import { createContactsClient } from './contacts/client.js';
 import { createPillarOwnerUriLookup } from './cron/pillar-lookup.js';
 import { startReconcileCrossPillarWorker } from './cron/reconcile-cross-pillar.js';
 import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
-import { buildFinanceManifest } from './manifest.js';
+import { buildFinanceCapabilityReporter, buildFinanceManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
 
 function resolvePort(): number {
@@ -75,6 +75,7 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
     manifest: buildFinanceManifest(version),
     baseUrl: selfBaseUrl,
+    capabilityReporter: buildFinanceCapabilityReporter(),
   });
 }
 

--- a/pillars/inventory/src/api/__tests__/manifest.test.ts
+++ b/pillars/inventory/src/api/__tests__/manifest.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import { inventoryManifest } from '../../contract/settings/index.js';
-import { buildInventoryManifest } from '../manifest.js';
+import { buildInventoryCapabilityReporter, buildInventoryManifest } from '../manifest.js';
 
 describe('buildInventoryManifest', () => {
   it('produces a payload that validates against ManifestPayloadSchema', () => {
@@ -78,5 +78,11 @@ describe('buildInventoryManifest', () => {
       const result = validateManifestPayload(payload);
       expect(result.ok).toBe(true);
     });
+  });
+});
+
+describe('buildInventoryCapabilityReporter (P2 settings federation)', () => {
+  it('reports settings: true so the shell routes settings to inventory', () => {
+    expect(buildInventoryCapabilityReporter()()).toEqual({ settings: true });
   });
 });

--- a/pillars/inventory/src/api/manifest.ts
+++ b/pillars/inventory/src/api/manifest.ts
@@ -11,11 +11,22 @@
  */
 import { inventoryManifest } from '../contract/settings/index.js';
 
+import type { CapabilityReporter } from '@pops/pillar-sdk/bootstrap';
 import type {
   ManifestPayload,
   NavConfigDescriptor,
   PageDescriptor,
 } from '@pops/pillar-sdk/manifest-schema';
+
+/**
+ * Runtime capability heartbeat for inventory. Advertises `settings: true` so
+ * the shell's live-registry settings discovery routes inventory's settings
+ * reads and writes to inventory's own federated `/settings/*` surface
+ * (capability-gated) rather than falling back to the registry pillar.
+ */
+export function buildInventoryCapabilityReporter(): CapabilityReporter {
+  return () => ({ settings: true });
+}
 
 const INVENTORY_NAV: NavConfigDescriptor = {
   id: 'inventory',

--- a/pillars/inventory/src/api/server.ts
+++ b/pillars/inventory/src/api/server.ts
@@ -22,7 +22,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { openInventoryDb } from '../db/index.js';
 import { createInventoryApiApp } from './app.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
-import { buildInventoryManifest } from './manifest.js';
+import { buildInventoryCapabilityReporter, buildInventoryManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
 
 function resolvePort(): number {
@@ -67,6 +67,7 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
     manifest: buildInventoryManifest(version),
     baseUrl: selfBaseUrl,
+    capabilityReporter: buildInventoryCapabilityReporter(),
   });
 }
 

--- a/pillars/media/src/api/__tests__/capability-reporter.test.ts
+++ b/pillars/media/src/api/__tests__/capability-reporter.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Capability-reporter regression guard (P2 settings federation). The media
+ * pillar must advertise `settings: true` on its registry heartbeat so the
+ * shell's live-registry settings discovery routes media settings to media's
+ * own federated `/settings/*` surface instead of the registry fallback. Drop
+ * this flag and the federated surface silently goes dormant.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildMediaCapabilityReporter } from '../manifest.js';
+
+describe('buildMediaCapabilityReporter', () => {
+  it('reports settings: true so the shell routes settings to media', () => {
+    expect(buildMediaCapabilityReporter()()).toEqual({ settings: true });
+  });
+});

--- a/pillars/media/src/api/manifest.ts
+++ b/pillars/media/src/api/manifest.ts
@@ -19,6 +19,7 @@ import {
 } from '../contract/settings/index.js';
 import { MEDIA_ROUTES } from './manifest-routes.js';
 
+import type { CapabilityReporter } from '@pops/pillar-sdk/bootstrap';
 import type {
   ManifestPayload,
   NavConfigDescriptor,
@@ -26,6 +27,16 @@ import type {
 } from '@pops/pillar-sdk/manifest-schema';
 
 export const MEDIA_PILLAR_ID = 'media' as const;
+
+/**
+ * Runtime capability heartbeat for media. Advertises `settings: true` so the
+ * shell's live-registry settings discovery routes media's settings reads and
+ * writes to media's own federated `/settings/*` surface (capability-gated)
+ * rather than falling back to the registry pillar.
+ */
+export function buildMediaCapabilityReporter(): CapabilityReporter {
+  return () => ({ settings: true });
+}
 
 const MEDIA_NAV: NavConfigDescriptor = {
   id: 'media',

--- a/pillars/media/src/api/server.ts
+++ b/pillars/media/src/api/server.ts
@@ -17,7 +17,7 @@ import { openMediaDb } from '../db/index.js';
 import { createMediaApiApp } from './app.js';
 import { plexScheduler } from './cron/plex-scheduler.js';
 import { rotationScheduler } from './cron/rotation-scheduler.js';
-import { buildMediaManifest } from './manifest.js';
+import { buildMediaCapabilityReporter, buildMediaManifest } from './manifest.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -86,6 +86,7 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
   pillarHandle = await bootstrapPillar({
     manifest: buildMediaManifest(version),
     baseUrl: selfBaseUrl,
+    capabilityReporter: buildMediaCapabilityReporter(),
   });
 }
 


### PR DESCRIPTION
## What this flips

The federated `/settings/*` surface is already mounted on every pillar against
its own DB. The only thing keeping it dormant was that no pillar advertised the
`settings` capability on its registry heartbeat, so the shell's live-registry
settings discovery (`useSettingsSections` → `capabilities.settings === true`)
fell back to the registry pillar for every section.

This PR flips the five pillars that own a federated settings surface —
**media, finance, inventory, cerebrum, ai** — to report `settings: true` on
their heartbeat. The shell then routes each pillar's settings reads/writes to
that pillar's own `/<pillar>-api/settings` instead of `/registry-api/settings`.

Each pillar now exposes a `build<Pillar>CapabilityReporter()` factory
co-located with its manifest builder, wired into `bootstrapPillar`. Keeping it
a named export (instead of an inline arrow in `server.ts`, which self-executes
on import) makes it unit-testable. **Cerebrum** merges `settings: true` into its
existing `vectorSearch` reporter without clobbering the live sqlite-vec status.

The registry pillar is deliberately untouched — it remains the fallback target.

## Finance in-process repoint

`pillars/finance/src/api/modules/corrections/ai-runtime.ts` was the last
cross-pillar settings dependency: its rejection-feedback store read/wrote the
dynamic `corrections.changeSetRejections:*` keys via
`pillar('registry').callDynamic('settings', ...)` (cross-pillar HTTP).

The default `FeedbackStore` now reads/writes finance's **local** settings store
**in-process** via the shared `@pops/pillar-settings` free-form bulk paths
(`getBulk`/`setBulk`), which accept the undeclared dynamic keys. The `FinanceDb`
is threaded through the store and its two callers (`ai-feedback`, `ai-propose`,
`corrections-ai-handlers`); the best-effort try/catch is preserved so a failed
read/write never throws into the AI flow.

## Tests

- A per-pillar test asserts each `build<Pillar>CapabilityReporter` emits
  `settings: true` (regression guard). Cerebrum's also asserts `vectorSearch`
  is preserved for both `true`/`false` sqlite-vec states.
- A finance test exercises the **default (non-mocked)** store end-to-end:
  `rejectChangeSet` → the feedback JSON lands in finance's local settings table
  (asserted via `getBulk(financeDb.db, ...)`), proving the repoint writes to
  finance.db rather than the registry pillar.

## Safety

- **Data-migration-free.** Live data has zero `corrections.*` rows, so there is
  nothing to migrate; the finance settings table already exists (the federated
  surface is mounted).
- **Incrementally deployable.** The shell auto-routes a pillar's settings to its
  own surface once its heartbeat carries `settings: true`, and falls back to the
  registry pillar otherwise. Pillars can roll out one at a time with no
  coordinated cutover.

## CI run locally

- `turbo typecheck test build` green for all 5 pillars (finance 386, media 428,
  inventory 259, ai 189, cerebrum 624 tests).
- Whole-repo `turbo typecheck` green (44 tasks, incl. `@pops/shell`).
- `pnpm lint` (oxlint --type-aware) exit 0, `oxfmt --check` clean,
  `pnpm lint:boundaries` clean.

The shell's `settings-persistence.spec.ts` e2e is not affected by this change;
no `settings-federation` e2e spec exists in the repo.
