### PR TITLE
fix(docs): repoint spec discovery packages/*→pillars/* after the lib move

### DIFF
--- a/apps/pops-docs/Dockerfile
+++ b/apps/pops-docs/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     corepack enable && pnpm install --frozen-lockfile --filter @pops/docs...
 
 COPY apps/pops-docs/ ./apps/pops-docs/
-COPY libs/ ./libs/
+COPY pillars/ ./pillars/
 
 WORKDIR /app/apps/pops-docs
 RUN pnpm build

--- a/apps/pops-docs/scripts/collect-specs.test.ts
+++ b/apps/pops-docs/scripts/collect-specs.test.ts
@@ -12,14 +12,23 @@ const APP_ROOT = resolve(HERE, '..');
 const REPO_ROOT = resolve(APP_ROOT, '..', '..');
 const DIST_DIR = resolve(APP_ROOT, 'dist');
 
+/**
+ * Every pillar that ships a committed `openapi/<id>.openapi.json`. The
+ * federation refactor folded the old `packages/<id>-contract` snapshots
+ * into each pillar, renamed `core`→`registry`, and added the `ai` and
+ * (Rust) `contacts` pillars — so this set is the live source of truth, not
+ * the pre-move `packages/*-contract` list.
+ */
 const EXPECTED_PILLARS = [
+  'ai',
   'cerebrum',
-  'core',
+  'contacts',
   'finance',
   'food',
   'inventory',
   'lists',
   'media',
+  'registry',
 ] as const;
 
 describe('collect-specs', () => {
@@ -53,10 +62,7 @@ describe('collect-specs', () => {
         readFileSync(resolve(DIST_DIR, 'openapi', `${pillar}.json`), 'utf8')
       ) as { info?: { title?: string } };
       const sourceSpec = JSON.parse(
-        readFileSync(
-          resolve(REPO_ROOT, `packages/${pillar}-contract/openapi/${pillar}.openapi.json`),
-          'utf8'
-        )
+        readFileSync(resolve(REPO_ROOT, `pillars/${pillar}/openapi/${pillar}.openapi.json`), 'utf8')
       ) as { info?: { title?: string } };
       expect(copiedSpec.info?.title).toBe(sourceSpec.info?.title);
     }

--- a/apps/pops-docs/scripts/collect-specs.ts
+++ b/apps/pops-docs/scripts/collect-specs.ts
@@ -1,12 +1,20 @@
 /**
- * Theme 13 PRD-219 — collect every contract package's OpenAPI snapshot
- * into the pops-docs image build context.
+ * Theme 13 PRD-219 — collect every pillar's OpenAPI snapshot into the
+ * pops-docs image build context.
  *
- * Walks `packages/*-contract/` from the monorepo root. For each contract:
+ * Walks `pillars/*` from the monorepo root. For each pillar:
  *   - if `openapi/<pillar>.openapi.json` exists → emit a catalog entry,
  *     copy the spec into `apps/pops-docs/dist/openapi/<pillar>.json`
- *   - otherwise → log a warning and skip (the contract is in flight but
- *     hasn't generated its snapshot yet; that is not an error)
+ *   - otherwise → skip (the pillar ships no contract snapshot; that is
+ *     not an error)
+ *
+ * The contract snapshots used to live under `packages/<pillar>-contract/`
+ * but were folded into each pillar (`pillars/<id>/openapi/`) by the
+ * federation refactor, so discovery now keys off the pillar directory and
+ * the presence of its OpenAPI file rather than a `-contract` suffix. Pillar
+ * package metadata (`package.json`) is optional: Rust pillars (e.g.
+ * `contacts`) ship a `Cargo.toml` and no `package.json`, and still get a
+ * catalog entry sourced from the OpenAPI `info` block.
  *
  * The output `catalog.json` is what `src/index.html` reads at runtime to
  * populate Stoplight Elements' multi-spec navigation. There is no runtime
@@ -21,6 +29,7 @@
 import { execSync } from 'node:child_process';
 import {
   cpSync,
+  existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -41,7 +50,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = resolve(HERE, '..');
 const REPO_ROOT = resolve(APP_ROOT, '..', '..');
-const PACKAGES_DIR = resolve(REPO_ROOT, 'packages');
+const PILLARS_DIR = resolve(REPO_ROOT, 'pillars');
 const SRC_DIR = resolve(APP_ROOT, 'src');
 const OUT_DIR = resolve(APP_ROOT, 'dist');
 const OUT_OPENAPI_DIR = resolve(OUT_DIR, 'openapi');
@@ -61,48 +70,66 @@ function resolveGitSha(): string {
 }
 
 /**
- * Discover every `packages/*-contract` directory that ships an OpenAPI
- * snapshot. Pure filesystem walk — no workspace manifest required.
+ * Read a pillar's `package.json` for its npm name/version when present.
+ * Rust pillars ship a `Cargo.toml` and no `package.json`; callers fall
+ * back to the OpenAPI `info` block for those.
+ */
+function readPillarPackage(pkgJsonPath: string): ContractPackageJson | null {
+  if (!existsSync(pkgJsonPath)) return null;
+  try {
+    return readJson<ContractPackageJson>(pkgJsonPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a catalog entry for pillar `id` if it ships a readable
+ * `openapi/<id>.openapi.json`, otherwise `null` (the pillar has no
+ * contract snapshot yet — not an error). Package metadata falls back to
+ * the OpenAPI `info` block so Rust pillars without a `package.json` still
+ * get a usable name/version.
+ */
+function collectPillar(id: string): CollectedContract | null {
+  const pillarDir = resolve(PILLARS_DIR, id);
+  const openapiPath = resolve(pillarDir, 'openapi', `${id}.openapi.json`);
+
+  let snapshot: OpenApiSnapshot;
+  try {
+    statSync(openapiPath);
+    snapshot = readJson<OpenApiSnapshot>(openapiPath);
+  } catch {
+    return null;
+  }
+
+  const pkg = readPillarPackage(resolve(pillarDir, 'package.json'));
+
+  return {
+    id,
+    packageName: pkg?.name ?? snapshot.info?.title ?? `@pops/${id}`,
+    packageVersion: pkg?.version ?? snapshot.info?.version ?? '0.0.0',
+    sourcePath: openapiPath,
+    snapshot,
+  };
+}
+
+/**
+ * Discover every `pillars/<id>` directory that ships an OpenAPI snapshot
+ * at `openapi/<id>.openapi.json`. Pure filesystem walk — no workspace
+ * manifest required. A missing `pillars/` directory degrades to an empty
+ * catalog rather than throwing, so the build never dies on `ENOENT`.
  */
 function discoverContracts(): CollectedContract[] {
-  const entries = readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  if (!existsSync(PILLARS_DIR)) {
+    console.warn(`[pops-docs] no pillars directory at ${PILLARS_DIR} — catalog will be empty`);
+    return [];
+  }
+
   const collected: CollectedContract[] = [];
-
-  for (const entry of entries) {
+  for (const entry of readdirSync(PILLARS_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    if (!entry.name.endsWith('-contract')) continue;
-
-    const id = entry.name.replace(/-contract$/, '');
-    const pkgDir = resolve(PACKAGES_DIR, entry.name);
-    const pkgJsonPath = resolve(pkgDir, 'package.json');
-    const openapiPath = resolve(pkgDir, 'openapi', `${id}.openapi.json`);
-
-    let pkg: ContractPackageJson;
-    try {
-      pkg = readJson<ContractPackageJson>(pkgJsonPath);
-    } catch {
-      console.warn(`[pops-docs] skipping ${entry.name}: package.json unreadable`);
-      continue;
-    }
-
-    let snapshot: OpenApiSnapshot;
-    try {
-      statSync(openapiPath);
-      snapshot = readJson<OpenApiSnapshot>(openapiPath);
-    } catch {
-      console.warn(
-        `[pops-docs] skipping ${entry.name}: no openapi snapshot at openapi/${id}.openapi.json`
-      );
-      continue;
-    }
-
-    collected.push({
-      id,
-      packageName: pkg.name,
-      packageVersion: pkg.version,
-      sourcePath: openapiPath,
-      snapshot,
-    });
+    const contract = collectPillar(entry.name);
+    if (contract) collected.push(contract);
   }
 
   return collected.toSorted((a, b) => a.id.localeCompare(b.id));

--- a/apps/pops-docs/scripts/dev-serve.ts
+++ b/apps/pops-docs/scripts/dev-serve.ts
@@ -3,9 +3,9 @@
  *
  * Behaviour:
  *   1. Runs `collect-specs.ts` once to populate `dist/`
- *   2. Watches every discovered `packages/*-contract/openapi/` directory
- *      and re-runs the collector when an OpenAPI snapshot changes (so
- *      contract authors can preview docs without restarting the server)
+ *   2. Watches every discovered `pillars/<id>/openapi/` directory and
+ *      re-runs the collector when an OpenAPI snapshot changes (so contract
+ *      authors can preview docs without restarting the server)
  *   3. Serves `dist/` over a tiny Node http server on `POPS_DOCS_PORT`
  *      (default 4280) with the same URL layout that nginx serves in prod
  *
@@ -14,7 +14,7 @@
  * `http`/`fs.watch` are enough for a local preview.
  */
 import { spawnSync } from 'node:child_process';
-import { createReadStream, readdirSync, statSync, watch } from 'node:fs';
+import { createReadStream, existsSync, readdirSync, statSync, watch } from 'node:fs';
 import { createServer } from 'node:http';
 import { dirname, extname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = resolve(HERE, '..');
 const REPO_ROOT = resolve(APP_ROOT, '..', '..');
-const PACKAGES_DIR = resolve(REPO_ROOT, 'packages');
+const PILLARS_DIR = resolve(REPO_ROOT, 'pillars');
 const DIST_DIR = resolve(APP_ROOT, 'dist');
 const COLLECT_SCRIPT = resolve(HERE, 'collect-specs.ts');
 
@@ -44,10 +44,12 @@ function runCollect(): void {
 }
 
 function watchOpenapiDirs(): void {
+  if (!existsSync(PILLARS_DIR)) return;
+
   const dirs: string[] = [];
-  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
-    if (!entry.isDirectory() || !entry.name.endsWith('-contract')) continue;
-    const candidate = resolve(PACKAGES_DIR, entry.name, 'openapi');
+  for (const entry of readdirSync(PILLARS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = resolve(PILLARS_DIR, entry.name, 'openapi');
     try {
       if (statSync(candidate).isDirectory()) dirs.push(candidate);
     } catch {


### PR DESCRIPTION
## Problem

The `pops-docs` image build is broken — a regression from #3514 (the `packages/*` → `libs/*` TS-libs move). That PR mechanically retargeted the docs `Dockerfile`'s `COPY packages/ ./packages/` to `COPY libs/ ./libs/`, but the docs build never consumed the TS libs. It scans the per-contract **OpenAPI snapshots**, which an earlier federation refactor had already folded out of `packages/<id>-contract/openapi/` into `pillars/<id>/openapi/<id>.openapi.json`.

So `apps/pops-docs/scripts/collect-specs.ts` kept scanning a hardcoded `packages/` directory that no longer exists, and `pnpm build` inside the image died with:

```
ENOENT: no such file or directory, scandir '/app/packages'
```

at `Dockerfile` `RUN pnpm build`. The next `publish-images` run would have failed on `pops-docs`.

## Fix

- **`collect-specs.ts` / `dev-serve.ts`** — discover `pillars/<id>/openapi/<id>.openapi.json` instead of `packages/*-contract`. Discovery now keys off the presence of the OpenAPI file in each pillar dir, not a `-contract` directory suffix.
- **Missing-dir guard** — the pillars-dir `readdir` is guarded with an existence check; a missing `pillars/` now degrades to an empty catalog (with a warning) instead of throwing `ENOENT`, so a future path slip can never again hard-fail the build.
- **Optional package metadata** — `package.json` is no longer required per pillar. The Rust `contacts` pillar ships a `Cargo.toml` and no `package.json`; its catalog name/version now fall back to the OpenAPI `info` block (`POPS Contacts` / `0.1.0`).
- **`Dockerfile`** — `COPY pillars/ ./pillars/` in place of `COPY libs/ ./libs/` (the actual spec source). `@pops/docs` has no workspace deps, so the earlier `pnpm install` stage is self-contained and dropping `libs/` is safe.
- **`collect-specs.test.ts`** — this test was effectively dead (it asserted the long-gone `core` pillar). Made it real and passing again: `EXPECTED_PILLARS` updated `core`→`registry`, added `ai` and `contacts`, and the source-spec path repointed to `pillars/<id>/`. It now asserts the live set of 9 pillars.

## Verification

- `pnpm --filter @pops/docs build` (the exact `Dockerfile` command) succeeds — emits a 9-contract catalog: `ai, cerebrum, contacts, finance, food, inventory, lists, media, registry`.
- `pnpm --filter @pops/docs test` — 7/7 pass.
- `pnpm --filter @pops/docs typecheck` clean; whole-repo `turbo typecheck` 43/43 green; `oxlint --type-aware` clean; `oxfmt --check` clean on touched files.
- **Built the real image** from repo root — `docker build -f apps/pops-docs/Dockerfile .` gets past `RUN pnpm build` and produces `dist/catalog.json` + `dist/openapi/*.json` (9 specs). The next `publish-images` run will not fail on `pops-docs`.

> Note: the per-package quality CI does not build the docs image, so the green proof here is the local docker build + the now-live `collect-specs` test.
