### PR TITLE
feat(media): table-back media.comparisons.* settings so UI edits take effect [OD-4]

### DIFF
--- a/pillars/media/src/api/__tests__/settings-federation.test.ts
+++ b/pillars/media/src/api/__tests__/settings-federation.test.ts
@@ -28,8 +28,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { REDACTED } from '@pops/pillar-settings';
 
-import { openMediaDb, type OpenedMediaDb } from '../../db/index.js';
+import { comparisonsService, openMediaDb, type OpenedMediaDb } from '../../db/index.js';
 import { plexSettings, rotationSettings, settings } from '../../db/schema.js';
+import * as settingsAdapter from '../../db/services/settings-adapter.js';
 import { createMediaApiApp } from '../app.js';
 
 let tmpDir: string;
@@ -185,5 +186,47 @@ describe('media federated /settings', () => {
     // The seed is preserved: the second ensure returns the originally-landed value.
     expect(second.body.data).toEqual({ key: 'plex_url', value: 'http://first' });
     expect(rawValue(plexSettings, 'plex_url')?.value).toBe('http://first');
+  });
+});
+
+/**
+ * Runtime-read assertions for the comparisons config readers (OD-4 / S2b,
+ * GAP-256-B). Proves the readers in
+ * `db/services/comparisons/config.ts` resolve the EFFECTIVE value from media's
+ * pillar-local `settings` table — so an edit persisted through `/settings` takes
+ * effect at runtime — falling back to the manifest default when nothing is
+ * stored. These exercise the real reader against the real temp SQLite db (no
+ * mocks): a table write is observed by the getter, and the unset path resolves
+ * the manifest default rather than a stale `process.env`-era value.
+ */
+describe('comparisons config runtime reads', () => {
+  it('reflects a stored override for the int eloK reader', async () => {
+    expect(comparisonsService.getEloK(mediaDb.db)).toBe(32);
+
+    await request(app()).put('/settings/media.comparisons.eloK').send({ value: '64' });
+    expect(comparisonsService.getEloK(mediaDb.db)).toBe(64);
+  });
+
+  it('reflects a stored override for the float stalenessThreshold reader', async () => {
+    expect(comparisonsService.getStalenessThreshold(mediaDb.db)).toBe(0.3);
+
+    settingsAdapter.setRaw(mediaDb.db, 'media.comparisons.stalenessThreshold', '0.45');
+    expect(comparisonsService.getStalenessThreshold(mediaDb.db)).toBe(0.45);
+  });
+
+  it('falls back to the manifest default for every reader when unset', () => {
+    expect(comparisonsService.getEloK(mediaDb.db)).toBe(32);
+    expect(comparisonsService.getDefaultScore(mediaDb.db)).toBe(1500);
+    expect(comparisonsService.getMaxTierListMovies(mediaDb.db)).toBe(8);
+    expect(comparisonsService.getStalenessThreshold(mediaDb.db)).toBe(0.3);
+    expect(comparisonsService.getDefaultLimit(mediaDb.db)).toBe(50);
+  });
+
+  it('resets restore the manifest default the reader observes', async () => {
+    await request(app()).put('/settings/media.comparisons.eloK').send({ value: '64' });
+    expect(comparisonsService.getEloK(mediaDb.db)).toBe(64);
+
+    await request(app()).post('/settings/media.comparisons.eloK/reset');
+    expect(comparisonsService.getEloK(mediaDb.db)).toBe(32);
   });
 });

--- a/pillars/media/src/api/rest/comparisons-handlers.ts
+++ b/pillars/media/src/api/rest/comparisons-handlers.ts
@@ -22,8 +22,6 @@ type Req = ServerInferRequest<typeof mediaComparisonsContract>;
 const DEFAULT_OFFSET = 0;
 
 export function makeComparisonsHandlers(db: MediaDb) {
-  const defaultLimit = comparisonsService.getDefaultLimit();
-
   return {
     listDimensions: () =>
       runHttp(() => ({
@@ -68,7 +66,7 @@ export function makeComparisonsHandlers(db: MediaDb) {
 
     listForMedia: ({ query }: Req['listForMedia']) =>
       runHttp(() => {
-        const limit = query.limit ?? defaultLimit;
+        const limit = query.limit ?? comparisonsService.getDefaultLimit(db);
         const offset = query.offset ?? DEFAULT_OFFSET;
         const { rows, total } = comparisonsService.listComparisonsForMedia(db, {
           mediaType: query.mediaType,
@@ -88,7 +86,7 @@ export function makeComparisonsHandlers(db: MediaDb) {
 
     listAll: ({ query }: Req['listAll']) =>
       runHttp(() => {
-        const limit = query.limit ?? defaultLimit;
+        const limit = query.limit ?? comparisonsService.getDefaultLimit(db);
         const offset = query.offset ?? DEFAULT_OFFSET;
         const { rows, total } = comparisonsService.listAllComparisons(db, {
           dimensionId: query.dimensionId,

--- a/pillars/media/src/api/rest/comparisons-scores-handlers.ts
+++ b/pillars/media/src/api/rest/comparisons-scores-handlers.ts
@@ -17,8 +17,6 @@ type Req = ServerInferRequest<typeof mediaComparisonsContract>;
 const DEFAULT_OFFSET = 0;
 
 export function makeComparisonsScoreHandlers(db: MediaDb) {
-  const defaultLimit = comparisonsService.getDefaultLimit();
-
   return {
     scores: ({ query }: Req['scores']) =>
       runHttp(() => ({
@@ -32,7 +30,7 @@ export function makeComparisonsScoreHandlers(db: MediaDb) {
 
     rankings: ({ query }: Req['rankings']) =>
       runHttp(() => {
-        const limit = query.limit ?? defaultLimit;
+        const limit = query.limit ?? comparisonsService.getDefaultLimit(db);
         const offset = query.offset ?? DEFAULT_OFFSET;
         const { rows, total } = comparisonsService.getRankings(db, {
           dimensionId: query.dimensionId,

--- a/pillars/media/src/db/services/comparisons/config.ts
+++ b/pillars/media/src/db/services/comparisons/config.ts
@@ -1,38 +1,63 @@
 /**
  * Tuning knobs for the comparisons ranking engine.
  *
- * The monolith read these from `core/settings` (`settingsService.getSetting`).
- * The pillar must not depend on `core/settings` or `apps/pops-api`, so each
- * value is read from `process.env` with the SAME default the settings table
- * shipped — mirroring the pattern the tmdb/thetvdb clients use for their
- * keys. Centralised here so every reader resolves the same value.
+ * Each value is resolved from media's pillar-local `settings` table (the
+ * federated `/settings` override the shell UI writes), falling back to the
+ * manifest default when no override is stored, and finally to the literal
+ * default baked in here if the manifest default is absent or unparseable.
+ * Reads happen per call so an edit persisted through `/settings` takes effect
+ * at runtime without a restart (GAP-256-B / risk R4).
  */
-import { getEnvFloat, getEnvInt } from '../../../api/clients/env.js';
+import { mediaKeyDefaults } from '../../../contract/settings/key-defaults.js';
+import * as adapter from '../settings-adapter.js';
+
+import type { MediaDb } from '../internal.js';
+
+const ELO_K = 'media.comparisons.eloK';
+const DEFAULT_SCORE = 'media.comparisons.defaultScore';
+const MAX_TIER_LIST_MOVIES = 'media.comparisons.maxTierListMovies';
+const STALENESS_THRESHOLD = 'media.comparisons.stalenessThreshold';
+const DEFAULT_LIMIT = 'media.comparisons.defaultLimit';
+
+/** The stored override (decoded) if present, else the manifest default. */
+function effective(db: MediaDb, key: string): string | undefined {
+  return adapter.getOrNull(db, key)?.value ?? mediaKeyDefaults.defaults[key];
+}
+
+function readInt(db: MediaDb, key: string, fallback: number): number {
+  const parsed = Number.parseInt(effective(db, key) ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function readFloat(db: MediaDb, key: string, fallback: number): number {
+  const parsed = Number.parseFloat(effective(db, key) ?? '');
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
 
 /** ELO K-factor for score updates. Larger = bigger swings per comparison. */
-export function getEloK(): number {
-  return getEnvInt('MEDIA_COMPARISONS_ELO_K', 32);
+export function getEloK(db: MediaDb): number {
+  return readInt(db, ELO_K, 32);
 }
 
 /** Baseline ELO score every media item starts at on a dimension. */
-export function getDefaultScore(): number {
-  return getEnvInt('MEDIA_COMPARISONS_DEFAULT_SCORE', 1500);
+export function getDefaultScore(db: MediaDb): number {
+  return readInt(db, DEFAULT_SCORE, 1500);
 }
 
 /** Maximum number of movies surfaced in a single tier-list placement round. */
-export function getMaxTierListMovies(): number {
-  return getEnvInt('MEDIA_COMPARISONS_MAX_TIER_LIST_MOVIES', 8);
+export function getMaxTierListMovies(db: MediaDb): number {
+  return readInt(db, MAX_TIER_LIST_MOVIES, 8);
 }
 
 /**
  * Minimum staleness (1.0 = fresh) a movie must retain to remain eligible for
  * tier-list selection. A fractional knob, so it reads as a float.
  */
-export function getStalenessThreshold(): number {
-  return getEnvFloat('MEDIA_COMPARISONS_STALENESS_THRESHOLD', 0.3);
+export function getStalenessThreshold(db: MediaDb): number {
+  return readFloat(db, STALENESS_THRESHOLD, 0.3);
 }
 
 /** Default page size for paginated comparison/ranking lists. */
-export function getDefaultLimit(): number {
-  return getEnvInt('MEDIA_COMPARISONS_DEFAULT_LIMIT', 50);
+export function getDefaultLimit(db: MediaDb): number {
+  return readInt(db, DEFAULT_LIMIT, 50);
 }

--- a/pillars/media/src/db/services/comparisons/dimension-exclusion.ts
+++ b/pillars/media/src/db/services/comparisons/dimension-exclusion.ts
@@ -50,7 +50,7 @@ export function excludeFromDimension(
           mediaType,
           mediaId,
           dimensionId,
-          score: getDefaultScore(),
+          score: getDefaultScore(db),
           comparisonCount: 0,
           excluded: 1,
         })

--- a/pillars/media/src/db/services/comparisons/elo-calculator.ts
+++ b/pillars/media/src/db/services/comparisons/elo-calculator.ts
@@ -1,9 +1,6 @@
 /**
  * Pure ELO math for the comparisons ranking engine. No DB access.
  */
-import { getEloK } from './config.js';
-
-export { getEloK };
 
 /** Map a draw tier to an ELO outcome. High = both gain, Mid = neutral, Low = both lose. */
 export function drawTierOutcome(tier: string | null | undefined): number {

--- a/pillars/media/src/db/services/comparisons/index.ts
+++ b/pillars/media/src/db/services/comparisons/index.ts
@@ -5,7 +5,10 @@
  * Everything here is HTTP-free and `(db, …)`-arg; the REST handler boundary
  * (`api/rest/comparisons-handlers.ts`) maps the typed errors to status codes.
  * Config (ELO K, default score, tier-list size, staleness threshold, default
- * limit) reads from `process.env` via `./config.js` — no `core/settings`.
+ * limit) resolves from media's pillar-local `settings` table via `./config.js`,
+ * falling back to the manifest default — no `core/settings`, no `process.env`.
+ * Each getter takes `db` so edits made through `/settings` take effect at
+ * runtime without a restart.
  */
 export {
   ComparisonNotFoundError,

--- a/pillars/media/src/db/services/comparisons/pairs/smart-pair-helpers.ts
+++ b/pillars/media/src/db/services/comparisons/pairs/smart-pair-helpers.ts
@@ -96,7 +96,7 @@ export function buildCandidates(args: BuildCandidatesArgs): CandidateMovie[] {
       posterPath: meta.posterPath,
       tmdbId: meta.tmdbId,
       posterOverridePath: meta.posterOverridePath,
-      score: scoreInfo?.score ?? getDefaultScore(),
+      score: scoreInfo?.score ?? getDefaultScore(db),
       comparisonCount: scoreInfo?.comparisonCount ?? 0,
       daysSinceLastWatch: daysSince(watchDateMap.get(movieId)),
       staleness: getStaleness(db, 'movie', movieId),

--- a/pillars/media/src/db/services/comparisons/score-management.ts
+++ b/pillars/media/src/db/services/comparisons/score-management.ts
@@ -5,8 +5,8 @@
 import { and, asc, eq } from 'drizzle-orm';
 
 import { comparisonDimensions, comparisons, mediaScores } from '../../schema.js';
-import { getDefaultScore } from './config.js';
-import { drawTierOutcome, expectedScore, getEloK } from './elo-calculator.js';
+import { getDefaultScore, getEloK } from './config.js';
+import { drawTierOutcome, expectedScore } from './elo-calculator.js';
 
 import type { MediaScoreRow } from '../../row-types.js';
 import type { MediaDb } from '../internal.js';
@@ -49,7 +49,7 @@ export function getOrCreateScore(
   if (existing) return existing;
 
   db.insert(mediaScores)
-    .values({ mediaType, mediaId, dimensionId, score: getDefaultScore(), comparisonCount: 0 })
+    .values({ mediaType, mediaId, dimensionId, score: getDefaultScore(db), comparisonCount: 0 })
     .run();
 
   const score = db
@@ -89,7 +89,7 @@ export function updateEloScores(
   const actualA = actualScoreA(input, isDraw, drawOutcome);
   const actualB = isDraw ? drawOutcome : 1 - actualA;
 
-  const k = getEloK();
+  const k = getEloK(db);
   const newScoreA = scoreA.score + k * (actualA - expectedA);
   const newScoreB = scoreB.score + k * (actualB - expectedB);
   const deltaA = Math.round(newScoreA - scoreA.score);
@@ -115,7 +115,7 @@ export function updateEloScores(
  */
 export function recalcDimensionElo(db: MediaDb, dimensionId: number): void {
   db.update(mediaScores)
-    .set({ score: getDefaultScore(), comparisonCount: 0, updatedAt: new Date().toISOString() })
+    .set({ score: getDefaultScore(db), comparisonCount: 0, updatedAt: new Date().toISOString() })
     .where(eq(mediaScores.dimensionId, dimensionId))
     .run();
 

--- a/pillars/media/src/db/services/comparisons/submit-tier-list.ts
+++ b/pillars/media/src/db/services/comparisons/submit-tier-list.ts
@@ -39,7 +39,7 @@ function fetchScoresMap(db: MediaDb, movieIds: number[], dimensionId: number): M
 function captureScores(db: MediaDb, input: SubmitTierListInput): Map<number, number> {
   const ids = input.placements.map((p) => p.movieId);
   const map = fetchScoresMap(db, ids, input.dimensionId);
-  for (const id of ids) if (!map.has(id)) map.set(id, getDefaultScore());
+  for (const id of ids) if (!map.has(id)) map.set(id, getDefaultScore(db));
   return map;
 }
 
@@ -64,8 +64,8 @@ function collectScoreChanges(
   const newScores = fetchScoresMap(db, ids, input.dimensionId);
   return input.placements.map((placement) => ({
     movieId: placement.movieId,
-    oldScore: oldScores.get(placement.movieId) ?? getDefaultScore(),
-    newScore: newScores.get(placement.movieId) ?? getDefaultScore(),
+    oldScore: oldScores.get(placement.movieId) ?? getDefaultScore(db),
+    newScore: newScores.get(placement.movieId) ?? getDefaultScore(db),
   }));
 }
 

--- a/pillars/media/src/db/services/comparisons/tier-list-selection.ts
+++ b/pillars/media/src/db/services/comparisons/tier-list-selection.ts
@@ -46,6 +46,7 @@ function toTierListMovie(row: ScoreRow, tierOverrideMap: Map<number, string>): T
 }
 
 function fetchEligibleRows(db: MediaDb, dimensionId: number): ScoreRow[] {
+  const stalenessThreshold = getStalenessThreshold(db);
   return db.all<ScoreRow>(sql`
     SELECT
       ms.media_id AS mediaId,
@@ -63,7 +64,7 @@ function fetchEligibleRows(db: MediaDb, dimensionId: number): ScoreRow[] {
       AND ms.media_type = 'movie'
       AND ms.excluded = 0
       AND wh.id IS NULL
-      AND COALESCE(cs.staleness, 1.0) >= ${getStalenessThreshold()}
+      AND COALESCE(cs.staleness, 1.0) >= ${stalenessThreshold}
     ORDER BY ms.comparison_count ASC, ms.score DESC
   `);
 }
@@ -134,10 +135,9 @@ function pickBestCandidate(
   return bestIdx;
 }
 
-function greedySelect(rows: ScoreRow[], existingPairs: Set<string>): ScoreRow[] {
+function greedySelect(rows: ScoreRow[], existingPairs: Set<string>, max: number): ScoreRow[] {
   const selected: ScoreRow[] = [];
   const selectedIds = new Set<number>();
-  const max = getMaxTierListMovies();
   for (let round = 0; round < max && rows.length > 0; round++) {
     const bestIdx = pickBestCandidate(rows, selected, selectedIds, existingPairs);
     if (bestIdx === -1) break;
@@ -165,9 +165,12 @@ export function getTierListMovies(db: MediaDb, dimensionId: number): TierListMov
 
   const tierOverrideMap = buildTierOverrideMap(getTierOverrides(db, dimensionId));
 
-  if (rows.length <= getMaxTierListMovies()) {
+  const maxTierListMovies = getMaxTierListMovies(db);
+  if (rows.length <= maxTierListMovies) {
     return rows.map((r) => toTierListMovie(r, tierOverrideMap));
   }
   const existingPairs = fetchExistingPairKeys(db, dimensionId);
-  return greedySelect(rows, existingPairs).map((r) => toTierListMovie(r, tierOverrideMap));
+  return greedySelect(rows, existingPairs, maxTierListMovies).map((r) =>
+    toTierListMovie(r, tierOverrideMap)
+  );
 }


### PR DESCRIPTION
## Why

The five `media.comparisons.*` tuning knobs — `eloK`, `defaultScore`, `maxTierListMovies`, `stalenessThreshold`, `defaultLimit` — were already fully wired into media's federated `/settings` surface: declared in the manifests, persisted to the pillar settings table, and read/written/reset by the REST handlers. But the runtime config readers in `pillars/media/src/db/services/comparisons/config.ts` still read `process.env`. So editing any of these in the shell UI persisted to the DB with **zero runtime effect** (GAP-256-B / risk R4) — the edit was a silent no-op until a restart that never re-read it.

This is OD-4 from `docs/plans/02-settings-federation.md`.

## What

- **Repoint the five readers from `process.env` to the pillar-local `settings` table** via the settings adapter (`getOrNull`), falling back to the manifest default (`mediaKeyDefaults.defaults[key]`) when no override is stored, and finally to the literal baked-in default if the manifest default is absent or unparseable.
- Each getter now takes `db: MediaDb` and resolves the effective value **per call**, so an edit through `/settings` takes effect at runtime without a restart.
- **Thread `db`** through every call site that already has it. For pure math / pure helpers (`elo-calculator`'s ELO functions, `greedySelect`, `fetchEligibleRows` SQL) the value is resolved at the nearest `db`-having caller and passed down as a plain number — the pure helpers are not polluted with a `db` arg.
  - `elo-calculator.ts` drops the `getEloK` re-export and stays pure; `score-management.ts` imports `getEloK` directly from `./config.js`.
  - `tier-list-selection.ts`: `getStalenessThreshold(db)` resolved in `fetchEligibleRows`; `getMaxTierListMovies(db)` resolved once in `getTierListMovies` and passed into `greedySelect(rows, existingPairs, max)`.
- **Per-request read change**: in `comparisons-handlers.ts` and `comparisons-scores-handlers.ts` the default page size was read **once at handler-construction time**; the read is moved inside the per-request handler body so edits apply without rebuilding the handler.

## Verification

- `pnpm typecheck` (media, via turbo with deps built) — exit 0.
- `pnpm test` (media) — **432 passed (33 files)**, including the new assertions.
- `pnpm lint` (oxlint type-aware) — 0 errors. `pnpm format:check` (oxfmt) — clean.

### New runtime-read test (the missing S2b assertion)

Added to `settings-federation.test.ts` (real temp SQLite db, no mocks):

- a value written through `/settings` (`media.comparisons.eloK = 64`) is observed by `getEloK(db)` → `64`;
- the float key written via the adapter (`media.comparisons.stalenessThreshold = 0.45`) is observed by `getStalenessThreshold(db)` → `0.45`;
- with nothing stored, every reader resolves the manifest default (`32`, `1500`, `8`, `0.3`, `50`);
- a `/settings/.../reset` restores the manifest default the reader observes (`64` → `32`).