### PR TITLE
chore(federation): close glob gate — pillars/+libs/ only [P3-T01/G1]

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 packages:
-  - 'apps/*'
-  - 'packages/*'
   - 'pillars/*'
   - 'pillars/*/*'
   - 'libs/*'


### PR DESCRIPTION
Closes the relocation gate. All Phase-2 lanes merged (P2-T01 TS libs→libs/, P2-T03 rust→libs/, P2-T02 apps→pillars/). Strips the now-empty `apps/*` and `packages/*` workspace globs; final form is `pillars/*`, `pillars/*/*`, `libs/*`. `apps/`,`packages/`,`crates/` are gone (zero tracked files).

Verify: `pnpm install --frozen-lockfile` clean (lock already reflects pillars/+libs/), lint, format:check, lint:boundaries (0 violations, 1543 modules), typecheck (42/42) — all green.

**After this merges, the layout reshuffle is structurally complete: `pillars/` + `libs/` are the only unit homes.**