### PR TITLE
build(federation): add tsc -b project-reference graph [P5-T01]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ package-lock.json
 dist/
 # Bundled nginx render + watcher CLIs (apps/pops-shell, built in-image)
 dist-scripts/
+# tsc -b project-reference incremental build state
+*.tsbuildinfo
 
 # Rust build output (crates/ cargo workspace + pillars/<id> Rust pillars).
 # Cargo.lock IS committed for the workspace (reproducible bin builds).

--- a/libs/ai-telemetry/package.json
+++ b/libs/ai-telemetry/package.json
@@ -37,7 +37,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/libs/ai-telemetry/tsconfig.build.json
+++ b/libs/ai-telemetry/tsconfig.build.json
@@ -8,7 +8,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "scripts"],
-  "references": [{ "path": "../../libs/types/tsconfig.build.json" }]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"],
+  "references": []
 }

--- a/libs/ai-telemetry/tsconfig.json
+++ b/libs/ai-telemetry/tsconfig.json
@@ -5,10 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts"]

--- a/libs/db-types/package.json
+++ b/libs/db-types/package.json
@@ -16,8 +16,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch --preserveWatchOutput",
+    "build": "tsc -b tsconfig.build.json",
+    "dev": "tsc -b tsconfig.build.json --watch --preserveWatchOutput",
     "typecheck": "tsc --noEmit",
     "test": "echo \"(no tests in @pops/db-types)\""
   },

--- a/libs/db-types/tsconfig.build.json
+++ b/libs/db-types/tsconfig.build.json
@@ -8,7 +8,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "scripts"],
-  "references": [{ "path": "../../libs/types/tsconfig.build.json" }]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"],
+  "references": []
 }

--- a/libs/db-types/tsconfig.json
+++ b/libs/db-types/tsconfig.json
@@ -5,10 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2022"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/libs/module-registry/tsconfig.json
+++ b/libs/module-registry/tsconfig.json
@@ -4,8 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
-    "declaration": true,
-    "declarationMap": true,
+    "noEmit": true,
     "outDir": "dist",
     "rootDir": ".",
     "types": ["vitest/globals", "node"]

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -61,7 +61,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/libs/sdk/tsconfig.build.json
+++ b/libs/sdk/tsconfig.build.json
@@ -8,7 +8,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "scripts"],
-  "references": [{ "path": "../../libs/types/tsconfig.build.json" }]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
+  "references": []
 }

--- a/libs/sdk/tsconfig.json
+++ b/libs/sdk/tsconfig.json
@@ -6,10 +6,7 @@
     "lib": ["ES2023", "DOM"],
     "types": ["node"],
     "jsx": "react-jsx",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]

--- a/libs/settings/package.json
+++ b/libs/settings/package.json
@@ -33,7 +33,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/libs/settings/tsconfig.build.json
+++ b/libs/settings/tsconfig.build.json
@@ -8,7 +8,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "scripts"],
-  "references": [{ "path": "../../libs/types/tsconfig.build.json" }]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"],
+  "references": []
 }

--- a/libs/settings/tsconfig.json
+++ b/libs/settings/tsconfig.json
@@ -5,10 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts"]

--- a/libs/types/tsconfig.build.json
+++ b/libs/types/tsconfig.build.json
@@ -1,4 +1,14 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"],
+  "references": []
 }

--- a/libs/types/tsconfig.json
+++ b/libs/types/tsconfig.json
@@ -4,8 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2022"],
-    "declaration": true,
-    "declarationMap": true,
+    "noEmit": true,
     "outDir": "dist",
     "rootDir": "src",
     "types": ["vitest/globals"]

--- a/pillars/ai/Dockerfile
+++ b/pillars/ai/Dockerfile
@@ -26,12 +26,15 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY libs/ai-telemetry/src ./libs/ai-telemetry/src
 COPY libs/ai-telemetry/tsconfig.json ./libs/ai-telemetry/tsconfig.json
+COPY libs/ai-telemetry/tsconfig.build.json ./libs/ai-telemetry/tsconfig.build.json
 
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -42,6 +45,7 @@ COPY pillars/ai/scripts ./pillars/ai/scripts
 COPY pillars/ai/openapi ./pillars/ai/openapi
 COPY pillars/ai/migrations ./pillars/ai/migrations
 COPY pillars/ai/tsconfig.json ./pillars/ai/tsconfig.json
+COPY pillars/ai/tsconfig.build.json ./pillars/ai/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/ai^..." build

--- a/pillars/ai/package.json
+++ b/pillars/ai/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/ai/tsconfig.build.json
+++ b/pillars/ai/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/ai-telemetry/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/ai/tsconfig.json
+++ b/pillars/ai/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/cerebrum/Dockerfile
+++ b/pillars/cerebrum/Dockerfile
@@ -29,12 +29,15 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/ai-telemetry
 COPY libs/ai-telemetry/src ./libs/ai-telemetry/src
 COPY libs/ai-telemetry/tsconfig.json ./libs/ai-telemetry/tsconfig.json
+COPY libs/ai-telemetry/tsconfig.build.json ./libs/ai-telemetry/tsconfig.build.json
 # @pops/pillar-sdk
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 # @pops/pillar-settings
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 # @pops/types
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -45,6 +48,7 @@ COPY pillars/cerebrum/scripts ./pillars/cerebrum/scripts
 COPY pillars/cerebrum/openapi ./pillars/cerebrum/openapi
 COPY pillars/cerebrum/migrations ./pillars/cerebrum/migrations
 COPY pillars/cerebrum/tsconfig.json ./pillars/cerebrum/tsconfig.json
+COPY pillars/cerebrum/tsconfig.build.json ./pillars/cerebrum/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/cerebrum^..." build

--- a/pillars/cerebrum/package.json
+++ b/pillars/cerebrum/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsx scripts/verify-manifest.ts && tsc && cp -R src/api/modules/templates/defaults dist/api/modules/templates/ && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsx scripts/verify-manifest.ts && tsc -b tsconfig.build.json && cp -R src/api/modules/templates/defaults dist/api/modules/templates/ && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "start:worker": "node dist/worker/index.js",

--- a/pillars/cerebrum/tsconfig.build.json
+++ b/pillars/cerebrum/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/ai-telemetry/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/cerebrum/tsconfig.json
+++ b/pillars/cerebrum/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/finance/Dockerfile
+++ b/pillars/finance/Dockerfile
@@ -29,12 +29,15 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY libs/ai-telemetry/src ./libs/ai-telemetry/src
 COPY libs/ai-telemetry/tsconfig.json ./libs/ai-telemetry/tsconfig.json
+COPY libs/ai-telemetry/tsconfig.build.json ./libs/ai-telemetry/tsconfig.build.json
 
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -45,6 +48,7 @@ COPY pillars/finance/scripts ./pillars/finance/scripts
 COPY pillars/finance/openapi ./pillars/finance/openapi
 COPY pillars/finance/migrations ./pillars/finance/migrations
 COPY pillars/finance/tsconfig.json ./pillars/finance/tsconfig.json
+COPY pillars/finance/tsconfig.build.json ./pillars/finance/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/finance^..." build

--- a/pillars/finance/package.json
+++ b/pillars/finance/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/finance/tsconfig.build.json
+++ b/pillars/finance/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/ai-telemetry/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/finance/tsconfig.json
+++ b/pillars/finance/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/food/Dockerfile
+++ b/pillars/food/Dockerfile
@@ -32,9 +32,11 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/ai-telemetry
 COPY libs/ai-telemetry/src ./libs/ai-telemetry/src
 COPY libs/ai-telemetry/tsconfig.json ./libs/ai-telemetry/tsconfig.json
+COPY libs/ai-telemetry/tsconfig.build.json ./libs/ai-telemetry/tsconfig.build.json
 # @pops/pillar-sdk
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 # @pops/types
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -45,6 +47,7 @@ COPY pillars/food/scripts ./pillars/food/scripts
 COPY pillars/food/openapi ./pillars/food/openapi
 COPY pillars/food/migrations ./pillars/food/migrations
 COPY pillars/food/tsconfig.json ./pillars/food/tsconfig.json
+COPY pillars/food/tsconfig.build.json ./pillars/food/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/food^..." build

--- a/pillars/food/package.json
+++ b/pillars/food/package.json
@@ -35,7 +35,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsx scripts/verify-manifest.ts && tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsx scripts/verify-manifest.ts && tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev:api": "tsx watch --clear-screen=false src/api/server.ts",
     "dev:worker": "tsx watch --clear-screen=false src/worker/worker.ts",
     "start:api": "node dist/api/server.js",

--- a/pillars/food/tsconfig.build.json
+++ b/pillars/food/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/ai-telemetry/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/food/tsconfig.json
+++ b/pillars/food/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/inventory/Dockerfile
+++ b/pillars/inventory/Dockerfile
@@ -28,9 +28,11 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/pillar-sdk
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 # @pops/pillar-settings
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 # @pops/types
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -41,6 +43,7 @@ COPY pillars/inventory/scripts ./pillars/inventory/scripts
 COPY pillars/inventory/openapi ./pillars/inventory/openapi
 COPY pillars/inventory/migrations ./pillars/inventory/migrations
 COPY pillars/inventory/tsconfig.json ./pillars/inventory/tsconfig.json
+COPY pillars/inventory/tsconfig.build.json ./pillars/inventory/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/inventory^..." build

--- a/pillars/inventory/package.json
+++ b/pillars/inventory/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsx scripts/verify-manifest.ts && tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsx scripts/verify-manifest.ts && tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/inventory/tsconfig.build.json
+++ b/pillars/inventory/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/inventory/tsconfig.json
+++ b/pillars/inventory/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/lists/Dockerfile
+++ b/pillars/lists/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/pillar-sdk
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 # @pops/types
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -37,6 +38,7 @@ COPY pillars/lists/scripts ./pillars/lists/scripts
 COPY pillars/lists/openapi ./pillars/lists/openapi
 COPY pillars/lists/migrations ./pillars/lists/migrations
 COPY pillars/lists/tsconfig.json ./pillars/lists/tsconfig.json
+COPY pillars/lists/tsconfig.build.json ./pillars/lists/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/lists^..." build

--- a/pillars/lists/package.json
+++ b/pillars/lists/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsx scripts/verify-manifest.ts && tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsx scripts/verify-manifest.ts && tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/lists/tsconfig.build.json
+++ b/pillars/lists/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/lists/tsconfig.json
+++ b/pillars/lists/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/media/Dockerfile
+++ b/pillars/media/Dockerfile
@@ -28,9 +28,11 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -41,6 +43,7 @@ COPY pillars/media/scripts ./pillars/media/scripts
 COPY pillars/media/openapi ./pillars/media/openapi
 COPY pillars/media/migrations ./pillars/media/migrations
 COPY pillars/media/tsconfig.json ./pillars/media/tsconfig.json
+COPY pillars/media/tsconfig.build.json ./pillars/media/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/media^..." build

--- a/pillars/media/package.json
+++ b/pillars/media/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/media/tsconfig.build.json
+++ b/pillars/media/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/media/tsconfig.json
+++ b/pillars/media/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/orchestrator/Dockerfile
+++ b/pillars/orchestrator/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # @pops/pillar-sdk
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 # @pops/types
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json

--- a/pillars/registry/Dockerfile
+++ b/pillars/registry/Dockerfile
@@ -26,9 +26,11 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 COPY libs/sdk/src ./libs/sdk/src
 COPY libs/sdk/tsconfig.json ./libs/sdk/tsconfig.json
+COPY libs/sdk/tsconfig.build.json ./libs/sdk/tsconfig.build.json
 
 COPY libs/settings/src ./libs/settings/src
 COPY libs/settings/tsconfig.json ./libs/settings/tsconfig.json
+COPY libs/settings/tsconfig.build.json ./libs/settings/tsconfig.build.json
 
 COPY libs/types/src ./libs/types/src
 COPY libs/types/tsconfig.json ./libs/types/tsconfig.json
@@ -39,6 +41,7 @@ COPY pillars/registry/scripts ./pillars/registry/scripts
 COPY pillars/registry/openapi ./pillars/registry/openapi
 COPY pillars/registry/migrations ./pillars/registry/migrations
 COPY pillars/registry/tsconfig.json ./pillars/registry/tsconfig.json
+COPY pillars/registry/tsconfig.build.json ./pillars/registry/tsconfig.build.json
 
 # Phase 3: build shared deps in pnpm topology order, then the pillar.
 RUN pnpm --filter "@pops/registry^..." build

--- a/pillars/registry/package.json
+++ b/pillars/registry/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
+    "build": "tsc -b tsconfig.build.json && tsx scripts/generate-openapi.ts && tsx scripts/generate-api-types.ts",
     "dev": "tsx watch --clear-screen=false src/api/server.ts",
     "start": "node dist/api/server.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",

--- a/pillars/registry/tsconfig.build.json
+++ b/pillars/registry/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"],
+  "references": [
+    {
+      "path": "../../libs/sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/settings/tsconfig.build.json"
+    },
+    {
+      "path": "../../libs/types/tsconfig.build.json"
+    }
+  ]
+}

--- a/pillars/registry/tsconfig.json
+++ b/pillars/registry/tsconfig.json
@@ -5,11 +5,7 @@
     "moduleResolution": "Node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "node_modules", "dist", "scripts"]

--- a/pillars/shell/tsconfig.build.json
+++ b/pillars/shell/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "../../libs/types/tsconfig.build.json" },
+    { "path": "../../libs/sdk/tsconfig.build.json" },
+    { "path": "../../libs/module-registry/tsconfig.build.json" }
+  ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "files": [],
+  "references": [
+    { "path": "libs/types/tsconfig.build.json" },
+    { "path": "libs/db-types/tsconfig.build.json" },
+    { "path": "libs/sdk/tsconfig.build.json" },
+    { "path": "libs/settings/tsconfig.build.json" },
+    { "path": "libs/ai-telemetry/tsconfig.build.json" },
+    { "path": "libs/module-registry/tsconfig.build.json" },
+    { "path": "pillars/registry/tsconfig.build.json" },
+    { "path": "pillars/ai/tsconfig.build.json" },
+    { "path": "pillars/cerebrum/tsconfig.build.json" },
+    { "path": "pillars/finance/tsconfig.build.json" },
+    { "path": "pillars/food/tsconfig.build.json" },
+    { "path": "pillars/inventory/tsconfig.build.json" },
+    { "path": "pillars/lists/tsconfig.build.json" },
+    { "path": "pillars/media/tsconfig.build.json" }
+  ]
+}


### PR DESCRIPTION
## P5-T01 (alias G-T01) — net-new `tsc -b` project-reference graph

Adds the `tsc -b` project-reference graph that reproduces turbo's `^build`
ordering as a TypeScript solution. Reference: `docs/plans/repo-federation/02-build-system.md` §2 / §7 (G-T01).

**Dual-runnable — turbo untouched.** `turbo.json` and the `turbo` devDep are
unchanged; turbo still drives `^build` today. `tsc -b` is added *alongside* it.
Turbo removal is P5-T05, not this PR.

### Compiled graph (composite + declaration + emit `dist`)

| tier | units |
| --- | --- |
| libs (6) | `types`, `db-types`, `sdk` (`@pops/pillar-sdk`), `settings` (`@pops/pillar-settings`), `ai-telemetry`, `module-registry` |
| pillar backends (8) | `registry` (the renamed core — **not** `core`), `ai`, `cerebrum`, `finance`, `food`, `inventory`, `lists`, `media` |

### Per-unit references (derived from each `package.json` @pops deps, compiled-libs only)

| unit | references |
| --- | --- |
| `libs/types`, `libs/db-types`, `libs/sdk`, `libs/settings`, `libs/ai-telemetry` | — (leaf) |
| `libs/module-registry` | types |
| `pillars/registry` | sdk, settings, types |
| `pillars/ai` | ai-telemetry, sdk, settings, types |
| `pillars/cerebrum` | ai-telemetry, sdk, settings, types |
| `pillars/finance` | ai-telemetry, sdk, settings, types |
| `pillars/food` | ai-telemetry, sdk, types |
| `pillars/inventory` | sdk, settings, types |
| `pillars/lists` | sdk, types |
| `pillars/media` | sdk, settings, types |

Source libs (`ui`/`navigation`/`overlay-ego`), JSON-only `locales`, and pillars
are excluded from references. Each unit's editor `tsconfig.json` is split to
`noEmit`, so references point at each dep's **`tsconfig.build.json`** (the
composite project) rather than the bare dir — a bare-dir reference resolves to
the `noEmit` editor config and fails `TS6306`/`TS6310` (verified empirically).

### tsconfigs

- **EDITED** existing build configs: `libs/types`, `libs/module-registry` (+ `composite`/refs).
- **CREATED** `tsconfig.build.json`: `libs/{db-types,sdk,settings,ai-telemetry}` + the 8 pillar backends.
- **shell**: non-composite solution `tsconfig.build.json` referencing its compiled-lib deps (types, sdk, module-registry) so `tsc -b` produces their `.d.ts` before vite; shell itself stays bundler-built, not composite.
- **root** `tsconfig.build.json`: `{ files:[], references:[…14 compiled units…] }`.

### Build-script flips (`tsc` → `tsc -b tsconfig.build.json`)

- 4 libs: `db-types`, `sdk`, `settings`, `ai-telemetry` (db-types `dev` → `tsc -b … --watch`).
- 8 pillar backends: required because their editor `tsconfig.json` is now `noEmit`,
  so the build script's plain `tsc` would emit nothing — flipping to `tsc -b` keeps
  turbo's build path emitting (dual-runnable). `types`/`module-registry` keep their
  existing `tsc -p tsconfig.build.json` (works against a composite config).

### Out of the graph

`mcp`, `orchestrator`, `docs`, `moltbot` — leaf deployables referenced by nothing
in the compiled graph (`moltbot` has no `package.json`; `docs` builds via `tsx`,
not `tsc`). Turbo still builds `mcp`/`orchestrator` via `^build`, so their build
path is unchanged. `contacts` is Rust (out of scope).

### Verification

- `rm -rf */dist; find . -name '*.tsbuildinfo' -delete; tsc -b tsconfig.build.json` → exit 0, every unit emits.
- `tsc -b pillars/finance/tsconfig.build.json` from clean → auto-builds only its 4 referenced libs; second whole-graph run rebuilds 0 projects.
- No `composite` in any source lib / FE / `pillars/*/app` tsconfig.
- `pnpm typecheck` (turbo) green — 42/42 (dual-runnable proof; also ran on pre-push).
- `turbo build --filter=@pops/finance` green end-to-end (openapi + api-types codegen on emitted dist).
- `pnpm lint`, `pnpm format:check`, `pnpm lint:boundaries` all clean.
- `*.tsbuildinfo` added to `.gitignore` (`dist/` already ignored); no artifacts committed.
