### PR TITLE
build(federation): per-unit mise.toml task entrypoints [P5-T02]

### DIFF
--- a/libs/ai-telemetry/mise.toml
+++ b/libs/ai-telemetry/mise.toml
@@ -1,0 +1,17 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/db-types/mise.toml
+++ b/libs/db-types/mise.toml
@@ -1,0 +1,14 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/locales/mise.toml
+++ b/libs/locales/mise.toml
@@ -1,0 +1,2 @@
+[tasks.lint]
+run = "oxfmt --check ."

--- a/libs/module-registry/mise.toml
+++ b/libs/module-registry/mise.toml
@@ -1,0 +1,17 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/navigation/mise.toml
+++ b/libs/navigation/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/libs/overlay-ego/mise.toml
+++ b/libs/overlay-ego/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/libs/pops-ai/mise.toml
+++ b/libs/pops-ai/mise.toml
@@ -1,0 +1,5 @@
+[tasks]
+build = { run = "cargo build --all-targets" }
+test = { run = "cargo test" }
+lint = { run = "cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check" }
+typecheck = { run = "cargo check --all-targets" }

--- a/libs/pops-settings/mise.toml
+++ b/libs/pops-settings/mise.toml
@@ -1,0 +1,5 @@
+[tasks]
+build = { run = "cargo build --all-targets" }
+test = { run = "cargo test" }
+lint = { run = "cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check" }
+typecheck = { run = "cargo check --all-targets" }

--- a/libs/sdk/mise.toml
+++ b/libs/sdk/mise.toml
@@ -1,0 +1,17 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/settings/mise.toml
+++ b/libs/settings/mise.toml
@@ -1,0 +1,17 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/types/mise.toml
+++ b/libs/types/mise.toml
@@ -1,0 +1,17 @@
+[tasks.build]
+description = "Emit dist/ + .d.ts"
+run = "tsc -b tsconfig.build.json"
+sources = ["src/**/*.ts", "tsconfig.build.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsc -b tsconfig.build.json --watch --preserveWatchOutput"

--- a/libs/ui/mise.toml
+++ b/libs/ui/mise.toml
@@ -1,0 +1,11 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run && node scripts/check-storybook-coverage.mjs"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.storybook]
+run = "storybook dev -p 6006"

--- a/mise.toml
+++ b/mise.toml
@@ -4,10 +4,17 @@
 
 [tools]
 node = "24.5.0"
+pnpm = "10.32.1"
+rust = "stable"
 
 [env]
 # Add common environment variables here if needed
 # Sensitive vars should still use .env files
+
+# Expose the pnpm-workspace-hoisted bin dir so per-unit mise tasks can call
+# bare `tsc`/`vitest`/`oxlint`/`tsx` (the §1 templates) without `pnpm exec`.
+# mise has no auto node_modules/.bin injection; this is the workspace glue.
+_.path = ["{{config_root}}/node_modules/.bin"]
 
 # ============================================================================
 # Development Servers

--- a/pillars/ai/app/mise.toml
+++ b/pillars/ai/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/ai/mise.toml
+++ b/pillars/ai/mise.toml
@@ -1,0 +1,25 @@
+[tasks.build]
+description = "tsc -b → openapi snapshot → typed client"
+run = [
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/cerebrum/app/mise.toml
+++ b/pillars/cerebrum/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/cerebrum/mise.toml
+++ b/pillars/cerebrum/mise.toml
@@ -1,0 +1,32 @@
+[tasks.build]
+description = "verify manifest → tsc -b → copy template defaults → openapi snapshot → typed client"
+run = [
+  "tsx scripts/verify-manifest.ts",
+  "tsc -b tsconfig.build.json",
+  "cp -R src/api/modules/templates/defaults dist/api/modules/templates/",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = [
+  "src/**/*.ts",
+  "src/api/modules/templates/defaults/**",
+  "scripts/**/*.ts",
+  "tsconfig.build.json",
+]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/contacts/mise.toml
+++ b/pillars/contacts/mise.toml
@@ -1,0 +1,6 @@
+[tasks]
+build = { run = "cargo build --all-targets" }
+test = { run = "cargo test" }
+lint = { run = "cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check" }
+typecheck = { run = "cargo check --all-targets" }
+dev = { run = "cargo watch -x run" }

--- a/pillars/docs/mise.toml
+++ b/pillars/docs/mise.toml
@@ -1,0 +1,16 @@
+[tasks.build]
+run = "tsx scripts/collect-specs.ts"
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx scripts/dev-serve.ts"

--- a/pillars/finance/app/mise.toml
+++ b/pillars/finance/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/finance/mise.toml
+++ b/pillars/finance/mise.toml
@@ -1,0 +1,25 @@
+[tasks.build]
+description = "tsc -b → openapi snapshot → typed client"
+run = [
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/food/app/mise.toml
+++ b/pillars/food/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/food/mise.toml
+++ b/pillars/food/mise.toml
@@ -1,0 +1,20 @@
+[tasks.build]
+description = "verify manifest → tsc -b → openapi snapshot → typed client"
+run = [
+  "tsx scripts/verify-manifest.ts",
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/inventory/app/mise.toml
+++ b/pillars/inventory/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/inventory/mise.toml
+++ b/pillars/inventory/mise.toml
@@ -1,0 +1,26 @@
+[tasks.build]
+description = "verify manifest → tsc -b → openapi snapshot → typed client"
+run = [
+  "tsx scripts/verify-manifest.ts",
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/lists/app/mise.toml
+++ b/pillars/lists/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/lists/mise.toml
+++ b/pillars/lists/mise.toml
@@ -1,0 +1,26 @@
+[tasks.build]
+description = "verify manifest → tsc -b → openapi snapshot → typed client"
+run = [
+  "tsx scripts/verify-manifest.ts",
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/mcp/mise.toml
+++ b/pillars/mcp/mise.toml
@@ -1,0 +1,19 @@
+[tasks.build]
+run = "tsc"
+sources = ["src/**/*.ts", "tsconfig.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/index.ts"
+
+[tasks.start]
+run = "node dist/index.js"

--- a/pillars/media/app/mise.toml
+++ b/pillars/media/app/mise.toml
@@ -1,0 +1,8 @@
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."

--- a/pillars/media/mise.toml
+++ b/pillars/media/mise.toml
@@ -1,0 +1,25 @@
+[tasks.build]
+description = "tsc -b → openapi snapshot → typed client"
+run = [
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/moltbot/mise.toml
+++ b/pillars/moltbot/mise.toml
@@ -1,0 +1,2 @@
+[tasks.validate]
+run = "bash scripts/validate-config.sh"

--- a/pillars/orchestrator/mise.toml
+++ b/pillars/orchestrator/mise.toml
@@ -1,0 +1,19 @@
+[tasks.build]
+run = "tsc"
+sources = ["src/**/*.ts", "tsconfig.json", "package.json"]
+outputs = ["dist/**"]
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/server.ts"
+
+[tasks.start]
+run = "node dist/server.js"

--- a/pillars/registry/mise.toml
+++ b/pillars/registry/mise.toml
@@ -1,0 +1,25 @@
+[tasks.build]
+description = "tsc -b → openapi snapshot → typed client"
+run = [
+  "tsc -b tsconfig.build.json",
+  "tsx scripts/generate-openapi.ts",
+  "tsx scripts/generate-api-types.ts",
+]
+sources = ["src/**/*.ts", "scripts/**/*.ts", "tsconfig.build.json"]
+outputs = ["dist/**", "openapi/*.json", "src/**/api-types.generated.ts"]
+
+[tasks.typecheck]
+run = ["tsc --noEmit", "tsc --noEmit -p scripts/tsconfig.json"]
+
+[tasks.test]
+depends = ["build"]
+run = "vitest run"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."
+
+[tasks.dev]
+run = "tsx watch --clear-screen=false src/api/server.ts"
+
+[tasks.start]
+run = "node dist/api/server.js"

--- a/pillars/shell/mise.toml
+++ b/pillars/shell/mise.toml
@@ -1,0 +1,18 @@
+[tasks.build]
+run = ["tsc", "vite build"]
+outputs = ["dist/**"]
+
+[tasks.dev]
+run = "vite"
+
+[tasks.typecheck]
+run = "tsc --noEmit"
+
+[tasks.test]
+run = "vitest run"
+
+[tasks."test:e2e"]
+run = "playwright test"
+
+[tasks.lint]
+run = "oxlint src && oxfmt --check ."


### PR DESCRIPTION
## P5-T02 (G-T02) — per-unit `mise.toml` task entrypoints

Adds a self-contained `mise.toml` to every unit using the `02-build-system.md` §1
templates. Task bodies are **unit-local with no sibling paths** — a unit dir copied
to a new repo still runs. Cross-unit ordering stays at the root (`tsc -b` / cargo /
pnpm); `mise depends` is used only intra-unit (pillar `test` → its own `build`).

### Templates applied

| Unit(s) | Template | Notes |
| --- | --- | --- |
| `libs/{types,db-types,sdk,settings,ai-telemetry,module-registry}` | compiled-lib | `tsc -b tsconfig.build.json` + dist outputs; `db-types` has no `test` (no test script) |
| `libs/{ui,navigation,overlay-ego}`, every `pillars/*/app` | source-lib | typecheck/test/lint, no build; `ui` adds `storybook` and keeps its `vitest + check-storybook-coverage` test |
| `pillars/{registry,ai,finance,media}` | pillar-backend | `tsc -b` → `generate-openapi` → `generate-api-types` |
| `pillars/{cerebrum,food,inventory,lists}` | pillar-backend | same, prefixed with `verify-manifest`; `cerebrum` also copies template defaults into dist; `food` has no dev/start script so those tasks are omitted |
| `pillars/shell` | shell | `tsc && vite build`, `vite` dev, `playwright test` e2e |
| `pillars/contacts`, `libs/{pops-ai,pops-settings}` | rust | cargo build/test/clippy+fmt/check; contacts adds `cargo watch` dev |
| `pillars/{mcp,orchestrator,docs}` | node-deployable | mirrors each one's package.json (`tsc` / `tsx scripts/collect-specs.ts`) |

### Edge cases
- `libs/locales` — JSON-only, no `src/`; minimal `mise.toml` with `lint = oxfmt --check .` only.
- `pillars/moltbot` — no `package.json`; `validate` task wrapping `scripts/validate-config.sh`.

### Root
- `[tools]` pinned: `node = 24.5.0`, `pnpm = 10.32.1`, `rust = stable`.
- `[env] _.path = ["{{config_root}}/node_modules/.bin"]` so the bare-binary task bodies
  (`tsc`, `vitest`, `oxlint`, `tsx`) resolve under mise. mise has no auto
  `node_modules/.bin` injection; this is the workspace glue (this token lives only in the
  root config, never in a unit).

### Dual-runnable
`turbo.json`, the `turbo` devDep, and the existing root mise `turbo run` wrappers are
**untouched**. Both the old (turbo) and new (mise) paths build the tree. turbo removal is
a later task (P5-T03/T05/T06).

### Verify
- `grep -rn '\.\./' --include=mise.toml libs pillars` → empty (sibling-path-free).
- `mise run -C libs/types build` → emits `dist/`.
- `mise run -C pillars/finance typecheck` → green (after compiled deps built via root `tsc -b`).
- `mise run -C pillars/finance build` → `tsc -b` + openapi + api-types.
- `mise run -C libs/ui typecheck` → green (no build task).
- `mise run -C pillars/contacts build` → cargo, compiles.
- `mise run -C libs/types test` → 30 tests pass.
- `pnpm typecheck` (turbo path) → 42/42 successful — dual-runnable proof.
- `pnpm lint` → exit 0 (only pre-existing `.gen.ts` warnings).
- `git status` → only the 33 new unit `mise.toml` + root `[tools]`/`_.path` edit.
