### PR TITLE
feat(registry): support REGISTRY_SQLITE_PATH (core→registry rename window) [S5]

### DIFF
--- a/pillars/registry/src/api/__tests__/core-sqlite-path.test.ts
+++ b/pillars/registry/src/api/__tests__/core-sqlite-path.test.ts
@@ -1,20 +1,26 @@
 /**
  * Resolver tests — guards the precedence chain so future pillar work
- * doesn't accidentally drift core-api away from pops-api's resolver.
+ * doesn't accidentally drift the registry-api away from the shared
+ * resolver, and pins the core→registry rename window (REGISTRY_SQLITE_PATH
+ * wins, CORE_SQLITE_PATH still honoured until the box DB rename lands).
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { DEFAULT_CORE_SQLITE_PATH, resolveCoreSqlitePath } from '../core-sqlite-path.js';
+import { DEFAULT_REGISTRY_SQLITE_PATH, resolveCoreSqlitePath } from '../core-sqlite-path.js';
 
+const originalRegistryPath = process.env['REGISTRY_SQLITE_PATH'];
 const originalCorePath = process.env['CORE_SQLITE_PATH'];
 const originalSharedPath = process.env['SQLITE_PATH'];
 
 beforeEach(() => {
+  delete process.env['REGISTRY_SQLITE_PATH'];
   delete process.env['CORE_SQLITE_PATH'];
   delete process.env['SQLITE_PATH'];
 });
 
 afterEach(() => {
+  if (originalRegistryPath === undefined) delete process.env['REGISTRY_SQLITE_PATH'];
+  else process.env['REGISTRY_SQLITE_PATH'] = originalRegistryPath;
   if (originalCorePath === undefined) delete process.env['CORE_SQLITE_PATH'];
   else process.env['CORE_SQLITE_PATH'] = originalCorePath;
   if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
@@ -22,22 +28,34 @@ afterEach(() => {
 });
 
 describe('resolveCoreSqlitePath', () => {
-  it('returns CORE_SQLITE_PATH verbatim when set', () => {
+  it('returns REGISTRY_SQLITE_PATH verbatim when set', () => {
+    process.env['REGISTRY_SQLITE_PATH'] = '/abs/path/registry.db';
+    expect(resolveCoreSqlitePath()).toBe('/abs/path/registry.db');
+  });
+
+  it('prefers REGISTRY_SQLITE_PATH over the legacy CORE_SQLITE_PATH', () => {
+    process.env['REGISTRY_SQLITE_PATH'] = '/new/registry.db';
+    process.env['CORE_SQLITE_PATH'] = '/old/core.db';
+    expect(resolveCoreSqlitePath()).toBe('/new/registry.db');
+  });
+
+  it('still honours CORE_SQLITE_PATH during the rename window when REGISTRY_SQLITE_PATH is unset', () => {
     process.env['CORE_SQLITE_PATH'] = '/abs/path/core.db';
     expect(resolveCoreSqlitePath()).toBe('/abs/path/core.db');
   });
 
-  it('derives <dirname(SQLITE_PATH)>/core.db when CORE_SQLITE_PATH is unset', () => {
+  it('derives <dirname(SQLITE_PATH)>/registry.db when no explicit path is set', () => {
     process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
-    expect(resolveCoreSqlitePath()).toBe('/opt/pops/data/core.db');
+    expect(resolveCoreSqlitePath()).toBe('/opt/pops/data/registry.db');
   });
 
   it('handles a relative SQLITE_PATH', () => {
     process.env['SQLITE_PATH'] = './data/pops.db';
-    expect(resolveCoreSqlitePath()).toBe('data/core.db');
+    expect(resolveCoreSqlitePath()).toBe('data/registry.db');
   });
 
-  it('falls back to ./data/core.db when neither env is set', () => {
-    expect(resolveCoreSqlitePath()).toBe(DEFAULT_CORE_SQLITE_PATH);
+  it('falls back to ./data/registry.db when no env is set', () => {
+    expect(resolveCoreSqlitePath()).toBe(DEFAULT_REGISTRY_SQLITE_PATH);
+    expect(DEFAULT_REGISTRY_SQLITE_PATH).toBe('./data/registry.db');
   });
 });

--- a/pillars/registry/src/api/core-sqlite-path.ts
+++ b/pillars/registry/src/api/core-sqlite-path.ts
@@ -1,27 +1,29 @@
 import { dirname, join } from 'node:path';
 
 /**
- * Standalone resolver for the core pillar's SQLite path inside the
- * core-api container.
+ * Standalone resolver for the registry pillar's SQLite path inside the
+ * registry-api container.
  *
- * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
- * — core-api is supposed to be runnable without pops-api in the
- * dependency graph. The precedence chain mirrors pops-api's resolver
- * verbatim so the two processes agree on the location of `core.db`
- * given the same env: a deployer who only sets `SQLITE_PATH`
- * (legacy contract) still ends up with `core.db` next to `pops.db`.
+ * The pillar was renamed core→registry; the on-disk DB is being renamed
+ * `core.db`→`registry.db` in lockstep. During the rename window the legacy
+ * `CORE_SQLITE_PATH` env is still honoured (the live compose sets it) so the
+ * image is deploy-safe BEFORE the file is renamed; once the deployer renames
+ * the file and sets `REGISTRY_SQLITE_PATH`, that wins.
  *
  * Resolution order:
- *   1. `CORE_SQLITE_PATH` (absolute or relative).
- *   2. `<dirname(SQLITE_PATH)>/core.db` if the shared path is set.
- *   3. `./data/core.db` (matches the shared default's `./data/pops.db`).
+ *   1. `REGISTRY_SQLITE_PATH` (absolute or relative) — the post-rename env.
+ *   2. `CORE_SQLITE_PATH` — legacy, retained for the rename window.
+ *   3. `<dirname(SQLITE_PATH)>/registry.db` if the shared path is set.
+ *   4. `./data/registry.db` (matches the shared default's `./data/pops.db`).
  */
-export const DEFAULT_CORE_SQLITE_PATH = './data/core.db';
+export const DEFAULT_REGISTRY_SQLITE_PATH = './data/registry.db';
 
 export function resolveCoreSqlitePath(): string {
-  const envPath = process.env['CORE_SQLITE_PATH'];
-  if (envPath) return envPath;
+  const registryPath = process.env['REGISTRY_SQLITE_PATH'];
+  if (registryPath) return registryPath;
+  const corePath = process.env['CORE_SQLITE_PATH'];
+  if (corePath) return corePath;
   const sharedPath = process.env['SQLITE_PATH'];
-  if (sharedPath) return join(dirname(sharedPath), 'core.db');
-  return DEFAULT_CORE_SQLITE_PATH;
+  if (sharedPath) return join(dirname(sharedPath), 'registry.db');
+  return DEFAULT_REGISTRY_SQLITE_PATH;
 }


### PR DESCRIPTION
S5(b-code) from the rename handoff. Adds `REGISTRY_SQLITE_PATH` as the first-precedence DB-path env on the registry pillar; keeps legacy `CORE_SQLITE_PATH` honoured during the rename window so the image is **deploy-safe before** the on-disk `core.db→registry.db` rename. Default + shared-path fallback now resolve `registry.db`.

Backward-compatible: capivara currently sets `CORE_SQLITE_PATH`, so live behaviour is unchanged until the operator renames the file + sets `REGISTRY_SQLITE_PATH`. **Unblocks** the operator DB-rename step (b-box).

Verify: 6/6 resolver tests (REGISTRY wins, CORE honoured in-window, registry.db defaults), registry typecheck + lint + format clean.