### PR TITLE
feat(isolation): cargo-deny + crate-boundary checks [P6-T04]

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -19,17 +19,21 @@ on:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
+      - "deny.toml"
       - "libs/pops-ai/**"
       - "libs/pops-settings/**"
       - "pillars/contacts/**"
+      - "scripts/extractability/**"
       - ".github/workflows/rust-quality.yml"
   pull_request:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
+      - "deny.toml"
       - "libs/pops-ai/**"
       - "libs/pops-settings/**"
       - "pillars/contacts/**"
+      - "scripts/extractability/**"
       - ".github/workflows/rust-quality.yml"
 
 concurrency:
@@ -50,13 +54,20 @@ jobs:
           rustc --version
           cargo --version
 
-      - name: Cache cargo registry + workspace target
+      # Node powers the crate-boundary guard (scripts/extractability/
+      # check-cargo-deps.mjs). Pinned to 22 to match the TS lanes.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Cache cargo registry + workspace target + installed tools
         uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
+            ~/.cargo/bin
             target
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'pillars/contacts/Cargo.toml') }}
           restore-keys: |
@@ -67,6 +78,21 @@ jobs:
 
       - name: Clippy (deny warnings)
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # Crate-boundary + supply-chain gate (federation isolation, P6-T04):
+      #   - cargo deny: licence / advisory / source policy over the whole graph
+      #     (config: deny.toml at repo root).
+      #   - check-cargo-deps.mjs: a lib crate must not depend on a pillar crate,
+      #     and no pillar may depend on another pillar (RUST-2a/2b).
+      # `--locked` keeps the cargo-deny install reproducible; the binary is
+      # cached in ~/.cargo/bin across runs, so the `cargo install` is a no-op
+      # after first build. NON-required — additive gate, the ruleset is untouched.
+      - name: Boundaries + supply chain
+        run: |
+          cargo install cargo-deny --locked
+          cargo deny check
+          node scripts/extractability/check-cargo-deps.mjs --self-test
+          node scripts/extractability/check-cargo-deps.mjs
 
       - name: Build
         run: cargo build --all-targets

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# cargo-deny configuration — supply-chain + license + source gate for the
+# repo-root cargo workspace (members: pillars/contacts, libs/pops-ai,
+# libs/pops-settings). Mirrors the TS isolation discipline on the Rust side:
+# every dependency is pinned (no wildcards — the Rust analogue of "exports
+# declares every subpath"), licensed permissively, advisory-clean, and sourced
+# only from crates.io.
+#
+# Run locally with `cargo deny check`; wired into `.github/workflows/
+# rust-quality.yml`. See docs/plans/repo-federation/04-isolation-enforcement.md
+# §8 (RUST-1).
+
+[graph]
+# Evaluate the dependency graph for every target the workspace builds for.
+# `all-features` keeps the licence/advisory surface honest — a feature-gated
+# dependency is still a shipped dependency.
+all-features = true
+
+[advisories]
+# RustSec advisory database. An unfixable advisory must be documented with an
+# explicit `ignore` entry + reason below — never blanket-disabled. Empty today:
+# `cargo deny check advisories` is clean against the current lockfile.
+yanked = "deny"
+ignore = []
+
+[licenses]
+# Permissive licences only. Every entry below is observed in the current
+# dependency tree (283 crates surveyed via `cargo metadata`); the list is the
+# minimal allow-set that makes `cargo deny check licenses` pass today and still
+# rejects a NEW copyleft/unknown licence appearing in a future dependency.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Zlib",
+  "BSL-1.0",
+  "CDLA-Permissive-2.0",
+  "Unlicense",
+]
+confidence-threshold = 0.9
+
+# The three workspace crates are `publish = false` and carry `license =
+# "UNLICENSED"` (proprietary, never published). Skipping private crates keeps
+# the licence gate focused on third-party supply chain without forcing a fake
+# SPDX id onto our own first-party code.
+[licenses.private]
+ignore = true
+
+[bans]
+# A duplicate transitive version is a smell, not a hard failure (the ecosystem
+# routinely carries two majors of low-level crates); surface it, don't block.
+multiple-versions = "warn"
+# No wildcard (`*`) version specs anywhere — every dependency is pinned so a
+# crate can be extracted and rebuilt deterministically in its own repo. This is
+# the Rust mirror of the TS "no `./*` catch-all export" rule.
+wildcards = "deny"
+allow = []
+deny = []
+
+[sources]
+# Only crates.io. A git or alternative-registry source would not survive
+# extraction to a standalone repo without dragging private infrastructure, so
+# any non-crates.io source is a hard failure that must be justified explicitly.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/scripts/extractability/__tests__/cargo-extract.test.ts
+++ b/scripts/extractability/__tests__/cargo-extract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { rewriteManifest } from '../cargo-extract.mjs';
+
+const ROOT = `[workspace]
+resolver = "2"
+members = ["pillars/contacts", "libs/pops-ai"]
+
+[workspace.package]
+edition = "2021"
+license = "UNLICENSED"
+publish = false
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+anyhow = "1"`;
+
+describe('rewriteManifest', () => {
+  it('inlines [workspace.package] inheritance', () => {
+    const member = `[package]
+name = "demo"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true`;
+    const out = rewriteManifest(member, ROOT);
+    expect(out).toContain('edition = "2021"');
+    expect(out).toContain('license = "UNLICENSED"');
+    expect(out).toContain('publish = false');
+    expect(out).not.toContain('.workspace = true');
+  });
+
+  it('resolves a string-form workspace dep to its pinned version', () => {
+    const member = `[package]
+name = "demo"
+[dependencies]
+anyhow = { workspace = true }`;
+    const out = rewriteManifest(member, ROOT);
+    expect(out).toContain('anyhow = { version = "1" }');
+  });
+
+  it('resolves a table-form workspace dep preserving its features', () => {
+    const member = `[package]
+name = "demo"
+[dependencies]
+serde = { workspace = true }`;
+    const out = rewriteManifest(member, ROOT);
+    expect(out).toContain('serde = { version = "1", features = ["derive"] }');
+  });
+
+  it('unions member-local features onto the workspace base features', () => {
+    const member = `[package]
+name = "demo"
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }`;
+    const out = rewriteManifest(member, ROOT);
+    const line = out.split('\n').find((l) => l.startsWith('tokio = '));
+    expect(line).toBeDefined();
+    for (const f of ['rt-multi-thread', 'macros', 'signal', 'test-util']) {
+      expect(line).toContain(`"${f}"`);
+    }
+    expect(line).not.toContain('workspace = true');
+  });
+
+  it('drops the package→workspace pointer and roots the crate with [workspace]', () => {
+    const member = `[package]
+name = "demo"
+workspace = "../.."
+edition.workspace = true`;
+    const out = rewriteManifest(member, ROOT);
+    expect(out).not.toContain('workspace = "../.."');
+    expect(out.trimEnd().endsWith('[workspace]')).toBe(true);
+  });
+
+  it('throws if a workspace=true dep is missing from [workspace.dependencies]', () => {
+    const member = `[package]
+name = "demo"
+[dependencies]
+ghost = { workspace = true }`;
+    expect(() => rewriteManifest(member, ROOT)).toThrow(/ghost/u);
+  });
+
+  it('leaves a non-workspace pinned dep untouched', () => {
+    const member = `[package]
+name = "demo"
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }`;
+    const out = rewriteManifest(member, ROOT);
+    expect(out).toContain('tower = { version = "0.5", features = ["util"] }');
+  });
+});

--- a/scripts/extractability/__tests__/check-cargo-deps.test.ts
+++ b/scripts/extractability/__tests__/check-cargo-deps.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  discoverCrates,
+  findViolations,
+  parseMemberManifest,
+  parseWorkspaceMembers,
+} from '../check-cargo-deps.mjs';
+
+type Crate = Parameters<typeof findViolations>[0][number];
+
+const pillar = (name: string, deps: string[] = []): Crate => ({
+  dir: `pillars/${name}`,
+  name,
+  kind: 'pillar',
+  deps,
+});
+
+const lib = (name: string, deps: string[] = []): Crate => ({
+  dir: `libs/${name}`,
+  name,
+  kind: 'lib',
+  deps,
+});
+
+describe('parseWorkspaceMembers', () => {
+  it('reads a single-line members array', () => {
+    const toml = `[workspace]
+resolver = "2"
+members = ["pillars/contacts", "libs/pops-ai", "libs/pops-settings"]`;
+    expect(parseWorkspaceMembers(toml)).toEqual([
+      'pillars/contacts',
+      'libs/pops-ai',
+      'libs/pops-settings',
+    ]);
+  });
+
+  it('reads a multi-line members array', () => {
+    const toml = `[workspace]
+members = [
+  "pillars/contacts",
+  "libs/pops-ai",
+]
+[workspace.package]
+edition = "2021"`;
+    expect(parseWorkspaceMembers(toml)).toEqual(['pillars/contacts', 'libs/pops-ai']);
+  });
+
+  it('ignores members-like lines outside [workspace]', () => {
+    const toml = `[package]
+members = ["not-a-real-member"]
+[workspace]
+members = ["libs/x"]`;
+    expect(parseWorkspaceMembers(toml)).toEqual(['libs/x']);
+  });
+});
+
+describe('parseMemberManifest', () => {
+  it('collects deps across dependencies / dev / build tables and resolves renames', () => {
+    const toml = `[package]
+name = "demo"
+[dependencies]
+axum = { workspace = true }
+serde = "1"
+[dev-dependencies]
+tower = { version = "0.5" }
+[build-dependencies]
+cc = "1"
+[target.'cfg(unix)'.dependencies]
+nix = "0.27"`;
+    const { name, deps } = parseMemberManifest(toml);
+    expect(name).toBe('demo');
+    expect(new Set(deps)).toEqual(new Set(['axum', 'serde', 'tower', 'cc', 'nix']));
+  });
+
+  it('resolves a renamed dependency to the real crate name', () => {
+    const toml = `[package]
+name = "demo"
+[dependencies]
+my-alias = { package = "real-crate", version = "1" }`;
+    const { deps } = parseMemberManifest(toml);
+    expect(deps).toContain('real-crate');
+    expect(deps).not.toContain('my-alias');
+  });
+
+  it('does not mistake a commented-out dep for a real one', () => {
+    const toml = `[package]
+name = "demo"
+[dependencies]
+# contacts = { path = "../../pillars/contacts" }
+serde = "1"`;
+    const { deps } = parseMemberManifest(toml);
+    expect(deps).toEqual(['serde']);
+  });
+});
+
+describe('findViolations', () => {
+  it('flags a lib that depends on a pillar (RUST-2a)', () => {
+    const found = findViolations([pillar('contacts'), lib('pops-ai', ['contacts', 'serde'])]);
+    expect(found).toEqual([{ from: 'pops-ai', fromKind: 'lib', to: 'contacts', rule: 'RUST-2a' }]);
+  });
+
+  it('flags a pillar that depends on another pillar (RUST-2b)', () => {
+    const found = findViolations([pillar('contacts'), pillar('finance', ['contacts', 'axum'])]);
+    expect(found).toEqual([
+      { from: 'finance', fromKind: 'pillar', to: 'contacts', rule: 'RUST-2b' },
+    ]);
+  });
+
+  it('does not flag a pillar self-edge or third-party deps', () => {
+    const found = findViolations([
+      pillar('contacts', ['contacts', 'axum', 'sqlx']),
+      lib('pops-settings', ['serde', 'axum', 'utoipa']),
+    ]);
+    expect(found).toEqual([]);
+  });
+
+  it('catches multiple violations at once', () => {
+    const found = findViolations([
+      pillar('contacts'),
+      pillar('finance', ['contacts']),
+      lib('pops-ai', ['contacts']),
+    ]);
+    expect(found).toHaveLength(2);
+    expect(found.map((v) => v.rule).toSorted()).toEqual(['RUST-2a', 'RUST-2b']);
+  });
+});
+
+describe('discoverCrates (real workspace)', () => {
+  it('classifies the live workspace as 1 pillar + 2 libs with no violations', () => {
+    const crates = discoverCrates();
+    const byKind = (k: string) =>
+      crates
+        .filter((c) => c.kind === k)
+        .map((c) => c.name)
+        .sort();
+    expect(byKind('pillar')).toEqual(['contacts']);
+    expect(byKind('lib')).toEqual(['pops-ai', 'pops-settings']);
+    expect(findViolations(crates)).toEqual([]);
+  });
+});

--- a/scripts/extractability/__tests__/tsconfig.json
+++ b/scripts/extractability/__tests__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts", "../*.mjs"]
+}

--- a/scripts/extractability/cargo-extract.mjs
+++ b/scripts/extractability/cargo-extract.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * cargo-extract — materialize a single workspace member crate as a standalone,
+ * workspace-free package in an output dir, ready to `cargo build` in isolation.
+ * The cargo analogue of the TS `rewrite-deps.mjs` step (docs/plans/repo-
+ * federation/04-isolation-enforcement.md §8, RUST-3).
+ *
+ * The single mutation it performs — the "changing only where shared deps come
+ * from" clause — is to break every workspace inheritance edge:
+ *
+ *   1. `[workspace.package]` inheritance (`edition.workspace = true`,
+ *      `license.workspace = true`, `publish.workspace = true`, …) is inlined
+ *      from the workspace root's `[workspace.package]`.
+ *   2. `[workspace.dependencies]` inheritance (`dep = { workspace = true }`) is
+ *      replaced with the dep's concrete spec from the root
+ *      `[workspace.dependencies]`, merging any member-local `features`/
+ *      `optional`/`default-features` overrides on top.
+ *   3. The member's `workspace = "../.."` package pointer (if present) is
+ *      dropped, and an empty `[workspace]` table is appended so the extracted
+ *      crate is its own root and does not climb back to the parent workspace.
+ *
+ * Everything else is copied verbatim. If the crate builds after this — with no
+ * workspace path resolution available — it is extraction-ready.
+ *
+ * Usage:
+ *   node scripts/extractability/cargo-extract.mjs <member-dir> <out-dir>
+ *   node scripts/extractability/cargo-extract.mjs libs/pops-ai /tmp/crate-out
+ *
+ * Exit 0 on success; exit 2 on usage / parse error.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+/**
+ * Strip a `#` comment outside any string. (Member manifests do not embed `#`
+ * inside the values this tool reads.)
+ *
+ * @param {string} line
+ * @returns {string}
+ */
+function stripComment(line) {
+  let inStr = false;
+  let quote = '';
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inStr) {
+      if (ch === quote) inStr = false;
+    } else if (ch === '"' || ch === "'") {
+      inStr = true;
+      quote = ch;
+    } else if (ch === '#') return line.slice(0, i);
+  }
+  return line;
+}
+
+/**
+ * Parse an inline-table body (the text between `{` and `}`) into a flat record
+ * of `key -> rawValue` (value kept as raw TOML text: a quoted string, an array,
+ * or a bareword like `true`). Sufficient for cargo dependency specs, which are
+ * single-level inline tables.
+ *
+ * @param {string} body
+ * @returns {Record<string, string>}
+ */
+function parseInlineTable(body) {
+  /** @type {Record<string, string>} */
+  const out = {};
+  let i = 0;
+  const n = body.length;
+  const skipWs = () => {
+    while (i < n && /\s/u.test(body[i])) i += 1;
+  };
+  while (i < n) {
+    skipWs();
+    if (i >= n) break;
+    const keyStart = i;
+    while (i < n && /[A-Za-z0-9_-]/u.test(body[i])) i += 1;
+    const key = body.slice(keyStart, i);
+    skipWs();
+    if (body[i] !== '=') break;
+    i += 1;
+    skipWs();
+    let valStart = i;
+    let val = '';
+    if (body[i] === '"' || body[i] === "'") {
+      const q = body[i];
+      i += 1;
+      while (i < n && body[i] !== q) i += 1;
+      i += 1;
+      val = body.slice(valStart, i);
+    } else if (body[i] === '[') {
+      let depth = 0;
+      do {
+        if (body[i] === '[') depth += 1;
+        else if (body[i] === ']') depth -= 1;
+        i += 1;
+      } while (i < n && depth > 0);
+      val = body.slice(valStart, i);
+    } else {
+      while (i < n && body[i] !== ',') i += 1;
+      val = body.slice(valStart, i).trim();
+    }
+    out[key] = val;
+    skipWs();
+    if (body[i] === ',') i += 1;
+  }
+  return out;
+}
+
+/**
+ * Read a section's raw key/value lines from a Cargo.toml, returning an ordered
+ * map of `key -> rawValueText` for the FIRST occurrence of `[<section>]`.
+ *
+ * @param {string} toml
+ * @param {string} section
+ * @returns {Map<string, string>}
+ */
+function readSection(toml, section) {
+  /** @type {Map<string, string>} */
+  const out = new Map();
+  let inSection = false;
+  for (const raw of toml.split('\n')) {
+    const line = stripComment(raw).trimEnd();
+    const header = line.trim().match(/^\[([^\]]+)\]$/u);
+    if (header) {
+      if (inSection) break;
+      inSection = header[1] === section;
+      continue;
+    }
+    if (!inSection) continue;
+    const eq = line.indexOf('=');
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (key) out.set(key, line.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/**
+ * Serialize a concrete dependency spec to a single TOML line, merging the
+ * workspace base spec with member-local overrides (the member's `features` are
+ * unioned with the workspace base features; other override keys win).
+ *
+ * @param {string} name
+ * @param {string} workspaceSpecRaw  Raw RHS of the workspace dep (string or `{…}`).
+ * @param {Record<string,string>} memberOverrides  Inline-table keys from the member, minus `workspace`.
+ * @returns {string}
+ */
+function mergeDepLine(name, workspaceSpecRaw, memberOverrides) {
+  /** @type {Record<string,string>} */
+  let base;
+  const trimmed = workspaceSpecRaw.trim();
+  if (trimmed.startsWith('{')) {
+    base = parseInlineTable(trimmed.slice(trimmed.indexOf('{') + 1, trimmed.lastIndexOf('}')));
+  } else {
+    base = { version: trimmed };
+  }
+  const merged = { ...base };
+  for (const [k, v] of Object.entries(memberOverrides)) {
+    if (k === 'features' && base.features) {
+      const union = new Set();
+      for (const src of [base.features, v]) {
+        for (const m of src.matchAll(/["']([^"']+)["']/gu)) union.add(m[1]);
+      }
+      merged.features = `[${[...union].map((f) => `"${f}"`).join(', ')}]`;
+    } else {
+      merged[k] = v;
+    }
+  }
+  const parts = Object.entries(merged).map(([k, v]) => `${k} = ${v}`);
+  return `${name} = { ${parts.join(', ')} }`;
+}
+
+/**
+ * Rewrite a member Cargo.toml to a standalone manifest: inline
+ * `[workspace.package]` inheritance, resolve `{ workspace = true }` deps from
+ * the root `[workspace.dependencies]`, drop the `workspace = "…"` pointer, and
+ * append an empty `[workspace]` so the crate roots itself.
+ *
+ * @param {string} memberToml  Member manifest text.
+ * @param {string} rootToml    Workspace-root manifest text.
+ * @returns {string}
+ */
+export function rewriteManifest(memberToml, rootToml) {
+  const wsPackage = readSection(rootToml, 'workspace.package');
+  const wsDeps = readSection(rootToml, 'workspace.dependencies');
+
+  const lines = memberToml.split('\n');
+  /** @type {string[]} */
+  const out = [];
+  let section = '';
+  const depTables = new Set(['dependencies', 'dev-dependencies', 'build-dependencies']);
+  const isDepTable = (s) => depTables.has(s) || [...depTables].some((t) => s.endsWith(`.${t}`));
+
+  for (const raw of lines) {
+    const codeOnly = stripComment(raw);
+    const header = codeOnly.trim().match(/^\[([^\]]+)\]$/u);
+    if (header) {
+      section = header[1];
+      out.push(raw);
+      continue;
+    }
+
+    if (section === 'package') {
+      const inherit = codeOnly.trim().match(/^([A-Za-z0-9_-]+)\.workspace\s*=\s*true\b/u);
+      if (inherit) {
+        const field = inherit[1];
+        const val = wsPackage.get(field);
+        out.push(val !== undefined ? `${field} = ${val}` : raw);
+        continue;
+      }
+      if (/^workspace\s*=/u.test(codeOnly.trim())) continue; // drop the package→workspace pointer
+      out.push(raw);
+      continue;
+    }
+
+    if (isDepTable(section)) {
+      const m = codeOnly.trim().match(/^([A-Za-z0-9_-]+)\s*=\s*(.*)$/u);
+      if (m && /\bworkspace\s*=\s*true\b/u.test(m[2])) {
+        const name = m[1];
+        const wsSpec = wsDeps.get(name);
+        if (wsSpec === undefined) {
+          throw new Error(
+            `'${name}' is { workspace = true } but absent from [workspace.dependencies]`
+          );
+        }
+        const inlineBody = m[2].trim().startsWith('{')
+          ? m[2].trim().slice(m[2].indexOf('{') + 1, m[2].lastIndexOf('}'))
+          : '';
+        const overrides = parseInlineTable(inlineBody);
+        delete overrides.workspace;
+        out.push(mergeDepLine(name, wsSpec, overrides));
+        continue;
+      }
+      out.push(raw);
+      continue;
+    }
+
+    out.push(raw);
+  }
+
+  out.push(
+    '',
+    '# Inserted by cargo-extract.mjs: root the crate so it does not',
+    '# climb to the parent workspace during isolated build.',
+    '[workspace]'
+  );
+  return `${out.join('\n').replace(/\n+$/u, '')}\n`;
+}
+
+function main() {
+  const [member, outDir] = process.argv.slice(2);
+  if (!member || !outDir || member === '--help' || member === '-h') {
+    console.error('Usage: node scripts/extractability/cargo-extract.mjs <member-dir> <out-dir>');
+    process.exit(2);
+  }
+  const memberAbs = resolve(repoRoot, member);
+  const memberToml = join(memberAbs, 'Cargo.toml');
+  const rootToml = join(repoRoot, 'Cargo.toml');
+  if (!existsSync(memberToml)) {
+    console.error(`no Cargo.toml at ${memberToml}`);
+    process.exit(2);
+  }
+
+  const out = resolve(outDir);
+  rmSync(out, { recursive: true, force: true });
+  mkdirSync(out, { recursive: true });
+  cpSync(memberAbs, out, {
+    recursive: true,
+    filter: (src) => !/(^|\/)(target|node_modules)(\/|$)/u.test(src),
+  });
+
+  let rewritten;
+  try {
+    rewritten = rewriteManifest(readFileSync(memberToml, 'utf8'), readFileSync(rootToml, 'utf8'));
+  } catch (err) {
+    console.error(`cargo-extract: ${err instanceof Error ? err.message : err}`);
+    process.exit(2);
+  }
+  writeFileSync(join(out, 'Cargo.toml'), rewritten);
+  console.log(`cargo-extract: ${member} -> ${out} (workspace edges inlined)`);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}

--- a/scripts/extractability/cargo-sandbox.sh
+++ b/scripts/extractability/cargo-sandbox.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# cargo-sandbox — the Rust analogue of the TS EX-2 sandbox extraction
+# (docs/plans/repo-federation/04-isolation-enforcement.md §8, RUST-3).
+#
+# Proves a workspace member crate builds ALONE, with no workspace path
+# resolution: it is copied out, every `{ workspace = true }` dep and every
+# `[workspace.package]` inheritance is materialized inline (by cargo-extract.mjs
+# — the "changing only where shared deps come from" mutation), and the result is
+# `cargo build`-ed in isolation. If it builds, the crate is extraction-ready.
+#
+# Heavy by design (cold registry fetch + full compile per crate) — this is the
+# NIGHTLY / on-demand check, NOT a per-PR gate. The fast per-PR boundary gate is
+# `cargo deny check` + `check-cargo-deps.mjs`.
+#
+# Usage:
+#   scripts/extractability/cargo-sandbox.sh <member-dir> [out-dir]
+#   scripts/extractability/cargo-sandbox.sh libs/pops-ai
+#
+# Exit 0 = the crate built in isolation. Non-zero = it reached behind the
+# workspace and cannot stand alone.
+set -euo pipefail
+
+crate="${1:-}"
+if [ -z "$crate" ]; then
+  echo "usage: $0 <member-dir> [out-dir]" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+out="${2:-$(mktemp -d "${TMPDIR:-/tmp}/cargo-sandbox.XXXXXX")}"
+
+echo "==> extracting $crate -> $out"
+node "$script_dir/cargo-extract.mjs" "$crate" "$out"
+
+echo "==> building $crate in isolation (no workspace path resolution)"
+# A fresh CARGO_HOME would re-download the whole index; reuse the caller's
+# registry cache for speed but keep target/ local to the sandbox so the build is
+# genuinely isolated from the workspace target dir.
+(
+  cd "$out"
+  CARGO_TARGET_DIR="$out/target" cargo build --all-targets
+)
+
+echo "==> OK: $crate builds standalone — extraction-ready"

--- a/scripts/extractability/check-cargo-deps.mjs
+++ b/scripts/extractability/check-cargo-deps.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+/**
+ * Federation isolation guard for the cargo workspace — the Rust mirror of
+ * `scripts/ci/check-lib-no-pillar-import.mjs` (docs/plans/repo-federation/
+ * 04-isolation-enforcement.md §8, RUST-2).
+ *
+ * Rust is structurally stronger than TS — a crate only sees another crate's
+ * `pub` surface, there is no path-import escape hatch — but cargo will happily
+ * let a lib crate take a `[dependencies]` edge on a pillar crate, inverting the
+ * dependency and blocking extraction. cargo itself won't stop it; this guard
+ * does.
+ *
+ * Two-kind taxonomy (same as the TS side, classified by directory):
+ *   - PILLAR : a workspace member under `pillars/`  (e.g. `pillars/contacts`).
+ *   - LIB    : a workspace member under `libs/`      (e.g. `libs/pops-ai`,
+ *              `libs/pops-settings`).
+ *
+ * Rules enforced (§8 crate-boundary table):
+ *   RUST-2a  a LIB crate must not `[dependencies]` (or dev/build-depend on) a
+ *            PILLAR crate.                                            (HARD)
+ *   RUST-2b  a PILLAR crate must not depend on ANOTHER pillar crate; cross-
+ *            pillar consumption is REST or a shared lib, never a crate edge.
+ *                                                                     (HARD)
+ *
+ * Disk-discovered (principle P-8): the member list and the pillar/lib split are
+ * read from the live workspace `Cargo.toml` + each member's `Cargo.toml`, so a
+ * new crate is gated the moment it joins `[workspace].members` with no edit
+ * here.
+ *
+ * A path/git dependency edge (`{ path = "..." }`) onto a sibling member, or a
+ * registry dependency whose name equals a workspace member crate name, both
+ * count as a crate edge for this guard — either form pulls the other crate into
+ * the build graph.
+ *
+ * Usage:
+ *   node scripts/extractability/check-cargo-deps.mjs
+ *   node scripts/extractability/check-cargo-deps.mjs --self-test
+ *
+ * Exit 0 = clean. Exit 1 = at least one violation. Exit 2 = usage / parse error.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+/** Dependency tables whose entries pull a crate into the build graph. */
+const DEP_TABLES = ['dependencies', 'dev-dependencies', 'build-dependencies'];
+
+/**
+ * @typedef {object} Crate
+ * @property {string} dir   Repo-relative dir, e.g. `pillars/contacts`.
+ * @property {string} name  Crate name from `[package].name`, e.g. `contacts`.
+ * @property {'pillar'|'lib'} kind
+ * @property {string[]} deps  Dependency crate names across all dep tables.
+ */
+
+/**
+ * Strip TOML comments (a `#` outside a string) and trim. Cargo manifests do not
+ * embed `#` inside the keys/values this guard reads (crate names, paths,
+ * versions), so a quote-aware single-pass strip is sufficient and avoids a
+ * full-TOML dependency.
+ *
+ * @param {string} line
+ * @returns {string}
+ */
+function stripComment(line) {
+  let inStr = false;
+  let quote = '';
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inStr) {
+      if (ch === quote) inStr = false;
+    } else if (ch === '"' || ch === "'") {
+      inStr = true;
+      quote = ch;
+    } else if (ch === '#') {
+      return line.slice(0, i).trim();
+    }
+  }
+  return line.trim();
+}
+
+/**
+ * Extract the `members` array from a workspace `Cargo.toml`. Handles the array
+ * written across one or many lines. Members are repo-relative paths.
+ *
+ * @param {string} toml
+ * @returns {string[]}
+ */
+export function parseWorkspaceMembers(toml) {
+  const lines = toml.split('\n').map(stripComment);
+  let inWorkspace = false;
+  /** @type {string[]} */
+  const collected = [];
+  let buffer = '';
+  let collecting = false;
+  for (const line of lines) {
+    if (/^\[[^\]]+\]$/u.test(line)) {
+      inWorkspace = line === '[workspace]';
+      if (!inWorkspace) collecting = false;
+      continue;
+    }
+    if (!inWorkspace) continue;
+    if (!collecting && /^members\s*=/u.test(line)) {
+      collecting = true;
+      buffer = line.slice(line.indexOf('=') + 1);
+    } else if (collecting) {
+      buffer += `\n${line}`;
+    }
+    if (collecting && buffer.includes(']')) {
+      const inner = buffer.slice(buffer.indexOf('[') + 1, buffer.lastIndexOf(']'));
+      for (const m of inner.matchAll(/["']([^"']+)["']/gu)) collected.push(m[1]);
+      collecting = false;
+      buffer = '';
+    }
+  }
+  return collected;
+}
+
+/**
+ * Parse a member `Cargo.toml` into its package name + the set of dependency
+ * crate names declared across `[dependencies]`, `[dev-dependencies]` and
+ * `[build-dependencies]` (incl. `[target.<cfg>.dependencies]`).
+ *
+ * Both inline forms count: `foo = "1"` and `foo = { workspace = true }`, and
+ * the renamed form `bar = { package = "foo" }` resolves to the real crate
+ * `foo`. Returns dependency names (post-rename) — sibling-member detection is
+ * by crate name, which is what the build graph keys on.
+ *
+ * @param {string} toml
+ * @returns {{ name: string; deps: string[] }}
+ */
+export function parseMemberManifest(toml) {
+  const lines = toml.split('\n');
+  let section = '';
+  let name = '';
+  /** @type {Set<string>} */
+  const deps = new Set();
+  for (const raw of lines) {
+    const line = stripComment(raw);
+    if (line === '') continue;
+    const header = line.match(/^\[([^\]]+)\]$/u);
+    if (header) {
+      section = header[1];
+      continue;
+    }
+    if (section === 'package') {
+      const m = line.match(/^name\s*=\s*["']([^"']+)["']/u);
+      if (m) name = m[1];
+      continue;
+    }
+    const isDepTable =
+      DEP_TABLES.includes(section) ||
+      DEP_TABLES.some((t) => section === t || section.endsWith(`.${t}`));
+    if (!isDepTable) continue;
+    const keyMatch = line.match(/^([A-Za-z0-9_-]+)\s*=/u);
+    if (!keyMatch) continue;
+    const key = keyMatch[1];
+    const renamed = line.match(/package\s*=\s*["']([^"']+)["']/u);
+    deps.add(renamed ? renamed[1] : key);
+  }
+  return { name, deps: [...deps] };
+}
+
+/**
+ * Discover every workspace member crate, classified by directory.
+ *
+ * @param {string} [root]  Repo root (override for tests).
+ * @returns {Crate[]}
+ */
+export function discoverCrates(root = repoRoot) {
+  const wsPath = join(root, 'Cargo.toml');
+  if (!existsSync(wsPath)) {
+    throw new Error(`no workspace Cargo.toml at ${wsPath}`);
+  }
+  const members = parseWorkspaceMembers(readFileSync(wsPath, 'utf8'));
+  /** @type {Crate[]} */
+  const crates = [];
+  for (const member of members) {
+    const memberToml = join(root, member, 'Cargo.toml');
+    if (!existsSync(memberToml)) {
+      throw new Error(`workspace member '${member}' has no Cargo.toml`);
+    }
+    const { name, deps } = parseMemberManifest(readFileSync(memberToml, 'utf8'));
+    if (!name) throw new Error(`member '${member}' has no [package].name`);
+    /** @type {'pillar'|'lib'|null} */
+    let kind = null;
+    if (member.startsWith('pillars/')) kind = 'pillar';
+    else if (member.startsWith('libs/')) kind = 'lib';
+    if (!kind) continue; // crate outside the pillar/lib taxonomy — not gated.
+    crates.push({ dir: member, name, kind, deps });
+  }
+  return crates.toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/**
+ * @typedef {object} Violation
+ * @property {string} from    Offending crate name.
+ * @property {'lib'|'pillar'} fromKind
+ * @property {string} to      Pillar crate name reached.
+ * @property {'RUST-2a'|'RUST-2b'} rule
+ */
+
+/**
+ * Pure detector — find every forbidden crate edge. Exported for tests.
+ *
+ *   RUST-2a : a lib depends on any pillar crate.
+ *   RUST-2b : a pillar depends on a DIFFERENT pillar crate (self-edge ignored).
+ *
+ * @param {Crate[]} crates
+ * @returns {Violation[]}
+ */
+export function findViolations(crates) {
+  const pillarNames = new Set(crates.filter((c) => c.kind === 'pillar').map((c) => c.name));
+  /** @type {Violation[]} */
+  const violations = [];
+  for (const crate of crates) {
+    for (const dep of crate.deps) {
+      if (!pillarNames.has(dep)) continue;
+      if (crate.kind === 'lib') {
+        violations.push({ from: crate.name, fromKind: 'lib', to: dep, rule: 'RUST-2a' });
+      } else if (crate.kind === 'pillar' && dep !== crate.name) {
+        violations.push({ from: crate.name, fromKind: 'pillar', to: dep, rule: 'RUST-2b' });
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Self-test: prove the detector flags a lib→pillar edge and a pillar→pillar
+ * edge, and passes a clean fixture. Mirrors the `--self-test` in
+ * check-lib-no-pillar-import.mjs so a regression that neuters the guard is
+ * caught without depending on a real-tree violation.
+ *
+ * @returns {boolean}
+ */
+function selfTest() {
+  /** @type {Crate[]} */
+  const fixture = [
+    { dir: 'pillars/contacts', name: 'contacts', kind: 'pillar', deps: ['axum', 'sqlx'] },
+    { dir: 'pillars/finance', name: 'finance', kind: 'pillar', deps: ['contacts'] },
+    { dir: 'libs/pops-ai', name: 'pops-ai', kind: 'lib', deps: ['contacts', 'serde'] },
+    { dir: 'libs/pops-settings', name: 'pops-settings', kind: 'lib', deps: ['serde', 'axum'] },
+  ];
+  const found = findViolations(fixture);
+  const caughtLib = found.some(
+    (v) => v.from === 'pops-ai' && v.to === 'contacts' && v.rule === 'RUST-2a'
+  );
+  const caughtPillar = found.some(
+    (v) => v.from === 'finance' && v.to === 'contacts' && v.rule === 'RUST-2b'
+  );
+  const cleanPassed = !found.some((v) => v.from === 'pops-settings');
+  const ok = caughtLib && caughtPillar && cleanPassed;
+  if (!ok) {
+    console.error('SELF-TEST FAILED — guard did not behave as expected:');
+    console.error(`  caught lib→pillar (RUST-2a):    ${caughtLib}`);
+    console.error(`  caught pillar→pillar (RUST-2b): ${caughtPillar}`);
+    console.error(`  clean lib passed:               ${cleanPassed}`);
+  } else {
+    console.log('self-test OK — guard flags lib→pillar + pillar→pillar, passes clean lib.');
+  }
+  return ok;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node scripts/extractability/check-cargo-deps.mjs [--self-test]\n' +
+        'Fails if a lib crate depends on a pillar crate, or a pillar crate ' +
+        'depends on another pillar crate.'
+    );
+    process.exit(2);
+  }
+  if (args.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+
+  let crates;
+  try {
+    crates = discoverCrates();
+  } catch (err) {
+    console.error(
+      `FAIL — could not read the cargo workspace: ${err instanceof Error ? err.message : err}`
+    );
+    process.exit(2);
+  }
+  const libs = crates.filter((c) => c.kind === 'lib');
+  const pillars = crates.filter((c) => c.kind === 'pillar');
+  console.log(
+    `Scanned ${crates.length} workspace crate(s): ${pillars.length} pillar(s), ${libs.length} lib(s).`
+  );
+
+  const violations = findViolations(crates);
+  if (violations.length === 0) {
+    console.log('OK — no lib→pillar and no pillar→pillar crate dependency.');
+    process.exit(0);
+  }
+  console.error(`FAIL — ${violations.length} crate-boundary violation(s):`);
+  for (const v of violations.toSorted((a, b) => a.from.localeCompare(b.from))) {
+    const why =
+      v.rule === 'RUST-2a'
+        ? 'a lib must never depend on a pillar (inverts the dependency, blocks extraction)'
+        : 'a pillar must consume another pillar via REST or a shared lib, never a crate edge';
+    console.error(`  [${v.rule}] ${v.from} (${v.fromKind}) → ${v.to} (pillar) — ${why}`);
+  }
+  process.exit(1);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}


### PR DESCRIPTION
## P6-T04 — Rust crate boundaries (aliases RUST-1 / RUST-2 / RUST-3)

Mirrors the TS federation isolation discipline on the Rust side. Spec: `docs/plans/repo-federation/04-isolation-enforcement.md` §8.

The cargo workspace lives at repo root with members `pillars/contacts` (pillar), `libs/pops-ai`, `libs/pops-settings` (libs). This PR adds the supply-chain + crate-boundary gates that cargo itself cannot enforce.

### RUST-1 — `deny.toml` + `cargo deny check`
- **Licenses** — allow-list derived from a survey of the full 283-crate dependency tree (`cargo metadata`). Allowed: `MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-3.0`, `Zlib`, `BSL-1.0`, `CDLA-Permissive-2.0`, `Unlicense`. The three workspace crates are `publish = false` / `UNLICENSED`, so `[licenses.private] ignore = true` skips them rather than forcing a fake SPDX id. `confidence-threshold = 0.9`.
- **Advisories** — `yanked = "deny"`, `ignore = []`. The current lockfile is advisory-clean, so **no advisory is ignored**. (If an unfixable advisory ever appears, it must be added to `ignore` with a documented reason — never blanket-disabled.)
- **Bans** — `wildcards = "deny"` (every dep pinned — the Rust mirror of "exports declares every subpath"); `multiple-versions = "warn"` (duplicate transitive majors are a smell, not a hard fail).
- **Sources** — crates.io only; `unknown-registry`/`unknown-git` denied.

`cargo deny check` exits **0** today (`advisories ok, bans ok, licenses ok, sources ok`). Verified non-vacuous: removing `MIT` from the allow-list makes it emit `error[rejected]: failed to satisfy license requirements`.

### RUST-2 — `scripts/extractability/check-cargo-deps.mjs`
Disk-discovered crate-boundary guard (no static crate list). Classifies members by directory (`pillars/*` = pillar, `libs/*` = lib) and fails if:
- **RUST-2a** a lib crate `[dependencies]`/dev/build-depends on a pillar crate;
- **RUST-2b** a pillar crate depends on another pillar crate.

Catches both the `{ path = ... }` and registry-name edge forms, and renamed deps (`{ package = "..." }`). Pure exported detector + `--self-test` + a vitest suite. **Found: 0 violations** on the current tree (1 pillar, 2 libs, all clean).

### RUST-3 — `scripts/extractability/cargo-sandbox.sh` + `cargo-extract.mjs` (nightly)
The cargo analogue of the TS EX-2 sandbox. `cargo-extract.mjs` copies a member out and performs the single "where shared deps come from" mutation: inline `[workspace.package]` inheritance, resolve every `{ workspace = true }` dep to its pinned `[workspace.dependencies]` spec (unioning member-local `features`), drop the `workspace = "../.."` pointer, append an empty `[workspace]` to root the crate. `cargo build --all-targets` in isolation. Heavy → nightly/on-demand, not per-PR. **Verified: `cargo-sandbox.sh libs/pops-ai` builds standalone (extraction-ready).**

### CI
`rust-quality.yml` gains a `Boundaries + supply chain` step (`cargo install cargo-deny --locked` → `cargo deny check` → `check-cargo-deps.mjs --self-test` + real run), plus a node-22 setup and `~/.cargo/bin` caching so the install is a no-op after the first run. **Additive / non-required** — the branch ruleset is untouched. Path triggers extended to `deny.toml` + `scripts/extractability/**`.

### Verification (all green locally)
| check | result |
|---|---|
| `cargo deny check` | exit 0 |
| `node scripts/extractability/check-cargo-deps.mjs` | exit 0 (0 violations) |
| `... --self-test` | exit 0 |
| `cargo build --workspace && cargo test --workspace` | green (12 tests + doctests) |
| `cargo-sandbox.sh libs/pops-ai` | builds standalone |
| `npx yaml-lint .github/workflows/rust-quality.yml` | ✔ |
| vitest (18 unit tests) / oxfmt / oxlint / shellcheck | all pass |

Planted-violation checks pass: a `contacts` dep added to `libs/pops-ai/Cargo.toml` trips RUST-2a (exit 1), reverted → exit 0.