### PR TITLE
fix(ci): guard test honors noUncheckedIndexedAccess

### DIFF
--- a/scripts/ci/__tests__/check-contract-isolation.test.ts
+++ b/scripts/ci/__tests__/check-contract-isolation.test.ts
@@ -39,7 +39,7 @@ describe('findReachBehindInSource', () => {
     const src = ['const ok = 1;', '', "import { x } from '@pops/ai/src/y.js';"].join('\n');
     const v = findReachBehindInSource(src, 'f.ts');
     expect(v).toHaveLength(1);
-    expect(v[0].line).toBe(3);
+    expect(v[0]?.line).toBe(3);
   });
 
   it('catches multiple reach-behinds across lines', () => {


### PR DESCRIPTION
## What

`scripts/ci/__tests__/check-contract-isolation.test.ts` derefs `v[0].line` after `expect(v).toHaveLength(1)`. Under `noUncheckedIndexedAccess` (TS2532) `v[0]` is possibly-undefined; tsc cannot see the length assertion. Switched to optional chaining `v[0]?.line`.

## Why it was latent

vitest/esbuild does not typecheck, and root `scripts/ci/__tests__` is outside the gated mise/tsc typecheck path, so neither CI nor the test run surfaced it. Caught by P6-T02's full-tree typecheck audit.

## Verify

- `tsc --noEmit -p scripts/ci/__tests__/tsconfig.json` → 0 errors
- `vitest run check-contract-isolation.test.ts` → 6 passed