### PR TITLE
fix(ci): make cargo-deny install idempotent in rust-quality

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -84,12 +84,14 @@ jobs:
       #     (config: deny.toml at repo root).
       #   - check-cargo-deps.mjs: a lib crate must not depend on a pillar crate,
       #     and no pillar may depend on another pillar (RUST-2a/2b).
-      # `--locked` keeps the cargo-deny install reproducible; the binary is
-      # cached in ~/.cargo/bin across runs, so the `cargo install` is a no-op
-      # after first build. NON-required — additive gate, the ruleset is untouched.
+      # `--locked` keeps the cargo-deny install reproducible. The binary is
+      # cached in ~/.cargo/bin across runs, so guard the install with `command
+      # -v`: a bare `cargo install` over an already-present binary ERRORS
+      # ("already exists in destination") rather than no-op'ing, so a cache-warm
+      # run would fail this step. NON-required — additive gate, ruleset untouched.
       - name: Boundaries + supply chain
         run: |
-          cargo install cargo-deny --locked
+          command -v cargo-deny >/dev/null 2>&1 || cargo install cargo-deny --locked
           cargo deny check
           node scripts/extractability/check-cargo-deps.mjs --self-test
           node scripts/extractability/check-cargo-deps.mjs


### PR DESCRIPTION
## Problem

`rust-quality.yml` caches `~/.cargo/bin`, so `cargo-deny` is restored on every cache-warm run. The `Boundaries + supply chain` step ran a bare:

```
cargo install cargo-deny --locked
```

Over an already-present binary, `cargo install` exits 101 — `error: binary \`cargo-deny\` already exists in destination. Add --force to overwrite` — it does **not** no-op. So the step passed only on the cold-cache run that first populated the cache (#3534's own merge), and has failed on every cache-warm run since (e.g. #3537's PR run). It was armed to fail main's next push too.

## Fix

Guard the install with `command -v` so it runs only when the binary is absent:

```
command -v cargo-deny >/dev/null 2>&1 || cargo install cargo-deny --locked
```

Cache hit → skip (fast, no error); cache miss → install. Comment corrected to match reality.

## Scope

Non-required job (ruleset untouched). One-line behavior change + comment. The PR itself touches `rust-quality.yml` so it re-runs the job and validates the fix.