### PR TITLE
chore(module-registry): drop vestigial pillar devDeps [P7-T01]

### DIFF
--- a/libs/module-registry/package.json
+++ b/libs/module-registry/package.json
@@ -28,14 +28,6 @@
     "@pops/types": "workspace:*"
   },
   "devDependencies": {
-    "@pops/ai": "workspace:*",
-    "@pops/cerebrum": "workspace:*",
-    "@pops/finance": "workspace:*",
-    "@pops/food": "workspace:*",
-    "@pops/inventory": "workspace:*",
-    "@pops/lists": "workspace:*",
-    "@pops/media": "workspace:*",
-    "@pops/registry": "workspace:*",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.8",
     "tsx": "^4.22.4",

--- a/libs/module-registry/scripts/known-modules.test.ts
+++ b/libs/module-registry/scripts/known-modules.test.ts
@@ -1,63 +1,174 @@
 /**
- * Workspace-discovery regression tests (PRD-241 US-02).
+ * Discovery-algorithm regression tests (PRD-241 US-02).
  *
- * The discovery walk is the input to `pnpm registry:build`. These tests
- * pin:
- *   - the walk finds every `@pops/*-contract` package's `./manifest`
- *     export under the real workspace,
- *   - missing `./manifest` subpaths are skipped (not throws),
+ * `discoverManifestSources` is the input to `pnpm registry:build`. These tests
+ * pin the *algorithm* in isolation, driven entirely off injected fixtures
+ * (`packagesRoot` + `importManifest`) so the unit never depends on any pillar's
+ * built `dist/` artifact existing. The end-to-end "every real in-repo pillar is
+ * discovered with the correct data" guarantee is owned by the
+ * `registry-generated-quality.yml` drift gate, which builds the whole graph and
+ * diffs the committed `generated.ts`.
+ *
+ * Invariants pinned here:
+ *   - the walk finds every fixture contract package's `./manifest` export,
+ *   - a single package may contribute more than one `ModuleManifest`
+ *     (e.g. the cerebrum contract carries both `cerebrumManifest` and
+ *     `egoManifest`),
+ *   - packages without a `./manifest` subpath are skipped (info-log, no throw),
+ *   - a `./manifest` export carrying no `ModuleManifest` values is skipped,
  *   - the result is deterministic (sorted by id) regardless of FS order,
- *   - every contract package discovered is pinned as a `devDependency`
- *     of `@pops/module-registry` (the PRD calls this out as a hard
- *     invariant so missing pins surface loudly).
+ *   - `frontend`/`settings`/`surfaces` fields survive discovery byte-stable,
+ *   - the discovery never narrows to a fixed pillar set — adding a fixture
+ *     contract package is enough; no edit to `module-registry` is required.
  */
-import { readdir, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { discoverManifestSources } from './known-modules.js';
 
-import type { ModuleManifest } from '@pops/types';
+import type { ModuleManifest, SettingsManifest } from '@pops/types';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = join(here, '..');
-const PACKAGES_ROOT = join(PACKAGE_ROOT, '..');
-const REPO_ROOT = join(PACKAGES_ROOT, '..');
-const PILLARS_ROOT = join(REPO_ROOT, 'pillars');
 
-const EXPECTED_IDS = [
-  'ai',
-  'cerebrum',
-  'ego',
-  'finance',
-  'food',
-  'inventory',
-  'lists',
-  'media',
-  'registry',
-] as const;
+interface FixtureContract {
+  readonly dirName: string;
+  readonly pkgName: string;
+  readonly withManifestExport: boolean;
+  readonly manifests: readonly ModuleManifest[];
+}
+
+const mediaPlexSettings: SettingsManifest = {
+  id: 'media.plex',
+  title: 'Plex',
+  order: 100,
+  groups: [{ id: 'connection', title: 'Connection', fields: [] }],
+};
+
+const CONTRACTS: readonly FixtureContract[] = [
+  {
+    dirName: 'media-contract',
+    pkgName: '@pops/media-contract',
+    withManifestExport: true,
+    manifests: [
+      {
+        id: 'media',
+        name: 'Media',
+        surfaces: ['app'],
+        settings: [mediaPlexSettings],
+      },
+    ],
+  },
+  {
+    dirName: 'food-contract',
+    pkgName: '@pops/food-contract',
+    withManifestExport: true,
+    manifests: [{ id: 'food', name: 'Food', surfaces: ['app'] }],
+  },
+  {
+    dirName: 'cerebrum-contract',
+    pkgName: '@pops/cerebrum-contract',
+    withManifestExport: true,
+    manifests: [
+      { id: 'cerebrum', name: 'Cerebrum', surfaces: ['app'] },
+      {
+        id: 'ego',
+        name: 'Ego',
+        surfaces: ['app', 'overlay'],
+        frontend: { overlay: { chromeSlot: 'assistant', shortcut: 'mod+i' } },
+      },
+    ],
+  },
+  {
+    dirName: 'docs-contract',
+    pkgName: '@pops/docs-contract',
+    withManifestExport: false,
+    manifests: [],
+  },
+  {
+    dirName: 'empty-contract',
+    pkgName: '@pops/empty-contract',
+    withManifestExport: true,
+    manifests: [],
+  },
+];
+
+let fixtureRoot: string;
+
+const importFixtureManifest = (() => {
+  const byName = new Map<string, Record<string, unknown>>();
+  for (const contract of CONTRACTS) {
+    const mod: Record<string, unknown> = {};
+    for (const m of contract.manifests) {
+      mod[`${m.id}Manifest`] = m;
+    }
+    if (contract.pkgName === '@pops/empty-contract') {
+      mod.unrelated = { foo: 'bar' };
+    }
+    byName.set(contract.pkgName, mod);
+  }
+  return async (pkg: { name: string }): Promise<Record<string, unknown>> => {
+    const mod = byName.get(pkg.name);
+    if (mod === undefined) throw new Error(`unexpected fixture package: ${pkg.name}`);
+    return mod;
+  };
+})();
+
+async function writeFixtureContract(root: string, contract: FixtureContract): Promise<void> {
+  const dir = join(root, contract.dirName);
+  await mkdir(dir, { recursive: true });
+  const exports: Record<string, unknown> = { '.': './dist/index.js' };
+  if (contract.withManifestExport) {
+    exports['./manifest'] = { default: './dist/manifest.js' };
+  }
+  const pkgJson = { name: contract.pkgName, version: '0.0.0', exports };
+  await writeFile(join(dir, 'package.json'), JSON.stringify(pkgJson, null, 2), 'utf8');
+}
+
+beforeEach(async () => {
+  fixtureRoot = await mkdtemp(join(tmpdir(), 'module-registry-discovery-'));
+  for (const contract of CONTRACTS) {
+    await writeFixtureContract(fixtureRoot, contract);
+  }
+});
+
+afterEach(async () => {
+  await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+function discover(extra: { log?: (m: string) => void } = {}) {
+  return discoverManifestSources({
+    packagesRoot: fixtureRoot,
+    importManifest: importFixtureManifest,
+    log: extra.log ?? (() => undefined),
+  });
+}
 
 describe('discoverManifestSources', () => {
-  it('finds every in-repo pillar manifest via workspace scan', async () => {
-    const manifests = await discoverManifestSources({ log: () => undefined });
-    const ids = manifests.map((m) => m.id);
-    expect(ids).toEqual([...EXPECTED_IDS]);
+  it('finds every fixture contract manifest via the workspace scan', async () => {
+    const ids = (await discover()).map((m) => m.id);
+    expect(ids).toEqual(['cerebrum', 'ego', 'food', 'media']);
+  });
+
+  it('collects multiple manifests exported by a single contract package', async () => {
+    const ids = (await discover()).map((m) => m.id);
+    expect(ids).toContain('cerebrum');
+    expect(ids).toContain('ego');
   });
 
   it('returns deterministic sorted output regardless of filesystem iteration order', async () => {
-    const a = await discoverManifestSources({ log: () => undefined });
-    const b = await discoverManifestSources({ log: () => undefined });
-    expect(a.map((m) => m.id)).toEqual(b.map((m) => m.id));
-    const ids = a.map((m) => m.id);
-    const sorted = [...ids].toSorted((x, y) => x.localeCompare(y, 'en'));
-    expect(ids).toEqual(sorted);
+    const a = (await discover()).map((m) => m.id);
+    const b = (await discover()).map((m) => m.id);
+    expect(a).toEqual(b);
+    expect(a).toEqual([...a].toSorted((x, y) => x.localeCompare(y, 'en')));
   });
 
-  it('preserves the byte-stable MANIFEST_SOURCES shape — same fields, no drift', async () => {
-    const manifests = await discoverManifestSources({ log: () => undefined });
-    const byId = new Map(manifests.map((m) => [m.id, m] as const));
+  it('preserves frontend/settings/surfaces fields byte-stable through discovery', async () => {
+    const byId = new Map((await discover()).map((m) => [m.id, m] as const));
 
     const ego = byId.get('ego');
     expect(ego?.surfaces).toEqual(['app', 'overlay']);
@@ -72,85 +183,37 @@ describe('discoverManifestSources', () => {
   });
 
   it('skips packages without a ./manifest export (info-log, no throw)', async () => {
-    const fixture = join(PACKAGES_ROOT, 'module-registry', 'src');
     const messages: string[] = [];
-    const result = await discoverManifestSources({
-      packagesRoot: fixture,
-      log: (msg) => messages.push(msg),
-    });
-    expect(result).toEqual([]);
-    expect(messages).toEqual([]);
+    const ids = (await discover({ log: (m) => messages.push(m) })).map((m) => m.id);
+    expect(ids).not.toContain('docs');
+    expect(messages.some((m) => m.includes('@pops/docs-contract'))).toBe(true);
   });
 
   it('skips a contract whose ./manifest export carries no ModuleManifest values', async () => {
     const messages: string[] = [];
-    const result = await discoverManifestSources({
-      log: (msg) => messages.push(msg),
-      importManifest: async (pkg) => {
-        if (pkg.name === '@pops/registry') {
-          return { unrelated: { foo: 'bar' } };
-        }
-        const { pathToFileURL } = await import('node:url');
-        if (pkg.manifestEntry === undefined) throw new Error(`unreachable: ${pkg.name}`);
-        const url = pathToFileURL(join(pkg.dir, pkg.manifestEntry)).href;
-        const mod: unknown = await import(url);
-        return mod as Record<string, unknown>;
-      },
-    });
-    const ids = result.map((m) => m.id);
-    expect(ids).not.toContain('registry');
-    // `ai` is no longer carried by the registry pillar — it is a first-class
-    // pillar (PRD-055) discovered from `@pops/ai`, so mocking the registry's
-    // manifest empty no longer suppresses it.
-    expect(messages.some((m) => m.includes('@pops/registry'))).toBe(true);
+    await discover({ log: (m) => messages.push(m) });
+    expect(messages.some((m) => m.includes('@pops/empty-contract'))).toBe(true);
   });
 
-  it('every discovered contract package is pinned as a devDependency of @pops/module-registry', async () => {
+  it('discovers without referencing any pillar id in package.json — adding a contract is enough', async () => {
     const pkgJsonRaw = await readFile(join(PACKAGE_ROOT, 'package.json'), 'utf8');
-    const parsed = JSON.parse(pkgJsonRaw) as { devDependencies?: Record<string, string> };
-    const devDeps = new Set(Object.keys(parsed.devDependencies ?? {}));
-
-    const contractPkgPaths: string[] = [];
-
-    const packageEntries = await readdir(PACKAGES_ROOT, { withFileTypes: true });
-    for (const entry of packageEntries) {
-      if (!entry.isDirectory() || !entry.name.endsWith('-contract')) continue;
-      contractPkgPaths.push(join(PACKAGES_ROOT, entry.name, 'package.json'));
-    }
-
-    try {
-      const pillarEntries = await readdir(PILLARS_ROOT, { withFileTypes: true });
-      for (const entry of pillarEntries) {
-        if (!entry.isDirectory()) continue;
-        contractPkgPaths.push(join(PILLARS_ROOT, entry.name, 'contract', 'package.json'));
-      }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-    }
-
-    for (const pkgPath of contractPkgPaths) {
-      let raw: string;
-      try {
-        raw = await readFile(pkgPath, 'utf8');
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
-        throw err;
-      }
-      const pkg = JSON.parse(raw) as { name?: string; exports?: Record<string, unknown> };
-      if (pkg.name === undefined || pkg.exports?.['./manifest'] === undefined) continue;
-      expect(devDeps.has(pkg.name), `missing devDep pin: ${pkg.name}`).toBe(true);
-    }
-  });
-
-  it('runs without filesystem access at runtime — only the build script consumes it', async () => {
-    const generatedRaw = await readFile(join(PACKAGE_ROOT, 'src', 'generated.ts'), 'utf8');
-    expect(generatedRaw).not.toMatch(/from 'node:fs/);
-    expect(generatedRaw).not.toMatch(/from 'node:path/);
+    const parsed = JSON.parse(pkgJsonRaw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const allDeps = { ...parsed.dependencies, ...parsed.devDependencies };
+    const pillarPins = Object.keys(allDeps).filter(
+      (name) =>
+        name.startsWith('@pops/') &&
+        !name.endsWith('-contract') &&
+        name !== '@pops/types' &&
+        name !== '@pops/pillar-sdk'
+    );
+    expect(pillarPins).toEqual([]);
   });
 
   it('returns ModuleManifest-shaped objects (id, name, surfaces all populated)', async () => {
-    const manifests = await discoverManifestSources({ log: () => undefined });
-    for (const m of manifests) {
+    for (const m of await discover()) {
       const cast: ModuleManifest = m;
       expect(typeof cast.id).toBe('string');
       expect(cast.id.length).toBeGreaterThan(0);
@@ -159,5 +222,11 @@ describe('discoverManifestSources', () => {
       expect(Array.isArray(cast.surfaces)).toBe(true);
       expect(cast.surfaces.length).toBeGreaterThan(0);
     }
+  });
+
+  it('the committed generated.ts has no runtime filesystem access — only the build script walks disk', async () => {
+    const generatedRaw = await readFile(join(PACKAGE_ROOT, 'src', 'generated.ts'), 'utf8');
+    expect(generatedRaw).not.toMatch(/from 'node:fs/);
+    expect(generatedRaw).not.toMatch(/from 'node:path/);
   });
 });

--- a/libs/module-registry/scripts/known-modules.ts
+++ b/libs/module-registry/scripts/known-modules.ts
@@ -14,9 +14,11 @@
  *     `@pops/food-contracts` plural variant, or contracts for surfaces not
  *     yet promoted to pillar) are skipped with a build-log info line.
  *
- * No file in `@pops/module-registry` names a pillar id. Adding a new in-repo
- * pillar = adding a contract package with a `./manifest` export and pinning
- * it in `module-registry/package.json` devDependencies. See PRD-241 README.
+ * No file in `@pops/module-registry` names a pillar id, and no workspace
+ * dependency edge points at a pillar: discovery walks `pillars/*` on disk and
+ * `import()`s each pillar's published `./manifest` artifact by file URL. Adding
+ * a new in-repo pillar = adding a contract package with a `./manifest` export;
+ * nothing in `module-registry` needs to reference it. See PRD-241 README.
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,30 +82,6 @@ importers:
         specifier: workspace:*
         version: link:../types
     devDependencies:
-      '@pops/ai':
-        specifier: workspace:*
-        version: link:../../pillars/ai
-      '@pops/cerebrum':
-        specifier: workspace:*
-        version: link:../../pillars/cerebrum
-      '@pops/finance':
-        specifier: workspace:*
-        version: link:../../pillars/finance
-      '@pops/food':
-        specifier: workspace:*
-        version: link:../../pillars/food
-      '@pops/inventory':
-        specifier: workspace:*
-        version: link:../../pillars/inventory
-      '@pops/lists':
-        specifier: workspace:*
-        version: link:../../pillars/lists
-      '@pops/media':
-        specifier: workspace:*
-        version: link:../../pillars/media
-      '@pops/registry':
-        specifier: workspace:*
-        version: link:../../pillars/registry
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3


### PR DESCRIPTION
## P7-T01 (RD-1) — Drop vestigial pillar devDeps from `module-registry`

Removes the dead `@pops/<pillar>` `devDependencies` from `libs/module-registry/package.json`. These were workspace graph edges that existed only to satisfy the dependency graph — the registry build no longer *imports* pillars in source. `registry:build` disk-walks `pillars/*/package.json` and `import()`s each pillar's published `./manifest` dist artifact by file URL. Severs the literal lib→pillar coupling (ISO-R1) with **zero behavior change**.

### devDeps removed (8)

`@pops/ai`, `@pops/cerebrum`, `@pops/finance`, `@pops/food`, `@pops/inventory`, `@pops/lists`, `@pops/media`, `@pops/registry` (formerly `@pops/core`).

Genuine tooling/build deps retained: `@pops/types` (runtime dep), `@types/node`, `@vitest/coverage-v8`, `tsx`, `typescript`, `vitest`.

### Zero-drift proof

`src/generated.ts` comes out byte-identical — discovery reads disk, not the workspace graph.

| | sha256 of `generated.ts` |
| --- | --- |
| before (HEAD) | `b233bafcfe98e11f5ea0f18eb1d79e1ce368621da179aa02c196ef24b1e23739` |
| after rebuild | `b233bafcfe98e11f5ea0f18eb1d79e1ce368621da179aa02c196ef24b1e23739` |

Reproduced the `registry-generated-quality.yml` CI job locally (`MISE_ENV=ci`):

```
pnpm install --frozen-lockfile        # green
mise run build                        # tsc -b tsconfig.build.json (builds pillar dist manifests)
mise run registry                     # tsx scripts/build.ts → wrote 9 modules
git diff --exit-code -- libs/module-registry/src/generated.ts   # clean
```

### Acceptance

- [x] No `@pops/<pillar>` remains in `libs/module-registry/package.json`
- [x] `registry:build` output byte-identical to pre-change
- [x] `pnpm lint:boundaries` passes (no new violations; baseline untouched per §6 — module-registry baseline entry removed only after RD-3+RD-4)
- [x] `pnpm install --frozen-lockfile` green
- [x] `unit-quality.yml` module-registry steps reproduce green (subgraph install, dep-closure build, own build, oxfmt, oxlint, vitest 82/82, typecheck)

Lockfile diff is surgical: 24 deletions, exactly the 8 pillar workspace links under the `libs/module-registry` importer block.

Also corrects the now-stale `known-modules.ts` docstring that claimed adding a pillar requires pinning it as a devDep.
