### PR TITLE
feat(shell): registry-driven boot install-set [P7-T03]

### DIFF
--- a/pillars/shell/src/app/App.tsx
+++ b/pillars/shell/src/app/App.tsx
@@ -5,15 +5,18 @@ import { isNetworkError } from '@/lib/network-error';
 import { useThemeStore } from '@/store/themeStore';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { RouterProvider } from 'react-router';
 import { toast } from 'sonner';
 
 import { PillarSdkProvider } from '@pops/pillar-sdk/react';
 import { Toaster, TooltipProvider } from '@pops/ui';
 
+import { BootRegistryProvider } from './BootRegistryProvider';
 import { PillarStatusProvider } from './pillars';
-import { router } from './router';
+import { buildRouter } from './router';
+
+import type { BootRegistry } from './boot-snapshot';
 
 const NETWORK_ERROR_TOAST_ID = 'network-down';
 
@@ -42,8 +45,21 @@ const queryClient = new QueryClient({
   mutationCache: new MutationCache({ onError: notifyNetworkError }),
 });
 
-export function App() {
+interface AppProps {
+  /**
+   * The boot-resolved install set (P7-T03). Resolved in `main.tsx` from the
+   * live registry snapshot (or the static floor when the registry is
+   * unreachable) before first render, then threaded in here.
+   */
+  readonly bootRegistry: BootRegistry;
+}
+
+export function App({ bootRegistry }: AppProps) {
   const theme = useThemeStore((state) => state.theme);
+
+  // The install set is fixed for the lifetime of a session: the snapshot is
+  // resolved once at boot, so the router is built once from those manifests.
+  const router = useMemo(() => buildRouter(bootRegistry.manifests), [bootRegistry.manifests]);
 
   // Apply theme class to root element
   useEffect(() => {
@@ -53,11 +69,13 @@ export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <PillarSdkProvider>
-        <PillarStatusProvider>
-          <TooltipProvider>
-            <RouterProvider router={router} />
-          </TooltipProvider>
-        </PillarStatusProvider>
+        <BootRegistryProvider value={bootRegistry}>
+          <PillarStatusProvider>
+            <TooltipProvider>
+              <RouterProvider router={router} />
+            </TooltipProvider>
+          </PillarStatusProvider>
+        </BootRegistryProvider>
         {!import.meta.env.VITE_E2E && <ReactQueryDevtools initialIsOpen={false} />}
         <Toaster />
       </PillarSdkProvider>

--- a/pillars/shell/src/app/BootRegistryProvider.tsx
+++ b/pillars/shell/src/app/BootRegistryProvider.tsx
@@ -1,0 +1,52 @@
+/**
+ * React context for the resolved boot install set (P7-T03 / RD-3).
+ *
+ * `main.tsx` resolves the registry snapshot into a {@link BootRegistry} before
+ * first render (the async boot boundary) and seeds this provider. The nav
+ * consumers (`AppRail`, `Sidebar`, `PageNav`, `RootLayout`, `IndexRedirect`)
+ * read `registeredApps` from here via {@link useRegisteredApps} instead of the
+ * old module-eval `registeredApps` constant, so the rail reflects the live
+ * install set (or the static floor when the registry is unreachable).
+ *
+ * Sibling to `PillarStatusProvider`: that one feeds health post-mount; this one
+ * feeds the boot-resolved install set, threaded down from the boot await.
+ */
+import { createContext, useContext } from 'react';
+
+import type { BootRegistry } from './boot-snapshot';
+import type { AppNavConfig } from './nav/types';
+
+const BootRegistryContext = createContext<BootRegistry | null>(null);
+
+export { BootRegistryContext };
+
+interface BootRegistryProviderProps {
+  readonly value: BootRegistry;
+  readonly children: React.ReactNode;
+}
+
+/** Provider seeded by `main.tsx` with the boot-resolved install set. */
+export function BootRegistryProvider({
+  value,
+  children,
+}: BootRegistryProviderProps): React.ReactElement {
+  return <BootRegistryContext.Provider value={value}>{children}</BootRegistryContext.Provider>;
+}
+
+/**
+ * Read the resolved boot install set. Throws if used outside the provider —
+ * the shell always mounts it at the root, so a missing provider is a wiring
+ * bug, not a runtime condition to tolerate.
+ */
+export function useBootRegistry(): BootRegistry {
+  const value = useContext(BootRegistryContext);
+  if (value === null) {
+    throw new Error('useBootRegistry must be used within a BootRegistryProvider');
+  }
+  return value;
+}
+
+/** The boot-resolved app-rail nav configs. */
+export function useRegisteredApps(): readonly AppNavConfig[] {
+  return useBootRegistry().registeredApps;
+}

--- a/pillars/shell/src/app/IndexRedirect.test.tsx
+++ b/pillars/shell/src/app/IndexRedirect.test.tsx
@@ -16,9 +16,39 @@ import { resolveBootRegistry } from './boot-snapshot';
 import { BootRegistryProvider } from './BootRegistryProvider';
 import { IndexRedirect } from './IndexRedirect';
 
+import type { PillarSnapshot } from '@pops/pillar-sdk';
+
 // Empty snapshot → the static bundle-map floor, so `registeredApps` carries
 // the in-repo pillars in nav.order — the ordering the redirect tests assert.
 const STATIC_FLOOR = resolveBootRegistry([]);
+
+function snapshotEntry(pillarId: string): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3001`,
+    manifest: {
+      pillar: pillarId,
+      version: '1.0.0',
+      contract: {
+        package: `@pops/${pillarId}`,
+        version: '1.0.0',
+        tag: `contract-${pillarId}@v1.0.0`,
+      },
+      routes: { queries: [], mutations: [], subscriptions: [] },
+      search: { adapters: [] },
+      ai: { tools: [] },
+      uri: { types: [] },
+      consumedSettings: { keys: [] },
+      healthcheck: { path: '/health' },
+    },
+    registered: true,
+    lastSeenAt: new Date(0),
+  };
+}
+
+// A live registry where finance is NOT registered: the rail's first live app
+// is `media`. The redirect must land there, NOT on a `/finance` literal.
+const FINANCE_LESS = resolveBootRegistry([snapshotEntry('media'), snapshotEntry('inventory')]);
 
 function LocationProbe() {
   const { pathname } = useLocation();
@@ -33,14 +63,17 @@ function LocationProbe() {
  * Without priming, the optimistic `/finance` fallback wins, which is the real
  * cold-start behaviour.
  */
-function renderAt(primed?: { apps: string[] }): void {
+function renderAt(
+  primed?: { apps: string[] },
+  bootRegistry: typeof STATIC_FLOOR = STATIC_FLOOR
+): void {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   if (primed) {
     client.setQueryData(['core', 'shell', 'manifest'], { apps: primed.apps, overlays: [] });
   }
   render(
     <QueryClientProvider client={client}>
-      <BootRegistryProvider value={STATIC_FLOOR}>
+      <BootRegistryProvider value={bootRegistry}>
         <MemoryRouter initialEntries={['/']}>
           <Routes>
             <Route path="/" element={<IndexRedirect />} />
@@ -89,5 +122,19 @@ describe('IndexRedirect', () => {
   it('redirects to /settings when no registered app is installed', () => {
     renderAt({ apps: ['unknown'] });
     expect(screen.getByTestId('landed')).toHaveTextContent('/settings');
+  });
+
+  it('falls back to the first LIVE app (not a /finance literal) when finance is unregistered', () => {
+    // Cold start (manifest unloaded) against a finance-less registry: the
+    // optimistic target must be the first live rail app (media), not /finance —
+    // navigating to an unmounted /finance would flash NotInstalledPage.
+    mocks.manifest.mockReturnValue(new Promise(() => undefined));
+    renderAt(undefined, FINANCE_LESS);
+    expect(screen.getByTestId('landed')).toHaveTextContent('/media');
+  });
+
+  it('picks the first live app present in the manifest on a finance-less registry', () => {
+    renderAt({ apps: ['inventory', 'media'] }, FINANCE_LESS);
+    expect(screen.getByTestId('landed')).toHaveTextContent('/media');
   });
 });

--- a/pillars/shell/src/app/IndexRedirect.test.tsx
+++ b/pillars/shell/src/app/IndexRedirect.test.tsx
@@ -12,7 +12,13 @@ vi.mock('@/core-api', () => ({
   shellManifest: (...args: unknown[]) => mocks.manifest(...args),
 }));
 
+import { resolveBootRegistry } from './boot-snapshot';
+import { BootRegistryProvider } from './BootRegistryProvider';
 import { IndexRedirect } from './IndexRedirect';
+
+// Empty snapshot → the static bundle-map floor, so `registeredApps` carries
+// the in-repo pillars in nav.order — the ordering the redirect tests assert.
+const STATIC_FLOOR = resolveBootRegistry([]);
 
 function LocationProbe() {
   const { pathname } = useLocation();
@@ -34,12 +40,14 @@ function renderAt(primed?: { apps: string[] }): void {
   }
   render(
     <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route path="/" element={<IndexRedirect />} />
-          <Route path="*" element={<LocationProbe />} />
-        </Routes>
-      </MemoryRouter>
+      <BootRegistryProvider value={STATIC_FLOOR}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<IndexRedirect />} />
+            <Route path="*" element={<LocationProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </BootRegistryProvider>
     </QueryClientProvider>
   );
 }

--- a/pillars/shell/src/app/IndexRedirect.tsx
+++ b/pillars/shell/src/app/IndexRedirect.tsx
@@ -3,7 +3,7 @@ import { unwrap } from '@/core-api-helpers';
 import { useQuery } from '@tanstack/react-query';
 import { Navigate } from 'react-router';
 
-import { registeredApps } from './nav/registry';
+import { useRegisteredApps } from './BootRegistryProvider';
 
 /**
  * `/` redirect that respects the installed-modules manifest (PRD-100).
@@ -16,6 +16,7 @@ import { registeredApps } from './nav/registry';
  * bundle map.
  */
 export function IndexRedirect() {
+  const registeredApps = useRegisteredApps();
   const { data } = useQuery({
     queryKey: ['core', 'shell', 'manifest'],
     queryFn: async () => unwrap(await shellManifest()),

--- a/pillars/shell/src/app/IndexRedirect.tsx
+++ b/pillars/shell/src/app/IndexRedirect.tsx
@@ -7,13 +7,16 @@ import { useRegisteredApps } from './BootRegistryProvider';
 
 /**
  * `/` redirect that respects the installed-modules manifest (PRD-100).
- * Picks the first installed app from `registeredApps` (manifest `nav.order`
- * ascending, lexicographic tiebreak — see `nav/registry.ts`); falls back
- * to `/settings` if no apps are installed.
+ * Picks the first installed app from the LIVE `registeredApps` (manifest
+ * `nav.order` ascending, lexicographic tiebreak — see `nav/registry.ts`);
+ * falls back to `/settings` if no apps are installed.
  *
- * Default deployments (POPS_APPS unset → all installed) land on `/finance`
- * because finance carries the lowest `nav.order` (10) in the workspace
- * bundle map.
+ * The landing target is derived from the boot-resolved install set, never a
+ * `/finance` literal: on a finance-less registry the first live app is the
+ * correct destination, and hardcoding `/finance` there would flash the
+ * router's NotInstalledPage. Default deployments (POPS_APPS unset → all
+ * installed) still land on `/finance` because finance carries the lowest
+ * `nav.order` (10) in the workspace bundle map, so it sorts first.
  */
 export function IndexRedirect() {
   const registeredApps = useRegisteredApps();
@@ -23,15 +26,24 @@ export function IndexRedirect() {
     staleTime: Infinity,
   });
 
+  // The first live app (lowest nav.order) is the always-valid optimistic
+  // default: it is guaranteed to be in the install set the router mounted, so
+  // navigating to it never hits NotInstalledPage. `/settings` only when the
+  // live rail is empty (no apps installed at all).
+  const firstLiveApp = registeredApps[0];
+  const fallbackTarget = firstLiveApp ? `/${firstLiveApp.id}` : '/settings';
+
   // Manifest hasn't loaded yet, the pillar is unreachable, or the contract
   // shape has drifted — `data` is undefined on any of those (the query errors
-  // on a failed fetch). Optimistically pick the historical default so the URL
-  // change is instant. The router's catch-all (`UnmatchedRoute`) will flip to
-  // NotInstalledPage if finance turns out to be absent.
+  // on a failed fetch). Optimistically pick the first live app so the URL
+  // change is instant and always lands on a mounted route.
   if (!data) {
-    return <Navigate to="/finance" replace />;
+    return <Navigate to={fallbackTarget} replace />;
   }
 
+  // `data.apps` is the operator's build-time install selection (POPS_APPS).
+  // When none of the live rail apps appear in it, settings is the only safe
+  // landing — the live default may be an app the operator excluded.
   const target = registeredApps.find((app) => data.apps.includes(app.id));
   return <Navigate to={target ? `/${target.id}` : '/settings'} replace />;
 }

--- a/pillars/shell/src/app/boot-online-render.test.tsx
+++ b/pillars/shell/src/app/boot-online-render.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Online-path render test (P7-T03 / RD-3, MUST-FIX 2).
+ *
+ * The registry-driven boot branch is this PR's entire purpose, yet it had no
+ * rendered coverage: the gated Playwright suite (workflow_dispatch only — it
+ * targets the deleted tRPC monolith) never runs in PR CI, and even when it
+ * did, dev Vite had no `/registry-api` proxy and the e2e harness swaps a
+ * build-time `@pops/module-registry` snapshot, so the boot fetch 404s and the
+ * shell silently soft-falls to `[]` → the static floor. Every e2e therefore
+ * exercises ONLY the floor; a regression that breaks only the live mount would
+ * pass all CI green and surface only in production.
+ *
+ * This drives the real online pipeline end-to-end in jsdom: a stubbed `fetch`
+ * serves a NON-EMPTY snapshot (one in-repo pillar + one external pillar) →
+ * `fetchBootRegistry()` resolves it (NOT a fixture, the production resolver) →
+ * the result seeds `BootRegistryProvider` → a rail consumer reading
+ * `useRegisteredApps()` renders the live install set. The assertion is the
+ * 2(a) non-blank guarantee at the render layer: `source === 'registry'` and
+ * the rendered rail carries the snapshot's apps, never the floor.
+ *
+ * It deliberately renders a minimal rail probe rather than the full `AppRail`
+ * so the test pins the boot→fetch→render contract without coupling to i18n,
+ * the UI store, or the tooltip/icon stack (which the rail's own concerns own).
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchBootRegistry } from './boot-snapshot';
+import { BootRegistryProvider, useRegisteredApps } from './BootRegistryProvider';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+import type { BootRegistry } from './boot-snapshot';
+
+function manifestPayload(pillar: string, extra: Partial<ManifestPayload> = {}): ManifestPayload {
+  return {
+    pillar,
+    version: '1.0.0',
+    contract: { package: `@pops/${pillar}`, version: '1.0.0', tag: `contract-${pillar}@v1.0.0` },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...extra,
+  };
+}
+
+/**
+ * One raw `GET /registry-api/registry/pillars` row, in the wire shape the
+ * fetcher normalises (`lastHeartbeatAt`, not `lastSeenAt`). Building the wire
+ * row — not a `PillarSnapshot` — keeps the fetch+parse layer in the loop.
+ */
+function wireEntry(pillarId: string, manifestExtra: Partial<ManifestPayload> = {}) {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3001`,
+    manifest: manifestPayload(pillarId, manifestExtra),
+    lastHeartbeatAt: new Date(0).toISOString(),
+  };
+}
+
+// Icons MUST be kebab-case on the wire (NavConfigDescriptorSchema): the wire
+// parse this test exercises rejects PascalCase, so the fixture uses `compass`.
+const EXTERNAL_WIRE = wireEntry('weather', {
+  assetsBaseUrl: 'https://cdn.example.com/weather/index.js',
+  nav: {
+    id: 'weather',
+    label: 'Weather',
+    labelKey: 'weather',
+    icon: 'compass',
+    basePath: '/weather',
+    order: 35,
+    items: [{ path: '', label: 'Home', labelKey: 'weather.home', icon: 'compass' }],
+  },
+  pages: [{ path: '', index: true, bundleSlot: 'home' }],
+});
+
+function snapshotResponse(pillars: readonly unknown[]): Response {
+  return new Response(JSON.stringify({ pillars }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** Minimal rail consumer: renders the live install set the rail would mount. */
+function RailProbe() {
+  const apps = useRegisteredApps();
+  return (
+    <ul aria-label="rail">
+      {apps.map((app) => (
+        <li key={app.id} data-testid={`rail-${app.id}`}>
+          {app.id}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function renderRail(bootRegistry: BootRegistry): void {
+  render(
+    <BootRegistryProvider value={bootRegistry}>
+      <RailProbe />
+    </BootRegistryProvider>
+  );
+}
+
+describe('shell online boot → render (registry-driven branch)', () => {
+  it('fetches a non-empty snapshot and renders the registry-driven rail (not the floor)', async () => {
+    const fetchStub = vi.fn(() =>
+      Promise.resolve(snapshotResponse([wireEntry('finance'), EXTERNAL_WIRE]))
+    );
+
+    // The exact production await `main.tsx` blocks first render on: fetch +
+    // parse + resolve, no fixture shortcut. The external pillar's nav is
+    // synthesized synchronously here; its remote bundle import() is lazy and
+    // only fires on first navigation into its route — which the rail probe
+    // never renders — so no network is touched.
+    const bootRegistry = await fetchBootRegistry({ fetch: fetchStub });
+    expect(bootRegistry.source).toBe('registry');
+
+    renderRail(bootRegistry);
+
+    // The rail is non-blank and carries the snapshot's apps — the live mount.
+    const rail = await screen.findByRole('list', { name: 'rail' });
+    expect(rail).toBeInTheDocument();
+    expect(screen.getByTestId('rail-finance')).toBeInTheDocument();
+    expect(screen.getByTestId('rail-weather')).toBeInTheDocument();
+    // Wire nav.order keeps the rail ordered (finance=10 in-repo < weather=35).
+    const ids = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(ids.indexOf('finance')).toBeLessThan(ids.indexOf('weather'));
+  });
+
+  it('renders the static floor (never blank) when the boot fetch fails', async () => {
+    const fetchStub = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+    const bootRegistry = await fetchBootRegistry({ fetch: fetchStub });
+    expect(bootRegistry.source).toBe('static-floor');
+
+    renderRail(bootRegistry);
+
+    // Even on a dead registry the rendered rail is the full in-repo floor.
+    await waitFor(() => expect(screen.getByTestId('rail-finance')).toBeInTheDocument());
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('rail-weather')).not.toBeInTheDocument();
+  });
+});

--- a/pillars/shell/src/app/boot-snapshot.test.ts
+++ b/pillars/shell/src/app/boot-snapshot.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Boot install-set resolver — resilience contract tests (P7-T03 / RD-3).
+ *
+ * The safety-critical guarantee under test: the shell mounts the live
+ * registry snapshot's pillars when the registry is reachable, and NEVER
+ * bricks when it is not — it falls back to the static in-repo bundle-map
+ * floor. Both branches are exercised with injected fixtures (no live fetch).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchBootRegistry, resolveBootRegistry } from './boot-snapshot';
+import { WORKSPACE_BUNDLE_MAP } from './bundle-map';
+import { filterAppManifests } from './installed-modules';
+
+import type { ManifestPayload, PillarSnapshot } from '@pops/pillar-sdk';
+
+import type { RemoteModuleImporter } from './external-ui';
+
+function manifestPayload(pillar: string, extra: Partial<ManifestPayload> = {}): ManifestPayload {
+  return {
+    pillar,
+    version: '1.0.0',
+    contract: { package: `@pops/${pillar}`, version: '1.0.0', tag: `contract-${pillar}@v1.0.0` },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...extra,
+  };
+}
+
+function snapshotEntry(
+  pillarId: string,
+  options: { registered?: boolean; manifest?: Partial<ManifestPayload> } = {}
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3001`,
+    manifest: manifestPayload(pillarId, options.manifest),
+    registered: options.registered ?? true,
+    lastSeenAt: new Date(0),
+  };
+}
+
+const EXTERNAL_NAV = {
+  id: 'weather',
+  label: 'Weather',
+  labelKey: 'weather',
+  icon: 'Compass',
+  basePath: '/weather',
+  order: 35,
+  items: [{ path: '', label: 'Home', labelKey: 'weather.home', icon: 'Compass' }],
+};
+
+const EXTERNAL_PAGES = [{ path: '', index: true, bundleSlot: 'home' }];
+
+function externalSnapshotEntry(): PillarSnapshot {
+  return snapshotEntry('weather', {
+    manifest: {
+      assetsBaseUrl: 'https://cdn.example.com/weather/index.js',
+      nav: EXTERNAL_NAV,
+      pages: EXTERNAL_PAGES,
+    },
+  });
+}
+
+/** A no-op importer; synthesis is synchronous, so it must never be invoked. */
+const inertImporter: RemoteModuleImporter = () =>
+  Promise.reject(new Error('importer must not run during synthesis'));
+
+const IN_REPO_IDS = Object.keys(WORKSPACE_BUNDLE_MAP);
+
+describe('resolveBootRegistry — registry-driven (snapshot non-empty)', () => {
+  it('derives the install set from the snapshot, not the full bundle map', () => {
+    const result = resolveBootRegistry([snapshotEntry('finance'), snapshotEntry('media')]);
+    expect(result.source).toBe('registry');
+    expect(result.manifests.map((m) => m.id).toSorted()).toEqual(['finance', 'media']);
+    // The bundle map carries seven in-repo pillars; the snapshot narrowed the
+    // install set to two, proving the registry is the source of truth.
+    expect(result.manifests.length).toBeLessThan(IN_REPO_IDS.length);
+  });
+
+  it('drops a backend-only registered pillar with no UI surface', () => {
+    const result = resolveBootRegistry([
+      snapshotEntry('finance'),
+      // `registry` is in the snapshot but absent from the bundle map and
+      // advertises no assetsBaseUrl → walk drops it silently.
+      snapshotEntry('registry'),
+    ]);
+    expect(result.manifests.map((m) => m.id)).toEqual(['finance']);
+  });
+
+  it('mounts an in-repo pillar AND an external pillar from one snapshot', () => {
+    const result = resolveBootRegistry(
+      [snapshotEntry('finance'), externalSnapshotEntry()],
+      inertImporter
+    );
+    expect(result.source).toBe('registry');
+    expect(result.manifests.map((m) => m.id).toSorted()).toEqual(['finance', 'weather']);
+
+    const railIds = result.registeredApps.map((a) => a.id);
+    expect(railIds).toContain('finance');
+    expect(railIds).toContain('weather');
+    // Wire nav.order (finance=10 in-repo, weather=35) keeps the rail ordered.
+    expect(railIds.indexOf('finance')).toBeLessThan(railIds.indexOf('weather'));
+  });
+
+  it('mounts an external pillar advertised only via assetsBaseUrl through the runtime loader', () => {
+    const result = resolveBootRegistry([externalSnapshotEntry()], inertImporter);
+    const weather = result.manifests.find((m) => m.id === 'weather');
+    expect(weather).toBeDefined();
+    expect(weather?.surfaces).toContain('app');
+    expect(Array.isArray(weather?.frontend?.routes)).toBe(true);
+    expect(result.registeredApps.map((a) => a.id)).toContain('weather');
+  });
+});
+
+describe('resolveBootRegistry — never-brick fallback (snapshot empty)', () => {
+  it('renders the FULL in-repo app set from the static floor when the snapshot is empty', () => {
+    const result = resolveBootRegistry([]);
+    expect(result.source).toBe('static-floor');
+
+    // The never-brick guarantee: every in-repo app-routed pillar still mounts.
+    // Assert the router-facing app set (the exact `filterAppManifests`
+    // predicate the router uses) is non-empty AND matches the bundle-map
+    // floor's app-routed pillars exactly — a blank shell would surface as [].
+    expect(result.manifests.length).toBeGreaterThan(0);
+    const floorAppIds = IN_REPO_IDS.filter((id) => {
+      const m = WORKSPACE_BUNDLE_MAP[id]?.manifest;
+      return m?.surfaces.includes('app') === true && Array.isArray(m.frontend?.routes);
+    }).toSorted();
+    const mountedAppIds = filterAppManifests(result.manifests)
+      .map((m) => m.id)
+      .toSorted();
+    expect(mountedAppIds).toEqual(floorAppIds);
+    expect(mountedAppIds.length).toBeGreaterThan(0);
+  });
+
+  it('renders the full in-repo app rail (not blank) on the fallback path', () => {
+    const result = resolveBootRegistry([]);
+    expect(result.registeredApps.length).toBeGreaterThan(0);
+    expect(result.registeredApps.map((a) => a.id)).toEqual([
+      'finance',
+      'media',
+      'inventory',
+      'food',
+      'lists',
+      'cerebrum',
+      'ai',
+    ]);
+  });
+});
+
+describe('fetchBootRegistry — fetch-failure resilience', () => {
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('uses the snapshot when the fetch returns registered pillars', async () => {
+    const fetchStub = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          pillars: [
+            {
+              pillarId: 'finance',
+              baseUrl: 'http://finance-api:3001',
+              manifest: manifestPayload('finance'),
+              lastHeartbeatAt: new Date(0).toISOString(),
+            },
+          ],
+        })
+      )
+    );
+    const result = await fetchBootRegistry({ fetch: fetchStub });
+    expect(result.source).toBe('registry');
+    expect(result.manifests.map((m) => m.id)).toEqual(['finance']);
+  });
+
+  it('falls back to the static floor when the fetch rejects (registry unreachable)', async () => {
+    const fetchStub = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+    const result = await fetchBootRegistry({ fetch: fetchStub });
+    expect(result.source).toBe('static-floor');
+    expect(result.manifests.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the static floor on a non-OK status', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({}, 502)));
+    const result = await fetchBootRegistry({ fetch: fetchStub });
+    expect(result.source).toBe('static-floor');
+    expect(result.registeredApps.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the static floor on an empty pillar list', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({ pillars: [] })));
+    const result = await fetchBootRegistry({ fetch: fetchStub });
+    expect(result.source).toBe('static-floor');
+    expect(result.registeredApps.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the static floor when the fetch times out', async () => {
+    const fetchStub = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        })
+    );
+    const result = await fetchBootRegistry({ fetch: fetchStub, timeoutMs: 1 });
+    expect(result.source).toBe('static-floor');
+    expect(result.manifests.length).toBeGreaterThan(0);
+  });
+});

--- a/pillars/shell/src/app/boot-snapshot.test.ts
+++ b/pillars/shell/src/app/boot-snapshot.test.ts
@@ -115,6 +115,98 @@ describe('resolveBootRegistry — registry-driven (snapshot non-empty)', () => {
     expect(Array.isArray(weather?.frontend?.routes)).toBe(true);
     expect(result.registeredApps.map((a) => a.id)).toContain('weather');
   });
+
+  // M2(a): the registry-driven branch is THIS PR's whole purpose, yet no
+  // rendered/e2e test exercises it (every e2e silently falls through to the
+  // floor — see the PR body). This focused unit pins the live-mount path
+  // non-blank: a non-empty snapshot with 1 in-repo pillar (bundle-map hit) and
+  // 1 external pillar (assetsBaseUrl) must yield source='registry' with BOTH a
+  // non-empty router manifest set (including the synthesized external route)
+  // and a non-empty app rail. A regression that breaks only the live mount —
+  // invisible to the floor-only e2e — fails here.
+  it('drives the live registry branch to a non-blank surface (in-repo + external)', () => {
+    const result = resolveBootRegistry(
+      [snapshotEntry('finance'), externalSnapshotEntry()],
+      inertImporter
+    );
+
+    expect(result.source).toBe('registry');
+
+    // Router-facing set: non-empty, both pillars present, external route synthesized.
+    expect(result.manifests.length).toBeGreaterThan(0);
+    expect(result.manifests.map((m) => m.id).toSorted()).toEqual(['finance', 'weather']);
+    const external = result.manifests.find((m) => m.id === 'weather');
+    expect(external?.surfaces).toContain('app');
+    const externalRoutes = external?.frontend?.routes;
+    expect(Array.isArray(externalRoutes)).toBe(true);
+    if (Array.isArray(externalRoutes)) {
+      expect(externalRoutes.length).toBeGreaterThan(0);
+    }
+
+    // App rail: non-empty, both pillars present.
+    expect(result.registeredApps.length).toBeGreaterThan(0);
+    expect(result.registeredApps.map((a) => a.id)).toEqual(
+      expect.arrayContaining(['finance', 'weather'])
+    );
+  });
+});
+
+describe('resolveBootRegistry — never-brick on a zero-UI live snapshot', () => {
+  // M1 (never-brick hole): a NON-EMPTY snapshot whose pillars are all
+  // backend-only — no bundle-map hit, no assetsBaseUrl — is the live state
+  // mid-deploy on a host restart, before the app pillars have re-registered
+  // (only `registry` / `orchestrator` are up). `snapshot.length > 0` is true,
+  // but the snapshot resolves to zero mountable UI. Treating that as
+  // "registry is the source of truth" would mount an app-less shell (manifests
+  // = [], registeredApps = []) — exactly the brick the resilience contract
+  // forbids, reachable on a real capivara restart. The resolver must fall back
+  // to the static floor instead.
+  const BACKEND_ONLY_SNAPSHOT = [snapshotEntry('registry'), snapshotEntry('orchestrator')];
+
+  it('falls back to the static floor (source) when a live snapshot resolves to zero mountable UI', () => {
+    const result = resolveBootRegistry(BACKEND_ONLY_SNAPSHOT);
+    expect(result.source).toBe('static-floor');
+  });
+
+  it('mounts the FULL in-repo rail (not an app-less shell) on the zero-UI fallback', () => {
+    const result = resolveBootRegistry(BACKEND_ONLY_SNAPSHOT);
+
+    // The router-facing app set must equal the floor's app-routed pillars
+    // exactly — a blank shell would surface as []. This is the literal
+    // never-brick guarantee under the precise hole M1 closes.
+    const floorAppIds = IN_REPO_IDS.filter((id) => {
+      const m = WORKSPACE_BUNDLE_MAP[id]?.manifest;
+      return m?.surfaces.includes('app') === true && Array.isArray(m.frontend?.routes);
+    }).toSorted();
+    const mountedAppIds = filterAppManifests(result.manifests)
+      .map((m) => m.id)
+      .toSorted();
+    expect(mountedAppIds).toEqual(floorAppIds);
+    expect(mountedAppIds.length).toBeGreaterThan(0);
+
+    // And the app rail is the full in-repo floor, in nav.order — never blank.
+    expect(result.registeredApps.map((a) => a.id)).toEqual([
+      'finance',
+      'media',
+      'inventory',
+      'food',
+      'lists',
+      'cerebrum',
+      'ai',
+    ]);
+
+    // The result must be byte-identical to the empty-snapshot floor: the
+    // zero-UI live snapshot degrades EXACTLY as if the registry were down.
+    const emptyFloor = resolveBootRegistry([]);
+    expect(mountedAppIds).toEqual(
+      filterAppManifests(emptyFloor.manifests)
+        .map((m) => m.id)
+        .toSorted()
+    );
+    expect(result.registeredApps.map((a) => a.id)).toEqual(
+      emptyFloor.registeredApps.map((a) => a.id)
+    );
+  });
 });
 
 describe('resolveBootRegistry — never-brick fallback (snapshot empty)', () => {

--- a/pillars/shell/src/app/boot-snapshot.ts
+++ b/pillars/shell/src/app/boot-snapshot.ts
@@ -1,0 +1,131 @@
+/**
+ * Boot install-set resolver (P7-T03 / RD-3) — the async boot boundary that
+ * makes the live registry snapshot the source of truth for which pillars the
+ * shell mounts.
+ *
+ * The shell historically built its router + app rail synchronously at
+ * module-eval time from the build-time `MODULES` constant. This module moves
+ * that decision behind an `await`: `main.tsx` fetches the registry snapshot
+ * before first render, resolves it here into a {@link BootRegistry}
+ * (`{ manifests, registeredApps }`), then builds the router and seeds the nav
+ * context from the resolved value.
+ *
+ * Resilience contract (never brick the shell):
+ *
+ *   - snapshot non-empty → the registry's `registered` entries ARE the install
+ *     set. In-repo pillars resolve via the static bundle map; external pillars
+ *     (advertising `assetsBaseUrl`) via the runtime loader; backend-only
+ *     pillars are dropped — exactly `walkRegistry`'s existing decision tree.
+ *   - snapshot empty / fetch failed / timed out → fall back to the static
+ *     bundle-map floor (the in-repo pillars, i.e. the pre-P7-T03 behaviour).
+ *     The shell MUST render its in-repo app set even with the registry down.
+ *
+ * The snapshot fetch itself soft-fails to `[]` (see `registry-snapshot-fetch`),
+ * so an unreachable registry surfaces here as the empty-snapshot branch.
+ */
+import {
+  fetchRegistrySnapshot,
+  type RegistrySnapshotFetchOptions,
+} from '@/lib/registry-snapshot-fetch';
+
+import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from './bundle-map';
+import { synthesizeExternalBundleEntry, type RemoteModuleImporter } from './external-ui';
+import {
+  bootEntries,
+  staticFloorEntries,
+  walkRegistry,
+  type FrontendManifest,
+  type RegistryEntry,
+} from './installed-modules';
+import { buildRegisteredAppsFromBundleMap } from './nav/registry';
+
+import type { PillarSnapshot } from '@pops/pillar-sdk';
+
+import type { AppNavConfig } from './nav/types';
+
+/**
+ * The resolved boot install set the shell renders. `manifests` drives the
+ * router's app routes; `registeredApps` drives the app rail / sidebar / page
+ * nav / index redirect.
+ */
+export interface BootRegistry {
+  readonly manifests: readonly FrontendManifest[];
+  readonly registeredApps: readonly AppNavConfig[];
+  /**
+   * `'registry'` when the live snapshot drove the install set, `'static-floor'`
+   * when the registry was unreachable and the in-repo bundle map was used.
+   * Exposed for diagnostics / tests; consumers render identically either way.
+   */
+  readonly source: 'registry' | 'static-floor';
+}
+
+/**
+ * Resolve the entry list to the bundle map the app rail walks. In-repo
+ * pillars pick up their static bundle entry (carrying the real `navOrder`);
+ * external pillars synthesise one from the wire descriptor via
+ * `synthesizeExternalBundleEntry` — the same call the router-side walk uses —
+ * so the rail orders both kinds through the single
+ * `buildRegisteredAppsFromBundleMap` projection. Entries with no resolvable
+ * UI surface contribute no rail entry.
+ */
+function railBundleMap(
+  entries: readonly RegistryEntry[],
+  importer?: RemoteModuleImporter
+): Record<string, BundleEntry> {
+  const out: Record<string, BundleEntry> = {};
+  for (const entry of entries) {
+    const inRepo = WORKSPACE_BUNDLE_MAP[entry.pillarId];
+    if (inRepo !== undefined) {
+      out[entry.pillarId] = inRepo;
+      continue;
+    }
+    if (entry.assetsBaseUrl === undefined) continue;
+    const synthesized = synthesizeExternalBundleEntry(
+      {
+        pillarId: entry.pillarId,
+        assetsBaseUrl: entry.assetsBaseUrl,
+        nav: entry.nav,
+        pages: entry.pages,
+      },
+      importer
+    );
+    if (synthesized !== null) out[entry.pillarId] = synthesized;
+  }
+  return out;
+}
+
+/**
+ * Resolve a registry snapshot into the boot install set. A non-empty snapshot
+ * is the source of truth; an empty one falls back to the static bundle-map
+ * floor (the never-brick guarantee).
+ *
+ * `importer` is injectable so tests exercise the external-pillar path without
+ * a network round-trip; production omits it and the runtime loader uses the
+ * real dynamic `import()`.
+ */
+export function resolveBootRegistry(
+  snapshot: readonly PillarSnapshot[],
+  importer?: RemoteModuleImporter
+): BootRegistry {
+  const useRegistry = snapshot.length > 0;
+  const entries = useRegistry ? bootEntries(snapshot) : staticFloorEntries();
+  const manifests = walkRegistry(entries, WORKSPACE_BUNDLE_MAP, importer);
+  const registeredApps = buildRegisteredAppsFromBundleMap(railBundleMap(entries, importer));
+  return {
+    manifests,
+    registeredApps,
+    source: useRegistry ? 'registry' : 'static-floor',
+  };
+}
+
+/**
+ * Fetch the live registry snapshot and resolve it into the boot install set.
+ * The await boundary `main.tsx` blocks first render on. Never throws: the
+ * fetch soft-fails to `[]`, which resolves to the static floor.
+ */
+export async function fetchBootRegistry(
+  options: RegistrySnapshotFetchOptions = {}
+): Promise<BootRegistry> {
+  const snapshot = await fetchRegistrySnapshot(options);
+  return resolveBootRegistry(snapshot);
+}

--- a/pillars/shell/src/app/boot-snapshot.ts
+++ b/pillars/shell/src/app/boot-snapshot.ts
@@ -12,13 +12,18 @@
  *
  * Resilience contract (never brick the shell):
  *
- *   - snapshot non-empty → the registry's `registered` entries ARE the install
- *     set. In-repo pillars resolve via the static bundle map; external pillars
- *     (advertising `assetsBaseUrl`) via the runtime loader; backend-only
- *     pillars are dropped — exactly `walkRegistry`'s existing decision tree.
- *   - snapshot empty / fetch failed / timed out → fall back to the static
- *     bundle-map floor (the in-repo pillars, i.e. the pre-P7-T03 behaviour).
- *     The shell MUST render its in-repo app set even with the registry down.
+ *   - snapshot non-empty AND it resolves to ≥1 mountable UI surface → the
+ *     registry's `registered` entries ARE the install set. In-repo pillars
+ *     resolve via the static bundle map; external pillars (advertising
+ *     `assetsBaseUrl`) via the runtime loader; backend-only pillars are
+ *     dropped — exactly `walkRegistry`'s existing decision tree.
+ *   - snapshot empty / fetch failed / timed out / resolves to ZERO mountable
+ *     UI → fall back to the static bundle-map floor (the in-repo pillars, i.e.
+ *     the pre-P7-T03 behaviour). The zero-UI case covers a live snapshot whose
+ *     pillars are all backend-only (e.g. only `registry`/`orchestrator`
+ *     registered mid-bring-up) — that must NOT mount an app-less shell. The
+ *     shell MUST render its in-repo app set even with the registry down or
+ *     mid-restart.
  *
  * The snapshot fetch itself soft-fails to `[]` (see `registry-snapshot-fetch`),
  * so an unreachable registry surfaces here as the empty-snapshot branch.
@@ -32,6 +37,7 @@ import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from './bundle-map';
 import { synthesizeExternalBundleEntry, type RemoteModuleImporter } from './external-ui';
 import {
   bootEntries,
+  ExternalUiLoadError,
   staticFloorEntries,
   walkRegistry,
   type FrontendManifest,
@@ -67,6 +73,12 @@ export interface BootRegistry {
  * so the rail orders both kinds through the single
  * `buildRegisteredAppsFromBundleMap` projection. Entries with no resolvable
  * UI surface contribute no rail entry.
+ *
+ * Synthesis is wrapped in the same `try/catch` the router-side
+ * `resolveExternalManifest` uses (`installed-modules.ts`): a structurally
+ * broken external descriptor logs once and is skipped on the rail path too,
+ * so the two walks stay symmetric and a bad descriptor can never throw out of
+ * boot resolution via the rail.
  */
 function railBundleMap(
   entries: readonly RegistryEntry[],
@@ -80,24 +92,62 @@ function railBundleMap(
       continue;
     }
     if (entry.assetsBaseUrl === undefined) continue;
-    const synthesized = synthesizeExternalBundleEntry(
-      {
-        pillarId: entry.pillarId,
-        assetsBaseUrl: entry.assetsBaseUrl,
-        nav: entry.nav,
-        pages: entry.pages,
-      },
-      importer
-    );
-    if (synthesized !== null) out[entry.pillarId] = synthesized;
+    try {
+      const synthesized = synthesizeExternalBundleEntry(
+        {
+          pillarId: entry.pillarId,
+          assetsBaseUrl: entry.assetsBaseUrl,
+          nav: entry.nav,
+          pages: entry.pages,
+        },
+        importer
+      );
+      if (synthesized !== null) out[entry.pillarId] = synthesized;
+    } catch (cause) {
+      const err = new ExternalUiLoadError(entry.pillarId, entry.assetsBaseUrl, cause);
+      console.warn(`[boot-snapshot] ${err.message}`, cause);
+    }
   }
   return out;
 }
 
 /**
- * Resolve a registry snapshot into the boot install set. A non-empty snapshot
- * is the source of truth; an empty one falls back to the static bundle-map
- * floor (the never-brick guarantee).
+ * The router manifests + app-rail nav an entry list resolves to. The two
+ * always travel together (the router and the rail must agree on the mounted
+ * set), so the resolver computes them in one pass and the never-brick check
+ * inspects both before deciding whether a snapshot yielded any UI.
+ */
+interface ResolvedSurface {
+  readonly manifests: readonly FrontendManifest[];
+  readonly registeredApps: readonly AppNavConfig[];
+}
+
+function resolveSurface(
+  entries: readonly RegistryEntry[],
+  importer?: RemoteModuleImporter
+): ResolvedSurface {
+  return {
+    manifests: walkRegistry(entries, WORKSPACE_BUNDLE_MAP, importer),
+    registeredApps: buildRegisteredAppsFromBundleMap(railBundleMap(entries, importer)),
+  };
+}
+
+/**
+ * Resolve a registry snapshot into the boot install set.
+ *
+ * A non-empty snapshot is normally the source of truth: its `registered`
+ * pillars ARE the install set (in-repo via the bundle map, external via the
+ * runtime loader). An empty snapshot — or one that resolves to zero mountable
+ * UI — falls back to the static bundle-map floor (the never-brick guarantee).
+ *
+ * The zero-UI fallback closes a real hole: a non-empty snapshot whose pillars
+ * are all backend-only (no bundle-map hit, no `assetsBaseUrl`) — e.g. only
+ * `registry` / `orchestrator` registered mid-bring-up, before the app pillars
+ * have re-registered after a host restart — resolves to no manifests and no
+ * rail entries. Treating that as "the registry is the source of truth" would
+ * mount an app-less shell, which the resilience contract forbids. So when a
+ * live snapshot resolves to an empty surface we degrade to the floor exactly
+ * as if the registry were unreachable.
  *
  * `importer` is injectable so tests exercise the external-pillar path without
  * a network round-trip; production omits it and the runtime loader uses the
@@ -107,15 +157,17 @@ export function resolveBootRegistry(
   snapshot: readonly PillarSnapshot[],
   importer?: RemoteModuleImporter
 ): BootRegistry {
-  const useRegistry = snapshot.length > 0;
-  const entries = useRegistry ? bootEntries(snapshot) : staticFloorEntries();
-  const manifests = walkRegistry(entries, WORKSPACE_BUNDLE_MAP, importer);
-  const registeredApps = buildRegisteredAppsFromBundleMap(railBundleMap(entries, importer));
-  return {
-    manifests,
-    registeredApps,
-    source: useRegistry ? 'registry' : 'static-floor',
-  };
+  const registryEntries = snapshot.length > 0 ? bootEntries(snapshot) : null;
+
+  if (registryEntries !== null) {
+    const surface = resolveSurface(registryEntries, importer);
+    if (surface.manifests.length > 0 || surface.registeredApps.length > 0) {
+      return { ...surface, source: 'registry' };
+    }
+  }
+
+  const floor = resolveSurface(staticFloorEntries(), importer);
+  return { ...floor, source: 'static-floor' };
 }
 
 /**

--- a/pillars/shell/src/app/installed-modules.test.ts
+++ b/pillars/shell/src/app/installed-modules.test.ts
@@ -1,18 +1,31 @@
 /**
- * PRD-101 US-03: shell-side aggregator that joins the build-time
- * `MODULES` install set to the live `@pops/app-*` / `@pops/overlay-*`
- * frontend manifests.
+ * Shell-side install-set aggregator.
+ *
+ * P7-T03 / RD-3 moved the install-set source from the build-time `MODULES`
+ * constant to the live registry snapshot: `bootEntries()` maps a snapshot onto
+ * registry entries and `staticFloorEntries()` is the in-repo fallback floor.
+ * `installedFrontendManifests()` walks that floor synchronously (the source
+ * the capture-overlay / manifest-validation tests read); the live install set
+ * is resolved by the async boot path (see `boot-snapshot.test.ts`).
  */
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { isInstalledModule } from '@pops/module-registry';
+
+import { WORKSPACE_BUNDLE_MAP } from './bundle-map';
 import {
   __resetInstalledFrontendManifestsOverride,
   __setInstalledFrontendManifestsOverride,
+  bootEntries,
+  filterAppManifests,
   hasRoutes,
   installedAppManifests,
   installedFrontendManifests,
+  staticFloorEntries,
   type FrontendManifest,
 } from './installed-modules';
+
+import type { ManifestPayload, PillarSnapshot } from '@pops/pillar-sdk';
 
 const SYNTHETIC_FINANCE: FrontendManifest = {
   id: 'finance',
@@ -38,7 +51,109 @@ const SYNTHETIC_EGO_OVERLAY: FrontendManifest = {
   },
 };
 
-describe('installedAppManifests (PRD-101 US-03)', () => {
+/**
+ * Minimal manifest payload satisfying `ManifestPayloadSchema`'s required
+ * fields. Tests spread `extra` to add the surface (`assetsBaseUrl` / `nav` /
+ * `pages`) the entry under test exercises.
+ */
+function manifestPayload(pillar: string, extra: Partial<ManifestPayload> = {}): ManifestPayload {
+  return {
+    pillar,
+    version: '1.0.0',
+    contract: { package: `@pops/${pillar}`, version: '1.0.0', tag: `contract-${pillar}@v1.0.0` },
+    routes: [],
+    search: { enabled: false },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: [],
+    healthcheck: { path: '/health' },
+    ...extra,
+  } as ManifestPayload;
+}
+
+function snapshotEntry(
+  pillarId: string,
+  options: { registered?: boolean; manifest?: Partial<ManifestPayload> } = {}
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `http://${pillarId}-api:3001`,
+    manifest: manifestPayload(pillarId, options.manifest),
+    registered: options.registered ?? true,
+    lastSeenAt: new Date(0),
+  };
+}
+
+describe('staticFloorEntries', () => {
+  it('lists the installed in-repo bundle-map pillars as registry entries', () => {
+    // The unit-test env leaves `POPS_APPS` unset, so every bundle-map pillar
+    // is installed and the floor covers the full map. The `isInstalledModule`
+    // narrowing it applies is exercised by the finance-only install-set e2e.
+    const ids = staticFloorEntries().map((e) => e.pillarId);
+    expect(new Set(ids)).toEqual(new Set(Object.keys(WORKSPACE_BUNDLE_MAP)));
+    for (const id of ids) {
+      expect(isInstalledModule(id)).toBe(true);
+    }
+  });
+
+  it('carries only the pillar id (in-repo pillars resolve via the bundle map)', () => {
+    for (const entry of staticFloorEntries()) {
+      expect(entry.assetsBaseUrl).toBeUndefined();
+      expect(entry.nav).toBeUndefined();
+      expect(entry.pages).toBeUndefined();
+    }
+  });
+});
+
+describe('bootEntries (P7-T03 snapshot → registry entries)', () => {
+  it('maps registered snapshot entries onto registry entries', () => {
+    const entries = bootEntries([snapshotEntry('finance'), snapshotEntry('media')]);
+    expect(entries.map((e) => e.pillarId)).toEqual(['finance', 'media']);
+  });
+
+  it('drops entries that are not registered', () => {
+    const entries = bootEntries([
+      snapshotEntry('finance'),
+      snapshotEntry('media', { registered: false }),
+    ]);
+    expect(entries.map((e) => e.pillarId)).toEqual(['finance']);
+  });
+
+  it('threads an external pillar surface (assetsBaseUrl / nav / pages) off the manifest', () => {
+    const nav = {
+      id: 'weather',
+      label: 'Weather',
+      labelKey: 'weather',
+      icon: 'Compass',
+      basePath: '/weather',
+      order: 80,
+      items: [{ path: '', label: 'Home', labelKey: 'weather.home', icon: 'Compass' }],
+    };
+    const pages = [{ path: '', index: true, bundleSlot: 'home' }];
+    const [entry] = bootEntries([
+      snapshotEntry('weather', {
+        manifest: {
+          assetsBaseUrl: 'https://cdn.example.com/weather/index.js',
+          nav,
+          pages,
+        },
+      }),
+    ]);
+    expect(entry?.assetsBaseUrl).toBe('https://cdn.example.com/weather/index.js');
+    expect(entry?.nav).toEqual(nav);
+    expect(entry?.pages).toEqual(pages);
+  });
+
+  it('omits the external-UI fields for an in-repo (no assetsBaseUrl) pillar', () => {
+    const [entry] = bootEntries([snapshotEntry('finance')]);
+    expect(entry?.pillarId).toBe('finance');
+    expect(entry?.assetsBaseUrl).toBeUndefined();
+    expect(entry?.nav).toBeUndefined();
+    expect(entry?.pages).toBeUndefined();
+  });
+});
+
+describe('installedAppManifests', () => {
   afterEach(() => {
     __resetInstalledFrontendManifestsOverride();
   });
@@ -65,18 +180,28 @@ describe('installedAppManifests (PRD-101 US-03)', () => {
     expect(installedAppManifests()).toEqual([]);
   });
 
-  it('production path reads from MODULES (build-time registry)', () => {
-    // No override applied — `installedFrontendManifests` reads from the
-    // committed `MODULES` registry. The shell deliberately supports builds
-    // with an empty install set (e.g. `POPS_APPS=` at registry:build time),
-    // so we don't assert a minimum length here; we only assert the
-    // manifest contract for whatever the registry returns.
+  it('the static floor surfaces only well-formed manifests with app surfaces', () => {
+    // No override applied — `installedFrontendManifests` walks the in-repo
+    // bundle-map floor (P7-T03). The shell supports an empty install set, so
+    // we assert the manifest contract for whatever the floor returns rather
+    // than a minimum length.
     const live = installedFrontendManifests();
     expect(Array.isArray(live)).toBe(true);
     for (const m of live) {
       expect(typeof m.id).toBe('string');
       expect(Array.isArray(m.surfaces)).toBe(true);
     }
+  });
+});
+
+describe('filterAppManifests', () => {
+  it('keeps app-surfaced, route-bearing manifests and drops the rest', () => {
+    const ids = filterAppManifests([
+      SYNTHETIC_FINANCE,
+      SYNTHETIC_INVENTORY_NO_ROUTES,
+      SYNTHETIC_EGO_OVERLAY,
+    ]).map((m) => m.id);
+    expect(ids).toEqual(['finance']);
   });
 });
 

--- a/pillars/shell/src/app/installed-modules.ts
+++ b/pillars/shell/src/app/installed-modules.ts
@@ -1,14 +1,21 @@
 /**
- * Shell-side aggregator that joins the build-time `MODULES` install set
- * (`@pops/module-registry`) with the workspace bundle map
- * (`./bundle-map.ts`) — the single place the shell still enumerates
- * in-repo pillar ids per PRD-243 US-03.
+ * Shell-side aggregator that resolves the shell's install set against the
+ * workspace bundle map (`./bundle-map.tsx`) — the single place the shell
+ * enumerates in-repo pillar ids per PRD-243 US-03.
  *
  * Prior to PRD-243 this file hand-imported each pillar's frontend
- * manifest by name and reduced the registry intersection through the
- * `KNOWN_FRONTEND_MANIFESTS` literal. The registry walk replaces both:
- * every installed pillar id resolves through `lookupBundleEntry()`,
- * which fronts the workspace bundle map.
+ * manifest by name. The registry walk replaces that: every installed
+ * pillar id resolves through the workspace bundle map.
+ *
+ * Install-set source (P7-T03 / RD-3): the live registry snapshot is now
+ * the source of truth for which pillars mount, not the build-time
+ * `MODULES` / `INSTALLED_MODULES` constants. The async boot path
+ * (`main.tsx` → `boot-snapshot.ts`) fetches the snapshot and walks
+ * {@link bootEntries}; if the registry is unreachable the shell falls
+ * back to {@link staticFloorEntries} (the in-repo bundle-map pillars) so
+ * it never bricks. `installedFrontendManifests()` is that static floor —
+ * the synchronous in-repo set the boot path degrades to, and the source
+ * the capture-overlay / manifest-validation tests read.
  *
  * External pillars (PRD-228) that the registry advertises via
  * `assetsBaseUrl` are absent from the workspace bundle map by design
@@ -21,7 +28,7 @@
  * See `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-03-shell-registry-walk.md`
  * and `us-05-external-pillar-ui-loading.md`.
  */
-import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
+import { isInstalledModule } from '@pops/module-registry';
 
 import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from './bundle-map';
 import {
@@ -32,7 +39,7 @@ import {
 
 import type { RouteObject } from 'react-router';
 
-import type { NavConfigDescriptor, PageDescriptor } from '@pops/pillar-sdk';
+import type { NavConfigDescriptor, PageDescriptor, PillarSnapshot } from '@pops/pillar-sdk';
 import type { ModuleManifest } from '@pops/types';
 
 /**
@@ -86,9 +93,9 @@ export class ExternalUiLoadError extends Error {
  * `nav` / `pages` descriptors the runtime loader (US-05) consumes.
  *
  * In-repo pillars carry only `pillarId`: their UI surface comes from the
- * static bundle map, never the wire. Backed by `MODULES` +
- * `INSTALLED_MODULES` today; PRD-228 wires the runtime registry behind
- * the same shape so external pillars flow through the same walk.
+ * static bundle map, never the wire. Sourced from the live registry
+ * snapshot via {@link bootEntries} (P7-T03), or from the in-repo bundle
+ * map via {@link staticFloorEntries} when the registry is unreachable.
  */
 export interface RegistryEntry {
   readonly pillarId: string;
@@ -98,15 +105,49 @@ export interface RegistryEntry {
 }
 
 /**
- * Build the default registry-entry list from the build-time `MODULES`
- * snapshot intersected with the runtime `INSTALLED_MODULES` shim. The
- * synchronous walk source the shell uses at boot.
+ * The static install-set floor: the in-repo pillars the shell renders when
+ * the live registry is unreachable (the never-brick fallback, P7-T03), and
+ * the synchronous source `installedFrontendManifests()` walks.
+ *
+ * The floor is the workspace bundle map narrowed by the runtime install
+ * shim `isInstalledModule` (the `@pops/module-registry` projection of the
+ * build-time `POPS_APPS` contract). The LIVE install set comes from the
+ * registry snapshot (`bootEntries`) and is the source of truth; this floor
+ * only governs the offline path. Honouring the install shim here keeps that
+ * path identical to the pre-P7-T03 behaviour — so an operator's `POPS_APPS`
+ * selection still narrows the shell when the registry is down (and the
+ * finance-only install-set e2e stays meaningful) — without the shell
+ * consulting the build-time `MODULES` superset for the live install set. In-
+ * repo pillars carry only `pillarId`; their UI surface comes from the static
+ * bundle map.
  */
-function defaultRegistryEntries(): readonly RegistryEntry[] {
+export function staticFloorEntries(): readonly RegistryEntry[] {
+  return Object.keys(WORKSPACE_BUNDLE_MAP)
+    .filter((pillarId) => isInstalledModule(pillarId))
+    .map((pillarId) => ({ pillarId }));
+}
+
+/**
+ * Map a live registry snapshot onto the registry-entry list the walk
+ * consumes (P7-T03 / RD-3). Only `registered` pillars contribute. For
+ * each, the wire `manifest` carries the external-UI surface
+ * (`assetsBaseUrl` / `nav` / `pages`); in-repo pillars omit `assetsBaseUrl`
+ * and resolve through the static bundle map instead. The snapshot is the
+ * sole truth for which pillars mount — backend-only pillars (no bundle-map
+ * entry, no `assetsBaseUrl`) are dropped by the walk's existing decision
+ * tree.
+ */
+export function bootEntries(snapshot: readonly PillarSnapshot[]): readonly RegistryEntry[] {
   const out: RegistryEntry[] = [];
-  for (const module of MODULES) {
-    if (!INSTALLED_MODULES.includes(module.id)) continue;
-    out.push({ pillarId: module.id });
+  for (const s of snapshot) {
+    if (!s.registered) continue;
+    const { assetsBaseUrl, nav, pages } = s.manifest;
+    out.push({
+      pillarId: s.pillarId,
+      ...(assetsBaseUrl !== undefined ? { assetsBaseUrl } : {}),
+      ...(nav !== undefined ? { nav } : {}),
+      ...(pages !== undefined ? { pages } : {}),
+    });
   }
   return out;
 }
@@ -194,45 +235,53 @@ export function walkRegistry(
 
 /**
  * Test-only override. When set, `installedFrontendManifests()` returns
- * this list verbatim instead of computing from the registry walk.
+ * this list verbatim instead of walking the static floor.
  * Reset between tests via `__resetInstalledFrontendManifestsOverride()`.
  *
- * The override exists because `MODULES` / `INSTALLED_MODULES` are
- * computed at build / module-load time — there is no public API for
- * tests to inject synthetic module manifests into either. PRD-243 US-04
- * is the integration test that exercises the live walk against a
- * synthetic registry without using this hook.
+ * The override exists so tests can inject synthetic module manifests
+ * without standing up the workspace bundle map.
  */
 let testOverride: readonly FrontendManifest[] | null = null;
 
 /**
- * Frontend manifests considered "installed" for this build. Walks the
- * registry: every id in the `MODULES` superset that survives the runtime
- * install set (`INSTALLED_MODULES`, per PRD-218 US-01) is resolved
- * against the workspace bundle map.
+ * The static install-set floor as frontend manifests: every in-repo
+ * pillar in the workspace bundle map, walked through {@link walkRegistry}.
  *
- * Skip path: a registered id with no entry in the workspace bundle map
- * AND no `assetsBaseUrl` to defer to logs a warning and is omitted —
- * external pillars (US-05 deferred) fall here today.
+ * This is the synchronous in-repo set the live install-set (P7-T03)
+ * degrades to when the registry is unreachable, and the source the
+ * capture-overlay walk and manifest-validation tests read. The live,
+ * snapshot-driven install set is built by the async boot path
+ * (`boot-snapshot.ts`), not here.
  */
 export function installedFrontendManifests(): readonly FrontendManifest[] {
   if (testOverride !== null) return testOverride;
-  return walkRegistry(defaultRegistryEntries(), WORKSPACE_BUNDLE_MAP);
+  return walkRegistry(staticFloorEntries(), WORKSPACE_BUNDLE_MAP);
 }
 
 /**
- * Subset of `installedFrontendManifests()` that surfaces a page-routed app
- * (i.e. declares `surfaces.includes('app')` and `frontend.routes`). Overlay
- * mounting is US-07; this getter returns only the modules the router
- * mounts under a top-level path.
+ * Filter a manifest list to the page-routed apps the router mounts under a
+ * top-level path (declares `surfaces.includes('app')` and `frontend.routes`).
+ * Pure over an arbitrary manifest list so the boot path can apply it to the
+ * snapshot-resolved set, not just the static floor.
+ */
+export function filterAppManifests(
+  manifests: readonly FrontendManifest[]
+): readonly (FrontendManifest & { frontend: { routes: RouteObject[] } })[] {
+  return manifests.filter(
+    (m): m is FrontendManifest & { frontend: { routes: RouteObject[] } } =>
+      m.surfaces.includes('app') && hasRoutes(m)
+  );
+}
+
+/**
+ * Subset of `installedFrontendManifests()` (the static floor) that surfaces a
+ * page-routed app. Retained for the synchronous in-repo consumers; the live
+ * router builds from the boot-resolved set via {@link filterAppManifests}.
  */
 export function installedAppManifests(): readonly (FrontendManifest & {
   frontend: { routes: RouteObject[] };
 })[] {
-  return installedFrontendManifests().filter(
-    (m): m is FrontendManifest & { frontend: { routes: RouteObject[] } } =>
-      m.surfaces.includes('app') && hasRoutes(m)
-  );
+  return filterAppManifests(installedFrontendManifests());
 }
 
 /**

--- a/pillars/shell/src/app/layout/AppRail.tsx
+++ b/pillars/shell/src/app/layout/AppRail.tsx
@@ -1,4 +1,4 @@
-import { registeredApps } from '@/app/nav/registry';
+import { useRegisteredApps } from '@/app/BootRegistryProvider';
 import { useUIStore } from '@/store/uiStore';
 import { useLocation } from 'react-router';
 
@@ -21,6 +21,7 @@ interface AppRailProps {
 }
 
 export function AppRail({ className }: AppRailProps) {
+  const registeredApps = useRegisteredApps();
   const location = useLocation();
   const railOpen = useUIStore((state) => state.railOpen);
   const toggleRail = useUIStore((state) => state.toggleRail);

--- a/pillars/shell/src/app/layout/PageNav.tsx
+++ b/pillars/shell/src/app/layout/PageNav.tsx
@@ -1,6 +1,6 @@
+import { useRegisteredApps } from '@/app/BootRegistryProvider';
 import { iconMap } from '@/app/nav/icon-map';
 import { findActiveApp, findActiveItem } from '@/app/nav/path-utils';
-import { registeredApps } from '@/app/nav/registry';
 /**
  * Page navigation panel
  *
@@ -17,6 +17,7 @@ export function PageNav() {
   const { t } = useTranslation('navigation');
   const { t: tShell } = useTranslation('shell');
   const location = useLocation();
+  const registeredApps = useRegisteredApps();
   const activeApp = findActiveApp(location.pathname, registeredApps);
 
   if (!activeApp) return null;

--- a/pillars/shell/src/app/layout/RootLayout.tsx
+++ b/pillars/shell/src/app/layout/RootLayout.tsx
@@ -1,5 +1,5 @@
+import { useRegisteredApps } from '@/app/BootRegistryProvider';
 import { findActiveApp } from '@/app/nav/path-utils';
-import { registeredApps } from '@/app/nav/registry';
 import { installedOverlays } from '@/app/overlays/registry';
 import { useUIStore } from '@/store/uiStore';
 import { Outlet, useLocation } from 'react-router';
@@ -35,6 +35,7 @@ export function RootLayout() {
   const pageNavOpen = useUIStore((state) => state.pageNavOpen);
   const setPageNavOpen = useUIStore((state) => state.setPageNavOpen);
   const location = useLocation();
+  const registeredApps = useRegisteredApps();
   const activeApp = findActiveApp(location.pathname, registeredApps);
   const appColorClass = activeApp?.color ? `app-${activeApp.color}` : undefined;
 

--- a/pillars/shell/src/app/layout/Sidebar.tsx
+++ b/pillars/shell/src/app/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { registeredApps } from '@/app/nav/registry';
+import { useRegisteredApps } from '@/app/BootRegistryProvider';
 import { useUIStore } from '@/store/uiStore';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,7 @@ interface SidebarProps {
 export function Sidebar({ open }: SidebarProps) {
   const { t } = useTranslation('shell');
   const location = useLocation();
+  const registeredApps = useRegisteredApps();
   const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
   const close = () => setSidebarOpen(false);
 

--- a/pillars/shell/src/app/nav/path-utils.ts
+++ b/pillars/shell/src/app/nav/path-utils.ts
@@ -15,7 +15,10 @@ export function matchesAtBoundary(pathname: string, prefix: string): boolean {
 }
 
 /** Find the active app by matching the current pathname against registered base paths. */
-export function findActiveApp(pathname: string, apps: AppNavConfig[]): AppNavConfig | undefined {
+export function findActiveApp(
+  pathname: string,
+  apps: readonly AppNavConfig[]
+): AppNavConfig | undefined {
   return apps.find((app) => matchesAtBoundary(pathname, app.basePath));
 }
 

--- a/pillars/shell/src/app/nav/registry.ts
+++ b/pillars/shell/src/app/nav/registry.ts
@@ -58,10 +58,16 @@ export function buildRegisteredAppsFromBundleMap(
 }
 
 /**
- * All registered app nav configs. Sorted by `navOrder` ascending with a
- * stable lexicographic tiebreak on `id`. Today's display order
- * (`finance, media, inventory, food, lists, cerebrum, ai`) is preserved
- * by the reconciled sparse scheme in `bundle-map.ts`.
+ * The static app-rail floor: every in-repo pillar in the workspace bundle
+ * map, sorted by `navOrder` ascending with a stable lexicographic tiebreak
+ * on `id`. The display order (`finance, media, inventory, food, lists,
+ * cerebrum, ai`) follows the reconciled sparse scheme in `bundle-map.tsx`.
+ *
+ * P7-T03 / RD-3: the LIVE app rail no longer reads this constant — it reads
+ * the boot-resolved install set from `BootRegistryProvider`
+ * (`useRegisteredApps()`), which is the registry snapshot (or this floor
+ * when the registry is unreachable). This export remains as the floor the
+ * boot path falls back to and the order parity gate pins.
  */
 export const registeredApps: AppNavConfig[] =
   buildRegisteredAppsFromBundleMap(WORKSPACE_BUNDLE_MAP);

--- a/pillars/shell/src/app/router.tsx
+++ b/pillars/shell/src/app/router.tsx
@@ -1,11 +1,16 @@
 /**
- * Shell route table — composed from the build-time module registry
- * (`@pops/module-registry` → `installedAppManifests()`).
+ * Shell route table — composed from the boot-resolved install set
+ * (`boot-snapshot.ts` → resolved `FrontendManifest[]`).
  *
- * PRD-101 US-03 removes the per-module hand-coded `<Route>` list from this
- * file: route entries derive from the install set, the runtime
- * `RequireModule` guard is gone, and direct navigation to an absent
- * module's URL renders `NotInstalledPage` via the catch-all.
+ * PRD-101 US-03 removed the per-module hand-coded `<Route>` list: route
+ * entries derive from the install set, the runtime `RequireModule` guard is
+ * gone, and direct navigation to an absent module's URL renders
+ * `NotInstalledPage` via the catch-all.
+ *
+ * P7-T03 / RD-3 moved the install-set source from the build-time `MODULES`
+ * constant to the live registry snapshot, resolved before first render. The
+ * router is therefore built by {@link buildRouter} (called from `App.tsx`
+ * with the boot-resolved manifests) rather than a module-eval constant.
  */
 import { Suspense } from 'react';
 import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-router';
@@ -13,7 +18,7 @@ import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-
 import { ALL_MODULE_IDS } from '@pops/pillar-sdk';
 
 import { IndexRedirect } from './IndexRedirect';
-import { installedAppManifests } from './installed-modules';
+import { filterAppManifests, type FrontendManifest } from './installed-modules';
 import { RootLayout } from './layout/RootLayout';
 import { FeaturesPage } from './pages/features-page/FeaturesPage';
 import { NotFoundPage } from './pages/NotFoundPage';
@@ -73,8 +78,8 @@ function withSuspense(routes: readonly RouteObject[]): RouteObject[] {
  * mature pillars migrate, their module's mapping flips and routes start
  * observing the pillar's reported health.
  */
-function appRouteEntries(): RouteObject[] {
-  return installedAppManifests().map((manifest) => {
+function appRouteEntries(manifests: readonly FrontendManifest[]): RouteObject[] {
+  return filterAppManifests(manifests).map((manifest) => {
     const pillarId = pillarIdForModule(manifest.id);
     return {
       path: manifest.id,
@@ -101,30 +106,40 @@ const ErrorElement = (
   </div>
 );
 
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <RootLayout />,
-    errorElement: ErrorElement,
-    children: [
-      { index: true, element: <IndexRedirect /> },
-      ...appRouteEntries(),
-      // Legacy /cerebrum/admin/* redirects — keep bookmarks pointing into
-      // the old in-cerebrum admin surface working after the AI app moved
-      // back to its own top-level /ai/* nav (#2618). Reverses the redirects
-      // added in #2333.
-      { path: 'cerebrum/admin', element: <Navigate to="/ai" replace /> },
-      { path: 'cerebrum/admin/prompts', element: <Navigate to="/finance/prompts" replace /> },
-      { path: 'cerebrum/admin/rules', element: <Navigate to="/finance/rules" replace /> },
-      { path: 'cerebrum/admin/cache', element: <Navigate to="/ai/cache" replace /> },
-      { path: 'settings', element: <SettingsPage /> },
-      { path: 'features', element: <FeaturesPage /> },
-      // Catch-all: if the first path segment names a routable module id
-      // (`ALL_MODULE_IDS`) the operator excluded via `POPS_APPS`, render
-      // NotInstalledPage. Genuinely unknown paths render NotFoundPage.
-      // Both decisions happen inside `UnmatchedRoute` so the route table
-      // stays free of inline module-id literals.
-      { path: '*', element: <UnmatchedRoute /> },
-    ],
-  },
-]);
+/**
+ * Build the shell's browser router from the boot-resolved install set. Called
+ * once from `App.tsx` after the boot snapshot resolves (P7-T03): the app
+ * routes derive from `manifests`, the rest of the table (index redirect,
+ * legacy redirects, settings/features, catch-all) is fixed.
+ */
+export function buildRouter(
+  manifests: readonly FrontendManifest[]
+): ReturnType<typeof createBrowserRouter> {
+  return createBrowserRouter([
+    {
+      path: '/',
+      element: <RootLayout />,
+      errorElement: ErrorElement,
+      children: [
+        { index: true, element: <IndexRedirect /> },
+        ...appRouteEntries(manifests),
+        // Legacy /cerebrum/admin/* redirects — keep bookmarks pointing into
+        // the old in-cerebrum admin surface working after the AI app moved
+        // back to its own top-level /ai/* nav (#2618). Reverses the redirects
+        // added in #2333.
+        { path: 'cerebrum/admin', element: <Navigate to="/ai" replace /> },
+        { path: 'cerebrum/admin/prompts', element: <Navigate to="/finance/prompts" replace /> },
+        { path: 'cerebrum/admin/rules', element: <Navigate to="/finance/rules" replace /> },
+        { path: 'cerebrum/admin/cache', element: <Navigate to="/ai/cache" replace /> },
+        { path: 'settings', element: <SettingsPage /> },
+        { path: 'features', element: <FeaturesPage /> },
+        // Catch-all: if the first path segment names a routable module id
+        // (`ALL_MODULE_IDS`) the operator excluded via `POPS_APPS`, render
+        // NotInstalledPage. Genuinely unknown paths render NotFoundPage.
+        // Both decisions happen inside `UnmatchedRoute` so the route table
+        // stays free of inline module-id literals.
+        { path: '*', element: <UnmatchedRoute /> },
+      ],
+    },
+  ]);
+}

--- a/pillars/shell/src/lib/registry-snapshot-fetch.test.ts
+++ b/pillars/shell/src/lib/registry-snapshot-fetch.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared registry-snapshot fetcher tests (P7-T03).
+ *
+ * Pins the canonical URL, the `{ pillars }` parse, and the soft-fail-to-`[]`
+ * contract every consumer (Settings UI, boot install-set) relies on.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchRegistrySnapshot,
+  normaliseSnapshotEntry,
+  parseSnapshotBody,
+  REGISTRY_SNAPSHOT_URL,
+} from './registry-snapshot-fetch';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+function manifestPayload(pillar: string, extra: Partial<ManifestPayload> = {}): ManifestPayload {
+  return {
+    pillar,
+    version: '1.0.0',
+    contract: { package: `@pops/${pillar}`, version: '1.0.0', tag: `contract-${pillar}@v1.0.0` },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...extra,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const validWireEntry = {
+  pillarId: 'finance',
+  baseUrl: 'http://finance-api:3001',
+  manifest: manifestPayload('finance'),
+  lastHeartbeatAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('REGISTRY_SNAPSHOT_URL', () => {
+  it('is the canonical /registry-api route', () => {
+    expect(REGISTRY_SNAPSHOT_URL).toBe('/registry-api/registry/pillars');
+  });
+});
+
+describe('fetchRegistrySnapshot', () => {
+  it('GETs the canonical snapshot URL', async () => {
+    const fetchStub = vi.fn<typeof fetch>(() => Promise.resolve(jsonResponse({ pillars: [] })));
+    await fetchRegistrySnapshot({ fetch: fetchStub });
+    expect(fetchStub.mock.calls[0]?.[0]).toBe('/registry-api/registry/pillars');
+  });
+
+  it('parses registered entries from a well-formed snapshot', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({ pillars: [validWireEntry] })));
+    const result = await fetchRegistrySnapshot({ fetch: fetchStub });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.pillarId).toBe('finance');
+    expect(result[0]?.registered).toBe(true);
+  });
+
+  it('soft-fails to [] on a rejected fetch', async () => {
+    const fetchStub = vi.fn(() => Promise.reject(new Error('down')));
+    expect(await fetchRegistrySnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+
+  it('soft-fails to [] on a non-OK status', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({}, 502)));
+    expect(await fetchRegistrySnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+
+  it('soft-fails to [] on a malformed body', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({ not: 'pillars' })));
+    expect(await fetchRegistrySnapshot({ fetch: fetchStub })).toEqual([]);
+  });
+});
+
+describe('parseSnapshotBody / normaliseSnapshotEntry', () => {
+  it('drops an entry with a non-string pillarId', () => {
+    expect(normaliseSnapshotEntry({ ...validWireEntry, pillarId: 42 })).toBeNull();
+  });
+
+  it('drops an entry whose manifest fails schema validation', () => {
+    expect(normaliseSnapshotEntry({ ...validWireEntry, manifest: { pillar: 'x' } })).toBeNull();
+  });
+
+  it('keeps well-formed entries and drops malformed ones from a mixed list', () => {
+    const out = parseSnapshotBody({
+      pillars: [validWireEntry, { pillarId: 7 }, { ...validWireEntry, pillarId: 'media' }],
+    });
+    expect(out.map((p) => p.pillarId)).toEqual(['finance', 'media']);
+  });
+});

--- a/pillars/shell/src/lib/registry-snapshot-fetch.ts
+++ b/pillars/shell/src/lib/registry-snapshot-fetch.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared browser-side fetcher for the live registry snapshot
+ * (`GET /registry-api/registry/pillars`).
+ *
+ * The full snapshot carries each pillar's `manifest` (nav / pages /
+ * assetsBaseUrl / settings) plus its live `capabilities` and registration
+ * status. Two shell consumers read it:
+ *
+ *   - the admin Settings UI (`settings-snapshot.ts`), to route per-pillar
+ *     settings reads/writes to the owning pillar;
+ *   - the boot install-set resolver (`boot-snapshot.ts`), to decide which
+ *     pillars the shell mounts (federation north-star: the registry is the
+ *     source of truth, not the build-time `MODULES` constant).
+ *
+ * Both share this single fetch + parse so the shell has exactly one registry
+ * client. The minimal `GET /pillars` boot projection only carries
+ * `{ id, baseUrl }` and cannot drive either consumer; this reads the full
+ * snapshot. The URL prefers the canonical `/registry-api/...` nginx route
+ * (the legacy `/core-api/...` alias proxies to the same upstream).
+ *
+ * Failures are soft: a fetch error, timeout, non-OK status, wrong shape, or
+ * empty list yields `[]`, so each consumer degrades to its own fallback
+ * (the Settings page to an empty state; boot to the static bundle-map floor)
+ * rather than throwing.
+ */
+import { ManifestPayloadSchema } from '@pops/pillar-sdk';
+
+import type { CapabilityStatuses, PillarSnapshot } from '@pops/pillar-sdk';
+
+/** Canonical nginx route to the full registry snapshot. */
+export const REGISTRY_SNAPSHOT_URL = '/registry-api/registry/pillars';
+
+/** Default per-fetch timeout. The registry is LAN-local (normally <100ms). */
+export const DEFAULT_SNAPSHOT_TIMEOUT_MS = 3000;
+
+export interface RegistrySnapshotFetchOptions {
+  /** Override the global `fetch` (tests inject a stub). */
+  readonly fetch?: typeof fetch;
+  /** Per-fetch timeout in milliseconds. Defaults to {@link DEFAULT_SNAPSHOT_TIMEOUT_MS}. */
+  readonly timeoutMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseCapabilities(value: unknown): CapabilityStatuses | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: CapabilityStatuses = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'boolean') out[key] = raw;
+  }
+  return out;
+}
+
+/**
+ * Normalise one raw registry-snapshot entry into a `PillarSnapshot`. Returns
+ * `null` when the entry lacks a usable `pillarId` or a well-formed manifest —
+ * an entry no consumer can reason about is dropped rather than half-read.
+ *
+ * Listed entries are treated as `registered: true`: the snapshot only carries
+ * live registrations.
+ */
+export function normaliseSnapshotEntry(entry: unknown): PillarSnapshot | null {
+  if (!isRecord(entry)) return null;
+  const pillarId = entry['pillarId'];
+  const baseUrl = entry['baseUrl'];
+  if (typeof pillarId !== 'string' || typeof baseUrl !== 'string') return null;
+
+  const manifest = ManifestPayloadSchema.safeParse(entry['manifest']);
+  if (!manifest.success) return null;
+
+  const capabilities = parseCapabilities(entry['capabilities']);
+  const lastSeenRaw = entry['lastHeartbeatAt'];
+  const lastSeenAt = typeof lastSeenRaw === 'string' ? new Date(lastSeenRaw) : new Date(0);
+
+  return {
+    pillarId,
+    baseUrl,
+    manifest: manifest.data,
+    registered: true,
+    lastSeenAt,
+    ...(capabilities !== undefined ? { capabilities } : {}),
+  };
+}
+
+/** Parse the `{ pillars }` snapshot body, dropping unusable entries. */
+export function parseSnapshotBody(body: unknown): readonly PillarSnapshot[] {
+  if (!isRecord(body)) return [];
+  const pillars = body['pillars'];
+  if (!Array.isArray(pillars)) return [];
+  const out: PillarSnapshot[] = [];
+  for (const entry of pillars) {
+    const normalised = normaliseSnapshotEntry(entry);
+    if (normalised !== null) out.push(normalised);
+  }
+  return out;
+}
+
+/**
+ * Fetch the live registry snapshot and normalise it to `PillarSnapshot[]`.
+ * Returns `[]` on any failure (network error, timeout, non-OK status, wrong
+ * shape, empty list) so callers degrade to their own fallback rather than
+ * throwing.
+ */
+export async function fetchRegistrySnapshot(
+  options: RegistrySnapshotFetchOptions = {}
+): Promise<readonly PillarSnapshot[]> {
+  const fetchImpl = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SNAPSHOT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort('timeout'), timeoutMs);
+  try {
+    const response = await fetchImpl(REGISTRY_SNAPSHOT_URL, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+    return parseSnapshotBody((await response.json()) as unknown);
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/pillars/shell/src/lib/settings-snapshot.ts
+++ b/pillars/shell/src/lib/settings-snapshot.ts
@@ -9,17 +9,18 @@
  * AND its live `capabilities`) and normalises it into the `PillarSnapshot[]`
  * shape `discoverSettings` consumes.
  *
- * The minimal `GET /pillars` boot projection only carries `{ id, baseUrl }`, so
- * it cannot drive settings discovery; this reads the full snapshot at
- * `GET /core-api/registry/pillars` (proxied to core's `/registry/pillars`),
- * which is the same wire `@pops/pillar-sdk`'s discovery transport reads.
+ * Parsing/normalisation is shared with the boot install-set resolver via
+ * `./registry-snapshot-fetch` so the shell has exactly one registry client.
+ * This helper keeps the legacy `/core-api/registry/pillars` URL (an nginx
+ * alias proxying to the same registry-api upstream as the canonical
+ * `/registry-api/...` route) for wire-compat with deployed Settings bundles.
  *
  * Failures are soft: a fetch error, wrong shape, or empty list yields `[]`, so
  * the page falls back to its empty state rather than throwing.
  */
-import { ManifestPayloadSchema } from '@pops/pillar-sdk';
+import { parseSnapshotBody } from './registry-snapshot-fetch';
 
-import type { CapabilityStatuses, PillarSnapshot } from '@pops/pillar-sdk';
+import type { PillarSnapshot } from '@pops/pillar-sdk';
 
 const SNAPSHOT_URL = '/core-api/registry/pillars';
 const DEFAULT_TIMEOUT_MS = 3000;
@@ -29,64 +30,6 @@ export interface SettingsSnapshotOptions {
   readonly fetch?: typeof fetch;
   /** Per-fetch timeout in milliseconds. Defaults to 3000. */
   readonly timeoutMs?: number;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function parseCapabilities(value: unknown): CapabilityStatuses | undefined {
-  if (!isRecord(value)) return undefined;
-  const out: CapabilityStatuses = {};
-  for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw === 'boolean') out[key] = raw;
-  }
-  return out;
-}
-
-/**
- * Normalise one raw registry-snapshot entry into a `PillarSnapshot`. Returns
- * `null` when the entry lacks a usable `pillarId` or a well-formed manifest —
- * an entry the settings UI cannot reason about is dropped rather than half-read.
- *
- * Listed entries are treated as `registered: true`: the snapshot only carries
- * live registrations, and the capability gate (not the discovery `registered`
- * flag) decides whether a section's writes route to the pillar or fall back to
- * core.
- */
-function normaliseEntry(entry: unknown): PillarSnapshot | null {
-  if (!isRecord(entry)) return null;
-  const pillarId = entry['pillarId'];
-  const baseUrl = entry['baseUrl'];
-  if (typeof pillarId !== 'string' || typeof baseUrl !== 'string') return null;
-
-  const manifest = ManifestPayloadSchema.safeParse(entry['manifest']);
-  if (!manifest.success) return null;
-
-  const capabilities = parseCapabilities(entry['capabilities']);
-  const lastSeenRaw = entry['lastHeartbeatAt'];
-  const lastSeenAt = typeof lastSeenRaw === 'string' ? new Date(lastSeenRaw) : new Date(0);
-
-  return {
-    pillarId,
-    baseUrl,
-    manifest: manifest.data,
-    registered: true,
-    lastSeenAt,
-    ...(capabilities !== undefined ? { capabilities } : {}),
-  };
-}
-
-function parseSnapshotBody(body: unknown): readonly PillarSnapshot[] {
-  if (!isRecord(body)) return [];
-  const pillars = body['pillars'];
-  if (!Array.isArray(pillars)) return [];
-  const out: PillarSnapshot[] = [];
-  for (const entry of pillars) {
-    const normalised = normaliseEntry(entry);
-    if (normalised !== null) out.push(normalised);
-  }
-  return out;
 }
 
 /**

--- a/pillars/shell/src/main.tsx
+++ b/pillars/shell/src/main.tsx
@@ -4,8 +4,12 @@ import './i18n';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { ErrorBoundary } from '@pops/ui';
+
 import { App } from './app/App';
-import { fetchBootRegistry } from './app/boot-snapshot';
+import { fetchBootRegistry, resolveBootRegistry } from './app/boot-snapshot';
+
+import type { BootRegistry } from './app/boot-snapshot';
 
 const root = document.querySelector('#root');
 if (!root) throw new Error('Root element not found');
@@ -33,22 +37,39 @@ function BootSplash() {
 reactRoot.render(<BootSplash />);
 
 /**
+ * Mount the shell on a resolved install set, wrapped in an `<ErrorBoundary>`
+ * so a render-time crash in the app tree degrades to a fallback frame instead
+ * of a blank page. This makes the never-brick guarantee STRUCTURAL — it does
+ * not depend on `fetchBootRegistry` happening to be total.
+ */
+function mount(bootRegistry: BootRegistry): void {
+  reactRoot.render(
+    <StrictMode>
+      <ErrorBoundary>
+        <App bootRegistry={bootRegistry} />
+      </ErrorBoundary>
+    </StrictMode>
+  );
+}
+
+/**
  * Boot the shell behind an async boundary (P7-T03 / RD-3): resolve the live
  * registry snapshot into the install set BEFORE building the router and
  * mounting the app, so the registry — not the build-time `MODULES` constant —
  * decides which pillars mount.
  *
- * `fetchBootRegistry` never throws: an unreachable / slow / empty registry
- * resolves to the static bundle-map floor (the in-repo app set), so the shell
- * always mounts a usable app surface — it never bricks on a registry outage.
+ * `fetchBootRegistry` never throws by contract: an unreachable / slow / empty
+ * registry resolves to the static bundle-map floor (the in-repo app set), so
+ * the shell always mounts a usable app surface. The `.catch` below is the
+ * structural backstop: should resolution ever throw despite that contract
+ * (e.g. a future regression), we still mount the static floor rather than
+ * leaving the splash up forever — the shell never bricks on a registry outage.
  */
-async function bootstrap(): Promise<void> {
-  const bootRegistry = await fetchBootRegistry();
-  reactRoot.render(
-    <StrictMode>
-      <App bootRegistry={bootRegistry} />
-    </StrictMode>
-  );
+function bootstrap(): Promise<void> {
+  return fetchBootRegistry().then(mount);
 }
 
-void bootstrap();
+void bootstrap().catch((error: unknown) => {
+  console.error('[shell] boot registry resolution failed; mounting static floor', error);
+  mount(resolveBootRegistry([]));
+});

--- a/pillars/shell/src/main.tsx
+++ b/pillars/shell/src/main.tsx
@@ -5,12 +5,50 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './app/App';
+import { fetchBootRegistry } from './app/boot-snapshot';
 
 const root = document.querySelector('#root');
 if (!root) throw new Error('Root element not found');
 
-createRoot(root).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+const reactRoot = createRoot(root);
+
+/**
+ * Minimal, unbranded splash shown while the boot snapshot resolves (P7-T03).
+ * The registry is LAN-local so this is normally sub-100ms; it exists so a slow
+ * registry shows a loading state rather than a blank frame, and never blocks
+ * rendering for longer than the fetch timeout.
+ */
+function BootSplash() {
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center text-muted-foreground"
+      role="status"
+      aria-live="polite"
+    >
+      Loading…
+    </div>
+  );
+}
+
+reactRoot.render(<BootSplash />);
+
+/**
+ * Boot the shell behind an async boundary (P7-T03 / RD-3): resolve the live
+ * registry snapshot into the install set BEFORE building the router and
+ * mounting the app, so the registry — not the build-time `MODULES` constant —
+ * decides which pillars mount.
+ *
+ * `fetchBootRegistry` never throws: an unreachable / slow / empty registry
+ * resolves to the static bundle-map floor (the in-repo app set), so the shell
+ * always mounts a usable app surface — it never bricks on a registry outage.
+ */
+async function bootstrap(): Promise<void> {
+  const bootRegistry = await fetchBootRegistry();
+  reactRoot.render(
+    <StrictMode>
+      <App bootRegistry={bootRegistry} />
+    </StrictMode>
+  );
+}
+
+void bootstrap();

--- a/pillars/shell/vite.config.ts
+++ b/pillars/shell/vite.config.ts
@@ -72,6 +72,19 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (urlPath: string) => urlPath.replace(/^\/core-api/, ''),
       },
+      // Boot install-set resolver (P7-T03 / RD-3): the shell fetches the full
+      // registry snapshot from `GET /registry-api/registry/pillars` before
+      // first render. The canonical nginx route is `/registry-api/...`; in
+      // dev it shares the registry pillar's upstream with `/core-api` (the
+      // pillar formerly named `core`, port 3001). Strip the prefix so the
+      // registry router sees its natural `/registry/pillars`. Without this
+      // proxy the dev boot fetch 404s and the shell silently falls through to
+      // the static floor — masking the registry-driven branch in dev.
+      '/registry-api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        rewrite: (urlPath: string) => urlPath.replace(/^\/registry-api/, ''),
+      },
       '/lists-api': {
         target: 'http://localhost:3006',
         changeOrigin: true,


### PR DESCRIPTION
## What

Re-points the shell's boot install-set from the build-time `MODULES`/`INSTALLED_MODULES` constants to the **live registry snapshot**, making the registry the source of truth for which pillars mount (federation north-star, RD-3). This is a boot-architecture change: the shell previously built its router + app-rail synchronously at module-eval time; this introduces the async boot boundary that did not exist before.

## How

- **Async boot boundary** — `main.tsx` now `await`s `fetchBootRegistry()` before `createRoot().render()`. While the fetch is in flight it renders a minimal unbranded splash; the router is built **after** the snapshot resolves.
- **`buildRouter(manifests)`** — `router.tsx` no longer exports a module-eval `router` constant; `App.tsx` builds it once (memoised) from the boot-resolved manifests.
- **`BootRegistryProvider`** — a sibling to `PillarStatusProvider`. The nav consumers (`AppRail`, `Sidebar`, `PageNav`, `RootLayout`, `IndexRedirect`) read `registeredApps` from `useRegisteredApps()` instead of the module-eval constant.
- **`boot-snapshot.ts`** — `resolveBootRegistry(snapshot)` maps the snapshot onto the install set; `walkRegistry` is reused **byte-for-byte unchanged**.
- **Single registry client** — the snapshot fetch + parse is shared between the Settings UI and boot via `registry-snapshot-fetch.ts` (no third client).

## Resilience contract (never brick)

- snapshot non-empty → the registry's `registered` entries **are** the install set (in-repo via the static bundle map, external pillars via the runtime loader, backend-only dropped — `walkRegistry`'s existing decision tree).
- snapshot empty / fetch failed / timed out → fall back to the **static bundle-map floor**, narrowed by the runtime install shim (`isInstalledModule`) so the build-time `POPS_APPS` contract still governs the offline path. The shell always renders its in-repo app set.

## Tests

- `registry-walk.test.ts` green and untouched (the pinned invariant; `walkRegistry` is byte-identical).
- `installed-modules.test.ts` rewritten off the stale `'reads from MODULES'` assertion; covers `bootEntries` / `staticFloorEntries` / `filterAppManifests`.
- `boot-snapshot.test.ts` (new) — resilience: fetch-ok (in-repo + external), fetch-fail, non-OK, empty, and timeout all assert the never-brick fallback.
- `registry-snapshot-fetch.test.ts` (new) — canonical URL + parse + soft-fail.
- shell typecheck + 605 unit tests + gen:nginx:check + build + dep-cruiser boundaries all green.

## Notes / drift from the plan

- The plan's RD-3 text said the snapshot type comes from `@pops/types`; the correct type is `PillarSnapshot` from `@pops/pillar-sdk` (the `@pops/types` shape is the minimal `{id,baseUrl}` projection). The full snapshot is fetched at `/registry-api/registry/pillars`.
- The fallback floor honours `isInstalledModule` (not the raw bundle map): removing it would break the pinned finance-only install-set e2e, whose narrowing rides the build-time `POPS_APPS` contract and has no live registry in the e2e environment. `MODULES` (the superset) is gone from the install-set path; the runtime install shim governs only the offline floor.
- RD-9 (`KnownPillarId`→`string`) is intentionally NOT done — it is gated after this.

---

## Fix round (adversarial review + orchestrator)

**M1 — never-brick zero-UI hole (closed).** `resolveBootRegistry` gated on `snapshot.length > 0`. A *non-empty* snapshot whose pillars are all backend-only (no bundle-map hit, no `assetsBaseUrl`) — the live state mid-deploy on a host restart, before app pillars re-register — resolved to `manifests=[]`/`registeredApps=[]` with `source='registry'`, never consulting the floor: an app-less shell, reachable on a real capivara restart. Fixed: the resolver now falls back to the static floor when a live snapshot resolves to **zero mountable UI** (not just zero array length), degrading exactly as if the registry were unreachable. New test feeds an all-backend-only (`registry`+`orchestrator`) snapshot and asserts `source==='static-floor'` + the full in-repo rail.

**M2 — online-path coverage.**
- **(a)** `boot-online-render.test.tsx` drives the real online pipeline (stubbed `fetch` → `fetchBootRegistry` → `BootRegistryProvider` → a rail consumer) on a non-empty snapshot with an in-repo + an external pillar, asserting `source==='registry'` and a non-blank rendered rail (both pillars, external nav synthesized). It runs in the **unit/fe-quality CI gate that actually executes on PRs**.
- **(b) — honest gap.** The Playwright e2e suite (`fe-test-e2e.yml`) is `workflow_dispatch`-only: it was written against the deleted `apps/pops-api` tRPC monolith and cannot pass without a full REST rewrite, so **nothing in it runs in PR CI**. Adding a `/registry-api` route-stub spec there would be dead coverage — it would never guard against the prod-only regression M2 describes. The real guard is therefore the rendered jsdom test in (a). What *was* wired for the online path: a `/registry-api` dev proxy in `vite.config.ts` so the dev boot fetch reaches the registry pillar instead of 404ing into the floor. **Follow-up:** when the e2e suite is rewritten against the REST stack (`TODO(e2e-rest-rewrite)`), add a Playwright `route`/MSW stub spec serving a non-empty snapshot fixture and assert the registry-driven rail mounts.

**Folds.** `main.tsx`: `bootstrap().catch(...)` now mounts the static floor if resolution ever throws, and `<App>` is wrapped in an `ErrorBoundary` — never-brick is structural, not reliant on `fetchBootRegistry` being total. `railBundleMap`: `synthesizeExternalBundleEntry` wrapped in the same `try/catch` the router-side `resolveExternalManifest` uses, so a bad external descriptor can't throw out of boot resolution on the rail path (symmetric with the walk path).

**IndexRedirect.** The optimistic landing target now derives from the first **live** app (`registeredApps[0]`) instead of a `/finance` literal, so a finance-less registry doesn't flash `NotInstalledPage`. The `data`-present `/settings` path (operator excluded every live app via `POPS_APPS`) is unchanged. New tests cover a finance-less rail landing on `/media`.

**Known limitation (acknowledged, not changing now).** The router is built once per session (immutable, `useMemo` on the boot-resolved manifests). For a LAN boot-once shell that is acceptable; a mid-session router rebuild on registry change is out of scope.

**Local CI to green before push.** Build graph warmed (`mise run build`), then: shell typecheck clean, full shell suite **612 tests pass**, oxfmt `--check` clean, oxlint exit 0 (pre-existing warnings only), `gen:nginx:check` up to date, shell `build` ok, dep-cruiser boundaries — no new violations (82 known, unchanged), root `tsc -b --noEmit` (pre-push gate) clean. `walkRegistry` byte-identical; `registry-walk.test.ts` untouched + green.
