### PR TITLE
fix(shell): repair relocation-stale import in e2e snapshot generator

### DIFF
--- a/pillars/shell/scripts/build-registry-snapshot.ts
+++ b/pillars/shell/scripts/build-registry-snapshot.ts
@@ -37,13 +37,13 @@ import { dirname, resolve } from 'node:path';
 import {
   ALWAYS_INSTALLED_IDS,
   discoverManifestSources,
-} from '../../../packages/module-registry/scripts/known-modules.ts';
+} from '../../../libs/module-registry/scripts/known-modules.ts';
 import {
   project,
   resolveInstalledIds,
   validateManifests,
   type SerialisableModule,
-} from '../../../packages/module-registry/scripts/lib.ts';
+} from '../../../libs/module-registry/scripts/lib.ts';
 
 function renderSnapshot(
   projected: readonly SerialisableModule[],


### PR DESCRIPTION
## Problem

`pillars/shell/scripts/build-registry-snapshot.ts` imported `known-modules.ts`+`lib.ts` from `../../../packages/module-registry/scripts/` — but the P2 relocation moved module-registry to `libs/`. The broken import slipped past PR CI because the script runs only in the `workflow_dispatch`-only Playwright e2e suite (`playwright.config.ts` finance-only project), so a dangling `packages/` reference survived the relocation.

## Fix

Repointed both imports to `libs/module-registry/scripts/`. Verified end-to-end: `tsx scripts/build-registry-snapshot.ts /tmp/out.js` now resolves the imports and emits a valid 9-module snapshot (previously `ERR_MODULE_NOT_FOUND`).

Completes the 'packages/ gone' relocation criterion.