### PR TITLE
refactor(sdk): widen KnownPillarId/ModuleId to string [P7-T07/RD-9]

### DIFF
--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pops/module-registry": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "^5.101.0",

--- a/libs/navigation/src/search-input/installed-module.test.ts
+++ b/libs/navigation/src/search-input/installed-module.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { KNOWN_MODULES } from '@pops/module-registry';
+
 /**
  * Frontend module-install filter tests (PRD-101 US-06).
  *
@@ -7,9 +9,13 @@ import { describe, expect, it } from 'vitest';
  * whose owning module isn't part of the build's installed set. The backend
  * engine is the primary filter; this hook prevents stale or
  * misconfigured payloads from rendering links into uninstalled apps.
+ *
+ * RD-9 re-homed the filter off the SDK's frozen `ALL_MODULE_IDS` onto
+ * `@pops/module-registry`'s runtime install set, so these assertions check
+ * membership of `KNOWN_MODULES` (the disk-discovered superset) rather than the
+ * retired SDK tuple. With env unset (the test default) the install set is
+ * `KNOWN_MODULES` verbatim.
  */
-import { ALL_MODULE_IDS } from '@pops/pillar-sdk';
-
 import { isInstalledModule } from './installed-module';
 
 describe('isInstalledModule', () => {
@@ -17,8 +23,8 @@ describe('isInstalledModule', () => {
     expect(isInstalledModule('registry')).toBe(true);
   });
 
-  it('returns true for every id in the canonical ALL_MODULE_IDS set', () => {
-    for (const id of ALL_MODULE_IDS) {
+  it('returns true for every id in the build install set (KNOWN_MODULES)', () => {
+    for (const id of KNOWN_MODULES) {
       expect(isInstalledModule(id)).toBe(true);
     }
   });
@@ -27,5 +33,12 @@ describe('isInstalledModule', () => {
     expect(isInstalledModule('nonexistent-module')).toBe(false);
     expect(isInstalledModule('')).toBe(false);
     expect(isInstalledModule('Finance')).toBe(false); // case-sensitive
+  });
+
+  it('returns false for contacts — a Rust pillar with no installed frontend/search surface', () => {
+    // `contacts` is in the SDK's old ALL_MODULE_IDS but NOT in KNOWN_MODULES
+    // (no TS manifest), so it has no search adapter the shell could mount. The
+    // re-homed filter correctly rejects a stray `contacts` section.
+    expect(isInstalledModule('contacts')).toBe(false);
   });
 });

--- a/libs/navigation/src/search-input/installed-module.ts
+++ b/libs/navigation/src/search-input/installed-module.ts
@@ -6,16 +6,22 @@
  * absent. This helper repeats the check on the frontend so an out-of-sync
  * build, a stale cache, or a future code path that bypasses the engine still
  * can't render results that link into a module the shell doesn't mount.
+ *
+ * RD-9 (POPS federation) re-homed this off the SDK's frozen `isModuleId`
+ * (which the type-widening turned into an always-true guard) onto
+ * `@pops/module-registry`'s runtime install-set check. That set is
+ * disk-discovered and `POPS_APPS`-gated, so the filter still rejects sections
+ * for modules absent from this deploy — the semantic the SDK guard could no
+ * longer carry once `ModuleId` became `string`.
  */
-import { isModuleId } from '@pops/pillar-sdk';
+import { isInstalledModule as isInstalledModuleId } from '@pops/module-registry';
 
 /**
- * `registry` (formerly `core`) is the always-mounted platform module
- * (PRD-100). `isModuleId` checks membership of the static `ALL_MODULE_IDS`
- * superset (pillars plus the two transitional sub-modules `ai`/`ego`), so
- * `registry` is already covered; the explicit branch is kept for clarity at
- * the call boundary.
+ * True when `moduleId` is in the build's runtime install set. `registry`
+ * (formerly `core`) is the always-mounted platform module (PRD-100) and is
+ * covered by the registry's `ALWAYS_INSTALLED` floor, so no explicit branch
+ * is needed here.
  */
 export function isInstalledModule(moduleId: string): boolean {
-  return moduleId === 'registry' || isModuleId(moduleId);
+  return isInstalledModuleId(moduleId);
 }

--- a/libs/sdk/src/capabilities/__tests__/modules.test.ts
+++ b/libs/sdk/src/capabilities/__tests__/modules.test.ts
@@ -1,49 +1,16 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { PILLARS, type KnownPillarId } from '../known-pillar-id.js';
-import {
-  ALL_MODULE_IDS,
-  MODULE_PARENT_PILLAR,
-  isKnownPillarId,
-  isModuleId,
-  type ModuleId,
-} from '../module-id.js';
-
-describe('ALL_MODULE_IDS', () => {
-  it('is a superset of PILLARS plus the transitional ego id', () => {
-    // `ai` is now a first-class pillar (PRD-055), so it lives in PILLARS; only
-    // `ego` remains a transitional sub-module id beyond the pillar set.
-    expect(ALL_MODULE_IDS).toHaveLength(PILLARS.length + 1);
-    for (const pillar of PILLARS) {
-      expect(ALL_MODULE_IDS).toContain(pillar);
-    }
-    expect(ALL_MODULE_IDS).toContain('ai');
-    expect(ALL_MODULE_IDS).toContain('ego');
-  });
-
-  it('includes contacts (the first Rust pillar)', () => {
-    expect(ALL_MODULE_IDS).toContain('contacts');
-    expect(MODULE_PARENT_PILLAR.contacts).toBe('contacts');
-  });
-
-  it('contains no duplicates', () => {
-    const unique = new Set<string>(ALL_MODULE_IDS);
-    expect(unique.size).toBe(ALL_MODULE_IDS.length);
-  });
-
-  it('typed as readonly tuple narrowing to ModuleId', () => {
-    expectTypeOf<(typeof ALL_MODULE_IDS)[number]>().toEqualTypeOf<ModuleId>();
-  });
-});
+import { type KnownPillarId, type PillarId, PILLARS } from '../known-pillar-id.js';
+import { isKnownPillarId, type ModuleId } from '../module-id.js';
 
 describe('isKnownPillarId', () => {
-  it('returns true for every entry in PILLARS', () => {
+  it('returns true for every entry in the curated PILLARS value', () => {
     for (const pillar of PILLARS) {
       expect(isKnownPillarId(pillar)).toBe(true);
     }
   });
 
-  it('returns true for ai (now a first-class pillar) and false for the transitional ego id', () => {
+  it('returns true for ai (now a first-class pillar) and false for the transitional ego sub-module', () => {
     expect(isKnownPillarId('ai')).toBe(true);
     expect(isKnownPillarId('ego')).toBe(false);
   });
@@ -54,6 +21,13 @@ describe('isKnownPillarId', () => {
     expect(isKnownPillarId('CORE')).toBe(false);
   });
 
+  it('returns false for a hypothetical not-yet-curated pillar id', () => {
+    // RD-9: a pillar the build has never heard of is NOT in the curated
+    // PILLARS value, so the runtime seam still rejects it — even though it is
+    // a valid `KnownPillarId` at the type level (see the type test below).
+    expect(isKnownPillarId('weather')).toBe(false);
+  });
+
   it('narrows the input to KnownPillarId when true', () => {
     const value: string = 'finance';
     if (isKnownPillarId(value)) {
@@ -62,52 +36,23 @@ describe('isKnownPillarId', () => {
   });
 });
 
-describe('isModuleId', () => {
-  it('returns true for every pillar', () => {
-    for (const pillar of PILLARS) {
-      expect(isModuleId(pillar)).toBe(true);
-    }
+describe('KnownPillarId / ModuleId are open (RD-9)', () => {
+  it('KnownPillarId resolves to string, not a closed literal union', () => {
+    expectTypeOf<KnownPillarId>().toEqualTypeOf<string>();
+    expectTypeOf<KnownPillarId>().toEqualTypeOf<PillarId>();
   });
 
-  it('returns true for ai and the transitional ego id', () => {
-    expect(isModuleId('ai')).toBe(true);
-    expect(isModuleId('ego')).toBe(true);
+  it('ModuleId resolves to string, not a closed literal union', () => {
+    expectTypeOf<ModuleId>().toEqualTypeOf<string>();
   });
 
-  it('returns false for unrelated strings', () => {
-    expect(isModuleId('')).toBe(false);
-    expect(isModuleId('shopping')).toBe(false);
-    expect(isModuleId('Core')).toBe(false);
-  });
-
-  it('narrows the input to ModuleId when true', () => {
-    const value: string = 'ai';
-    if (isModuleId(value)) {
-      expectTypeOf(value).toEqualTypeOf<ModuleId>();
-    }
-  });
-});
-
-describe('MODULE_PARENT_PILLAR', () => {
-  it('maps every pillar to itself', () => {
-    for (const pillar of PILLARS) {
-      expect(MODULE_PARENT_PILLAR[pillar]).toBe(pillar);
-    }
-  });
-
-  it('maps ai to itself (first-class pillar, PRD-055) and ego to cerebrum per ADR-026', () => {
-    expect(MODULE_PARENT_PILLAR.ai).toBe('ai');
-    expect(MODULE_PARENT_PILLAR.ego).toBe('cerebrum');
-  });
-
-  it('has an entry for every ModuleId', () => {
-    for (const id of ALL_MODULE_IDS) {
-      expect(MODULE_PARENT_PILLAR[id]).toBeDefined();
-      expect(isKnownPillarId(MODULE_PARENT_PILLAR[id])).toBe(true);
-    }
-  });
-
-  it('value type is exactly KnownPillarId', () => {
-    expectTypeOf(MODULE_PARENT_PILLAR).toEqualTypeOf<Record<ModuleId, KnownPillarId>>();
+  it('a hypothetical new pillar / module id is assignable with NO type edit', () => {
+    // The whole point of RD-9: adding `pillars/weather/` requires no edit to
+    // the SDK type — its id is already a valid KnownPillarId / ModuleId. If
+    // either of these stopped compiling, the union closed back up.
+    const newPillar: KnownPillarId = 'weather';
+    const newModule: ModuleId = 'weather-overlay';
+    expect(newPillar).toBe('weather');
+    expect(newModule).toBe('weather-overlay');
   });
 });

--- a/libs/sdk/src/capabilities/__tests__/projections.test.ts
+++ b/libs/sdk/src/capabilities/__tests__/projections.test.ts
@@ -183,10 +183,14 @@ describe('CallResult discriminant', () => {
 });
 
 describe('KnownPillarId', () => {
-  it('covers every entry in PILLARS', () => {
-    expectTypeOf<KnownPillarId>().toEqualTypeOf<
-      'registry' | 'finance' | 'media' | 'inventory' | 'cerebrum' | 'food' | 'lists' | 'contacts'
-    >();
+  it('is the open string tier after RD-9 (no closed literal union)', () => {
+    // RD-9 widened the formerly-closed compile-time tier to `string`, so any
+    // arbitrary id — including one the build has never compiled against — is a
+    // valid `KnownPillarId`. The runtime curated set lives in the `PILLARS`
+    // value, gated by `isKnownPillarId`, not in this type.
+    expectTypeOf<KnownPillarId>().toEqualTypeOf<string>();
+    const arbitrary: KnownPillarId = 'a-pillar-the-build-has-never-heard-of';
+    expectTypeOf(arbitrary).toEqualTypeOf<string>();
   });
 
   it('PILLARS is a readonly tuple at the value level', () => {
@@ -200,6 +204,7 @@ describe('KnownPillarId', () => {
         'food',
         'lists',
         'contacts',
+        'ai',
       ]
     >();
   });

--- a/libs/sdk/src/capabilities/index.ts
+++ b/libs/sdk/src/capabilities/index.ts
@@ -30,4 +30,4 @@ export type { CallablePillar } from './callable-pillar.js';
 export type { KnownPillarId, PillarId } from './known-pillar-id.js';
 export { PILLARS } from './known-pillar-id.js';
 export type { ModuleId } from './module-id.js';
-export { ALL_MODULE_IDS, MODULE_PARENT_PILLAR, isKnownPillarId, isModuleId } from './module-id.js';
+export { isKnownPillarId } from './module-id.js';

--- a/libs/sdk/src/capabilities/known-pillar-id.ts
+++ b/libs/sdk/src/capabilities/known-pillar-id.ts
@@ -1,11 +1,15 @@
 /**
- * Canonical list of pillar ids known to the SDK.
+ * Curated runtime list of the pillar ids that ship in this tree.
  *
- * The long-term home for this list is PRD-156's import discipline rule —
- * once that lands the constant will be re-sourced from there and this file
- * becomes a re-export. Keeping the list local in the interim lets PRD-160
- * ship its `KnownPillarId` projection without taking a build-time dependency
- * on a not-yet-shipped sibling PRD.
+ * This is a *value*, not the source of a closed type. It is the canonical
+ * "pillars baked into this build" list that runtime code legitimately needs:
+ * the nginx generator's coverage assert (`assertRenderOrderCoversAllPillars`)
+ * and the `isKnownPillarId` narrowing guard both check membership against it.
+ * Adding a pillar to the tree means adding a string here so those runtime
+ * surfaces stay in sync — but it is no longer a *type* edit (see
+ * `KnownPillarId` below): a pillar the build has never heard of is a valid
+ * `KnownPillarId` at compile time, and `isKnownPillarId` is the runtime seam
+ * that tells the curated set apart from an arbitrary registry id.
  *
  * The set started from the seven pillars ADR-026 carves the platform into;
  * `contacts` (the first Rust pillar) extends it as the canonical entities
@@ -14,8 +18,6 @@
  * budgets, alerts, the cross-pillar telemetry ingest) out of it.
  * The `registry` pillar (formerly `core`) is the platform registry /
  * discovery / settings host.
- * Adding a new pillar = add a string here → every consumer that types a
- * pillar id against `KnownPillarId` updates at compile time.
  */
 export const PILLARS = [
   'registry',
@@ -30,37 +32,33 @@ export const PILLARS = [
 ] as const;
 
 /**
- * Closed union over the in-tree pillars (build-time tier).
- *
- * Use `KnownPillarId` where a missing entry *should* fail the build: the
- * nginx upstream map (`Record<KnownPillarId, …>`), `MODULE_PARENT_PILLAR`,
- * and the typed `pillar<P extends KnownPillarId>()` projection (PRD-160).
- * Adding a `pillars/<x>/` without wiring it here becomes a compile error —
- * that guard rail is deliberate and stays.
- */
-export type KnownPillarId = (typeof PILLARS)[number];
-
-/**
- * Open pillar id (runtime tier) — a plain `string` alias, intentionally
- * *not* a brand, because registry/runtime ids are genuinely open and a
- * brand would force a cast at every registry boundary.
+ * Open pillar id — a plain `string` alias, intentionally *not* a brand,
+ * because registry/runtime ids are genuinely open and a brand would force a
+ * cast at every registry boundary.
  *
  * Use `PillarId` on every surface fed by the runtime registry: registry
  * snapshot entries, the nginx render's pillar set, routing/dispatch, and
  * the shell's nav/app-context. A pillar the build has never heard of
  * (a runtime/registry/LAN registration per PRD-228/PRD-242) is expressible
  * here without a compile error.
- *
- * The seam between the two tiers is the existing
- * `isKnownPillarId(id): id is KnownPillarId` guard — a real narrowing, not
- * an `as`-widening. Narrow a `PillarId` to `KnownPillarId` through that
- * guard wherever a closed-set operation (docker upstream lookup,
- * parent-pillar table) is required; the open path otherwise routes via the
- * registry `baseUrl`.
- *
- * Two-tier rule (PRD-256):
- * - **closed** `KnownPillarId` on `PILLAR_UPSTREAMS`, `MODULE_PARENT_PILLAR`,
- *   and the typed `pillar()` projection (PRD-160, unchanged);
- * - **open** `PillarId` on registry / routing / nav.
  */
 export type PillarId = string;
+
+/**
+ * Pillar id known to the SDK — now an alias of the open {@link PillarId}.
+ *
+ * RD-9 (POPS federation) collapsed the formerly-closed compile-time tier:
+ * `KnownPillarId` no longer derives from the {@link PILLARS} tuple, so adding
+ * a pillar to the tree (or registering one at runtime over the LAN) needs no
+ * type edit — the registry is the sole source of truth for which pillars
+ * exist. The two-tier *runtime* seam is unchanged: `isKnownPillarId(id)`
+ * narrows an arbitrary string by checking membership of the curated
+ * {@link PILLARS} value, which is still the right gate for build-time
+ * surfaces (the nginx upstream map, the render-order coverage assert) that
+ * must enumerate the in-tree pillars.
+ *
+ * Kept as a distinct name (rather than replacing every use with `PillarId`)
+ * so call sites that document "this should be a pillar the build curates"
+ * stay self-describing; both resolve to `string`.
+ */
+export type KnownPillarId = PillarId;

--- a/libs/sdk/src/capabilities/module-id.ts
+++ b/libs/sdk/src/capabilities/module-id.ts
@@ -1,87 +1,39 @@
 /**
- * Module-id projections — superset of `KnownPillarId` that includes the one
- * remaining transitional sub-module id the shell still routes on (`ego`).
+ * Module-id projection.
  *
- * Per ADR-026 the platform is carved into pillars: `core`, `finance`, `media`,
- * `inventory`, `cerebrum`, `food`, `lists`, `contacts`, and `ai` (a first-class
- * pillar as of PRD-055). Ego is a sub-system of `cerebrum` — it is NOT a pillar.
- * `@pops/module-registry`'s build-time `KNOWN_MODULES` still emits it as a
- * routable id because the shell, the settings UI, and a handful of cross-pillar
- * URI consumers have not yet folded it into its parent pillar.
+ * Historically this file carried a closed `ALL_MODULE_IDS` tuple and the
+ * `ModuleId` union derived from it (pillars + the transitional `ego`
+ * sub-module). RD-9 (POPS federation) widened the type tier to `string` so
+ * the registry is the sole source of truth for which modules exist; the
+ * frozen tuple, its `isModuleId` guard, and the `MODULE_PARENT_PILLAR` table
+ * were retired in the same pass.
  *
- * The `ego` entry here is transitional. Once the FE migration tracked under
- * PRD-218 completes and every routable surface dispatches on the parent pillar,
- * it drops out of the SDK and `ModuleId` collapses back into `KnownPillarId`.
+ * Runtime "is this a module the build curates?" checks live in
+ * `@pops/module-registry` (`KNOWN_MODULES` / `isInstalledModule`), which is
+ * disk-discovered and per-deploy gated. Parent-pillar dispatch lives in the
+ * shell's `pillarIdForModule` (`pillars/shell/src/app/pillars.ts`). The only
+ * surviving member here is `isKnownPillarId`, the narrowing seam against the
+ * curated `PILLARS` value.
  */
 
-import { PILLARS, type KnownPillarId } from './known-pillar-id.js';
+import { PILLARS, type KnownPillarId, type PillarId } from './known-pillar-id.js';
 
 /**
- * Canonical superset of routable module ids: every `KnownPillarId` (the
- * `PILLARS` set, including `contacts` and `ai`) plus the one remaining
- * transitional sub-module id (`ego`). The test in `__tests__/modules.test.ts`
- * pins this to `PILLARS + {ego}`.
+ * Routable module id — an alias of the open {@link PillarId}.
  *
- * This is deliberately NOT in lock-step with `@pops/module-registry`'s
- * build-time `KNOWN_MODULES`. That registry is manifest-driven — it only
- * lists pillars that ship a JS/TS contract with a `./manifest` export.
- * `contacts` is a Rust pillar with no such manifest yet, so it is a routable
- * pillar id here but absent from `KNOWN_MODULES` until it gains a TS manifest
- * in N1+.
+ * Was a closed union over `pillars + {ego}`; now `string`, so a module id the
+ * build has never compiled against (a runtime/registry/LAN registration) is
+ * expressible without a type edit. Membership in the build's curated set is a
+ * runtime question answered by `@pops/module-registry`.
  */
-export const ALL_MODULE_IDS = [
-  'ai',
-  'cerebrum',
-  'contacts',
-  'ego',
-  'finance',
-  'food',
-  'inventory',
-  'lists',
-  'media',
-  'registry',
-] as const;
+export type ModuleId = PillarId;
 
 /**
- * Union of every routable module id. Superset of `KnownPillarId` that adds
- * the two transitional sub-module ids (`ai`, `ego`).
- */
-export type ModuleId = (typeof ALL_MODULE_IDS)[number];
-
-/**
- * Runtime type guard narrowing an arbitrary string to `KnownPillarId`.
- * Use at the boundary of untyped inputs (URL params, env vars, untyped
- * tRPC inputs) before routing on the value.
+ * Runtime type guard narrowing an arbitrary string to `KnownPillarId` by
+ * membership of the curated {@link PILLARS} value. Use at the boundary of
+ * untyped inputs (URL params, env vars, untyped REST inputs) when a build-time
+ * surface needs to know whether the id is one of the in-tree pillars.
  */
 export function isKnownPillarId(id: string): id is KnownPillarId {
   return (PILLARS as readonly string[]).includes(id);
 }
-
-/**
- * Runtime type guard narrowing an arbitrary string to the `ModuleId`
- * superset (pillars + `ai` + `ego`).
- */
-export function isModuleId(id: string): id is ModuleId {
-  return (ALL_MODULE_IDS as readonly string[]).includes(id);
-}
-
-/**
- * Maps every `ModuleId` to its owning pillar. Pillars map to themselves
- * (`ai → ai` now that AI Ops is a first-class pillar per PRD-055);
- * `ego → cerebrum` per ADR-026.
- *
- * Used by routers and the shell to dispatch a sub-module id onto the
- * pillar that physically owns its contract.
- */
-export const MODULE_PARENT_PILLAR: Record<ModuleId, KnownPillarId> = {
-  ai: 'ai',
-  cerebrum: 'cerebrum',
-  contacts: 'contacts',
-  ego: 'cerebrum',
-  finance: 'finance',
-  food: 'food',
-  inventory: 'inventory',
-  lists: 'lists',
-  media: 'media',
-  registry: 'registry',
-};

--- a/pillars/shell/scripts/generate-nginx-conf.ts
+++ b/pillars/shell/scripts/generate-nginx-conf.ts
@@ -45,7 +45,7 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PILLARS, isKnownPillarId, type KnownPillarId, type PillarId } from '@pops/pillar-sdk';
+import { PILLARS, type PillarId } from '@pops/pillar-sdk';
 import {
   HttpDiscoveryTransport,
   type DiscoveredPillar,
@@ -59,14 +59,24 @@ import { NGINX_CONF_HEAD, NGINX_CONF_REST_INTRO, NGINX_CONF_TAIL } from './nginx
 import { DEFAULT_REGISTRY_URL, resolveRegistryUrl } from './registry-url-env.ts';
 
 /**
+ * In-tree pillar id, keyed off the curated `PILLARS` value (NOT the SDK's
+ * `KnownPillarId` type, which RD-9 widened to `string`). This local literal
+ * union is what `PILLAR_UPSTREAMS` is keyed on, so the exhaustiveness guard —
+ * "every curated pillar ships a port" — survives the type-widening: a new
+ * entry in `PILLARS` without a matching `PILLAR_UPSTREAMS` port still fails
+ * typecheck here.
+ */
+type BuildPillarId = (typeof PILLARS)[number];
+
+/**
  * Internal port assignment for each pillar's API container. Matches every
  * `proxy_pass` in the pre-generator hand-written `nginx.conf`.
  *
- * `Record<KnownPillarId, …>` forces every new pillar added to `PILLARS`
- * (in `@pops/pillar-sdk`) to ship a port here; missing entries fail
+ * `Record<BuildPillarId, …>` forces every pillar in the curated `PILLARS`
+ * value (in `@pops/pillar-sdk`) to ship a port here; missing entries fail
  * typecheck.
  */
-export const PILLAR_UPSTREAMS: Record<KnownPillarId, { host: string; port: number }> = {
+export const PILLAR_UPSTREAMS: Record<BuildPillarId, { host: string; port: number }> = {
   registry: { host: 'registry-api', port: 3001 },
   inventory: { host: 'inventory-api', port: 3002 },
   media: { host: 'media-api', port: 3003 },
@@ -78,12 +88,25 @@ export const PILLAR_UPSTREAMS: Record<KnownPillarId, { host: string; port: numbe
   contacts: { host: 'contacts-api', port: 3010 },
 };
 
+const PILLAR_UPSTREAMS_BY_ID: ReadonlyMap<string, { host: string; port: number }> = new Map(
+  Object.entries(PILLAR_UPSTREAMS)
+);
+
+/**
+ * Look up a curated pillar's canonical in-cluster upstream by raw id.
+ * Returns `undefined` for any id outside the curated `PILLARS` set — the
+ * dynamic path uses that to fall through to parsing the registry `baseUrl`.
+ */
+function knownUpstream(pillarId: string): { host: string; port: number } | undefined {
+  return PILLAR_UPSTREAMS_BY_ID.get(pillarId);
+}
+
 /**
  * Stable ordering for the rendered `/<id>-api/` blocks. Matches the
  * order PRD-190 shipped in the hand-written conf so the generator's
  * first run produces a byte-identical (modulo header comment) file.
  */
-export const PILLAR_RENDER_ORDER: readonly KnownPillarId[] = [
+export const PILLAR_RENDER_ORDER: readonly BuildPillarId[] = [
   'registry',
   'inventory',
   'media',
@@ -104,7 +127,7 @@ export interface PillarUpstream {
 }
 
 export function assertRenderOrderCoversAllPillars(): void {
-  const ordered = new Set<KnownPillarId>(PILLAR_RENDER_ORDER);
+  const ordered = new Set<string>(PILLAR_RENDER_ORDER);
   const missing = PILLARS.filter((id) => !ordered.has(id));
   if (missing.length > 0) {
     throw new Error(
@@ -112,9 +135,8 @@ export function assertRenderOrderCoversAllPillars(): void {
         `Add them to PILLAR_RENDER_ORDER (and PILLAR_UPSTREAMS) and re-run.`
     );
   }
-  const extra = PILLAR_RENDER_ORDER.filter(
-    (id) => !(PILLARS as readonly KnownPillarId[]).includes(id)
-  );
+  const curated = new Set<string>(PILLARS);
+  const extra = PILLAR_RENDER_ORDER.filter((id) => !curated.has(id));
   if (extra.length > 0) {
     throw new Error(
       `generate-nginx-conf: PILLAR_RENDER_ORDER contains unknown pillar(s): ${extra.join(', ')}.`
@@ -126,7 +148,7 @@ function nginxVarName(pillarId: PillarId): string {
   return pillarId.replace(/-/g, '_');
 }
 
-function upstreamForId(id: KnownPillarId): PillarUpstream {
+function upstreamForId(id: BuildPillarId): PillarUpstream {
   const upstream = PILLAR_UPSTREAMS[id];
   return { pillarId: id, host: upstream.host, port: upstream.port };
 }
@@ -149,7 +171,7 @@ function renderPillarRestBlockFromUpstream(upstream: PillarUpstream): string {
   ].join('\n');
 }
 
-function renderPillarRestBlock(id: KnownPillarId): string {
+function renderPillarRestBlock(id: BuildPillarId): string {
   return renderPillarRestBlockFromUpstream(upstreamForId(id));
 }
 
@@ -158,7 +180,7 @@ function renderPillarRestBlock(id: KnownPillarId): string {
  * the full `nginx.conf` body. Exported so the drift-detection test can
  * call it without touching the filesystem.
  */
-export function renderNginxConf(order: readonly KnownPillarId[] = PILLAR_RENDER_ORDER): string {
+export function renderNginxConf(order: readonly BuildPillarId[] = PILLAR_RENDER_ORDER): string {
   const restBlocks = order.map(renderPillarRestBlock).join('\n\n');
   return `${NGINX_CONF_HEAD}\n${NGINX_CONF_REST_INTRO}\n${restBlocks}\n\n${NGINX_CONF_ORCHESTRATOR}\n${NGINX_CONF_TAIL}`;
 }
@@ -188,8 +210,8 @@ export function renderNginxConfFromUpstreams(upstreams: readonly PillarUpstream[
 export function resolveUpstreamForEntry(
   entry: Pick<DiscoveredPillar, 'pillarId' | 'baseUrl'>
 ): PillarUpstream {
-  if (isKnownPillarId(entry.pillarId)) {
-    const known = PILLAR_UPSTREAMS[entry.pillarId];
+  const known = knownUpstream(entry.pillarId);
+  if (known !== undefined) {
     return { pillarId: entry.pillarId, host: known.host, port: known.port };
   }
   let parsed: URL;

--- a/pillars/shell/src/app/router.tsx
+++ b/pillars/shell/src/app/router.tsx
@@ -15,7 +15,7 @@
 import { Suspense } from 'react';
 import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-router';
 
-import { ALL_MODULE_IDS } from '@pops/pillar-sdk';
+import { KNOWN_MODULES } from '@pops/module-registry';
 
 import { IndexRedirect } from './IndexRedirect';
 import { filterAppManifests, type FrontendManifest } from './installed-modules';
@@ -29,20 +29,22 @@ import { PillarGuard, pillarIdForModule } from './pillars';
 import type { RouteObject } from 'react-router';
 
 /**
- * Catch-all element: if the URL's first path segment names a routable
- * module id (`ALL_MODULE_IDS`) that isn't installed in this build,
+ * Catch-all element: if the URL's first path segment names a module the
+ * codebase could ship (`KNOWN_MODULES`) that isn't installed in this build,
  * render `NotInstalledPage`. Otherwise fall through to `NotFoundPage`.
  *
- * Using the full `ALL_MODULE_IDS` set (rather than just `MODULES`) here
- * means the "not installed" message fires for any module the codebase
- * could ship — including ones excluded by `POPS_APPS` — while truly
- * unknown paths still get a proper 404. The superset includes the two
- * transitional sub-module ids (`ai`, `ego`) so they remain routable.
+ * `KNOWN_MODULES` is `@pops/module-registry`'s disk-discovered superset of
+ * every in-repo pillar manifest — the right "could-ship" set, broader than
+ * the per-deploy install set (`POPS_APPS`-gated) so the "not installed"
+ * message fires for an excluded-but-buildable module while truly unknown
+ * paths still get a proper 404. RD-9 re-sourced this off the SDK's frozen
+ * `ALL_MODULE_IDS` tuple onto this runtime set so adding a pillar needs no
+ * SDK type edit.
  */
 function UnmatchedRoute() {
   const { pathname } = useLocation();
   const first = pathname.split('/').find((s) => s.length > 0) ?? '';
-  const knownModules: readonly string[] = ALL_MODULE_IDS;
+  const knownModules: readonly string[] = KNOWN_MODULES;
   if (first.length > 0 && knownModules.includes(first)) {
     return <NotInstalledPage />;
   }
@@ -133,8 +135,8 @@ export function buildRouter(
         { path: 'cerebrum/admin/cache', element: <Navigate to="/ai/cache" replace /> },
         { path: 'settings', element: <SettingsPage /> },
         { path: 'features', element: <FeaturesPage /> },
-        // Catch-all: if the first path segment names a routable module id
-        // (`ALL_MODULE_IDS`) the operator excluded via `POPS_APPS`, render
+        // Catch-all: if the first path segment names a buildable module
+        // (`KNOWN_MODULES`) the operator excluded via `POPS_APPS`, render
         // NotInstalledPage. Genuinely unknown paths render NotFoundPage.
         // Both decisions happen inside `UnmatchedRoute` so the route table
         // stays free of inline module-id literals.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
 
   libs/navigation:
     dependencies:
+      '@pops/module-registry':
+        specifier: workspace:*
+        version: link:../module-registry
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
## P7-T07 / RD-9 — widen `KnownPillarId`/`ModuleId` to `string`

The last and most invasive POPS federation task: collapse the closed
compile-time pillar-id tier so **adding a pillar needs no type edit** — the
registry is the sole source of truth for which pillars exist.

The two-tier design already existed (`PillarId = string`). This PR collapses
the closed tier only: it widens the **types** `KnownPillarId`/`ModuleId` →
`string` while keeping the `PILLARS` **value** tuple as the curated runtime
list (still needed by the nginx generator + `isKnownPillarId`).

### Widened symbols (`libs/sdk/src/capabilities/`)
- `KnownPillarId` → `PillarId` (`string`). Was `(typeof PILLARS)[number]`.
- `ModuleId` → `PillarId` (`string`). Was `(typeof ALL_MODULE_IDS)[number]`.

### Kept
- The `PILLARS` value tuple (curated in-tree pillar list).
- `isKnownPillarId` — the legitimate two-tier narrowing seam
  (`PILLARS.includes`).

### Deleted (zero live consumers)
- `ALL_MODULE_IDS` tuple, SDK `isModuleId` guard, `MODULE_PARENT_PILLAR` table
  (the shell's `pillarIdForModule` already supersedes the parent map) and its
  test block.

### The 3 closed-dispatch risk sites (`generate-nginx-conf.ts`)
- **`PILLAR_UPSTREAMS`** + **`PILLAR_RENDER_ORDER`** keyed/typed off a local
  `BuildPillarId = (typeof PILLARS)[number]` instead of the now-open
  `KnownPillarId`, so the "every curated pillar ships a port" exhaustiveness
  guard and `assertRenderOrderCoversAllPillars()` stay meaningful.
- Dynamic upstream lookup (`resolveUpstreamForEntry`) now resolves through a
  runtime `Map` (`knownUpstream`) — no literal-keyed index of a `string`, no
  cast. Output is **byte-identical** (`gen:nginx:check` clean).
- `MODULE_PARENT_PILLAR` — deleted.

### Runtime-list re-homes (would break as always-true / empty if widened naively)
- **Shell router catch-all** (`router.tsx`): the NotInstalled-vs-NotFound split
  now sources its "could-ship" set from `@pops/module-registry`'s
  disk-discovered `KNOWN_MODULES` instead of the SDK's frozen `ALL_MODULE_IDS`.
- **Navigation search filter** (`installed-module.ts`): now gates on
  `@pops/module-registry`'s runtime `isInstalledModule` (was the SDK
  `isModuleId`, which the widening would have turned always-true). Adds
  `@pops/module-registry` to navigation's deps.

`@pops/module-registry`'s own separate `ModuleId`/`isModuleId` (build-time
manifest validator, already `string`) is left untouched.

### Tests
- Rewrote the SDK type-equality tests for the open tier; added a proof that a
  hypothetical new pillar id is a valid `KnownPillarId`/`ModuleId` with **no
  type edit**, and that `isKnownPillarId` still rejects a not-yet-curated id.
- Adapted the navigation filter test to the re-homed runtime set (still
  rejects absent modules; added a `contacts` rejection case — it has no
  installed search surface).
- `call-result.test.ts` and `generate-nginx-conf.test.ts` stay green (they
  test the retained `PILLARS` value).

### Local CI (all green on a warm worktree)
- `mise run build` ✓ · full-graph `pnpm typecheck` ✓ · `mise run test` ✓
  (sdk 625, navigation 127, shell 612, all pillars)
- `pnpm lint` ✓ · `pnpm format:check` ✓ · `pnpm lint:boundaries` ✓
  (new `navigation → module-registry` edge allowed; no new violations)
- `pnpm exports:check` ✓ · `extractability:deps` ✓ (declared deps complete) ·
  `extractability:baseline` ✓ (82 → 82) · `bundle-map` ✓ ·
  module-registry `generated.ts` no drift · `gen:nginx:check` no drift
- No `as any` / `as unknown as T` / suppressions.

### Verify the goal
`grep -rn "KnownPillarId" libs pillars` shows only the `string` alias def +
type annotations + the `isKnownPillarId` seam — no literal union remains.
