### PR TITLE
feat(infra): empty POPS_PILLARS seed — registry sole truth [P7-T06 / RD-8]

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -64,9 +64,12 @@ services:
       CORE_SQLITE_PATH: /data/sqlite/core.db
       REGISTRY_SELF_BASE_URL: http://registry-api:3001
       # Cross-pillar registry — registry-api hosts the authoritative
-      # `/pillars` snapshot that the shell's nginx proxy fans out to,
-      # so it MUST default to the full sibling list rather than empty.
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      # `/pillars` snapshot that the shell's nginx proxy fans out to. The
+      # seed defaults to EMPTY: every pillar self-registers over the SDK
+      # transport (POPS_REGISTRY_ENABLED), so the snapshot is built from live
+      # registrations, not a static list. POPS_PILLARS stays an operator
+      # escape hatch for air-gapped/seed boots (the env.ts parser is retained).
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3001'
     healthcheck:
@@ -107,7 +110,7 @@ services:
       PORT: '3002'
       INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3002'
     depends_on:
@@ -155,7 +158,7 @@ services:
       # it never collides with a self-pointing POPS_API_URL.
       AI_API_URL: http://ai-api:3008
       POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3004'
     depends_on:
@@ -198,7 +201,7 @@ services:
       PORT: '3003'
       MEDIA_SQLITE_PATH: /data/sqlite/media.db
       MEDIA_SELF_BASE_URL: http://media-api:3003
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3003'
     depends_on:
@@ -245,7 +248,7 @@ services:
       # self-pointing POPS_API_URL (see @pops/ai-telemetry report-sink).
       AI_API_URL: http://ai-api:3008
       POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3005'
     depends_on:
@@ -288,7 +291,7 @@ services:
       PORT: '3006'
       LISTS_SQLITE_PATH: /data/sqlite/lists.db
       LISTS_SELF_BASE_URL: http://lists-api:3006
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3006'
     depends_on:
@@ -336,7 +339,7 @@ services:
       # Validates `x-pops-internal-token` on `POST /ai-usage/record`. The
       # reporting pillars (finance/food/cerebrum) carry the same token.
       POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3008'
     depends_on:
@@ -461,7 +464,7 @@ services:
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
       EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3007'
     depends_on:
@@ -518,7 +521,7 @@ services:
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
       EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -556,7 +559,7 @@ services:
       POPS_REGISTRY_ENABLED: 'true'
       POPS_REGISTRY_URL: ${POPS_REGISTRY_URL:-http://registry-api:3001}
       POPS_API_INTERNAL_TOKEN: ${POPS_API_INTERNAL_TOKEN:-}
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3010'
     depends_on:
@@ -588,7 +591,7 @@ services:
       NODE_ENV: production
       PORT: '3009'
       ORCHESTRATOR_SELF_BASE_URL: http://pops-orchestrator:3009
-      POPS_PILLARS: ${POPS_PILLARS:-registry:http://registry-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007,ai:http://ai-api:3008,contacts:http://contacts-api:3010}
+      POPS_PILLARS: ${POPS_PILLARS:-}
     expose:
       - '3009'
     depends_on:


### PR DESCRIPTION
## What

Defaults the in-repo `POPS_PILLARS` seed to **empty** (`${POPS_PILLARS:-}`) on every service. The registry's `/pillars` snapshot is now built from live pillar self-registration, not a static list. `POPS_PILLARS` stays as an operator escape hatch (the `env.ts` parser is retained) for air-gapped/seed boots.

This kills the last RD-* static artifact — the federation's registry-decoupling DONE criterion.

## Why it's safe (verified against live capivara)

- All **10 pillars self-register healthy** with fresh heartbeats; `mergedRegistry = seed ∪ self-registered`, so the snapshot is **identical** with an empty seed (live count = 10 either way).
- `POPS_PILLARS` is **not** env-set on capivara, so the compose default is what the registry uses today (confirmed via `docker exec pops-registry printenv`).
- The registry DB persists across restarts; a cold boot reloads registrations + pillars re-heartbeat.
- Rollback = `git revert` → restores the P7-T02-corrected 9-pillar seed (instant safe fallback).

## Verify
- `docker compose -f infra/docker-compose.yml config` → parses ✓
- 0 non-empty seeds remain; comment updated to reflect registry-sole-truth.

## Note
This is the **in-repo** reference compose. The **live** homelab seed (`../homelab/infra`) emptying is a separate, surfaced deploy (a brief fleet restart with identical end-state).