### PR TITLE
ci: close three false-confidence gate gaps

### DIFF
--- a/.github/workflows/_discover-units.yml
+++ b/.github/workflows/_discover-units.yml
@@ -10,6 +10,25 @@ name: Discover Units
 # (libs/sdk publishes @pops/pillar-sdk; the dir-name != pkg-name skew is
 # LOCKED — selecting on the basename silently matches zero packages).
 #
+# SCOPE — `maxdepth 1` is deliberate, NOT an oversight. The nested
+# `pillars/*/app` frontend members (real pnpm workspace members per
+# `pnpm-workspace.yaml` `pillars/*/*`, npm name `@pops/app-<id>`) live at
+# maxdepth 2 and collide on basename `app`, so they are intentionally OUT of
+# this discovery and OUT of `unit-quality.yml`'s matrix. They are routed to
+# the FE workflows instead, with NO double-coverage:
+#   - ALL `@pops/app-*` are static deps of `@pops/shell` (see its
+#     package.json + `pillars/shell/src/app/bundle-map.tsx`), so
+#     `fe-quality.yml`'s shell typecheck + build compile every app's source
+#     transitively. `bundle-map-coverage` (RD-10) asserts every app appears in
+#     that map, which is what makes "the shell build reaches every app"
+#     provable rather than assumed.
+#   - `@pops/app-ai` additionally runs its own `typecheck` + `test` in
+#     `ai-quality.yml` (the only app with a dedicated unit job today).
+# The `assert-app-coverage` job below turns this from a comment into a gate:
+# it enumerates the `pillars/*/app` members on disk and FAILS if any one is
+# not routed to a covering FE workflow — so a newly added pillar app whose
+# coverage was forgotten breaks discovery loudly instead of shipping untested.
+#
 # Outputs:
 #   units   — every discovered unit (full list)
 #   changed — units touched by this PR's diff, OR all units when a shared
@@ -88,3 +107,48 @@ jobs:
             echo "$changed" | jq .
             echo "changed=$changed" >> "$GITHUB_OUTPUT"
           fi
+
+  assert-app-coverage:
+    # Proves the maxdepth-1 scope above leaves NO `pillars/*/app` member
+    # uncovered. Each such member (npm name `@pops/app-<id>`) is excluded from
+    # the unit matrix by design; this job fails loud if any one is not routed
+    # to a covering FE workflow, so "every unit is covered" is a gate, not a
+    # hope. Pure disk + workflow-file reads — no install.
+    name: Assert pillars/*/app are routed to FE workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Every pillars/*/app is named @pops/app-* and covered by fe-quality
+        run: |
+          set -euo pipefail
+
+          fe=.github/workflows/fe-quality.yml
+          [ -f "$fe" ] || { echo "::error::$fe missing — pillars/*/app lose their build coverage"; exit 1; }
+
+          # fe-quality's shell typecheck + build compile every @pops/app-* via
+          # the shell's static deps; this glob is what fires that build on any
+          # app change. If it is ever dropped, app changes ship untested.
+          grep -qE '^\s*-\s*["'\'']?pillars/\*/app/\*\*' "$fe" \
+            || { echo "::error::$fe no longer triggers on 'pillars/*/app/**' — app build coverage lost"; exit 1; }
+
+          missing=0
+          while IFS= read -r appdir; do
+            [ -f "$appdir/package.json" ] || continue
+            pkg=$(jq -r '.name' "$appdir/package.json")
+            case "$pkg" in
+              @pops/app-*) : ;;
+              *) echo "::error::$appdir is a nested workspace member named '$pkg' (expected @pops/app-*); unit-discovery does not see maxdepth-2 members — give it explicit coverage or fix the name"; missing=1; continue ;;
+            esac
+            id=${pkg#@pops/app-}
+            # app-ai also gets a dedicated unit job (typecheck+test). The rest
+            # rely on fe-quality's shell build (asserted above) + RD-10
+            # bundle-map coverage. Either path is acceptable coverage.
+            if [ -f ".github/workflows/${id}-quality.yml" ]; then
+              echo "$pkg -> ${id}-quality.yml (dedicated) + fe-quality (shell build)"
+            else
+              echo "$pkg -> fe-quality (shell build)"
+            fi
+          done < <(find pillars -mindepth 2 -maxdepth 2 -type d -name app | sort)
+
+          [ "$missing" = 0 ] || { echo "::error::one or more pillars/*/app members are uncovered"; exit 1; }
+          echo "All pillars/*/app members are routed to a covering FE workflow."

--- a/.github/workflows/pillar-quality.yml
+++ b/.github/workflows/pillar-quality.yml
@@ -1,38 +1,27 @@
-name: Pillar Quality
+name: Pillar Image
 
-# Single matrix gate that replaces the seven hand-written per-pillar
-# `<id>-quality.yml` files. Pillars are discovered from disk
-# (`pillars/<x>/`) rather than a static list, so adding or removing a
-# pillar needs no workflow edit (mirrors publish-images' discover job +
-# pillar-schema-coverage's matrix shape).
+# Push-to-main full pillar Docker image build.
 #
-# Per pillar this runs the same checks the individual files did:
-# typecheck, test, lint, format, build (deps + pillar), a contract
-# codegen drift check, and a Docker image build. The codegen check runs
-# every `generate:*` script the pillar's package.json defines and then
-# `git diff --exit-code`s the pillar tree, so it covers whichever of
-# openapi / api-types / manifest that pillar actually generates — no
-# per-pillar artifact list to drift.
+# This workflow USED to also run typecheck + test + lint + format + build +
+# codegen drift per pillar. That source-side matrix is now owned end-to-end by
+# `unit-quality.yml` (disk-discovered, maxdepth-1, a strict SUPERSET — it also
+# covers the Rust `contacts` pillar and the libs, which this file never did),
+# so keeping it here duplicated every pillar check on every PR. It has been
+# removed to kill that overlap (one `finance (pillar) — ts` lane, not two).
 #
-# Bubble-of-happiness rule: this workflow is the one that MUST stay green
-# for each pillar. Other workflows may be red while the rest of the
-# codebase still imports dead legacy package names — that's deliberate
-# and resolves as each consumer migrates to `@pops/<pillar>`.
+# What remains is the ONE thing nothing else does automatically: building the
+# FULL pillar image (not just the builder stage) on push to main. On PRs the
+# builder stage of every `pillars/*/Dockerfile` is already validated by
+# `docker-build.yml`; `publish-images.yml` does full builds but is
+# `workflow_dispatch`-only during the colocation series, so without this job
+# nothing would surface a broken full-image build when main advances. Pillars
+# are discovered from disk so adding/removing one needs no edit here.
+#
+# NOT a pull_request gate — that trigger was the source of the duplication.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "pillars/**"
-      - "libs/sdk/**"
-      - "libs/types/**"
-      - "libs/db-types/**"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tsconfig.base.json"
-      - ".oxfmtrc.json"
-      - ".github/workflows/pillar-quality.yml"
-  pull_request:
     paths:
       - "pillars/**"
       - "libs/sdk/**"
@@ -59,8 +48,11 @@ jobs:
       - uses: actions/checkout@v6
       - id: list
         name: Enumerate pillars from disk
-        # A pillar is any `pillars/<x>` carrying a package.json. Derived
-        # from disk so adding or removing a pillar needs no workflow edit.
+        # A pillar is any `pillars/<x>` carrying a package.json. Derived from
+        # disk so adding or removing a pillar needs no workflow edit. Matches
+        # the original discover scope exactly — this de-dup PR only drops the
+        # redundant per-pillar source matrix + the PR trigger, it does not
+        # widen the set of images built on push.
         run: |
           set -euo pipefail
           json=$(find pillars -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
@@ -72,69 +64,8 @@ jobs:
           count=$(echo "$json" | jq 'length')
           echo "pillars=$json" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Discovered $count pillar(s):"
+          echo "Discovered $count pillar image(s):"
           echo "$json" | jq .
-
-  quality:
-    name: ${{ matrix.pillar }} pillar — typecheck + test + lint + format + build
-    needs: [discover]
-    if: needs.discover.outputs.count != '0'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        pillar: ${{ fromJson(needs.discover.outputs.pillars) }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install (subgraph only)
-        run: pnpm install --frozen-lockfile --filter "@pops/${{ matrix.pillar }}..."
-
-      - name: Format check
-        run: pnpm exec oxfmt --check pillars/${{ matrix.pillar }}/
-
-      - name: Lint
-        run: pnpm exec oxlint pillars/${{ matrix.pillar }}/src
-
-      - name: Build transitive deps
-        run: pnpm --filter "@pops/${{ matrix.pillar }}^..." build
-
-      - name: Typecheck
-        run: pnpm --filter @pops/${{ matrix.pillar }} typecheck
-
-      - name: Build pillar
-        run: pnpm --filter @pops/${{ matrix.pillar }} build
-
-      - name: Verify generated contract artifacts are up to date
-        # Run every codegen script the pillar defines (openapi / api-types
-        # / manifest — whichever exist) then fail on any diff. Replaces the
-        # per-pillar hand-listed `generate:* + git diff` steps so the set of
-        # verified artifacts can't drift from what the pillar actually
-        # generates.
-        run: |
-          set -euo pipefail
-          scripts=$(node -e "const s=require('./pillars/${{ matrix.pillar }}/package.json').scripts||{}; process.stdout.write(Object.keys(s).filter(k=>k.startsWith('generate:')).join('\n'))")
-          if [ -z "$scripts" ]; then
-            echo "No generate:* scripts for ${{ matrix.pillar }} — skipping codegen drift check."
-          else
-            while IFS= read -r script; do
-              [ -z "$script" ] && continue
-              echo "::group::pnpm --filter @pops/${{ matrix.pillar }} $script"
-              pnpm --filter @pops/${{ matrix.pillar }} "$script"
-              echo "::endgroup::"
-            done <<< "$scripts"
-            git diff --exit-code pillars/${{ matrix.pillar }}/
-          fi
-
-      - name: Test
-        run: pnpm --filter @pops/${{ matrix.pillar }} test
 
   docker:
     name: ${{ matrix.pillar }} pillar — Docker image builds
@@ -150,17 +81,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build pillar image (builder stage only — fast feedback)
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: pillars/${{ matrix.pillar }}/Dockerfile
-          target: builder
-          push: false
-
       - name: Build pillar image (full)
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -103,7 +103,12 @@ jobs:
       # boilerplate is identical across every consumer by construction —
       # counting it as duplication penalises codegen, not authored code,
       # the same reason `**/generated.ts` is already ignored.
-      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/src/*-api/**,**/db/schema.ts,**/db/seeder.ts" --reporters "console" --exitCode 0 .
+      # Fails when TOTAL duplication exceeds `--threshold` (jscpd v4 gates on
+      # the aggregate, not per-format). Current tree sits at 2.33% total
+      # (measured 2026-06-23 with these exact flags), so threshold 5 is a real
+      # gate that is green now with headroom. NO `--exitCode 0` override — that
+      # would pin the exit to 0 and make this required check unable to fail.
+      - run: npx jscpd@^4 --threshold 5 --min-lines 8 --min-tokens 70 --ignore "**/*.test.{ts,tsx},**/*.spec.{ts,tsx},**/dist/**,**/node_modules/**,**/*.snap,**/*.d.ts,**/generated.ts,**/src/*-api/**,**/db/schema.ts,**/db/seeder.ts" --reporters "console" .
 
   # --- Extractability fast gates (EX-1 / EX-3) -------------------------------
   # NON-REQUIRED by design: these jobs are deliberately kept out of the branch

--- a/.github/workflows/unit-quality.yml
+++ b/.github/workflows/unit-quality.yml
@@ -7,6 +7,11 @@ name: Unit Quality
 #   - moltbot (manifest-less) — its own config gate
 #   - the module-registry generated.ts drift gate — registry-generated-quality.yml
 #
+# The `pillars/*/app` exclusion is not just assumed — `_discover-units.yml`'s
+# `assert-app-coverage` job enumerates those members and FAILS if any one is
+# not routed to a covering FE workflow, so "discovery covers every unit" is a
+# gate, not a hope.
+#
 # The unit list + changed-set come from `_discover-units.yml`. Each lane is
 # selected by `matrix.unit.lang`; the per-unit `mise.toml` pins the toolchain
 # so the steps are uniform regardless of unit. jdx/mise-action@v2 is the sole


### PR DESCRIPTION
Closes three false-confidence caveats found by a CI-gate audit. One PR, no behavior change to passing CI today.

## 1. Un-toothless the required Duplication check
`quality.yml`'s `Duplication check` (a REQUIRED status check on `main`) ran `jscpd` with `--exitCode 0`, pinning its exit to 0 so the gate could never fail. Removed `--exitCode 0`; jscpd now exits non-zero when total duplication exceeds `--threshold 5`.

Confirmed locally with the exact CI flags: **total duplication = 2.33%** (12,841 / 552,043 lines, 653 clones), well under 5. jscpd v4 gates on the aggregate, not per-format, so the few formats above 5% (sql 7.78%, json 6.92%, toml 7.18%) do not trip it. The gate is real and green with headroom — no threshold bump needed.

## 2. Close the unit-discovery gap
`_discover-units.yml` discovers units with `find ... -maxdepth 1`, which never sees the 7 nested `pillars/*/app` workspace members (`@pops/app-{ai,cerebrum,finance,food,inventory,lists,media}`, real pnpm members per `pnpm-workspace.yaml` `pillars/*/*`).

Picked option (b): documented the deliberate maxdepth-1 scope and added an `assert-app-coverage` job that enumerates every `pillars/*/app` member and **fails loud** if any one is not routed to a covering FE workflow. Routing verified:
- all 7 are static deps of `@pops/shell` (via `bundle-map.tsx`), so `fe-quality.yml`'s shell typecheck + build compile each app's source transitively; `bundle-map-coverage` (RD-10) already proves every app is in that map;
- `app-ai` additionally runs its own typecheck + test in `ai-quality.yml`.

No double-coverage added. "Discovery covers every unit" is now a gate, not a comment — a future `pillars/*/app` added without coverage breaks discovery.

## 3. De-dup overlapping pillar CI
`pillar-quality.yml` and `unit-quality.yml` both ran typecheck+test+build per pillar on PRs (two lanes per pillar, e.g. `finance (pillar) — ts` and `finance pillar — …`). `unit-quality.yml` is a strict superset of pillar-quality's source checks (it also covers the Rust `contacts` pillar and the libs, which pillar-quality never did).

Retired pillar-quality's redundant source matrix and its `pull_request` trigger. It is now **push-to-main only** and keeps just the FULL pillar image build — the one thing nothing else does automatically (PR-time builder-stage Dockerfile validation already lives in `docker-build.yml`; `publish-images.yml`'s full builds are `workflow_dispatch`-gated during colocation). No pillar loses coverage.

The `main` ruleset's required checks (`agent-review`, `Lint`, `Format`, `Module boundaries`, `Duplication check`) do not include any pillar-quality job name, so retiring its PR trigger cannot strand a required check.

## Validation
- `npx yaml-lint` passes on all four touched workflows (the exact tool `workflows-quality.yml` runs).
- `bash -n` clean on every new/changed embedded script.
- `assert-app-coverage` script dry-run locally: all 7 apps route correctly; negative-case grep confirmed it fails if the `pillars/*/app/**` trigger is removed.
