### PR TITLE
test(sdk): enforce expectTypeOf capability/projection type contract

### DIFF
--- a/libs/sdk/src/capabilities/__tests__/fixtures.ts
+++ b/libs/sdk/src/capabilities/__tests__/fixtures.ts
@@ -95,10 +95,10 @@ export const procedureConforms: AssertProcedureConforms = true;
 export type EmptyContract = {
   readonly pillar: 'registry';
   readonly version: '0.0.0';
-  readonly types: Record<string, never>;
-  readonly schemas: Record<string, never>;
-  readonly router: Record<string, never>;
-  readonly errors: Record<string, never>;
+  readonly types: Record<never, never>;
+  readonly schemas: Record<never, never>;
+  readonly router: Record<never, never>;
+  readonly errors: Record<never, never>;
   readonly search: { readonly adapters: readonly [] };
   readonly ai: { readonly tools: readonly [] };
   readonly uri: { readonly types: readonly [] };

--- a/libs/sdk/src/registry-paths.ts
+++ b/libs/sdk/src/registry-paths.ts
@@ -1,12 +1,13 @@
 /**
  * Canonical (new) registry handshake/discovery HTTP paths.
  *
- * Idiomatic slash routes that will replace the tRPC-vestigial dotted shape
- * (`/core.registry.*`). PLANNED for a later phase, NOT yet wired: in Phase 0
- * core mounts only the legacy dotted paths and the SDK calls them directly.
- * Once Phase 1 dual-serves these alongside the legacy paths, the SDK transport/
- * discovery will prefer them and fall back to {@link LEGACY_REGISTRY_PATHS} on a
- * 404 during the rolling-deploy window.
+ * Idiomatic slash routes that replace the tRPC-vestigial dotted shape
+ * (`/core.registry.*`). LIVE: the registry pillar dual-serves these alongside
+ * {@link LEGACY_REGISTRY_PATHS} (each operation mounted on both paths, same
+ * handler), and the SDK transport/discovery prefer the slash path, falling back
+ * to the legacy dotted path on a 404 during the rolling-deploy window. The
+ * legacy aliases are removed once every pillar image is on the new SDK and the
+ * legacy-path-hit metric reads zero.
  */
 export const REGISTRY_PATHS = {
   register: '/registry/register',

--- a/libs/sdk/tsconfig.vitest.json
+++ b/libs/sdk/tsconfig.vitest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/capabilities/__tests__/**/*"],
+  "exclude": ["**/dist/**", "**/node_modules/**"]
+}

--- a/libs/sdk/vitest.config.ts
+++ b/libs/sdk/vitest.config.ts
@@ -4,6 +4,16 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    // Compile the `expectTypeOf` capability/projection assertions so a broken
+    // type contract FAILS the run instead of being a runtime no-op. `tsc
+    // --noEmit` cannot guard these: libs/sdk's tsconfig excludes test files.
+    // Scoped to the capability contract suite — the other `*.test.ts` files are
+    // runtime-only and lean on deliberately loose typing.
+    typecheck: {
+      enabled: true,
+      tsconfig: './tsconfig.vitest.json',
+      include: ['src/capabilities/__tests__/**/*.test.{ts,tsx}'],
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],


### PR DESCRIPTION
## Problem

`libs/sdk`'s `expectTypeOf` assertions (`capabilities/__tests__/projections.test.ts`, `modules.test.ts`) asserted the capability/projection type contract — including the RD-9 `KnownPillarId`→`string` canary — but **nothing machine-checked them**:

- `test` was a plain `vitest run` (`expectTypeOf` is a runtime no-op).
- `typecheck` is `tsc --noEmit` whose tsconfig **excludes** `**/*.test.ts(x)`.

So a broken type contract passed CI silently.

## Fix

Enable Vitest type testing for the capability contract suite:

- **`vitest.config.ts`** — `test.typecheck.enabled` pointed at a dedicated tsconfig, scoped via `typecheck.include` to `src/capabilities/__tests__/**`. The other `*.test.ts` files are runtime-only and lean on deliberately loose typing, so they stay out of the type lane.
- **`tsconfig.vitest.json`** (new) — includes the capability test files (the unit tsconfig excludes them) and adds `vitest/globals` types.

The CI **unit-quality** `Test` step runs `pnpm --filter <pkg> test` → `vitest run`, which now compiles the assertions and **fails on a mismatch** — no workflow change needed.

### Latent fixture bug surfaced by the now-enforced gate

`EmptyContract` modelled its empty collection subtrees as `Record<string, never>` — a keyspace of `string`, not the empty set. So `keyof CallablePillar<EmptyContract>` was `string`, not `never`, and the "empty contracts project to empty callable" assertion was false. Switched to `Record<never, never>` so the assertion holds for the right reason.

### Stale docstring

`registry-paths.ts` claimed the canonical slash routes were "planned, not yet wired" and that the SDK "calls legacy directly". That is false: the registry pillar dual-serves both path shapes (`pillars/registry/src/api/app.ts`) and the SDK transport/discovery prefer the slash path with legacy fallback (`bootstrap/transport.ts`). Corrected to describe reality.

## Proof the gate has teeth

Temporarily broke the RD-9 canary in **both** files (asserted the old closed literal union instead of `string`), ran `vitest run`:

- `projections.test.ts` → exit **1**, `Type Errors 1 failed`, `TypeCheckError` at `projections.test.ts:192`.
- `modules.test.ts` → exit **1**, `Type Errors 1 failed`, `TypeCheckError` at `modules.test.ts:46`.

Both reverted; the real suite passes: **664 tests, `Type Errors no errors`**, exit 0.

## Local verification (libs/sdk unit lane)

`tsc --noEmit` ✓ · `vitest run` (incl. type lane) ✓ · `oxlint src` ✓ · `oxfmt --check` ✓