### PR TITLE
ci(publish-images): restore push:[main] auto-publish (federation complete)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,10 +1,13 @@
 name: Publish Images
 
-# Triggers gated to workflow_dispatch only during the pillar-colocation work
-# so Watchtower on capivara doesn't roll forward to a half-migrated image.
-# Restore `push: branches: [main]` + `tags: ["v*"]` once the colocation
-# series stabilises.
+# The pillar-colocation / federation series is complete, so auto-publish is
+# restored: every push to `main` (and `v*` tags) rebuilds + pushes the full
+# fleet, and Watchtower on capivara rolls the live containers forward. Use the
+# `workflow_dispatch` `only` input to rebuild a single image on demand.
 on:
+  push:
+    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       only:


### PR DESCRIPTION
Re-enables the documented auto-publish (every main push + v* tags rebuilds the full fleet → Watchtower rolls capivara). Ends the workflow_dispatch-only gating that pinned the live fleet to pre-federation images. Merging this triggers the full-fleet build at HEAD.