### PR TITLE
fix(extractability): close cross-pillar codegen reaches + make app-unit EX-2 honest

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -170,3 +170,22 @@ jobs:
         run: node scripts/check-bundle-map-coverage.mjs --self-test
       - name: Every pillar app is referenced by the shell bundle map
         run: node scripts/check-bundle-map-coverage.mjs
+
+  vendored-contracts:
+    name: Vendored contract drift (ADR-033)
+    # A consumer that vendors a producer pillar's OpenAPI snapshot (because the
+    # producer has no npm package to depend on — e.g. the Rust `contacts`
+    # pillar) must keep its copy byte-identical to the canonical source, or the
+    # generated client silently lags the contract. This guard reads the source
+    # tree directly and pulls in no third-party deps, so it skips
+    # `pnpm install`. See scripts/ci/check-vendored-contracts.mjs and ADR-033.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Gate self-test (proves the guard catches drift + orphan)
+        run: node scripts/ci/check-vendored-contracts.mjs --self-test
+      - name: Every vendored contract matches its canonical source
+        run: node scripts/ci/check-vendored-contracts.mjs

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -35,6 +35,7 @@
     "pnpm-lock.yaml",
     "package-lock.json",
     "pillars/contacts/openapi/*.openapi.json",
+    "pillars/*/app/contracts/*.openapi.json",
     "**/__tests__/fixtures/*.json",
     "libs/*/tests/fixtures/*.json",
     "*.csv",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -18,7 +18,15 @@ export default {
   },
 
   '*.{json,md,css}': (filenames) => {
-    const formattable = filenames.filter((f) => !/\/openapi\/[^/]+\.openapi\.json$/.test(f));
+    // Never reformat an OpenAPI snapshot: a pillar's canonical
+    // `**/openapi/<name>.openapi.json` is emitted by codegen, and a vendored
+    // copy under `**/app/contracts/<name>.openapi.json` must stay byte-identical
+    // to it (the check-vendored-contracts drift gate enforces equality).
+    // Formatting either would create silent drift at commit time.
+    const isOpenApiSnapshot = (/** @type {string} */ f) =>
+      /\/openapi\/[^/]+\.openapi\.json$/.test(f) ||
+      /\/app\/contracts\/[^/]+\.openapi\.json$/.test(f);
+    const formattable = filenames.filter((f) => !isOpenApiSnapshot(f));
     if (formattable.length === 0) return [];
     const formatFiles = formattable.map(esc).join(' ');
     return [`oxfmt --write ${formatFiles}`];

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "exports:check": "node scripts/check-exports.mjs",
     "check:bundle-map": "node scripts/check-bundle-map-coverage.mjs",
     "check:bundle-map:self-test": "node scripts/check-bundle-map-coverage.mjs --self-test",
+    "check:vendored-contracts": "node scripts/ci/check-vendored-contracts.mjs",
+    "check:vendored-contracts:self-test": "node scripts/ci/check-vendored-contracts.mjs --self-test",
     "ci:fix": "pnpm lint:fix && pnpm format && pnpm typecheck",
     "registry:build": "pnpm --filter @pops/module-registry registry:build",
     "prepare": "husky"

--- a/pillars/ai/app/openapi-ts.finance.config.ts
+++ b/pillars/ai/app/openapi-ts.finance.config.ts
@@ -6,15 +6,23 @@
  * cache-maintenance endpoints are served by the FINANCE pillar (the
  * finance-categorizer cache re-homed from core, gap #3489), not the ai
  * pillar. So the cache UI consumes a per-consumer finance client generated
- * from `pillars/finance/openapi/finance.openapi.json` — separate from the
+ * from the finance pillar's published OpenAPI contract, separate from the
  * `ai-api` client (see `openapi-ts.config.ts`).
+ *
+ * The spec is resolved through `@pops/finance`'s `./openapi` package export (a
+ * declared devDependency), never by reaching into the sibling pillar's folder,
+ * so this unit stays black-box-isolated and extraction-ready.
  *
  * Regenerate: pnpm --filter @pops/app-ai generate:finance-client
  */
+import { createRequire } from 'node:module';
+
 import { defineConfig } from '@hey-api/openapi-ts';
 
+const require = createRequire(import.meta.url);
+
 export default defineConfig({
-  input: '../../finance/openapi/finance.openapi.json',
+  input: require.resolve('@pops/finance/openapi'),
   output: {
     path: 'src/finance-api',
   },

--- a/pillars/ai/app/package.json
+++ b/pillars/ai/app/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.98.2",
+    "@pops/finance": "workspace:*",
     "@pops/locales": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pillars/finance/app/contracts/contacts.openapi.json
+++ b/pillars/finance/app/contracts/contacts.openapi.json
@@ -1,0 +1,780 @@
+{
+  "components": {
+    "schemas": {
+      "CreateEntityBody": {
+        "description": "Body accepted by `POST /entities`. `type` defaults to `company`; the array\nfields default to empty.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Entity": {
+        "description": "The wire shape served by every entities route — the `toEntity` projection.\n`notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed\n(internal/integration columns), matching core's `EntitySchema`.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastEditedTime": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "aliases",
+          "defaultTags",
+          "lastEditedTime"
+        ],
+        "type": "object"
+      },
+      "EntityListResponse": {
+        "description": "`GET /entities` response body.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Entity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "EntityLookup": {
+        "description": "Wire shape of one bulk-lookup entry.",
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "aliases"
+        ],
+        "type": "object"
+      },
+      "EntityMutation": {
+        "description": "Create/update response body — the entity plus a human-readable message.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Entity"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "message"
+        ],
+        "type": "object"
+      },
+      "EntityResponse": {
+        "description": "`GET /entities/:id` response body.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Entity"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ErrorBody": {
+        "description": "Error envelope returned by every fallible route. `code` carries the\noriginating error class name (e.g. `NotFoundError`) so clients can branch\nwithout parsing `message`.",
+        "properties": {
+          "code": {
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "HealthResponse": {
+        "description": "`GET /health` response body. Field-for-field identical to the TS pillar\nhealth envelope: `ok`, `status`, `pillar`, `version`, `ts` (an RFC 3339 /\nISO 8601 UTC timestamp, matching the TS `new Date().toISOString()`). The\nregistry health probe parses this shape across every pillar.",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "pillar": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ts": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "status",
+          "pillar",
+          "version",
+          "ts"
+        ],
+        "type": "object"
+      },
+      "LookupBody": {
+        "description": "`POST /entities/lookup` body — reserved for a future field selector; an\nempty body fetches the default match columns.",
+        "properties": {
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LookupResponse": {
+        "description": "`POST /entities/lookup` response — the whole contact set's match columns in\none round-trip, plus the fetch instant for the caller's in-run cache.",
+        "properties": {
+          "entities": {
+            "items": {
+              "$ref": "#/components/schemas/EntityLookup"
+            },
+            "type": "array"
+          },
+          "fetchedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entities",
+          "fetchedAt"
+        ],
+        "type": "object"
+      },
+      "MatchType": {
+        "enum": [
+          "exact",
+          "prefix",
+          "contains"
+        ],
+        "type": "string"
+      },
+      "MessageResponse": {
+        "description": "Bare `{ message }` body returned by delete.",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "PaginationMeta": {
+        "description": "Pagination envelope returned by every list endpoint. Mirrors core's\n`PaginationMetaSchema`.",
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "offset": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "SearchHit": {
+        "description": "One ranked search hit. `uri` is the canonical `pops:contacts/contact/<id>`.",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SearchHitData"
+          },
+          "matchField": {
+            "type": "string"
+          },
+          "matchType": {
+            "$ref": "#/components/schemas/MatchType"
+          },
+          "score": {
+            "format": "double",
+            "type": "number"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "score",
+          "matchField",
+          "matchType",
+          "data"
+        ],
+        "type": "object"
+      },
+      "SearchHitData": {
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "aliases"
+        ],
+        "type": "object"
+      },
+      "SearchQuery": {
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "SearchRequest": {
+        "description": "`POST /search` request body. `query.text` is the term; `context` is\naccepted and ignored (parity with the orchestrator's wire shape).",
+        "properties": {
+          "context": {},
+          "query": {
+            "$ref": "#/components/schemas/SearchQuery"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SearchResponse": {
+        "description": "`POST /search` response body.",
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "hits"
+        ],
+        "type": "object"
+      },
+      "UpdateEntityBody": {
+        "description": "Body accepted by `PATCH /entities/:id`. Every field is optional; a present\nfield (even `null` for the nullable columns) is applied, an absent field is\nleft untouched. The nullable columns use `Option<Option<T>>` to tell\n\"absent\" (outer `None` — leave the column alone) apart from \"set to null\"\n(`Some(None)` — clear the column). serde collapses a JSON `null` into the\nouter `None` by default, so those fields deserialize through\n[`double_option`], which preserves the present-but-null case.",
+        "properties": {
+          "abn": {
+            "nullable": true,
+            "type": "string"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "defaultTags": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "defaultTransactionType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "Contacts pillar — authoritative entities store (first Rust pillar).",
+    "license": {
+      "identifier": "UNLICENSED",
+      "name": "UNLICENSED"
+    },
+    "title": "POPS Contacts",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "root.get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Pillar identity banner"
+          }
+        },
+        "summary": "Stub root. A human-friendly landing string so `GET /` is not a 404 while\nthe real surface is still under construction.",
+        "tags": [
+          "crate::health"
+        ]
+      }
+    },
+    "/entities": {
+      "get": {
+        "operationId": "entities.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityListResponse"
+                }
+              }
+            },
+            "description": "Paginated entity list"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "post": {
+        "operationId": "entities.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEntityBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityMutation"
+                }
+              }
+            },
+            "description": "Created entity"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Invalid body"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Duplicate name"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
+    "/entities/lookup": {
+      "post": {
+        "operationId": "entities.lookup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LookupBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupResponse"
+                }
+              }
+            },
+            "description": "Bulk match columns"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
+    "/entities/{id}": {
+      "delete": {
+        "operationId": "entities.delete",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "get": {
+        "operationId": "entities.get",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityResponse"
+                }
+              }
+            },
+            "description": "The entity"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      },
+      "patch": {
+        "operationId": "entities.update",
+        "parameters": [
+          {
+            "description": "Entity id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEntityBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityMutation"
+                }
+              }
+            },
+            "description": "Updated entity"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "No such entity"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            },
+            "description": "Duplicate name"
+          }
+        },
+        "tags": [
+          "crate::entities::routes"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health.get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Pillar is live"
+          }
+        },
+        "summary": "Liveness probe.",
+        "tags": [
+          "crate::health"
+        ]
+      }
+    },
+    "/search": {
+      "post": {
+        "operationId": "search.search",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Ranked contact hits"
+          }
+        },
+        "tags": [
+          "crate::search::routes"
+        ]
+      }
+    }
+  }
+}

--- a/pillars/finance/app/openapi-ts.contacts.config.ts
+++ b/pillars/finance/app/openapi-ts.contacts.config.ts
@@ -7,14 +7,25 @@
  * the rule/transaction/import entity pickers read the entity list. Per-consumer
  * client (not a shared SDK): app-finance owns its own slice of the contacts
  * surface via the wire contract, decoupled from `@pops/app-ai`.
- * `pillars/contacts/openapi/contacts.openapi.json` is the source of truth.
+ *
+ * contacts is a Rust pillar with no npm package (it is invisible to pnpm by
+ * design — see docs/plans/repo-federation/02-build-system.md), so its contract
+ * cannot be consumed through a `@pops/*` dependency. Per ADR-033 the OpenAPI
+ * snapshot IS the cross-language contract, so this unit vendors a copy of that
+ * published snapshot under `contracts/` and generates against the local copy.
+ * No reach into the sibling pillar's folder — finance/app carries its own
+ * contract input on extraction. A repo-level drift gate
+ * (scripts/ci/check-vendored-contracts.mjs) keeps the copy in lockstep with
+ * the canonical `pillars/contacts/openapi/contacts.openapi.json`.
  *
  * Regenerate: pnpm --filter @pops/app-finance generate:contacts-client
  */
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@hey-api/openapi-ts';
 
 export default defineConfig({
-  input: '../../contacts/openapi/contacts.openapi.json',
+  input: fileURLToPath(new URL('./contracts/contacts.openapi.json', import.meta.url)),
   output: {
     path: 'src/contacts-api',
   },

--- a/pillars/food/app/openapi-ts.lists.config.ts
+++ b/pillars/food/app/openapi-ts.lists.config.ts
@@ -5,15 +5,22 @@
  * app-food is a cross-pillar consumer of lists (the send-to-list modal
  * reads the user's shopping lists). Per-consumer client: app-food owns its
  * own slice of the lists surface via the wire contract, decoupled from
- * `@pops/app-lists`. `pillars/lists/openapi/lists.openapi.json` is the
- * source of truth.
+ * `@pops/app-lists`.
+ *
+ * The spec is resolved through `@pops/lists`'s `./openapi` package export (a
+ * declared devDependency), never by reaching into the sibling pillar's folder,
+ * so this unit stays black-box-isolated and extraction-ready.
  *
  * Regenerate: pnpm --filter @pops/app-food generate:lists-client
  */
+import { createRequire } from 'node:module';
+
 import { defineConfig } from '@hey-api/openapi-ts';
 
+const require = createRequire(import.meta.url);
+
 export default defineConfig({
-  input: '../../lists/openapi/lists.openapi.json',
+  input: require.resolve('@pops/lists/openapi'),
   output: {
     path: 'src/lists-api',
   },

--- a/pillars/food/app/package.json
+++ b/pillars/food/app/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.98.2",
     "@lezer/generator": "^1.8.0",
+    "@pops/lists": "workspace:*",
     "@pops/locales": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       '@hey-api/openapi-ts':
         specifier: ^0.98.2
         version: 0.98.2(magicast@0.5.3)(typescript@6.0.3)
+      '@pops/finance':
+        specifier: workspace:*
+        version: link:../../finance
       '@pops/locales':
         specifier: workspace:*
         version: link:../../../libs/locales
@@ -1229,6 +1232,9 @@ importers:
       '@lezer/generator':
         specifier: ^1.8.0
         version: 1.8.0
+      '@pops/lists':
+        specifier: workspace:*
+        version: link:../../lists
       '@pops/locales':
         specifier: workspace:*
         version: link:../../../libs/locales

--- a/scripts/ci/check-vendored-contracts.mjs
+++ b/scripts/ci/check-vendored-contracts.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Vendored-contract drift guard.
+ *
+ * Some app units consume a sibling pillar's OpenAPI contract at codegen time
+ * but cannot depend on it through a `@pops/*` package — the producing pillar
+ * has no npm package (e.g. `contacts`, a Rust pillar invisible to pnpm by
+ * design, see docs/plans/repo-federation/02-build-system.md). Per ADR-033 the
+ * OpenAPI snapshot IS that pillar's cross-language contract, so the consumer
+ * vendors a copy of the published snapshot inside its OWN unit boundary
+ * (`pillars/<consumer>/app/contracts/<pillar>.openapi.json`) and generates its
+ * client from the local copy. That keeps the unit black-box-isolated and
+ * extraction-ready: it never reaches into the sibling pillar's folder, and on
+ * extraction it carries its own contract input.
+ *
+ * The one risk a vendored copy introduces is drift: the snapshot the consumer
+ * ships could lag the producer's canonical spec. This guard closes that gap —
+ * every vendored copy must be byte-identical to the canonical
+ * `pillars/<pillar>/openapi/<pillar>.openapi.json`. If the producer's contract
+ * changes, this fails until the consumer re-vendors (and regenerates its
+ * client), so the seam stays honest.
+ *
+ * It is a whole-tree check (reads the working tree directly, pulls in no
+ * third-party deps) and is mapping-driven: a vendored file
+ * `.../contracts/<name>.openapi.json` is paired with the canonical producer
+ * spec `pillars/<name>/openapi/<name>.openapi.json` by filename. A vendored
+ * file with no matching producer spec is itself a failure (stale or
+ * mis-named) so the convention can't rot silently.
+ *
+ * Usage:
+ *   node scripts/ci/check-vendored-contracts.mjs
+ *   node scripts/ci/check-vendored-contracts.mjs --self-test
+ *
+ * Exit 0 = every vendored copy matches its source. Exit 1 = drift / orphan.
+ */
+
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+
+const VENDORED_SUFFIX = '.openapi.json';
+
+/**
+ * @typedef {object} VendoredContract
+ * @property {string} copy        Absolute path to the vendored snapshot.
+ * @property {string} source      Absolute path to the canonical producer spec.
+ * @property {string} pillarId    Producer pillar id (derived from the filename).
+ */
+
+/**
+ * Discover every vendored contract under `pillars/<consumer>/app/contracts/`
+ * and pair each with the canonical producer spec it must mirror.
+ *
+ * @param {string} root Repo root to scan.
+ * @returns {VendoredContract[]}
+ */
+export function discoverVendoredContracts(root) {
+  /** @type {VendoredContract[]} */
+  const found = [];
+  const pillarsDir = join(root, 'pillars');
+  if (!existsSync(pillarsDir)) return found;
+
+  for (const consumer of readdirSync(pillarsDir, { withFileTypes: true })) {
+    if (!consumer.isDirectory()) continue;
+    const contractsDir = join(pillarsDir, consumer.name, 'app', 'contracts');
+    if (!existsSync(contractsDir)) continue;
+    for (const entry of readdirSync(contractsDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(VENDORED_SUFFIX)) continue;
+      const pillarId = entry.name.slice(0, -VENDORED_SUFFIX.length);
+      found.push({
+        copy: join(contractsDir, entry.name),
+        source: join(pillarsDir, pillarId, 'openapi', entry.name),
+        pillarId,
+      });
+    }
+  }
+  return found.toSorted((a, b) => a.copy.localeCompare(b.copy));
+}
+
+/**
+ * @typedef {object} DriftFinding
+ * @property {'orphan' | 'drift'} kind
+ * @property {string} copy
+ * @property {string} source
+ */
+
+/**
+ * Compare each vendored copy against its canonical source.
+ *
+ * @param {VendoredContract[]} contracts
+ * @param {(p: string) => string | null} read Reads a file, or null if absent.
+ * @returns {DriftFinding[]}
+ */
+export function findDrift(contracts, read) {
+  /** @type {DriftFinding[]} */
+  const findings = [];
+  for (const { copy, source } of contracts) {
+    const sourceText = read(source);
+    if (sourceText === null) {
+      findings.push({ kind: 'orphan', copy, source });
+      continue;
+    }
+    const copyText = read(copy);
+    if (copyText !== sourceText) {
+      findings.push({ kind: 'drift', copy, source });
+    }
+  }
+  return findings;
+}
+
+/** @param {string} path @returns {string | null} */
+function readOrNull(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} to */
+function rel(to) {
+  return to.startsWith(`${repoRoot}/`) ? to.slice(repoRoot.length + 1) : to;
+}
+
+/**
+ * Self-test: prove the detector flags drift and an orphan, and passes an
+ * identical pair. CI runs this so a regression that neuters the matcher is
+ * caught deterministically.
+ *
+ * @returns {boolean}
+ */
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'vendored-contracts-'));
+  try {
+    const files = new Map([
+      [join(dir, 'src-match.json'), '{"a":1}\n'],
+      [join(dir, 'copy-match.json'), '{"a":1}\n'],
+      [join(dir, 'src-drift.json'), '{"a":1}\n'],
+      [join(dir, 'copy-drift.json'), '{"a":2}\n'],
+      [join(dir, 'copy-orphan.json'), '{"a":1}\n'],
+    ]);
+    for (const [path, text] of files) writeFileSync(path, text);
+
+    const read = (/** @type {string} */ p) => (files.has(p) ? (files.get(p) ?? null) : null);
+    const contracts = [
+      { copy: join(dir, 'copy-match.json'), source: join(dir, 'src-match.json'), pillarId: 'm' },
+      { copy: join(dir, 'copy-drift.json'), source: join(dir, 'src-drift.json'), pillarId: 'd' },
+      {
+        copy: join(dir, 'copy-orphan.json'),
+        source: join(dir, 'src-missing.json'),
+        pillarId: 'o',
+      },
+    ];
+    const findings = findDrift(contracts, read);
+    const drift = findings.find((f) => f.kind === 'drift' && f.copy.endsWith('copy-drift.json'));
+    const orphan = findings.find((f) => f.kind === 'orphan' && f.copy.endsWith('copy-orphan.json'));
+    const matchedAllowed = !findings.some((f) => f.copy.endsWith('copy-match.json'));
+
+    const ok = Boolean(drift) && Boolean(orphan) && matchedAllowed && findings.length === 2;
+    if (!ok) {
+      console.error('SELF-TEST FAILED:');
+      console.error(`  caught drift:          ${Boolean(drift)}`);
+      console.error(`  caught orphan:         ${Boolean(orphan)}`);
+      console.error(`  allowed identical:     ${matchedAllowed}`);
+      console.error(`  exactly 2 findings:    ${findings.length === 2}`);
+    } else {
+      console.log('self-test OK — flags drift + orphan, allows an identical copy.');
+    }
+    return ok;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log('Usage: node scripts/ci/check-vendored-contracts.mjs [--self-test]');
+    process.exit(2);
+  }
+  if (argv.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+
+  const contracts = discoverVendoredContracts(repoRoot);
+  if (contracts.length === 0) {
+    console.log('OK — no vendored pillar contracts found.');
+    process.exit(0);
+  }
+
+  const findings = findDrift(contracts, readOrNull);
+  if (findings.length === 0) {
+    console.log(`OK — ${contracts.length} vendored contract(s) match their canonical source.`);
+    process.exit(0);
+  }
+
+  console.error(`FAIL — ${findings.length} vendored contract problem(s):`);
+  for (const f of findings) {
+    if (f.kind === 'orphan') {
+      console.error(
+        `  ${rel(f.copy)}\n      no canonical source at ${rel(f.source)} (stale or mis-named vendored copy)`
+      );
+    } else {
+      console.error(
+        `  ${rel(f.copy)}\n      drifted from ${rel(f.source)} — re-vendor and regenerate the client`
+      );
+    }
+  }
+  console.error(
+    '\nA vendored contract must stay byte-identical to its producing pillar’s ' +
+      'canonical OpenAPI snapshot. Copy the source over the vendored file and ' +
+      'rerun the consumer’s generate:*-client script.'
+  );
+  process.exit(1);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}

--- a/scripts/extractability/materialize-tsconfig.mjs
+++ b/scripts/extractability/materialize-tsconfig.mjs
@@ -140,6 +140,11 @@ function serialisableCompilerOptions(options, _baseDir) {
   const out = {};
   const drop = new Set([
     'configFilePath',
+    // `pathsBasePath` is an INTERNAL field TS injects alongside a resolved
+    // `paths`/`baseUrl` — it is not a writable tsconfig option, so emitting it
+    // makes tsc reject the materialised config (TS5023 "Unknown compiler
+    // option"). Dropped together with the path-bearing options below.
+    'pathsBasePath',
     'outDir',
     'rootDir',
     'baseUrl',

--- a/scripts/extractability/pack-deps.mjs
+++ b/scripts/extractability/pack-deps.mjs
@@ -33,20 +33,42 @@ function main(argv) {
   const unit = resolveUnit(unitArg, cwd);
   const byName = new Map(discoverUnits(undefined, cwd).map((u) => [u.name, u]));
 
-  const popsDeps = workspacePopsDeps(unit.pkg);
+  // Pack the TRANSITIVE @pops/* closure, not just the unit's direct edges. A
+  // packed dep's tarball declares its own @pops/* deps as concrete versions
+  // (pnpm pack rewrites `workspace:*` -> the version), which the isolated
+  // install would otherwise try to fetch from the public registry and 404 on
+  // (they are private workspace packages). Packing the whole closure and
+  // pointing every @pops/* edge at its tarball (via pnpm.overrides, see
+  // rewrite-deps.mjs) is what lets a unit with @pops/* runtime deps — e.g. a
+  // pillar app importing its own pillar contract — install in isolation.
   /** @type {Record<string, string>} */
   const manifest = {};
-  for (const depName of popsDeps) {
+  // Seed the closure with the unit's OWN edges INCLUDING devDependencies: the
+  // proof we run is build (or typecheck+test for shell-bundled app units), and
+  // those legitimately import workspace devDeps — e.g. `@pops/locales` provides
+  // the JSON resources a finance/app test-setup imports. A consumer's devDeps
+  // are not transitively installed, so the BFS expansion below stays
+  // runtime-only (devDeps are pulled for the root unit alone).
+  /** @type {string[]} */
+  const queue = workspacePopsDeps(unit.pkg, true);
+  const seen = new Set(queue);
+  while (queue.length > 0) {
+    const depName = /** @type {string} */ (queue.shift());
     const dep = byName.get(depName);
     if (!dep) {
       process.stderr.write(
-        `pack-deps: ${depName} not found in workspace (declared by ${unit.name})\n`
+        `pack-deps: ${depName} not found in workspace (declared in the closure of ${unit.name})\n`
       );
       return 1;
     }
     buildUnit(dep.dir);
-    const tgz = packUnit(dep.dir, outDir);
-    manifest[depName] = tgz;
+    manifest[depName] = packUnit(dep.dir, outDir);
+    for (const next of workspacePopsDeps(dep.pkg, false)) {
+      if (!seen.has(next)) {
+        seen.add(next);
+        queue.push(next);
+      }
+    }
   }
   process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
   return 0;
@@ -54,15 +76,23 @@ function main(argv) {
 
 /**
  * Returns the @pops/* deps declared with a workspace protocol (the edges that
- * must be rewritten for isolation). Spans dependencies + peerDependencies +
- * optionalDependencies (runtime surfaces); devDeps are not needed to build a
- * consumer of the packed unit.
+ * must be rewritten for isolation). Always spans dependencies +
+ * peerDependencies + optionalDependencies (runtime surfaces); when
+ * `includeDev` is set it also spans devDependencies — used only for the root
+ * unit, whose own build/typecheck/test legitimately needs its workspace
+ * devDeps. A consumer never installs a packed dep's devDeps, so the transitive
+ * walk passes `includeDev=false`.
+ *
  * @param {Record<string, unknown>} pkg
+ * @param {boolean} includeDev
  */
-function workspacePopsDeps(pkg) {
+function workspacePopsDeps(pkg, includeDev) {
   /** @type {string[]} */
   const out = [];
-  for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+  const fields = includeDev
+    ? ['dependencies', 'peerDependencies', 'optionalDependencies', 'devDependencies']
+    : ['dependencies', 'peerDependencies', 'optionalDependencies'];
+  for (const field of fields) {
     const block = pkg[field];
     if (block && typeof block === 'object') {
       for (const [name, spec] of Object.entries(block)) {
@@ -79,8 +109,30 @@ function workspacePopsDeps(pkg) {
   return out;
 }
 
-/** @param {string} dir */
+/**
+ * Builds a packed dep so its `dist/` exists before `pnpm pack`. Source-only
+ * `@pops/*` libs (e.g. `@pops/navigation`, `@pops/ui`, `@pops/locales`) ship
+ * their `src/` directly — `main`/`exports` point at `./src/index.ts`, there is
+ * no compile step and so no `build` script. Packing those as-is is correct (the
+ * tarball carries the source the consumer resolves), so skip the build step for
+ * them rather than erroring on a missing script — otherwise the sandbox could
+ * never run on any unit that depends on a source-only lib (every pillar app
+ * depends on `@pops/navigation`/`@pops/ui`).
+ *
+ * @param {string} dir
+ */
 function buildUnit(dir) {
+  const scripts = resolveUnit(dir).pkg.scripts;
+  const hasBuild =
+    scripts &&
+    typeof scripts === 'object' &&
+    typeof (/** @type {Record<string, unknown>} */ (scripts).build) === 'string';
+  if (!hasBuild) {
+    process.stderr.write(
+      `pack-deps: ${packageNameAt(dir)} has no build script (source-only lib) — packing src/ as-is.\n`
+    );
+    return;
+  }
   // stdout is reserved for the manifest JSON; build chatter must go to stderr
   // so the caller can capture stdout cleanly.
   execFileSync('pnpm', ['--filter', packageNameAt(dir), 'run', 'build'], {

--- a/scripts/extractability/rewrite-deps.mjs
+++ b/scripts/extractability/rewrite-deps.mjs
@@ -62,6 +62,27 @@ function main(argv) {
     }
   }
 
+  // Force the TRANSITIVE @pops/* edges to resolve from the packed tarballs too.
+  // A packed dep's own manifest declares its @pops/* deps as concrete versions
+  // (`@pops/types: 0.1.0` — pnpm pack froze the `workspace:*`), which the
+  // isolated `--ignore-workspace` install would chase to the public registry
+  // and 404 on. A pnpm `overrides` block keyed on each packed name pins the
+  // whole tree to the tarballs, so the closure resolves entirely offline — the
+  // faithful stand-in for "every @pops/* dep comes from a published artifact".
+  if (Object.keys(manifest).length > 0) {
+    const pnpmField =
+      pkg.pnpm && typeof pkg.pnpm === 'object'
+        ? /** @type {Record<string, unknown>} */ (pkg.pnpm)
+        : (pkg.pnpm = {});
+    const overrides =
+      pnpmField.overrides && typeof pnpmField.overrides === 'object'
+        ? /** @type {Record<string, string>} */ (pnpmField.overrides)
+        : (pnpmField.overrides = {});
+    for (const [name, tgz] of Object.entries(manifest)) {
+      overrides[name] = `file:${tgz}`;
+    }
+  }
+
   writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
   process.stdout.write(
     `rewrote ${pkgPath} (${Object.keys(manifest).length} @pops dep(s) -> file:)\n`

--- a/scripts/extractability/sandbox.sh
+++ b/scripts/extractability/sandbox.sh
@@ -44,11 +44,35 @@ if [[ ! -f "$abs_unit/package.json" ]]; then
 fi
 
 has_build="$(node -e "const s=require('$abs_unit/package.json').scripts||{}; process.stdout.write(s.build?'1':'')")"
-if [[ -z "$has_build" ]]; then
-  echo "sandbox: $unit has no build script — nothing to prove, skipping." >&2
+has_typecheck="$(node -e "const s=require('$abs_unit/package.json').scripts||{}; process.stdout.write(s.typecheck?'1':'')")"
+has_test="$(node -e "const s=require('$abs_unit/package.json').scripts||{}; process.stdout.write((s['test:coverage']||s.test)?'1':'')")"
+
+# What proof do we owe this unit? Three honest cases — never a silent skip when
+# there IS a surface to prove:
+#
+#   * build present            -> emit-build is the proof (a consumer could
+#                                 `tsc -b` against the published .d.ts).
+#   * no build, typecheck/test -> a SHELL-BUNDLED app unit (ADR-002): the 7
+#                                 `pillars/*/app` React FE fragments have no
+#                                 standalone `build` because they are compiled
+#                                 into the shell's single Vite SPA, not emitted
+#                                 as a library. A standalone bundle is therefore
+#                                 meaningless for them. Their extraction proof
+#                                 is "installs in isolation against packed
+#                                 @pops/* tarballs, then typechecks (+ tests)" —
+#                                 which is exactly what this sandbox runs below.
+#                                 So we DO prove them; we just skip emit-build.
+#                                 (Mirrors app-quality.yml, which type+tests the
+#                                 app units but never `pnpm build`s them.)
+#   * none of the three        -> genuinely nothing to prove (config/data-only
+#                                 package); skip with a reason.
+if [[ -z "$has_build" && -z "$has_typecheck" && -z "$has_test" ]]; then
+  echo "sandbox: $unit has no build/typecheck/test script — nothing to prove, skipping." >&2
   exit 0
 fi
-has_typecheck="$(node -e "const s=require('$abs_unit/package.json').scripts||{}; process.stdout.write(s.typecheck?'1':'')")"
+if [[ -z "$has_build" ]]; then
+  echo "sandbox: $unit has no build script — shell-bundled app unit (ADR-002); proving extraction via isolated typecheck/test, not a standalone bundle." >&2
+fi
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/ex2-sandbox.XXXXXX")"
 cleanup() { [[ "$keep" == "--keep" ]] || rm -rf "$work"; }
@@ -78,17 +102,46 @@ node "$repo_root/scripts/extractability/rewrite-deps.mjs" "$work/u/package.json"
 #     resolved values are just frozen — exactly what an extracted repo carries).
 node "$repo_root/scripts/extractability/materialize-tsconfig.mjs" "$work/u" "$abs_unit"
 
-# 4) Install + build with NO workspace resolution — the proof.
+# 4) Install + prove with NO workspace resolution — the litmus.
+#
+# Lint is deliberately NOT run here. oxlint/oxfmt and their rule config live
+# ONLY at the repo root (by design — no per-unit lint configs; lint stays
+# monorepo-only), so an extracted unit cannot lint standalone. Running it in
+# this isolated sandbox would either fail (no config) or silently no-op, and
+# either way it would NOT be an honest claim of "lint-clean extraction". Lint
+# is a monorepo-wide gate (`pnpm lint`), not part of the extraction proof; the
+# sandbox proves only what an extracted repo could genuinely run on its own:
+# install + build (or typecheck/test for shell-bundled app units).
 cd "$work/u"
 echo "sandbox: installing (isolated, --ignore-workspace) …" >&2
 pnpm install --ignore-workspace --no-frozen-lockfile
 
-echo "sandbox: building …" >&2
-pnpm run build
+if [[ -n "$has_build" ]]; then
+  echo "sandbox: building …" >&2
+  pnpm run build
+fi
 
 if [[ -n "$has_typecheck" ]]; then
   echo "sandbox: typecheck …" >&2
   pnpm run typecheck
 fi
 
-echo "✔ EX-2: $unit builds in isolation." >&2
+# Shell-bundled app units (no build script) prove extraction via their own
+# test suite too — it exercises the packed @pops/* contracts at runtime, the
+# strongest evidence the unit needs nothing behind a contract. For units that
+# DO emit a build, the build + typecheck above is the proof and tests stay in
+# the dedicated test lanes (kept out here to keep EX-2 fast).
+if [[ -z "$has_build" && -n "$has_test" ]]; then
+  echo "sandbox: test (isolated) …" >&2
+  if node -e "process.exit((require('./package.json').scripts||{})['test:coverage']?0:1)"; then
+    pnpm run test:coverage
+  else
+    pnpm run test
+  fi
+fi
+
+if [[ -n "$has_build" ]]; then
+  echo "✔ EX-2: $unit builds in isolation." >&2
+else
+  echo "✔ EX-2: $unit typechecks/tests in isolation (shell-bundled app unit; no standalone build by design)." >&2
+fi


### PR DESCRIPTION
## What

Closes the real extractability violations a prior audit found, in one PR.

### 1. Cross-pillar codegen reaches (black-box violation)

Three `pillars/*/app` units generated their Hey API client from a **sibling pillar's** openapi folder via `../../<pillar>/openapi/...`, and did not declare that pillar as a dependency. Extracting the unit dragged a path into a sibling — a behind-the-contract reach (ISO-R2 / `00-architecture.md` §2).

| Unit | Was | Now |
| --- | --- | --- |
| `@pops/app-ai` (finance client) | `input: '../../finance/openapi/finance.openapi.json'` | `require.resolve('@pops/finance/openapi')` + `@pops/finance` declared (devDep) |
| `@pops/app-food` (lists client) | `input: '../../lists/openapi/lists.openapi.json'` | `require.resolve('@pops/lists/openapi')` + `@pops/lists` declared (devDep) |
| `@pops/app-finance` (contacts client) | `input: '../../contacts/openapi/contacts.openapi.json'` | vendored snapshot under `contracts/`, generated from the local copy |

`@pops/finance` and `@pops/lists` already publish `./openapi` in their `exports` + `files`, so those consume the contract through a declared `@pops/*` dependency. They are **devDependencies**: the spec is read only at codegen time, the generated client is committed, and no app imports the backend at runtime — so EX-2 never drags the backend into the FE extraction via runtime deps.

`contacts` is a **Rust pillar with no npm package** (invisible to pnpm by design — `02-build-system.md`), so it cannot be consumed through `@pops/*`. Per **ADR-033** the OpenAPI snapshot *is* the cross-language contract, so `app-finance` vendors a copy of that published snapshot under `pillars/finance/app/contracts/` and generates from the local copy — no reach into the sibling folder, and the unit carries its own contract input on extraction. A new drift gate (`scripts/ci/check-vendored-contracts.mjs`, wired into the **Quality** workflow + a self-test) keeps the vendored copy byte-identical to the canonical `pillars/contacts/openapi/contacts.openapi.json`.

All three regenerate to **byte-identical** clients — pure source-of-spec refactor, zero behavioural change.

> Out of scope: `pillars/shell/openapi-ts.config.ts` has the same `../../pillars/registry/openapi/...` pattern, but the shell is a UI pillar (`pillars/shell`), not a `pillars/*/app` unit. Flagged for a follow-up.

### 2. App-unit extraction was unproven → now honest

`pillars/*/app` units are React FE fragments bundled into the shell's single Vite SPA (ADR-002), so they have **no standalone `build`** (matching `app-quality.yml`). The EX-2 sandbox silently `exit 0`'d on them ("no build script — nothing to prove"), so their extraction was never proven.

The sandbox now proves app units via **isolated typecheck + test** (the honest bar for a shell-bundled fragment) instead of a meaningless standalone bundle, and documents why. Compiled units still prove via `build` (unchanged). Making the proof actually run surfaced latent `pack-deps`/`materialize-tsconfig` gaps the silent skip had hidden, now fixed:

- pack the **transitive `@pops/*` closure** and pin it with `pnpm.overrides` so a unit importing its own pillar contract installs offline (no registry 404 on private packages);
- pack the **root unit's workspace devDeps** (an app's typecheck/test legitimately imports e.g. `@pops/locales`);
- **skip the build step for source-only libs** (`@pops/navigation`/`@pops/ui`/`@pops/locales` ship `src/`, no `build` script);
- drop the internal `pathsBasePath` key when materialising tsconfig (it is not a writable option → TS5023).

### 3. Lint is monorepo-only — sandbox now says so

oxlint/oxfmt + rules live only at the repo root (by design — no per-unit configs). The sandbox now explicitly documents that lint is **not** part of the extraction litmus, so it never falsely claims lint-clean extraction.

## Local proof (EX-2 sandbox, run on every touched unit)

```
EX-2 pillars/finance/app : typecheck + 379 tests PASS in isolation (vendored contacts client works)
EX-2 pillars/ai/app      : typecheck + tests PASS in isolation
EX-2 pillars/food/app    : typecheck + tests PASS in isolation
EX-2 libs/types          : builds in isolation (build path unchanged)
```

Also green locally: `typecheck`, `lint`, `format:check`, `lint:boundaries`, `exports:check`, EX-1 (all 29 units) + EX-3 (baseline 82→82), bundle-map / contract-isolation / lib-no-pillar guards, the new vendored-contracts gate + self-test, and jscpd duplication (2.46% < 5%). `pnpm install --frozen-lockfile` is consistent.