### PR TITLE
fix(shell): consume registry openapi via @pops/registry/openapi export

### DIFF
--- a/pillars/shell/openapi-ts.config.ts
+++ b/pillars/shell/openapi-ts.config.ts
@@ -7,7 +7,9 @@
  * all read/write the registry's `settings.*`, `shell.manifest` and
  * `features.*` surface over REST. Per-consumer client (not a shared SDK): the
  * shell owns its slice of the registry surface via the wire contract.
- * `pillars/registry/openapi/registry.openapi.json` is the source of truth.
+ * Consumed via the published `@pops/registry/openapi` contract export (a
+ * declared devDependency), NOT a `../../pillars/registry/...` sibling-folder
+ * path — so the shell carries nothing from the registry pillar's folder.
  *
  * The generated client posts to the shell's `/registry-api` proxy prefix
  * (see `src/registry-api-runtime-config.ts`), stripped by the generated
@@ -15,10 +17,14 @@
  *
  * Regenerate: pnpm --filter @pops/shell generate:registry-client
  */
+import { createRequire } from 'node:module';
+
 import { defineConfig } from '@hey-api/openapi-ts';
 
+const require = createRequire(import.meta.url);
+
 export default defineConfig({
-  input: '../../pillars/registry/openapi/registry.openapi.json',
+  input: require.resolve('@pops/registry/openapi'),
   output: {
     path: 'src/registry-api',
   },

--- a/pillars/shell/package.json
+++ b/pillars/shell/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.98.2",
     "@playwright/test": "^1.60.0",
+    "@pops/registry": "workspace:*",
     "@tanstack/react-query-devtools": "^5.101.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2007,6 +2007,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@pops/registry':
+        specifier: workspace:*
+        version: link:../registry
       '@tanstack/react-query-devtools':
         specifier: ^5.101.0
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
The shell's hey-api codegen read `../../pillars/registry/openapi/registry.openapi.json` — reaching into the registry pillar's folder (a black-box / extractability violation). Repointed to the published `@pops/registry/openapi` contract export (codegen-time devDependency; committed client → no runtime backend dep). Regenerated client is **byte-identical** (pure source-of-spec refactor). The **last** cross-pillar openapi reach — the 3 `pillars/*/app` ones were fixed in #3557.