### PR TITLE
chore(food): agent-first comment hygiene — frontend (Wave 5, 5b/12)

### DIFF
--- a/pillars/food/app/src/__tests__/manifest.test.ts
+++ b/pillars/food/app/src/__tests__/manifest.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { manifest, navConfig, routes } from '../index.js';
 
-describe('PRD-118 — app-food module manifest', () => {
+describe('food app module manifest (pillars/food/docs/prds/app-shell)', () => {
   it('declares id="food"', () => {
     expect(manifest.id).toBe('food');
   });
@@ -26,7 +26,7 @@ describe('PRD-118 — app-food module manifest', () => {
     expect(routes[0]).toMatchObject({ index: true });
   });
 
-  it('does NOT yet declare a backend slot (Epic 00 implementation fills it)', () => {
+  it('declares no backend slot', () => {
     expect(manifest.backend).toBeUndefined();
   });
 });

--- a/pillars/food/app/src/ai/__tests__/prompt-registry.test.ts
+++ b/pillars/food/app/src/ai/__tests__/prompt-registry.test.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-133 — drift catcher for the prompt registry.
+ * Drift catcher for the prompt registry.
  *
  * Discovers every module under `pillars/food/app/src/prompts/` at
  * runtime via `import.meta.glob` so adding a new prompt file forces
@@ -25,7 +25,7 @@ function collectVersionExports(): string[] {
   return versions;
 }
 
-describe('PRD-133 — FOOD_PROMPTS registry', () => {
+describe('FOOD_PROMPTS registry', () => {
   it('discovers at least one prompt module under src/prompts/', () => {
     expect(Object.keys(promptModules).length).toBeGreaterThan(0);
   });

--- a/pillars/food/app/src/ai/prompt-registry.ts
+++ b/pillars/food/app/src/ai/prompt-registry.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-133 — Food prompt registry.
+ * Food prompt registry — see pillars/food/docs/prds/ai-usage-prompts.
  *
  * Single source of truth for the read-only `/food/prompts` viewer. Each
  * entry pins a prompt template + version + owning PRD. The viewer page

--- a/pillars/food/app/src/components/DslEditor.stories.tsx
+++ b/pillars/food/app/src/components/DslEditor.stories.tsx
@@ -1,10 +1,9 @@
 /**
- * DslEditor stories — covers the 120-A scaffold, the 120-C `issues`
- * surface (squiggles + tooltip + gutter), the 120-D chip widgets, and
- * the read-only mode.
+ * DslEditor stories — cover the scaffold, the `issues` surface (squiggles
+ * + tooltip + gutter), the chip widgets, and the read-only mode.
  *
- * `apps/pops-storybook/.storybook/main.ts` discovers stories from
- * `packages/*\/src/**\/*.stories.@(ts|tsx)`, so this file lives next to
+ * `libs/ui/.storybook/main.ts` discovers stories from
+ * `pillars/*\/*\/src/**\/*.stories.@(ts|tsx)`, so this file lives next to
  * the component (same convention `RecipeRenderer.stories.tsx` adopted).
  *
  * Stories use a `StoryHost` wrapper that owns the document via

--- a/pillars/food/app/src/components/DslEditor.tsx
+++ b/pillars/food/app/src/components/DslEditor.tsx
@@ -41,14 +41,14 @@ export interface DslEditorProps {
   className?: string;
   /**
    * Autocomplete lookups. When omitted, the dropdown stays empty.
-   * Production wiring uses `useDslAutocompleteSources()` which wraps tRPC
-   * + React Query.
+   * Production wiring uses `useDslAutocompleteSources()`, which calls the
+   * generated REST SDK directly per keystroke.
    */
   autocompleteSources?: DslAutocompleteSources;
   /**
-   * PRD-135 — imperative cursor move target. The DecisionPane sets this
-   * when the user clicks a proposed-slug entry; the editor scrolls + sets
-   * the selection at `{ line, col }` and focuses. `nonce` lets callers
+   * Imperative cursor move target. The DecisionPane sets this when the
+   * user clicks a proposed-slug entry; the editor scrolls + sets the
+   * selection at `{ line, col }` and focuses. `nonce` lets callers
    * re-trigger the move with the same coordinates (e.g. clicking the same
    * entry twice). `line` + `col` are 1-indexed to match `SourceSpan`.
    */

--- a/pillars/food/app/src/components/HeroImageUploader.test.tsx
+++ b/pillars/food/app/src/components/HeroImageUploader.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-124 — HeroImageUploader RTL suite.
+ * HeroImageUploader RTL suite.
  *
  * Mocks the generated food SDK so the upload + remove mutations can be
  * exercised in isolation. Toast errors are observed via `sonner.toast`

--- a/pillars/food/app/src/components/RecipeRenderer.helpers.ts
+++ b/pillars/food/app/src/components/RecipeRenderer.helpers.ts
@@ -64,7 +64,7 @@ export function formatQty(value: number): string {
 }
 
 /**
- * Assemble the yield label per PRD line 118:
+ * Assemble the yield label (see pillars/food/docs/prds/dsl-renderer):
  *   "Roma tomato, braised, shredded (500 g)"
  * Falls back to ingredient name alone when variant + prep are null.
  */

--- a/pillars/food/app/src/components/RecipeRenderer.stories.tsx
+++ b/pillars/food/app/src/components/RecipeRenderer.stories.tsx
@@ -11,11 +11,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ResolvedStepBody, RecipeVersionWithCompiledData } from './recipe-render-types.js';
 
 /**
- * PRD-121 stories — `apps/pops-storybook/.storybook/main.ts` discovers
- * stories from `packages/*\/src/**\/*.stories.@(...)`, so this file lives
- * inside the package even though PRD line 249 spells out the path
- * `apps/pops-storybook/src/stories/food/...`. The story coverage matches
- * the PRD list verbatim; the path note is in the PR description.
+ * RecipeRenderer stories — `libs/ui/.storybook/main.ts` discovers stories
+ * from `pillars/*\/*\/src/**\/*.stories.@(...)`, so this file lives next
+ * to the component.
  */
 
 function useFoodI18n(): i18n {

--- a/pillars/food/app/src/components/__tests__/DslEditor.accessibility.test.tsx
+++ b/pillars/food/app/src/components/__tests__/DslEditor.accessibility.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-120 part F — axe-core accessibility sweep for the DSL editor.
+ * axe-core accessibility sweep for the DSL editor.
  *
  * The editor wraps an imperative CodeMirror EditorView, so a single
  * axe-core pass over the React-rendered container covers both the
@@ -64,7 +64,7 @@ async function assertNoViolations(container: HTMLElement): Promise<void> {
   expect(results.violations).toEqual([]);
 }
 
-describe('PRD-120 part F — DslEditor accessibility', () => {
+describe('DslEditor accessibility', () => {
   it('editable editor passes axe-core basic checks', async () => {
     const { container } = render(
       <Wrapper>

--- a/pillars/food/app/src/components/__tests__/DslEditor.reorder.test.tsx
+++ b/pillars/food/app/src/components/__tests__/DslEditor.reorder.test.tsx
@@ -1,10 +1,10 @@
 /**
- * DslEditor — reorder + renumber RTL tests for PRD-120 part E.
+ * DslEditor — reorder + renumber RTL tests.
  *
  * Exercises the toolbar button, the modal's reorder controls, and the
  * single-transaction renumber dispatch into the editor view. The pure
  * renumber transform has its own deep coverage in
- * `dsl/__tests__/renumber.test.ts`; these tests focus on the React/CM
+ * `src/dsl/__tests__/renumber.test.ts`; these tests focus on the React/CM
  * integration surface.
  */
 import { undo } from '@codemirror/commands';
@@ -43,7 +43,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('DslEditor reorder — PRD-120 part E', () => {
+describe('DslEditor reorder', () => {
   it('hides the reorder button in read-only mode', () => {
     render(<DslEditor initialValue={SAMPLE} readOnly onChange={() => {}} />);
     expect(screen.queryByTestId('dsl-editor-reorder-open')).toBeNull();

--- a/pillars/food/app/src/components/__tests__/DslEditor.test.tsx
+++ b/pillars/food/app/src/components/__tests__/DslEditor.test.tsx
@@ -1,13 +1,4 @@
 /**
- * DslEditor — RTL smoke tests for PRD-120 part A.
- *
- * Focused on the acceptance criteria that 120-A owns: the editor mounts,
- * fires `onChange` after the debounce, swaps the document when
- * `initialValue` changes, and switches into read-only mode (banner +
- * blocked input) when `readOnly` is true. The PRD-120 part B suite at
- * the bottom of this file covers autocomplete wiring; the part D suite
- * covers chip widgets + mobile fallback.
- *
  * jsdom doesn't implement the parts of the DOM that CodeMirror leans on
  * for input events (range selection, beforeinput key handling), so the
  * "fires onChange" assertion drives the editor by dispatching a
@@ -28,10 +19,10 @@ import { DslEditor } from '../DslEditor';
 import type { DslAutocompleteSources } from '../dsl-editor/autocomplete-types';
 import type { CompileEditorIssue } from '../dsl-editor/issues-types';
 
-/** CodeMirror exposes `EditorView.findFromDOM(node)` which walks up from
- *  any descendant until it locates the live view. We use it to drive the
- *  editor with synthetic transactions since jsdom can't pump real input
- *  events through CodeMirror's contenteditable surface. */
+/** `EditorView.findFromDOM(node)` walks up from any descendant until it
+ *  locates the live view. We use it to drive the editor with synthetic
+ *  transactions since jsdom can't pump real input events through
+ *  CodeMirror's contenteditable surface. */
 function getEditorView(): EditorView {
   const surface = screen.getByTestId('dsl-editor-surface');
   const cmEditor = surface.querySelector('.cm-editor');
@@ -76,7 +67,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('DslEditor — PRD-120 part A', () => {
+describe('DslEditor — core editing', () => {
   it('renders with the initial value populated', () => {
     render(<DslEditor initialValue='@recipe(slug="x", title="X")' onChange={() => {}} />);
     expect(screen.getByTestId('dsl-editor')).toBeInTheDocument();
@@ -165,7 +156,7 @@ describe('DslEditor — PRD-120 part A', () => {
     expect(screen.queryByTestId('dsl-editor-readonly-banner')).toBeNull();
   });
 
-  it('moves the cursor to pendingCursor.{line,col} and focuses (PRD-135 amendment)', () => {
+  it('moves the cursor to pendingCursor.{line,col} and focuses', () => {
     const dsl = ['line one', 'line two', 'line three'].join('\n');
     const { rerender } = render(<DslEditor initialValue={dsl} onChange={() => {}} />);
     const view = getEditorView();
@@ -209,10 +200,10 @@ describe('DslEditor — PRD-120 part A', () => {
   });
 });
 
-describe('DslEditor — PRD-120 part B autocomplete', () => {
+describe('DslEditor — autocomplete', () => {
   /** Build a fake `DslAutocompleteSources` with vitest spies so tests
-   *  can assert dispatch behaviour without exercising the live tRPC
-   *  React Query path that `useDslAutocompleteSources` wraps. */
+   *  can assert dispatch behaviour without exercising the live SDK
+   *  lookups that `useDslAutocompleteSources` wraps. */
   function makeSources(): {
     sources: DslAutocompleteSources;
     spies: {
@@ -286,7 +277,7 @@ describe('DslEditor — PRD-120 part B autocomplete', () => {
   });
 });
 
-describe('DslEditor — PRD-120 part D (chip widgets)', () => {
+describe('DslEditor — chip widgets', () => {
   beforeEach(() => {
     installMatchMedia(false);
   });
@@ -400,7 +391,7 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
   });
 });
 
-describe('DslEditor — PRD-120 part C (issues prop)', () => {
+describe('DslEditor — issues prop', () => {
   const SAMPLE = '@ingredient(1, banana:raw:foo, 1:cup)';
   const ERROR_ISSUE: CompileEditorIssue = {
     severity: 'error',
@@ -519,7 +510,7 @@ describe('DslEditor — PRD-120 part C (issues prop)', () => {
   });
 });
 
-describe('DslEditor — PRD-120 part F (read-only autocomplete + mobile drawer + a11y)', () => {
+describe('DslEditor — read-only autocomplete + mobile drawer + a11y', () => {
   beforeEach(() => {
     installMatchMedia(false);
   });

--- a/pillars/food/app/src/components/__tests__/RecipeRenderer.parity.test.tsx
+++ b/pillars/food/app/src/components/__tests__/RecipeRenderer.parity.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Round-trip parity test — PRD-121 AC line 248.
+ * Round-trip parity test.
  *
  * Feeds a static `RecipeVersionWithCompiledData` fixture (typed from the
  * `recipes.getForRendering` wire response) to `RecipeRenderer` and asserts
@@ -251,7 +251,7 @@ function makeLine(
   };
 }
 
-describe('PRD-121 — Round-trip parity (compiled fixture → render)', () => {
+describe('Round-trip parity (compiled fixture → render)', () => {
   it('renders every recipe_lines row as an ingredient list <li>', () => {
     render(<RecipeRenderer recipeVersion={PANCAKES} />);
     expect(screen.getAllByTestId('recipe-ingredient-row')).toHaveLength(3);

--- a/pillars/food/app/src/components/__tests__/RecipeRenderer.test.tsx
+++ b/pillars/food/app/src/components/__tests__/RecipeRenderer.test.tsx
@@ -15,7 +15,7 @@ import { ingredientBanana, makeLine, makeRecipeData, yieldIngredientPancake } fr
 
 import type { ResolvedStepBody } from '../recipe-render-types.js';
 
-describe('PRD-121 — RecipeRenderer helpers', () => {
+describe('RecipeRenderer helpers', () => {
   it('clampScaleFactor passes valid scales through', () => {
     expect(clampScaleFactor(undefined)).toBe(1);
     expect(clampScaleFactor(2)).toBe(2);
@@ -125,7 +125,7 @@ describe('PRD-121 — RecipeRenderer helpers', () => {
   });
 });
 
-describe('PRD-121 — RecipeRenderer detail layout', () => {
+describe('RecipeRenderer detail layout', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
@@ -214,7 +214,7 @@ describe('PRD-121 — RecipeRenderer detail layout', () => {
   });
 });
 
-describe('PRD-121 — Ingredient list scaling + formatting', () => {
+describe('Ingredient list scaling + formatting', () => {
   it('scales canonical quantities and leaves original text alone', () => {
     const data = makeRecipeData();
     render(<RecipeRenderer recipeVersion={data} scaleFactor={2} />);
@@ -310,7 +310,7 @@ describe('PRD-121 — Ingredient list scaling + formatting', () => {
   });
 });
 
-describe('PRD-121 — Step body two-pass substitution', () => {
+describe('Step body two-pass substitution', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
@@ -433,7 +433,7 @@ describe('PRD-121 — Step body two-pass substitution', () => {
     expect(onTimerStart).toHaveBeenNthCalledWith(2, 60, 3); // 1 h = 60 min
   });
 
-  it('renders step-level duration + temperature badges from PRD-116 hoist columns', () => {
+  it('renders step-level duration + temperature badges from hoist columns', () => {
     const bodyResolved: ResolvedStepBody = [{ kind: 'text', value: 'Bake until done.' }];
     const data = makeRecipeData({
       steps: [
@@ -498,7 +498,7 @@ describe('PRD-121 — Step body two-pass substitution', () => {
   });
 });
 
-describe('PRD-121 — Compile-status placeholder', () => {
+describe('Compile-status placeholder', () => {
   it('renders "not yet compiled" placeholder when compile_status != compiled', () => {
     const data = makeRecipeData({
       version: { ...makeRecipeData().version, compileStatus: 'failed' },
@@ -519,7 +519,7 @@ describe('PRD-121 — Compile-status placeholder', () => {
   });
 });
 
-describe('PRD-121 — Compact variant', () => {
+describe('Compact variant', () => {
   it('renders the compact card with title, time and yield', () => {
     const data = makeRecipeData();
     render(<RecipeRenderer recipeVersion={data} variant="compact" />);
@@ -548,7 +548,7 @@ describe('PRD-121 — Compact variant', () => {
   });
 });
 
-describe('PRD-121 — Accessibility surface', () => {
+describe('Accessibility surface', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });

--- a/pillars/food/app/src/components/__tests__/dsl-editor-issues-span.test.ts
+++ b/pillars/food/app/src/components/__tests__/dsl-editor-issues-span.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for `spanToRange` — the SourceSpan → CodeMirror offset
- * converter used by the issues extension (PRD-120 part C).
+ * converter used by the issues extension.
  *
  * Covers the contract documented at the top of `issues-span.ts`:
  *   - 1-indexed line/column input, exclusive `endCol`
@@ -21,7 +21,7 @@ function stateFor(doc: string): EditorState {
   return EditorState.create({ doc });
 }
 
-describe('spanToRange — PRD-120 part C', () => {
+describe('spanToRange', () => {
   it('maps a single-line span to the correct offset pair', () => {
     const state = stateFor('@ingredient(1, banana:raw:foo, 1:cup)');
     // `foo` lives at columns 27–29 (1-indexed). The `:` after `raw` is at

--- a/pillars/food/app/src/components/__tests__/dsl-editor-issues-state.test.ts
+++ b/pillars/food/app/src/components/__tests__/dsl-editor-issues-state.test.ts
@@ -1,6 +1,5 @@
 /**
- * Unit tests for the issues `StateField` + `setIssuesEffect` — PRD-120
- * part C.
+ * Unit tests for the issues `StateField` + `setIssuesEffect`.
  *
  * Drives the state field through an `EditorState` directly so we cover:
  *   - dispatching `setIssuesEffect` populates decorations
@@ -47,7 +46,7 @@ const ISSUE_B: CompileEditorIssue = {
   slug: 'banana',
 };
 
-describe('issues StateField — PRD-120 part C', () => {
+describe('issues StateField', () => {
   it('starts with no decorations', () => {
     const state = stateFor('hello world');
     expect(decorationCount(state)).toBe(0);
@@ -121,7 +120,7 @@ describe('issues StateField — PRD-120 part C', () => {
   });
 });
 
-describe('getIssuesForOffset — PRD-120 part C', () => {
+describe('getIssuesForOffset', () => {
   it('returns issues whose span covers the offset', () => {
     const state = stateFor('hello world');
     // ISSUE_A covers cols 1..5 → offsets [0, 4) (half-open, like

--- a/pillars/food/app/src/components/__tests__/fixtures.ts
+++ b/pillars/food/app/src/components/__tests__/fixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Fixtures shared across PRD-121 renderer tests.
+ * Fixtures shared across the renderer tests.
  *
  * Each fixture is built like the compile pipeline would emit it — `body_md`
  * is the rewritten markdown with structural anchors, `body_resolved_json`

--- a/pillars/food/app/src/components/cook/BatchOverridePicker.same-variant.tsx
+++ b/pillars/food/app/src/components/cook/BatchOverridePicker.same-variant.tsx
@@ -1,9 +1,6 @@
 /**
- * PRD-149 — Same-variant section of `BatchOverridePicker`.
- *
- * Behaviour unchanged from PRD-146 — only relocated so the parent
- * picker stays under the per-file lint cap with the new Substitutions
- * section sitting alongside it.
+ * Same-variant section of `BatchOverridePicker`: batches whose variant
+ * matches the line's, FIFO-ordered.
  */
 import { useTranslation } from 'react-i18next';
 

--- a/pillars/food/app/src/components/cook/BatchOverridePicker.substitutions.tsx
+++ b/pillars/food/app/src/components/cook/BatchOverridePicker.substitutions.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-149 — Substitutions section of `BatchOverridePicker`.
+ * Substitutions section of `BatchOverridePicker`.
  *
  * Cross-product candidate × batch rendering with a 5-item display cap
  * + "Show all" expander. Loading / error / empty states sit alongside

--- a/pillars/food/app/src/components/cook/BatchOverridePicker.tsx
+++ b/pillars/food/app/src/components/cook/BatchOverridePicker.tsx
@@ -1,13 +1,11 @@
 /**
- * `BatchOverridePicker` — PRD-146 + PRD-149 (sections amendment).
+ * `BatchOverridePicker` — two sticky-header sections inside one dropdown:
  *
- * Two sticky-header sections inside one dropdown:
- *
- *   - **Same-variant** (PRD-146): batches whose `variantId` matches the
- *     line's variant, FIFO-ordered.
- *   - **Substitutions** (PRD-149): every valid sub edge for the line's
- *     variant × its non-empty batches, ranked by the picker's pure
- *     ranking fn. Capped at 5 entries with a "Show all" expander.
+ *   - **Same-variant**: batches whose `variantId` matches the line's
+ *     variant, FIFO-ordered.
+ *   - **Substitutions**: every valid sub edge for the line's variant ×
+ *     its non-empty batches, ranked by the picker's pure ranking fn.
+ *     Capped at 5 entries with a "Show all" expander.
  *
  * Selection routes through a discriminated `BatchPickerSelection` so the
  * shortfall row can wire same-variant vs sub picks into the right

--- a/pillars/food/app/src/components/cook/ConsumePreviewPanel.tsx
+++ b/pillars/food/app/src/components/cook/ConsumePreviewPanel.tsx
@@ -1,10 +1,8 @@
 /**
- * `ConsumePreviewPanel` — PRD-146.
- *
- * Embeds inside PRD-144's `CookModal` between the field grid and the
- * action buttons. Lists every line whose resolution has a deterministic
- * disposition (FIFO, batch-override, partial, or external) so the user
- * can confirm what will be touched at submit time.
+ * `ConsumePreviewPanel` — embeds inside `CookModal` between the field
+ * grid and the action buttons. Lists every line whose resolution has a
+ * deterministic disposition (FIFO, batch-override, partial, or external)
+ * so the user can confirm what will be touched at submit time.
  *
  * Auto-collapses in the happy path (no shortfalls); defaults to
  * expanded when any shortfall exists.

--- a/pillars/food/app/src/components/cook/CookModal.tsx
+++ b/pillars/food/app/src/components/cook/CookModal.tsx
@@ -1,15 +1,16 @@
 /**
- * PRD-144 — cook event recording modal.
+ * Cook event recording modal. Captures scale, yield, location, expires,
+ * rating, notes. The Mark cooked button gates on form validity AND the
+ * shortfall resolution state from `useCookResolution`.
  *
- * Opens from two entry points (PRD-119's "Cook now" action menu and
- * PRD-143's plan-entry "Mark cooked" — when 143 lands). Captures scale,
- * yield, location, expires, rating, notes. The Mark cooked button gates
- * on form validity AND PRD-146's shortfall resolution state (the
- * `useCookResolution` hook is a stub returning `unresolvedCount: 0` for
- * now; PRD-146 wires the real shortfall UI).
+ * The modal feeds `useCookResolution` an empty shortfall set because
+ * `prepareCook` does not yet emit server shortfalls, so the gate is
+ * currently inert (`unresolvedShortfallCount` stays 0). The live
+ * server→modal shortfall feed is tracked in
+ * `pillars/food/docs/ideas/fifo-consumption-ui-live-wiring.md`.
  *
- * The mutation is one transactional `food.cook.markCooked` round-trip;
- * success closes the modal — the parent `CookNowPortal` owns the toast.
+ * The mutation is one transactional `markCooked` round-trip; success
+ * closes the modal — the parent `CookNowPortal` owns the toast.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +36,7 @@ export interface CookedSuccess {
   /**
    * The location the user selected for the yielded batch, propagated so
    * the parent toast can render a location-aware message instead of
-   * hardcoding "fridge" (Copilot R1). `null` for yieldless cooks.
+   * hardcoding "fridge". `null` for yieldless cooks.
    */
   location: 'pantry' | 'fridge' | 'freezer' | 'other' | null;
 }
@@ -46,7 +47,7 @@ export interface CookModalProps {
   planEntryId?: number;
   isOpen: boolean;
   onClose: () => void;
-  /** Called after a successful `food.cook.markCooked`. */
+  /** Called after a successful `markCooked`. */
   onCookedSuccess?: (result: CookedSuccess) => void;
 }
 

--- a/pillars/food/app/src/components/cook/CookModalContent.tsx
+++ b/pillars/food/app/src/components/cook/CookModalContent.tsx
@@ -5,12 +5,10 @@ import { CookModalYieldFields } from './CookModalYieldFields.js';
 import { ShortfallList } from './ShortfallList.js';
 
 /**
- * Body of the cook modal — PRD-144.
- *
- * Hosts the scale + rating + notes fields, the yield-section fields
- * (when applicable), and the PRD-146 stub panels (`ConsumePreviewPanel`,
- * `ShortfallList`). Split out of `CookModal.tsx` to stay under the
- * per-file lint cap; the parent owns the dialog framing + state.
+ * Body of the cook modal: the scale + rating + notes fields, the
+ * yield-section fields (when applicable), and the consume-preview +
+ * shortfall panels (`ConsumePreviewPanel`, `ShortfallList`). The parent
+ * owns the dialog framing + state.
  */
 import type { Dispatch, ReactElement, SetStateAction } from 'react';
 
@@ -45,10 +43,9 @@ export function CookModalContent({
             setForm((prev) => ({
               ...prev,
               location: loc,
-              // Only freeze the expiry when the user has manually edited
-              // the expires field itself (Copilot R1). Earlier `dirty`-
-              // based gating would lock auto-expiry after the very first
-              // location toggle.
+              // Freeze the expiry only once the user has manually edited
+              // the expires field itself; until then it tracks the
+              // location change.
               expiresAt: prev.expiresAtDirty
                 ? prev.expiresAt
                 : deriveAutoExpires(prep.yieldDefault, loc),

--- a/pillars/food/app/src/components/cook/CookModalFields.tsx
+++ b/pillars/food/app/src/components/cook/CookModalFields.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Input, Label, Textarea } from '@pops/ui';
 
 /**
- * Scale + rating + notes fields for `CookModal` — PRD-144.
+ * Scale + rating + notes fields for `CookModal`.
  */
 import type { ChangeEvent, Dispatch, ReactElement, SetStateAction } from 'react';
 

--- a/pillars/food/app/src/components/cook/CookModalYieldFields.tsx
+++ b/pillars/food/app/src/components/cook/CookModalYieldFields.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Input, Label } from '@pops/ui';
 
 /**
- * Yield qty + unit + location + expires fields for `CookModal` — PRD-144.
+ * Yield qty + unit + location + expires fields for `CookModal`.
  *
  * Hidden when the recipe's version has no `yield_ingredient_id`; the
  * parent only mounts this component for yielding recipes.

--- a/pillars/food/app/src/components/cook/ShortfallList.tsx
+++ b/pillars/food/app/src/components/cook/ShortfallList.tsx
@@ -1,9 +1,8 @@
 /**
- * `ShortfallList` — PRD-146.
- *
- * Lists every unresolved-need line with three resolution radios. The
- * parent `CookModal` reads `unresolvedShortfallCount` from
- * `useCookResolution` to gate Mark-cooked.
+ * `ShortfallList` — lists every unresolved-need line with three
+ * resolution radios. The parent `CookModal` reads
+ * `unresolvedShortfallCount` from `useCookResolution` to gate
+ * Mark-cooked.
  *
  * Expanded by default; collapsing is allowed but Mark-cooked stays
  * disabled regardless of panel visibility (state is independent).
@@ -21,7 +20,7 @@ export interface ShortfallListProps {
   shortfalls: readonly LineShortfall[];
   needsByLine: ReadonlyMap<number, LineConsumeNeed>;
   resolutionMap: ReadonlyMap<number, LineResolution>;
-  /** PRD-149 — threaded down to the per-row `BatchOverridePicker`. */
+  /** Threaded down to the per-row `BatchOverridePicker`. */
   recipeVersionId: number;
   onResolve: (lineIndex: number, resolution: LineResolution) => void;
   scaleResetSignal: number;

--- a/pillars/food/app/src/components/cook/ShortfallRow.tsx
+++ b/pillars/food/app/src/components/cook/ShortfallRow.tsx
@@ -1,17 +1,15 @@
 /**
- * `ShortfallRow` — PRD-146 + PRD-149.
- *
- * One row per unresolved shortfall. Surfaces the three resolution
- * radios (`batch-override`, `external`, `partial`) plus the
+ * `ShortfallRow` — one row per unresolved shortfall. Surfaces the three
+ * resolution radios (`batch-override`, `external`, `partial`) plus the
  * `BatchOverridePicker` mount when the user opts for a batch.
  *
  * `partial` mode adds `Batch qty` + `External qty` number inputs so the
  * user can split the need; defaults are `consumeQty = available`,
  * `externalQty = needed - available`.
  *
- * PRD-149 — when the user picks from the Substitutions section, the
- * resolution carries `substitutionEdgeId` and `consumeQty` is computed
- * from `lineQty × ratio` (capped at the chosen batch's remaining qty).
+ * When the user picks from the Substitutions section, the resolution
+ * carries `substitutionEdgeId` and `consumeQty` is computed from
+ * `lineQty × ratio` (capped at the chosen batch's remaining qty).
  */
 import { useState } from 'react';
 
@@ -58,11 +56,11 @@ function defaultBatchOverrideFor(
   return { kind: 'batch-override', batchId: batch.id, consumeQty };
 }
 
-// `candidate.ratio` matches the solver's convention (`line-evaluator.ts:88`):
-// 1 unit of substitute equals `ratio` units of the original ingredient.
-// So a shortfall of `needed` original units takes `needed / ratio` substitute
-// units to fully cover, and `consumed * ratio` substitute draws fill that many
-// original-units of need.
+// `candidate.ratio` matches the solver's convention (see the solver's
+// `line-evaluator.ts`): 1 unit of substitute equals `ratio` units of the
+// original ingredient. So a shortfall of `needed` original units takes
+// `needed / ratio` substitute units to fully cover, and `consumed * ratio`
+// substitute draws fill that many original-units of need.
 
 function substitutionPartialFor(
   shortfall: LineShortfall,

--- a/pillars/food/app/src/components/cook/SubstitutionCandidateRow.tsx
+++ b/pillars/food/app/src/components/cook/SubstitutionCandidateRow.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-149 — one (substitution edge × batch) candidate row inside the
+ * One (substitution edge × batch) candidate row inside the
  * `BatchOverridePicker` Substitutions section. Rendered for each batch
  * under a sub candidate; "no batches" rows render the edge itself with
  * a disabled state so the user can see which subs exist but aren't

--- a/pillars/food/app/src/components/cook/__tests__/BatchOverridePicker.test.tsx
+++ b/pillars/food/app/src/components/cook/__tests__/BatchOverridePicker.test.tsx
@@ -1,13 +1,4 @@
 /**
- * PRD-149 — RTL coverage for the picker's section split.
- *
- *  - Both sections render with the right counts.
- *  - Substitutions section shows the prep-mismatch chip when applicable.
- *  - Selecting a substitution row routes through `onSelect` with the
- *    `substitution` discriminant + the candidate + the batch.
- *  - "Show all" expander reveals candidates beyond the 5-row cap.
- *  - Loading / empty / error states render their respective copy.
- *
  * The picker drives `batchesSearchForConsume` + `substitutionsResolveForLine`
  * through React Query, so the generated SDK module is mocked and each render
  * is wrapped in a `QueryClientProvider`.
@@ -159,7 +150,7 @@ function renderPicker(
   );
 }
 
-describe('BatchOverridePicker — PRD-149 sections', () => {
+describe('BatchOverridePicker — sections', () => {
   it('renders Same-variant + Substitutions sections with their counts', async () => {
     mockSearchItems([makeBatch({ id: 18 }), makeBatch({ id: 19 })]);
     mockResolution(

--- a/pillars/food/app/src/components/cook/__tests__/ConsumePreviewPanel.test.tsx
+++ b/pillars/food/app/src/components/cook/__tests__/ConsumePreviewPanel.test.tsx
@@ -1,12 +1,3 @@
-/**
- * PRD-146 — RTL coverage for `ConsumePreviewPanel`.
- *
- *  - happy path: 8 fully-covered lines; panel auto-collapsed when no
- *    shortfalls exist
- *  - expanding shows the first N rows + a "show 3 more" expander
- *  - shortfall presence flips the panel to expanded-by-default
- *  - empty-need state renders the dashed empty card
- */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
@@ -36,7 +27,7 @@ function fifoFor(needs: readonly LineConsumeNeed[]): Map<number, LineResolution>
   return map;
 }
 
-describe('ConsumePreviewPanel — PRD-146', () => {
+describe('ConsumePreviewPanel', () => {
   it('renders the empty state when no lines are resolved', () => {
     render(<ConsumePreviewPanel lineNeeds={[]} resolutionMap={new Map()} hasShortfalls={false} />);
     expect(screen.getByText(/no ingredient lines to consume/i)).toBeInTheDocument();

--- a/pillars/food/app/src/components/cook/__tests__/CookModal.test.tsx
+++ b/pillars/food/app/src/components/cook/__tests__/CookModal.test.tsx
@@ -1,10 +1,6 @@
 /**
- * PRD-144 — RTL coverage for `CookModal`.
- *
  * Mocks the food SDK (`cookPrepareCook` / `cookMarkCooked`) so both are
- * controllable per test. Covers: open-from-recipe-detail pre-fill,
- * yieldless-recipe field hiding, submit happy path, server-error
- * surfacing, submit-disabled when scale is empty.
+ * controllable per test.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/pillars/food/app/src/components/cook/__tests__/ShortfallList.test.tsx
+++ b/pillars/food/app/src/components/cook/__tests__/ShortfallList.test.tsx
@@ -1,16 +1,4 @@
 /**
- * PRD-146 — RTL coverage for the shortfall resolution surface.
- *
- *  - 3 unresolved shortfalls render with three radio options each
- *  - external radio resolves the shortfall in-place
- *  - batch-override radio opens `BatchOverridePicker`; selecting a
- *    batch writes a `kind='batch-override'` resolution
- *  - partial radio opens the same picker; selecting writes
- *    `kind='partial'` with the partial-qty editor visible
- *  - mark-cooked gate flips from disabled to enabled exactly when all
- *    three shortfalls have been resolved
- *  - scale change resets state + surfaces the scale-reset banner
- *
  * The nested `BatchOverridePicker` drives `batchesSearchForConsume` +
  * `substitutionsResolveForLine` through React Query, so the generated SDK
  * module is mocked and each render is wrapped in a `QueryClientProvider`.
@@ -142,7 +130,7 @@ function renderHost(props: HostProps): ReturnType<typeof render> {
   return render(<ShortfallHost {...props} />, { wrapper: Wrapper });
 }
 
-describe('ShortfallList — PRD-146', () => {
+describe('ShortfallList', () => {
   it('lists every unresolved shortfall with the expected radios + Mark-cooked stays disabled until all are resolved', async () => {
     mockSearchItems([makeBatch({ id: 42 })]);
     sdk.substitutionsResolveForLine.mockResolvedValue({ data: undefined });

--- a/pillars/food/app/src/components/cook/__tests__/substitution-ranking.test.ts
+++ b/pillars/food/app/src/components/cook/__tests__/substitution-ranking.test.ts
@@ -1,7 +1,6 @@
 /**
- * PRD-149 — unit tests for the picker's candidate sort key.
- *
- * Pins the PRD's documented ordering:
+ * Pins the candidate sort key documented in
+ * `pillars/food/docs/prds/cook-time-substitutions`:
  *   1. |ratio - 1.0| ASC
  *   2. context-tag overlap with the recipe DESC
  *   3. earliest batch expiry ASC NULLS LAST

--- a/pillars/food/app/src/components/cook/__tests__/useCookResolution.test.ts
+++ b/pillars/food/app/src/components/cook/__tests__/useCookResolution.test.ts
@@ -1,14 +1,3 @@
-/**
- * PRD-146 — unit tests for `useCookResolution`.
- *
- *  - seeds `kind: 'fifo'` for every non-optional, fully-covered line
- *  - skips optional lines entirely
- *  - leaves shortfall lines unresolved (counted by
- *    `unresolvedShortfallCount`)
- *  - mark-cooked gate flips when every shortfall is resolved
- *  - scale-factor change resets the resolution map and bumps the
- *    `scaleResetSignal` so the UI can surface the reset banner
- */
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
@@ -144,7 +133,7 @@ describe('useCookResolution', () => {
     expect(result.current.unresolvedShortfallCount).toBe(0);
   });
 
-  it('skips optional shortfalls per PRD-108 silent-skip contract', () => {
+  it('skips optional shortfalls per the fifo-consumption-ui silent-skip contract', () => {
     const needs: LineConsumeNeed[] = [makeNeed({ lineIndex: 1, optional: true })];
     const shortfalls: LineShortfall[] = [makeShortfall({ lineIndex: 1 })];
 

--- a/pillars/food/app/src/components/cook/cook-format.ts
+++ b/pillars/food/app/src/components/cook/cook-format.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-146 — display formatters shared by the cook-modal panels.
+ * Display formatters shared by the cook-modal panels.
  *
  * `formatQty` mirrors `RecipeRenderer.helpers.formatQty` so quantity
  * formatting stays consistent across the food surfaces (integer →

--- a/pillars/food/app/src/components/cook/cook-modal-helpers.ts
+++ b/pillars/food/app/src/components/cook/cook-modal-helpers.ts
@@ -1,11 +1,11 @@
 import type { MarkCookedInput } from './cook-modal-types.js';
 /**
- * State helpers for `CookModal` — PRD-144.
+ * State helpers for `CookModal`.
  *
  * `initialForm` + `seedForm` keep the modal pure: the open effect calls
  * `seedForm` once with the resolved `CookPreparation`, then the user
  * mutates fields freely. `buildSubmitInput` snaps the form into the
- * `food.cook.markCooked` wire shape.
+ * `markCooked` wire shape.
  */
 import type {
   ConsumptionOverride,

--- a/pillars/food/app/src/components/cook/cook-modal-types.ts
+++ b/pillars/food/app/src/components/cook/cook-modal-types.ts
@@ -1,11 +1,9 @@
 /**
- * Local wire-shape mirrors for the cook modal — PRD-144.
+ * Local mirror of the `markCooked` request body for the cook modal.
  *
- * Mirrors `MarkCookedInputSchema` from the API package without pulling
- * `@pops/api` into this frontend package (cyclic dep — the api-client
- * re-exports the trpc procedures, but the request shape is the modal's
- * own concern). PRD-146 imports the same shape from this file when it
- * lands its real shortfall-resolution UX.
+ * Kept hand-maintained here rather than derived from the generated food
+ * SDK types so the modal owns the shape it builds before it hits the
+ * wire.
  */
 
 import type { ConsumptionOverride } from './cook-resolution-types.js';

--- a/pillars/food/app/src/components/cook/cook-resolution-types.ts
+++ b/pillars/food/app/src/components/cook/cook-resolution-types.ts
@@ -1,12 +1,12 @@
 /**
- * Cook-flow view + resolution types (PRD-144 / PRD-146).
+ * Cook-flow view + resolution types.
  *
  * Wire-shaped values (`CookPreparation`, `CookYieldDefault`,
  * `LineConsumeNeed`, `BatchForConsumeRow`, `ConsumptionOverride`) are
  * projected from the generated food SDK so the modal stays in lockstep
  * with the `/cook/*` + `/batches/*` REST surface. `LineResolution` and
- * `LineShortfall` are FE-only modal state (PRD-146) — they never cross the
- * wire, so they live here.
+ * `LineShortfall` are FE-only modal state — they never cross the wire,
+ * so they live here.
  */
 import type {
   BatchesSearchForConsumeResponses,
@@ -25,11 +25,11 @@ export type ConsumptionOverride = NonNullable<
 >[number];
 
 /**
- * PRD-146 — per-line resolution state held by `useCookResolution`.
+ * Per-line resolution state held by `useCookResolution`.
  *
- * `fifo` = accept PRD-108's default; `batch-override` = user picked a
- * specific batch; `external` = user marks the line as consumed outside
- * the batch system; `partial` = some FIFO + some external.
+ * `fifo` = accept the default FIFO consumption; `batch-override` = user
+ * picked a specific batch; `external` = user marks the line as consumed
+ * outside the batch system; `partial` = some FIFO + some external.
  */
 export type LineResolution =
   | { kind: 'fifo' }
@@ -44,8 +44,8 @@ export type LineResolution =
     };
 
 /**
- * PRD-146 — per-line shortfall the cook modal surfaces when FIFO can't
- * fully cover a line. `lineIndex` matches `recipe_lines.position` (1-based).
+ * Per-line shortfall the cook modal surfaces when FIFO can't fully cover
+ * a line. `lineIndex` matches `recipe_lines.position` (1-based).
  */
 export interface LineShortfall {
   lineIndex: number;

--- a/pillars/food/app/src/components/cook/shortfall-row-parts.tsx
+++ b/pillars/food/app/src/components/cook/shortfall-row-parts.tsx
@@ -5,9 +5,8 @@ import { Button } from '@pops/ui';
 import { formatQty } from './cook-format.js';
 
 /**
- * PRD-146 — sub-components for `ShortfallRow`: the radio fieldset, the
- * partial-qty editor, and the row header. Split out to keep the parent
- * row under the per-function line cap.
+ * Sub-components for `ShortfallRow`: the radio fieldset, the partial-qty
+ * editor, and the row header.
  */
 import type { ReactNode } from 'react';
 

--- a/pillars/food/app/src/components/cook/substitution-ranking.ts
+++ b/pillars/food/app/src/components/cook/substitution-ranking.ts
@@ -1,8 +1,8 @@
 /**
- * PRD-149 — substitution candidate ranking.
+ * Substitution candidate ranking.
  *
- * Pure function so the Vitest fixture in `BatchOverridePicker.test.tsx`
- * can pin the order independent of React. Sort key per the PRD:
+ * Pure function so the Vitest fixture in `substitution-ranking.test.ts`
+ * can pin the order independent of React. Sort key:
  *
  *   1. `|ratio - 1.0|` ASC
  *   2. context-tag overlap (with the recipe's tags) DESC

--- a/pillars/food/app/src/components/cook/useCookResolution.ts
+++ b/pillars/food/app/src/components/cook/useCookResolution.ts
@@ -1,11 +1,9 @@
 /**
- * `useCookResolution` — PRD-146.
- *
- * Holds the per-line `LineResolution` map for the cook modal. Seeds the
- * map with `kind: 'fifo'` for every line PRD-108's FIFO can fully
- * cover; lines with a matching `LineShortfall` start unresolved and the
- * UI prompts the user to pick `batch-override`, `external`, or
- * `partial` before Mark-cooked enables.
+ * `useCookResolution` — holds the per-line `LineResolution` map for the
+ * cook modal. Seeds the map with `kind: 'fifo'` for every line the
+ * default FIFO can fully cover; lines with a matching `LineShortfall`
+ * start unresolved and the UI prompts the user to pick `batch-override`,
+ * `external`, or `partial` before Mark-cooked enables.
  *
  * State is local to the modal session — closing discards it. A
  * `scaleFactor` change resets the entire map because the per-line `qty`

--- a/pillars/food/app/src/components/cook/useMarkCookedMutation.ts
+++ b/pillars/food/app/src/components/cook/useMarkCookedMutation.ts
@@ -1,14 +1,13 @@
 /**
- * Mutation hook for `food.cook.markCooked` — PRD-144.
+ * Mutation hook for `markCooked`.
  *
  * Owns the result-shape branching (`ok: true` → close + onSuccess; `ok:
  * false` → i18n error surface) and the search-for-consume cache
- * invalidation. PRD-146 reads the same cache when its real
- * `BatchOverridePicker` lands, so any cook must invalidate it.
+ * invalidation. The `BatchOverridePicker` reads that cache, so any cook
+ * must invalidate it.
  *
  * `onSuccess` receives the chosen yield location alongside the run +
- * batch ids so the parent toast can localise the message per location
- * (Copilot R1).
+ * batch ids so the parent toast can localise the message per location.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';

--- a/pillars/food/app/src/components/cook/useSubstitutionResolution.ts
+++ b/pillars/food/app/src/components/cook/useSubstitutionResolution.ts
@@ -1,9 +1,8 @@
 /**
- * PRD-149 — hook wrapping `food.substitutions.resolveForLine`.
- *
- * Wires the cook-modal picker's Substitutions section to the new tRPC
- * query owned by Epic 06. Returns the resolved candidates plus the
- * loading / error state the picker uses to gate rendering.
+ * Hook wrapping the `substitutionsResolveForLine` query, which feeds the
+ * cook-modal picker's Substitutions section. Returns the resolved
+ * candidates plus the loading / error state the picker uses to gate
+ * rendering.
  *
  * The query keys on `(recipeVersionId, lineIndex)` so opening the picker
  * for a different line re-fetches automatically. Stale data is fine for
@@ -50,8 +49,8 @@ export function useSubstitutionResolution(
   const resolution = query.data;
   // Stable JSON key for the contextTags array so useMemo's dep array
   // doesn't see a fresh reference on every render (callers often spread
-  // the recipe's tags inline). Mirrors the pattern used by
-  // useCookResolution for shortfall keys.
+  // the recipe's tags inline). Mirrors the stable-key pattern in
+  // useCookResolution.
   const contextTagsKey = JSON.stringify(
     args.recipeContextTags ?? resolution?.recipeContextTags ?? []
   );

--- a/pillars/food/app/src/components/dsl-editor/ReorderIngredientsPanel.tsx
+++ b/pillars/food/app/src/components/dsl-editor/ReorderIngredientsPanel.tsx
@@ -1,6 +1,5 @@
 /**
- * Pure-presentational dialog for the "Reorder ingredients" affordance —
- * PRD-120 part E.
+ * Pure-presentational dialog for the "Reorder ingredients" affordance.
  *
  * The dialog takes the current list of `@ingredient` declarations (from
  * the renumber scanner), surfaces up/down buttons for each row, and

--- a/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-context.test.ts
+++ b/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-context.test.ts
@@ -1,11 +1,11 @@
 /**
- * Cursor-context classifier — unit suite (PRD-120 part B).
+ * Cursor-context classifier — unit suite.
  *
  * The classifier is the single brain that decides which autocomplete
- * source to fire for a given (document, cursor) pair. The matrix in
- * PRD-120 line ~85 maps cursor positions to sources; this suite has one
- * `it` per row, plus negatives (cursor in a position that should NOT
- * surface a popup).
+ * source to fire for a given (document, cursor) pair. The cursor-position
+ * → source matrix lives in pillars/food/docs/prds/dsl-editor; this suite
+ * has one `it` per row, plus negatives (cursor in a position that should
+ * NOT surface a popup).
  */
 import { describe, expect, it } from 'vitest';
 
@@ -149,7 +149,6 @@ describe('classifyCursor', () => {
     it('returns none when the cursor sits outside any @ in a step body', () => {
       const { text, pos } = cursorAt('@step("plain text |here");');
       const ctx = classifyCursor(text, pos);
-      // No @ to anchor a step-ref → no popup.
       expect(ctx).toEqual({ kind: 'none' });
     });
   });

--- a/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-source.test.ts
+++ b/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-source.test.ts
@@ -1,5 +1,5 @@
 /**
- * CompletionSource integration suite (PRD-120 part B).
+ * CompletionSource integration suite.
  *
  * Drives `buildDslCompletionSource` directly with a fake
  * `CompletionContext` so we can assert the result shape (options list,
@@ -156,7 +156,7 @@ describe('dslCompletionSource', () => {
     expect(result).toBeNull();
   });
 
-  describe('read-only mode (PRD-120 part F)', () => {
+  describe('read-only mode', () => {
     it('returns null at @ even when the cursor is in a function-name context', async () => {
       const { sources, searchSpy } = makeSources();
       const source = buildDslCompletionSource(sources);

--- a/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
+++ b/pillars/food/app/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
@@ -1,5 +1,5 @@
 /**
- * Step-body scanner — unit suite (PRD-120 part B).
+ * Step-body scanner — unit suite.
  *
  * Covers `findStepBodyAtOffset` (membership test for the cursor) and
  * `collectStepIndexes` (the index → descriptor map that feeds step-ref
@@ -74,7 +74,6 @@ describe('findStepBodyAtOffset', () => {
     const cleaned = text.replace('|', '');
     const result = findStepBodyAtOffset(cleaned, cursor);
     expect(result).not.toBeNull();
-    // The outer body starts right after the first `"`.
     expect(result?.bodyStart).toBe(cleaned.indexOf('"') + 1);
   });
 });

--- a/pillars/food/app/src/components/dsl-editor/__tests__/chip-scanner.test.ts
+++ b/pillars/food/app/src/components/dsl-editor/__tests__/chip-scanner.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the chip scanner (PRD-120 part D).
+ * Unit tests for the chip scanner.
  *
  * Pure function — no DOM, no CodeMirror. Each case asserts on the chip
  * offsets and the `index → declaration` map directly.
@@ -93,7 +93,7 @@ describe('scanForChips', () => {
   });
 
   it('survives unterminated @step body without throwing', () => {
-    const source = '@step("Mash the @1 in a bowl'; // missing closing quote
+    const source = '@step("Mash the @1 in a bowl';
     expect(() => scanForChips(source)).not.toThrow();
     expect(scanForChips(source).chips).toEqual([]);
   });

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-context.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-context.ts
@@ -1,21 +1,17 @@
 /**
- * DSL editor autocomplete — cursor-context classifier (PRD-120 part B).
+ * DSL editor autocomplete — cursor-context classifier.
  *
  * Inspects the document slice immediately before the cursor and reports
- * which of the seven autocomplete sources should fire. Pure: no
- * CodeMirror imports, no async work, no document mutation. Tests drive
- * it with raw strings + offsets so the matrix from PRD-120's
- * "Autocomplete" section can be verified case-by-case without spinning
- * up an editor.
+ * which autocomplete source should fire. Pure: no CodeMirror imports, no
+ * async work, no document mutation.
  *
  * The classifier walks **backwards** from the cursor over the prefix
  * because the grammar is line-aware (`@step("...")` bodies can span
  * lines via the parser but autocomplete only needs the unbalanced-paren
  * region between the cursor and the most recent unclosed `@<func>(` or
- * the last newline outside a step body). Implementation note: a full
- * recursive-descent reparse on every keystroke is overkill — the
- * suffix-walk is sufficient for the contexts the PRD enumerates and
- * stays under the per-file lint cap.
+ * the last newline outside a step body). A full recursive-descent reparse
+ * on every keystroke is overkill — the suffix-walk is sufficient for the
+ * contexts that exist.
  */
 import { findStepBodyAtOffset } from './autocomplete-step-bodies';
 
@@ -37,9 +33,10 @@ export type CursorContext =
   /** Inside a `@step("...")` body after `@` — step refs (index OR slug). */
   | { kind: 'step-ref'; from: number; query: string; bodyStart: number };
 
-/** Identifier characters per PRD-114's grammar: lowercase + digits +
- *  hyphen. Numbers also need to be recognised at the start (for `@N`
- *  step refs and `qty:` values). */
+/** Identifier characters per the DSL grammar
+ *  (pillars/food/docs/prds/dsl-parser): lowercase + digits + hyphen.
+ *  Numbers also need to be recognised at the start (for `@N` step refs
+ *  and `qty:` values). */
 const IDENT_RE = /^[a-z0-9-]+$/;
 
 export function classifyCursor(text: string, pos: number): CursorContext {

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-extension.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-extension.ts
@@ -1,5 +1,5 @@
 /**
- * DSL editor autocomplete — CodeMirror extension factory (PRD-120 part B).
+ * DSL editor autocomplete — CodeMirror extension factory.
  *
  * Returns an `Extension[]` to be merged into the editor state. The
  * extension is built once per `DslEditor` mount and never reconfigured
@@ -7,15 +7,13 @@
  * each call sees the latest props without re-creating the extension
  * compartment.
  *
- * `closeOnBlur` defaults to `true` so clicking outside the editor
- * dismisses the popup; `activateOnTyping` defaults to `true` so the
- * source fires as the user types without needing Ctrl-Space. The
- * defaults are explicit here so future debugging doesn't blame
- * @codemirror/autocomplete's release-version drift.
+ * `closeOnBlur` and `activateOnTyping` are set explicitly (rather than
+ * relying on @codemirror/autocomplete's defaults) so version drift in the
+ * dependency can't silently change the behaviour.
  *
- * Part F adds a `tooltipClass` marker so the bottom-drawer CSS rules in
- * `dslAutocompleteTheme` can re-anchor the popup to the viewport floor
- * on screens narrower than 768px (PRD-120 mobile rule).
+ * The `tooltipClass` marker lets the bottom-drawer CSS rules in
+ * `dslAutocompleteTheme` re-anchor the popup to the viewport floor on
+ * screens narrower than 768px.
  */
 import { autocompletion } from '@codemirror/autocomplete';
 import { EditorView } from '@codemirror/view';

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-source.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-source.ts
@@ -3,7 +3,7 @@ import { collectStepIndexes } from './autocomplete-step-bodies';
 import { DSL_FUNCTION_SUGGESTIONS, DSL_UNIT_SUGGESTIONS } from './autocomplete-units';
 
 /**
- * DSL editor autocomplete — CompletionSource wiring (PRD-120 part B).
+ * DSL editor autocomplete — CompletionSource wiring.
  *
  * Single CodeMirror `CompletionSource` that classifies the cursor
  * position via `classifyCursor` (pure) and then fan-outs to whichever
@@ -31,9 +31,9 @@ export function buildDslCompletionSource(sources: DslAutocompleteSources) {
   return async function dslCompletionSource(
     context: CompletionContext
   ): Promise<CompletionResult | null> {
-    // Published versions render in read-only mode (PRD-107); the popup
-    // must not open even for explicit Ctrl-Space requests since the user
-    // can't apply a suggestion to a frozen document anyway.
+    // Published versions render in read-only mode; the popup must not open
+    // even for explicit Ctrl-Space requests since the user can't apply a
+    // suggestion to a frozen document anyway.
     if (context.state.readOnly) return null;
     const text = context.state.doc.toString();
     const ctx = classifyCursor(text, context.pos);
@@ -107,9 +107,9 @@ function slugResult(
   explicit: boolean
 ): CompletionResult | null {
   if (items.length === 0) {
-    // Surface the "Create new ingredient" affordance per PRD edge-cases
-    // table — but only when the user explicitly invoked autocomplete OR
-    // typed at least one character. Empty + implicit = no popup at all.
+    // Surface the "Create new ingredient" affordance, but only when the
+    // user explicitly invoked autocomplete OR typed at least one
+    // character. Empty + implicit = no popup at all.
     if (!explicit && ctx.query === '') return null;
     if (ctx.query === '') return null;
     return {

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-step-bodies.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-step-bodies.ts
@@ -1,5 +1,5 @@
 /**
- * DSL editor autocomplete — step-body scanner (PRD-120 part B).
+ * DSL editor autocomplete — step-body scanner.
  *
  * Two pure passes over the document:
  *
@@ -17,9 +17,10 @@
  *
  * Neither pass parses the document — both are tokenisation-shallow
  * string walks that honour the `\"` and `\\` escapes the DSL string
- * literal allows. The hand-rolled parser at PRD-114 is the only thing
- * that knows the full grammar; this scanner only needs enough
- * structure to disambiguate top-level vs string-body cursor positions.
+ * literal allows. The hand-rolled parser (pillars/food/src/dsl, the
+ * `@pops/food/dsl` entry) is the only thing that knows the full grammar;
+ * this scanner only needs enough structure to disambiguate top-level vs
+ * string-body cursor positions.
  */
 export interface StepBodyContext {
   /** Offset of the first character inside the opening `"` of the body. */
@@ -162,9 +163,9 @@ export function collectStepIndexes(text: string): readonly IngredientIndexEntry[
       match = re.exec(region);
     }
   }
-  // Sort numerically — the regex order is document order; PRD-119 may
-  // renumber, so the autocomplete should always show ascending indexes
-  // even if the user mid-edit has them out of order in the doc.
+  // Sort numerically — the regex order is document order, but the doc can
+  // hold out-of-order indexes mid-edit; the autocomplete always shows
+  // ascending indexes.
   return out.toSorted((a, b) => Number(a.index) - Number(b.index));
 }
 

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-types.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-types.ts
@@ -1,12 +1,12 @@
 /**
- * DSL editor autocomplete — public type surface (PRD-120 part B).
+ * DSL editor autocomplete — public type surface.
  *
  * The CodeMirror sources are pure: they call a small set of async lookups
- * to fetch suggestions and never touch tRPC or React Query directly.
- * `useDslAutocompleteSources()` builds production lookups against the
- * food routers; tests inject deterministic stubs implementing the same
- * shape. Keeping the contract narrow (three async methods) lets PRD-119
- * mount the editor without exposing every food endpoint to it.
+ * to fetch suggestions. `useDslAutocompleteSources()` builds production
+ * lookups against the food REST API; tests inject deterministic stubs
+ * implementing the same shape. Keeping the contract narrow (three async
+ * methods) lets a parent mount the editor without exposing every food
+ * endpoint to it.
  */
 export type SlugKind = 'ingredient' | 'recipe' | 'prep_state';
 
@@ -35,9 +35,7 @@ export interface PrepStateSuggestion {
 
 /**
  * Lookups the autocomplete extension calls. Implementations cache as they
- * see fit; the extension does not memoise on its own. Production wiring
- * (`useDslAutocompleteSources`) wraps tRPC + React Query so repeated calls
- * with the same args hit the in-memory cache.
+ * see fit; the extension does not memoise on its own.
  */
 export interface DslAutocompleteSources {
   searchSlugs: (query: string, kinds?: readonly SlugKind[]) => Promise<readonly SlugSuggestion[]>;

--- a/pillars/food/app/src/components/dsl-editor/autocomplete-units.ts
+++ b/pillars/food/app/src/components/dsl-editor/autocomplete-units.ts
@@ -1,14 +1,13 @@
 /**
- * DSL editor autocomplete — canonical unit list (PRD-120 part B).
+ * DSL editor autocomplete — canonical unit list.
  *
- * The DSL grammar (ADR-023 + PRD-114) allows any lowercase identifier
- * after `qty:`; the parser does not constrain unit names. PRD-116's
- * normaliser only knows `g`, `ml`, `count` natively, plus the alias
- * table populated by PRD-123. The suggestion list mirrors the built-in
- * units the editor knows about deterministically — anything else the
- * user types still parses; the suggestion list is a convenience, not a
- * gate. Add a constant here when PRD-123 promotes a new alias to first-
- * class status.
+ * The DSL grammar (ADR-023) allows any lowercase identifier after `qty:`;
+ * the parser does not constrain unit names. The normaliser only knows
+ * `g`, `ml`, `count` natively, plus the alias table. The suggestion list
+ * mirrors the built-in units the editor knows about deterministically —
+ * anything else the user types still parses; the suggestion list is a
+ * convenience, not a gate. Add a constant here when a new alias is
+ * promoted to first-class status.
  *
  * Keep the ordering stable: canonical units first, then volume aliases,
  * then weight aliases, then time/temperature, then `none`. The dropdown
@@ -38,8 +37,8 @@ export const DSL_UNIT_SUGGESTIONS: readonly UnitSuggestion[] = [
 
 /** The DSL function names the editor surfaces after a bare `@`. The
  *  insertion text omits the trailing `(` so the user keeps their typing
- *  momentum into the argument list. Keep the order matching PRD-120's
- *  Autocomplete table so the smoke tests stay deterministic. */
+ *  momentum into the argument list. The order is load-bearing — the smoke
+ *  tests assert against it. */
 export interface FunctionSuggestion {
   slug: string;
   label: string;

--- a/pillars/food/app/src/components/dsl-editor/chip-scanner-step-body.ts
+++ b/pillars/food/app/src/components/dsl-editor/chip-scanner-step-body.ts
@@ -1,10 +1,9 @@
 /**
- * Step-body chip extraction (PRD-120 part D).
+ * Step-body chip extraction.
  *
- * Extracted from `chip-scanner.ts` to keep both files under the per-file
- * line cap. The functions here walk the *interior* of a single
- * `@step("...")` body and emit chip ranges for `@N`, `@slug`,
- * `@time(qty:unit)`, and `@temperature(qty:unit)`. The outer scanner owns
+ * The functions here walk the *interior* of a single `@step("...")` body
+ * and emit chip ranges for `@N`, `@slug`, `@time(qty:unit)`, and
+ * `@temperature(qty:unit)`. The outer scanner (`chip-scanner.ts`) owns
  * step-body detection, escape-aware string termination, and the parallel
  * `@ingredient(N, ...)` sweep.
  */
@@ -56,7 +55,7 @@ function handleSlugOrFunc(source: string, at: number, end: number, out: Chip[]):
     return afterName;
   }
   // Slug followed by `(` is treated as an inline function. Only `@time`
-  // and `@temperature` are recognised (matches PRD-114's parser, which
+  // and `@temperature` are recognised (matches the DSL parser, which
   // emits `BadInline` for any other identifier). For unknown functions,
   // skip the whole `name(...)` span without emitting any chip. When the
   // closing `)` is missing (common mid-edit), advance past the body's

--- a/pillars/food/app/src/components/dsl-editor/chip-scanner-types.ts
+++ b/pillars/food/app/src/components/dsl-editor/chip-scanner-types.ts
@@ -1,5 +1,5 @@
 /**
- * Public types for the DSL chip scanner (PRD-120 part D).
+ * Public types for the DSL chip scanner.
  *
  * `Chip` is a single in-body decoration target with absolute document
  * offsets. `IngredientDeclaration` is the per-index lookup entry used to

--- a/pillars/food/app/src/components/dsl-editor/chip-scanner.ts
+++ b/pillars/food/app/src/components/dsl-editor/chip-scanner.ts
@@ -1,12 +1,11 @@
 /**
- * Self-contained source scanner for the DSL editor's chip widgets (PRD-120
- * part D).
+ * Self-contained source scanner for the DSL editor's chip widgets.
  *
- * The chip extension cannot use PRD-114's AST: `parseRecipeDsl` returns
- * `{ ok: false, errors }` with NO ast on any parse failure, and the user is
- * constantly producing partial documents while typing. `StepBodyPart` also
- * carries no `SourceSpan` for inline refs, so even a successful parse
- * wouldn't supply chip offsets.
+ * The chip extension cannot use the DSL parser's AST: `parseRecipeDsl`
+ * returns `{ ok: false, errors }` with NO ast on any parse failure, and the
+ * user is constantly producing partial documents while typing.
+ * `StepBodyPart` also carries no `SourceSpan` for inline refs, so even a
+ * successful parse wouldn't supply chip offsets.
  *
  * Instead this scanner walks the text linearly:
  *

--- a/pillars/food/app/src/components/dsl-editor/chip-widgets-extension.ts
+++ b/pillars/food/app/src/components/dsl-editor/chip-widgets-extension.ts
@@ -1,15 +1,15 @@
 /**
- * CodeMirror extension wiring for the DSL chip widgets (PRD-120 part D).
+ * CodeMirror extension wiring for the DSL chip widgets.
  *
  * Two visual modes selected by the caller:
  *
  *   - `chipWidgetsExtension({ compact: false })` — replaces each chip range
  *     with a `WidgetType` (the default desktop behaviour).
  *   - `chipWidgetsExtension({ compact: true })` — uses `Decoration.mark`
- *     instead so the source characters stay visible. PRD-120 calls this out
- *     for mobile widths (<768px): widget replacement shrinks tap targets
- *     dangerously, so on mobile the chip becomes an inline label that
- *     simply colours the source range.
+ *     instead so the source characters stay visible. This is the mobile
+ *     mode (<768px): widget replacement shrinks tap targets dangerously,
+ *     so on mobile the chip becomes an inline label that simply colours the
+ *     source range.
  *
  * The matchMedia → compartment dance that picks between the two lives in
  * `useDslEditorView.ts`; this module just builds the extension array.
@@ -149,8 +149,8 @@ function formatPillLabel(chip: InlineFuncChip): string {
  * event-routing pipeline doesn't fire reliably for synthetic clicks on
  * widget DOM in jsdom — attaching directly to `contentDOM` bypasses that
  * and lets the tests drive the chip via `fireEvent.click`. The keydown
- * handler covers Enter/Space so chips stay reachable via Tab → activate,
- * which the PRD calls out as an accessibility requirement.
+ * handler covers Enter/Space so chips stay reachable via Tab → activate
+ * (accessibility requirement).
  */
 function jumpToFromChip(chip: HTMLElement, view: EditorView): boolean {
   const raw = chip.getAttribute('data-chip-jump-from');

--- a/pillars/food/app/src/components/dsl-editor/chip-widgets.ts
+++ b/pillars/food/app/src/components/dsl-editor/chip-widgets.ts
@@ -1,5 +1,5 @@
 /**
- * `WidgetType` subclasses rendered by the chip extension (PRD-120 part D).
+ * `WidgetType` subclasses rendered by the chip extension.
  *
  * Each widget produces a small inline DOM element that replaces (or marks)
  * the source range while keeping the document text intact — the user can

--- a/pillars/food/app/src/components/dsl-editor/issues-extension.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-extension.ts
@@ -4,8 +4,7 @@ import { issuesTheme } from './issues-theme';
 import { issuesHoverTooltip } from './issues-tooltip';
 
 /**
- * Public extension factory for the DSL editor's issues surface (PRD-120
- * part C).
+ * Public extension factory for the DSL editor's issues surface.
  *
  * `issuesExtension()` bundles every CodeMirror extension the issues
  * feature needs — the `StateField` holding the diagnostic list, inline

--- a/pillars/food/app/src/components/dsl-editor/issues-gutter.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-gutter.ts
@@ -1,5 +1,5 @@
 /**
- * Diagnostic gutter for the issues extension (PRD-120 part C).
+ * Diagnostic gutter for the issues extension.
  *
  * Renders a single marker per line that contains at least one issue.
  * Error wins over info when both exist on the same line (so the user
@@ -59,7 +59,6 @@ export const issuesGutter = gutter({
     if (count === 0) return null;
     return new IssueMarker(hasError ? 'error' : 'info', count);
   },
-  // Force a re-render when the issues field updates.
   lineMarkerChange(update) {
     const before = update.startState.field(issuesField, false);
     const after = update.state.field(issuesField, false);

--- a/pillars/food/app/src/components/dsl-editor/issues-span.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-span.ts
@@ -1,5 +1,5 @@
 /**
- * `spanToRange` — convert a PRD-114 `SourceSpan` (1-indexed line + column,
+ * `spanToRange` — convert a DSL `SourceSpan` (1-indexed line + column,
  * `endCol` exclusive) into a CodeMirror `{ from, to }` offset pair.
  *
  * Returns `null` when the span points outside the current document. Span

--- a/pillars/food/app/src/components/dsl-editor/issues-state.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-state.ts
@@ -1,9 +1,9 @@
 /**
- * Issues `StateField` + `StateEffect` for the DSL editor (PRD-120 part C).
+ * Issues `StateField` + `StateEffect` for the DSL editor.
  *
- * The parent (PRD-119, downstream) passes a fresh `CompileEditorIssue[]`
- * whenever the most-recent compile result changes. The `useDslEditorView`
- * hook dispatches `setIssuesEffect.of(issues)` and this field rebuilds the
+ * The parent passes a fresh `CompileEditorIssue[]` whenever the
+ * most-recent compile result changes. The `useDslEditorView` hook
+ * dispatches `setIssuesEffect.of(issues)` and this field rebuilds the
  * decoration set + a parallel ranged-marker set used by the gutter.
  *
  * Both sets are kept in a single `StateField` so a single dispatch

--- a/pillars/food/app/src/components/dsl-editor/issues-theme.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-theme.ts
@@ -1,5 +1,5 @@
 /**
- * Inline styles for the issues extension (PRD-120 part C).
+ * Inline styles for the issues extension.
  *
  * `EditorView.theme` keeps the rules scoped to a generated class so the
  * extension is self-contained — the editor pages don't need to import a

--- a/pillars/food/app/src/components/dsl-editor/issues-tooltip.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-tooltip.ts
@@ -1,5 +1,5 @@
 /**
- * Hover tooltip provider for the issues extension (PRD-120 part C).
+ * Hover tooltip provider for the issues extension.
  *
  * On hover, looks up every `CompileEditorIssue` whose `loc` covers the
  * pointer offset and renders them stacked in a single tooltip. Multiple

--- a/pillars/food/app/src/components/dsl-editor/issues-types.ts
+++ b/pillars/food/app/src/components/dsl-editor/issues-types.ts
@@ -1,15 +1,15 @@
 /**
- * Shared types for the DSL editor's issues extension (PRD-120 part C).
+ * Shared types for the DSL editor's issues extension.
  *
- * `CompileEditorIssue` is the unified diagnostic shape the parent (PRD-119,
- * downstream) feeds into the editor. The parent assembles the list from:
- *   - errors returned by `food.recipes.saveDraft`'s `CompileResult`
- *     (parse / resolve / cycle errors per PRD-114 / PRD-115 / PRD-117)
- *   - rows from `recipe_version_proposed_slugs` (PRD-116) for the current
- *     `versionId`, fetched via `food.recipes.listProposedSlugs(versionId)`
+ * `CompileEditorIssue` is the unified diagnostic shape the parent feeds
+ * into the editor. The parent assembles the list from:
+ *   - parse / resolve / cycle errors carried by the draft-save
+ *     `CompileResult`
+ *   - proposed-slug rows (`recipe_version_proposed_slugs`) for the current
+ *     `versionId`
  *
  * Each issue carries `severity` so the editor colours errors red and
- * proposed slugs blue. `loc` reuses PRD-114's `SourceSpan` (1-indexed
+ * proposed slugs blue. `loc` reuses the DSL `SourceSpan` (1-indexed
  * line/col, `endCol` exclusive) so the editor can convert it to a
  * CodeMirror offset range deterministically.
  */

--- a/pillars/food/app/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
+++ b/pillars/food/app/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
@@ -1,6 +1,6 @@
 /**
  * `useDslAutocompleteSources` — production wiring for the autocomplete
- * extension (PRD-120 part B).
+ * extension.
  *
  * Builds three async lookups that the CodeMirror source calls per
  * keystroke:
@@ -12,8 +12,7 @@
  * Each lookup goes straight through the generated Hey API SDK and reads
  * `result.data`. React Query is intentionally not involved here — the
  * CodeMirror source owns its own per-keystroke calls and the SDK client
- * is cheap to invoke; the prior tRPC-utils read-through cache is dropped
- * with the pillar-call shim.
+ * is cheap to invoke.
  *
  * Tests do NOT import this hook — `DslEditor` accepts an
  * `autocompleteSources` prop and tests construct a synthetic object

--- a/pillars/food/app/src/components/dsl-editor/useReorderController.ts
+++ b/pillars/food/app/src/components/dsl-editor/useReorderController.ts
@@ -1,6 +1,6 @@
 /**
  * `useReorderController` — bridges the React panel state with the
- * imperative CodeMirror view for PRD-120 part E.
+ * imperative CodeMirror view.
  *
  * Responsibilities:
  *
@@ -12,10 +12,9 @@
  *
  * The hook deliberately does NOT debounce, persist, or re-scan as the
  * user moves rows — the snapshot is frozen for the lifetime of the open
- * dialog. If the underlying document changed between open and apply
- * (e.g. the user typed in another tab via tRPC sync), we re-check by
- * rescanning at apply-time and bail out with a no-op if the structure
- * changed underneath us.
+ * dialog. If the underlying document changed between open and apply, we
+ * re-check by rescanning at apply-time and bail out with a no-op if the
+ * structure changed underneath us.
  */
 import { useCallback, useMemo, useRef, useState } from 'react';
 

--- a/pillars/food/app/src/components/hero-image-uploader/useHeroMutations.ts
+++ b/pillars/food/app/src/components/hero-image-uploader/useHeroMutations.ts
@@ -1,7 +1,7 @@
 /**
- * Wraps the food.heroImage upload + remove tRPC mutations and the
- * client-side file validation. Returns a single object so the parent
- * component reads only the four fields it actually needs.
+ * Wraps the hero-image upload + remove mutations and the client-side file
+ * validation. Returns a single object so the parent component reads only the
+ * four fields it actually needs.
  */
 import { useMutation } from '@tanstack/react-query';
 import { useCallback } from 'react';
@@ -29,7 +29,7 @@ function validateFile(file: File, maxBytes: number): ValidationResult {
   }
   if (file.size > maxBytes) {
     // Round up + clamp to 1 so the toast never tells the user the limit is
-    // "0 MB" when the configured cap is sub-1MB (rare, but seen in tests).
+    // "0 MB" when the configured cap is sub-1MB.
     const mb = Math.max(1, Math.ceil(maxBytes / (1024 * 1024)));
     return { ok: false, reason: `Image exceeds the ${mb} MB limit.` };
   }

--- a/pillars/food/app/src/components/recipe-render-types.ts
+++ b/pillars/food/app/src/components/recipe-render-types.ts
@@ -1,13 +1,13 @@
 /**
- * View types consumed by `RecipeRenderer` (PRD-121).
+ * View types consumed by `RecipeRenderer`.
  *
  * Every joined-row shape is projected from the generated food SDK's
- * `recipes.getForRendering` response (PRD-119) so the renderer stays in
- * lockstep with the REST wire surface. `ResolvedStepBody` is the FE-side
- * parse of each step's `bodyResolvedJson` blob — the wire ships it as an
- * opaque string, so the structured shape lives here (it mirrors the
- * compiler's emitted JSON). FE-only ergonomics (`RecipeRendererProps`,
- * `RecipeRendererVariant`) round out the set.
+ * `recipesGetForRendering` response so the renderer stays in lockstep with
+ * the REST wire surface. `ResolvedStepBody` is the FE-side parse of each
+ * step's `bodyResolvedJson` blob — the wire ships it as an opaque string,
+ * so the structured shape lives here (it mirrors the compiler's emitted
+ * JSON). FE-only ergonomics (`RecipeRendererProps`, `RecipeRendererVariant`)
+ * round out the set.
  */
 import type { QtyUnit } from '@pops/food/dsl';
 

--- a/pillars/food/app/src/components/useDslEditorPendingCursor.ts
+++ b/pillars/food/app/src/components/useDslEditorPendingCursor.ts
@@ -1,10 +1,9 @@
 /**
- * PRD-135 — imperative cursor-move hook for the DSL editor.
+ * Imperative cursor-move hook for the DSL editor.
  *
- * Extracted from `useDslEditorView.ts` to keep that hook under the per-file
- * line cap. The dispatch fires whenever the `pendingCursor` prop changes
- * identity, so callers should bump `nonce` (or supply a fresh object) when
- * they want the same coordinates re-applied.
+ * The dispatch fires whenever the `pendingCursor` prop changes identity, so
+ * callers should bump `nonce` (or supply a fresh object) when they want the
+ * same coordinates re-applied.
  */
 import { type MutableRefObject, useEffect } from 'react';
 

--- a/pillars/food/app/src/components/useDslEditorView.ts
+++ b/pillars/food/app/src/components/useDslEditorView.ts
@@ -39,16 +39,16 @@ export interface UseDslEditorViewOptions {
    * Accessible name for CodeMirror's contenteditable surface (the
    * `.cm-content` element). Attached via `EditorView.contentAttributes`
    * so it lands on the role=textbox node where axe-core expects it,
-   * rather than the wrapper div (PRD-120 part F).
+   * rather than the wrapper div.
    */
   ariaLabel?: string;
   /**
-   * Imperative cursor move target — set by PRD-135's decision pane when the
-   * user clicks a proposed-slug entry. The hook watches the entire object
+   * Imperative cursor move target — set by the decision pane when the user
+   * clicks a proposed-slug entry. The hook watches the entire object
    * identity, so callers should provide a stable reference and bump the
    * `nonce` (or supply a fresh object) when they want the cursor to move.
    * `line` is 1-indexed; `col` is 1-indexed inside the line, matching the
-   * `SourceSpan` shape PRD-114 emits.
+   * `SourceSpan` shape the parser emits.
    */
   pendingCursor?: { line: number; col: number; nonce: number };
 }
@@ -216,7 +216,7 @@ function mountEditorView(args: MountEditorViewArgs): () => void {
 function createEditorView(host: HTMLDivElement, args: CreateEditorViewArgs): EditorView {
   const { options, compartments, emit, sourcesRef } = args;
   // Initial `options.issues` is seeded by `useSyncEffects` (one dispatch
-  // post-mount); seeding here would double-render — see PR #2716.
+  // post-mount); seeding here too would double-render.
   const compact = detectCompactInitial();
   return new EditorView({
     state: EditorState.create({

--- a/pillars/food/app/src/dsl/__tests__/lezer-parity.test.ts
+++ b/pillars/food/app/src/dsl/__tests__/lezer-parity.test.ts
@@ -1,17 +1,19 @@
 /**
- * Lezer-vs-parser parity test — PRD-120 part A acceptance criterion.
+ * Lezer-vs-parser parity test.
  *
- * The hand-rolled parser at `../parser.ts` is the canonical spec
- * (PRD-114 / ADR-023). The Lezer grammar at `../dsl.grammar` exists only
- * to drive CodeMirror highlighting. If they ever diverge, the editor will
- * colourise content that the runtime parser rejects (or vice versa) and
- * authors will see misleading visual cues.
+ * The hand-rolled parser exported as `@pops/food/dsl` (food pillar's
+ * `src/dsl`) is the canonical spec (grammar in ADR-023). The Lezer grammar
+ * at `../dsl.grammar` exists only to drive CodeMirror highlighting. If they
+ * ever diverge, the editor will colourise content that the runtime parser
+ * rejects (or vice versa) and authors will see misleading visual cues.
  *
- * This suite walks each PRD-114 sample recipe through BOTH parsers and
- * asserts the top-level function-call sequence matches by name and arity.
- * It deliberately does NOT compare full AST shapes — the Lezer grammar is
+ * This suite walks each sample recipe through BOTH parsers and asserts the
+ * top-level function-call sequence matches by name and arity. It
+ * deliberately does NOT compare full AST shapes — the Lezer grammar is
  * permissive and doesn't validate semantics; the parity contract is
  * "calls land in the same order with the same names".
+ *
+ * See pillars/food/docs/prds/dsl-editor and pillars/food/docs/prds/dsl-parser.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -187,7 +189,7 @@ function countSourceArgs(input: string, span: CallSpan): number {
   return commas + 1;
 }
 
-describe('PRD-120 — Lezer ↔ parser parity', () => {
+describe('Lezer ↔ parser parity', () => {
   for (const [label, source] of ALL_SAMPLES) {
     it(`matches call signature on sample "${label}"`, () => {
       const result = parseRecipeDsl(source);

--- a/pillars/food/app/src/dsl/__tests__/samples.ts
+++ b/pillars/food/app/src/dsl/__tests__/samples.ts
@@ -1,12 +1,13 @@
 /**
- * 11 sample recipes covering the grammar's positive surface — PRD-114 AC.
+ * Sample recipes covering the grammar's positive surface.
+ * See pillars/food/docs/prds/dsl-parser.
  *
  * Duplicated from the food pillar's `src/dsl/__tests__/samples.ts`. The
  * canonical copy lives there alongside the parser tests; this copy stays
- * here because the Lezer parity test (which stays in app-food alongside
- * the Lezer grammar) needs the same fixtures and importing test files
- * across workspace boundaries would require exporting test data through
- * the public package barrel.
+ * here because the Lezer parity test (which lives alongside the Lezer
+ * grammar under pillars/food/app) needs the same fixtures, and importing
+ * test files across pillar boundaries would require exporting test data
+ * through the package's public barrel.
  */
 
 export const SIMPLE_PLATE = `@recipe(
@@ -110,7 +111,6 @@ export const NON_YIELDING_TECHNIQUE = `@recipe(slug="blanch", title="Blanching",
 @step("Drop @1 into salted boiling water for @time(60:s), then shock in ice water.")
 `;
 
-/** Round-trip sample list for the printer test. */
 export const ALL_SAMPLES = [
   ['simple plate', SIMPLE_PLATE],
   ['component with yield', COMPONENT_WITH_YIELD],

--- a/pillars/food/app/src/dsl/renumber-scanner.ts
+++ b/pillars/food/app/src/dsl/renumber-scanner.ts
@@ -7,10 +7,9 @@
  * Why a text scanner instead of the AST?
  *
  *   1. `parseRecipeDsl` returns no AST on parse failure, and the editor
- *      mid-edit is constantly in transitional states (PRD-120 part D
- *      survey finding 1).
- *   2. `StepBodyPart` (PRD-114) carries no `SourceSpan` for `ref` parts —
- *      only the outer `StepBlock` does (survey finding 2).
+ *      mid-edit is constantly in transitional states.
+ *   2. `StepBodyPart` carries no `SourceSpan` for `ref` parts — only the
+ *      outer `StepBlock` does.
  *
  * The scanner walks the document directly, honours `\"` and `\\` escapes
  * inside step strings, and is robust to a half-typed document.

--- a/pillars/food/app/src/dsl/renumber.ts
+++ b/pillars/food/app/src/dsl/renumber.ts
@@ -1,5 +1,5 @@
 /**
- * Recipe-DSL renumber transform — PRD-120 part E.
+ * Recipe-DSL renumber transform.
  *
  * Given a source string and a permutation describing the desired order of
  * `@ingredient(...)` declarations, produces:

--- a/pillars/food/app/src/food-api-helpers.ts
+++ b/pillars/food/app/src/food-api-helpers.ts
@@ -6,8 +6,7 @@
  *
  * `unwrap` turns a Hey API `{ data, error, response }` result into its
  * data payload, throwing `FoodApiError` (carrying the HTTP status) on
- * failure. The status lets call sites reproduce the pillar-sdk UX
- * distinctions that used to come from `usePillarQuery`:
+ * failure. The status lets call sites distinguish UX states:
  *   - 404            → "not found"    (isNotFoundError)
  *   - 503            → "unavailable"  (isUnavailableError — e.g. ingest queue down)
  *   - 5xx / no status → "unavailable" (isUnavailableError)

--- a/pillars/food/app/src/index.ts
+++ b/pillars/food/app/src/index.ts
@@ -15,9 +15,7 @@ export type { TimerButtonProps } from './components/TimerButton';
 export { TempBadge } from './components/TempBadge';
 export type { TempBadgeProps } from './components/TempBadge';
 
-// PRD-120 — DSL Editor (Part A scaffold + Part B autocomplete + Part C
-// issues prop + Part D chip widgets + Part E reorder/renumber). Panel +
-// scanner exported so downstream stories / pages can drive them
+// Panel + scanner exported so downstream stories / pages can drive them
 // deterministically without reaching into the dsl-editor subtree.
 export { DslEditor } from './components/DslEditor';
 export type { DslEditorProps } from './components/DslEditor';

--- a/pillars/food/app/src/jobs/ingest-job.ts
+++ b/pillars/food/app/src/jobs/ingest-job.ts
@@ -1,11 +1,1 @@
-/**
- * PRD-125 — BullMQ contract for the `food.ingest` queue.
- *
- * Canonical source of truth lives in `@pops/food/queue` so producer
- * (`@pops/api`) and consumer (`pops-worker-food`, PRD-126) can both
- * depend on the same types without a `pops-api → @pops/app-food`
- * package-level cycle (api-client / navigation / api). This file
- * re-exports them at the path PRD-125's acceptance criteria specify so
- * the entry-point stays stable for downstream code.
- */
 export * from '@pops/food/queue';

--- a/pillars/food/app/src/pages/PromptViewerPage.stories.tsx
+++ b/pillars/food/app/src/pages/PromptViewerPage.stories.tsx
@@ -1,11 +1,3 @@
-/**
- * PRD-133 — Storybook coverage for the prompt viewer page.
- *
- * `apps/pops-storybook/.storybook/main.ts` discovers stories from
- * `packages/*\/src/**\/*.stories.@(ts|tsx)`, so this file lives next to
- * the page (same convention `DslEditor.stories.tsx` /
- * `RecipeRenderer.stories.tsx` adopted).
- */
 import { createInstance, type i18n as I18n } from 'i18next';
 import { useMemo } from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';

--- a/pillars/food/app/src/pages/PromptViewerPage.tsx
+++ b/pillars/food/app/src/pages/PromptViewerPage.tsx
@@ -1,9 +1,7 @@
 /**
- * PRD-133 — Read-only viewer for the food AI prompt templates.
- *
- * Mirrors `@pops/app-finance`'s PromptViewerPage. Renders one card per
- * entry in `FOOD_PROMPTS`. Operator-facing surface — useful when
- * iterating on ingest quality without opening the repo.
+ * Read-only operator viewer for the food AI prompt templates — one card per
+ * entry in `FOOD_PROMPTS`. Useful when iterating on ingest quality without
+ * opening the repo.
  *
  * To edit a prompt: change the constant in
  * `pillars/food/app/src/prompts/`, bump its version string, deploy.

--- a/pillars/food/app/src/pages/__tests__/FoodLandingPage.test.tsx
+++ b/pillars/food/app/src/pages/__tests__/FoodLandingPage.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FoodLandingPage } from '../FoodLandingPage.js';
 
-describe('PRD-118 — FoodLandingPage', () => {
+describe('FoodLandingPage', () => {
   it('renders heading + intro without crashing', () => {
     render(<FoodLandingPage />);
     expect(screen.getByRole('heading', { name: /food/i, level: 1 })).toBeInTheDocument();
@@ -14,7 +14,6 @@ describe('PRD-118 — FoodLandingPage', () => {
     render(<FoodLandingPage />);
     expect(screen.getByText(/^Recipes$/)).toBeInTheDocument();
     expect(screen.getByText(/^Manage data$/)).toBeInTheDocument();
-    // Two cards, two "Coming soon" tags.
     expect(screen.getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/pillars/food/app/src/pages/__tests__/PromptViewerPage.test.tsx
+++ b/pillars/food/app/src/pages/__tests__/PromptViewerPage.test.tsx
@@ -1,13 +1,10 @@
-/**
- * PRD-133 — RTL coverage for the read-only prompt viewer.
- */
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { FOOD_PROMPTS } from '../../ai/prompt-registry.js';
 import { PromptViewerPage } from '../PromptViewerPage.js';
 
-describe('PRD-133 — PromptViewerPage', () => {
+describe('PromptViewerPage', () => {
   it('renders the page header + editing-hint footer text', () => {
     render(<PromptViewerPage />);
     expect(

--- a/pillars/food/app/src/pages/data/AliasesTab.tsx
+++ b/pillars/food/app/src/pages/data/AliasesTab.tsx
@@ -1,6 +1,6 @@
 /**
  * `/food/data/aliases` route entry. Defers to the tab's content tree
- * under `./aliases/` (PRD-122-C).
+ * under `./aliases/`.
  */
 import { AliasesTabContent } from './aliases/index.js';
 

--- a/pillars/food/app/src/pages/data/PrepStatesTab.tsx
+++ b/pillars/food/app/src/pages/data/PrepStatesTab.tsx
@@ -1,6 +1,6 @@
 /**
  * `/food/data/prep-states` route entry. Defers to the tab's content
- * tree under `./prep-states/` (PRD-122-C).
+ * tree under `./prep-states/`.
  */
 import { PrepStatesTabContent } from './prep-states/index.js';
 

--- a/pillars/food/app/src/pages/data/__tests__/FoodDataLayout.test.tsx
+++ b/pillars/food/app/src/pages/data/__tests__/FoodDataLayout.test.tsx
@@ -1,14 +1,13 @@
 /**
- * PRD-122 — /food/data shell smoke tests.
+ * /food/data shell smoke tests.
  *
  * Drives the layout through `createMemoryRouter` so the `Outlet`
  * + `NavLink` + redirect machinery exercises the real React Router
- * resolution path. Each tab's body is asserted via the i18n title
- * (sourced from `apps/pops-shell/.../food.json`).
+ * resolution path.
  *
  * The route tree imports tab modules via `React.lazy`, so the
  * RouterProvider is wrapped in a Suspense boundary; without it,
- * CI runs hit the lazy module's pending promise and `findByText`
+ * runs hit the lazy module's pending promise and `findByText`
  * times out before resolution.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -70,27 +69,15 @@ function renderAt(initialPath: string) {
   );
 }
 
-describe('PRD-122 — /food/data shell', () => {
+describe('/food/data shell', () => {
   it('redirects /food/data to /food/data/ingredients by default', async () => {
     renderAt('/food/data');
     expect(await screen.findByRole('heading', { name: /manage data/i })).toBeInTheDocument();
-    // The redirect lands on the Ingredients tab; the mobile dropdown
-    // mirrors the active slug, so its value reflects the redirect target.
     const dropdown = (await screen.findByLabelText(/data tabs/i, {
       selector: 'select',
     })) as HTMLSelectElement;
     expect(dropdown.value).toBe('ingredients');
   });
-
-  // Per-tab content + route tests below previously asserted on the
-  // placeholder text rendered by each lazy tab module. Under vitest's
-  // full-suite run, the lazy chunk loading cascades through the same
-  // worker pool that other test files have already exercised, and the
-  // resolution intermittently stalls on the Suspense fallback. The
-  // active-tab semantics are covered by `getActiveTabSlug` unit tests
-  // below (pure function, deterministic) and the tablist + dropdown
-  // tests further down (which run synchronously off the URL via
-  // `useLocation`, no lazy chunks involved).
 
   it('exposes a desktop tablist with one entry per tab', async () => {
     renderAt('/food/data/ingredients');

--- a/pillars/food/app/src/pages/data/__tests__/GlobalSearchBar.test.tsx
+++ b/pillars/food/app/src/pages/data/__tests__/GlobalSearchBar.test.tsx
@@ -62,7 +62,7 @@ beforeEach(() => {
   slugsSearchMock.mockResolvedValue({ data: { items: [] } });
 });
 
-describe('PRD-122-D — GlobalSearchBar', () => {
+describe('GlobalSearchBar', () => {
   it('renders a search input with the data-search testid', () => {
     renderInRouter('/food/data/ingredients');
     expect(screen.getByTestId('food-data-global-search')).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe('PRD-122-D — GlobalSearchBar', () => {
     expect(router.state.location.search).toBe('?focus=diced');
   });
 
-  it('recipe results are shown with a badge but disabled (no recipe tab yet)', async () => {
+  it('recipe results are shown with a badge but disabled (recipe tab is not navigable)', async () => {
     slugsSearchMock.mockResolvedValue({
       data: {
         items: [{ slug: 'weeknight-pasta', kind: 'recipe', targetId: 1, name: 'Weeknight Pasta' }],

--- a/pillars/food/app/src/pages/data/aliases/AddAliasDialog.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AddAliasDialog.tsx
@@ -1,9 +1,9 @@
 /**
- * Add-alias dialog (PRD-122-C).
+ * Add-alias dialog.
  *
  * Composes the target picker with a single text input + source selector.
- * Source defaults to `user` per PRD-122. The submit button is disabled
- * until both the alias text is non-empty AND a target is picked.
+ * Source defaults to `user`. The submit button is disabled until both the
+ * alias text is non-empty AND a target is picked.
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/aliases/AliasTargetPicker.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasTargetPicker.tsx
@@ -1,9 +1,9 @@
 /**
- * Two-step picker for alias targets (PRD-122-C).
+ * Two-step picker for alias targets.
  *
- * Step 1 — type to search ingredients via `food.slugs.search`. Selecting
- * an ingredient hydrates the row via `food.ingredients.get` so the
- * embedded variants list is available without an extra round-trip.
+ * Step 1 — type to search ingredients via `slugsSearch`. Selecting an
+ * ingredient hydrates the row via `ingredientsGet` so the embedded
+ * variants list is available without an extra round-trip.
  *
  * Step 2 — optionally pick a variant (chip below the ingredient row).
  * When no variant is picked the target is the ingredient itself.

--- a/pillars/food/app/src/pages/data/aliases/AliasesTabContent.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasesTabContent.tsx
@@ -1,14 +1,14 @@
 /**
- * `/food/data/aliases` tab content (PRD-122-C).
+ * `/food/data/aliases` tab content.
  *
  * Orchestrates the data hook, mutation hooks, toolbar, table, and the
  * Add/Merge dialogs. Keeps no data state of its own beyond dialog
  * open/closed — everything else lives in `useAliasesData`.
  *
- * Per Copilot review on PR #2724 — dialog `useState` setters are
- * declared BEFORE `useAliasMutations`, so the mutation hook can close
- * dialogs from its per-mutation success path. A failed create/merge
- * leaves the dialog open so the user can retry without re-typing.
+ * Dialog `useState` setters are declared BEFORE `useAliasMutations`, so
+ * the mutation hook can close dialogs from its per-mutation success path.
+ * A failed create/merge leaves the dialog open so the user can retry
+ * without re-typing.
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/aliases/AliasesTable.stories.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasesTable.stories.tsx
@@ -1,12 +1,9 @@
 /**
- * Storybook coverage for the pure sub-components of the Aliases tab
- * (PRD-122-C).
+ * Storybook coverage for the pure sub-components of the Aliases tab.
  *
- * The full `AliasesTabContent` consumes tRPC hooks that aren't trivial
- * to mock at the Storybook level; the table and toolbar both take all
- * their data via props, so they get stories directly. `apps/pops-storybook/`
- * picks these up via the `packages/*\/src/**\/*.stories.*` glob the
- * RecipeRenderer story file documents.
+ * The full `AliasesTabContent` consumes data hooks that aren't trivial to
+ * mock at the Storybook level; the table and toolbar both take all their
+ * data via props, so they get stories directly.
  */
 import { createInstance, type i18n } from 'i18next';
 import { useMemo, useState } from 'react';

--- a/pillars/food/app/src/pages/data/aliases/AliasesTable.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasesTable.tsx
@@ -1,5 +1,5 @@
 /**
- * Aliases table (PRD-122-C).
+ * Aliases table.
  *
  * Sortable header + per-row checkbox + inline edit + delete. Each
  * column header is a button that flips between asc/desc on the same key

--- a/pillars/food/app/src/pages/data/aliases/AliasesTableRow.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasesTableRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Single row inside the Aliases table (PRD-122-C).
+ * Single row inside the Aliases table.
  *
  * Switches between read mode and inline edit mode. Read mode shows the
  * alias text, target label, source chip, and the raw ISO `created_at`
@@ -76,7 +76,7 @@ function AliasCell({ row, onUpdateAlias }: AliasCellProps) {
   // Cancel is tracked via a ref because the onKeyDown → blur transition
   // is synchronous and `useState` updates don't flush until the next
   // render. A ref is read in the same tick `commitEdit` runs, so Escape
-  // reliably suppresses the commit (Copilot review round 2 on PR #2724).
+  // reliably suppresses the commit.
   const cancelRef = useRef(false);
 
   function commitEdit(): void {

--- a/pillars/food/app/src/pages/data/aliases/AliasesToolbar.tsx
+++ b/pillars/food/app/src/pages/data/aliases/AliasesToolbar.tsx
@@ -1,5 +1,5 @@
 /**
- * Aliases tab toolbar (PRD-122-C).
+ * Aliases tab toolbar.
  *
  * Holds the source filter chips + the search box + the action buttons
  * (Add, Bulk approve LLM, Merge). Action buttons enable based on the

--- a/pillars/food/app/src/pages/data/aliases/MergeAliasesDialog.tsx
+++ b/pillars/food/app/src/pages/data/aliases/MergeAliasesDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Merge-aliases dialog (PRD-122-C).
+ * Merge-aliases dialog.
  *
  * Pick a canonical target; the selected alias rows re-point at it inside
  * one server-side transaction. Rows already at the chosen target are

--- a/pillars/food/app/src/pages/data/aliases/__tests__/AliasesTabContent.test.tsx
+++ b/pillars/food/app/src/pages/data/aliases/__tests__/AliasesTabContent.test.tsx
@@ -1,5 +1,6 @@
 /**
- * RTL coverage for `/food/data/aliases` (PRD-122-C).
+ * RTL coverage for the `/food/data/aliases` tab
+ * (spec: pillars/food/docs/prds/data-page).
  *
  * The food SDK is mocked at the top level so vitest can hoist it. Each
  * SDK fn reads + records against the module-scoped `state` object so

--- a/pillars/food/app/src/pages/data/aliases/__tests__/format.test.ts
+++ b/pillars/food/app/src/pages/data/aliases/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pure-function coverage for `format.ts` (PRD-122-C).
+ * Pure-function coverage for `format.ts`.
  *
  * The sort comparator + target label helpers are the only "business
  * logic" in the Aliases tab — keeping them unit-tested ensures the

--- a/pillars/food/app/src/pages/data/aliases/format.ts
+++ b/pillars/food/app/src/pages/data/aliases/format.ts
@@ -1,5 +1,5 @@
 /**
- * Pure label + sort helpers for the Aliases tab (PRD-122-C).
+ * Pure label + sort helpers for the Aliases tab.
  *
  * Kept separate from the table component so the sort comparator can be
  * unit-tested without rendering React.

--- a/pillars/food/app/src/pages/data/aliases/index.ts
+++ b/pillars/food/app/src/pages/data/aliases/index.ts
@@ -1,5 +1,5 @@
 /**
- * Barrel for the `/food/data/aliases` tab content (PRD-122-C).
+ * Barrel for the `/food/data/aliases` tab content.
  *
  * The top-level `AliasesTab` wrapper imports from here so the file-tree
  * exposes only one entry point per tab.

--- a/pillars/food/app/src/pages/data/aliases/types.ts
+++ b/pillars/food/app/src/pages/data/aliases/types.ts
@@ -1,9 +1,9 @@
 /**
- * Shared types for the Aliases tab on `/food/data/aliases` (PRD-122-C).
+ * Shared types for the Aliases tab on `/food/data/aliases`.
  *
- * These mirror the wire shapes exposed by the food.aliases tRPC router.
- * Keeping them in one place stops accidental drift across the sub-files
- * that compose the tab (toolbar, table, dialogs).
+ * These mirror the wire shapes exposed by the food pillar's aliases REST
+ * contract. Keeping them in one place stops accidental drift across the
+ * sub-files that compose the tab (toolbar, table, dialogs).
  */
 export type AliasSource = 'user' | 'llm' | 'ingest';
 

--- a/pillars/food/app/src/pages/data/aliases/use-aliases-data.ts
+++ b/pillars/food/app/src/pages/data/aliases/use-aliases-data.ts
@@ -1,5 +1,5 @@
 /**
- * Aliases tab data + selection state (PRD-122-C).
+ * Aliases tab data + selection state.
  *
  * Wraps `aliasesListWithTargets` plus the table's own UI state
  * (sort, filter, selection). Mutations live alongside in
@@ -97,7 +97,7 @@ export function useAliasesData(): UseAliasesData {
   // Filter changes always clear the current selection — once the visible
   // rows change, the selection count + has-llm-selection flags would
   // otherwise reflect rows the user can no longer see, which makes the
-  // toolbar's enabled state misleading (Copilot review on PR #2724).
+  // toolbar's enabled state misleading.
   const setFilter = useCallback((next: AliasesFilter) => {
     setFilterState(next);
     setSelectedIds(new Set());

--- a/pillars/food/app/src/pages/data/aliases/use-aliases-mutations.ts
+++ b/pillars/food/app/src/pages/data/aliases/use-aliases-mutations.ts
@@ -1,15 +1,14 @@
 /**
- * Mutations used by the Aliases tab (PRD-122-C).
+ * Mutations used by the Aliases tab.
  *
- * Each tRPC mutation lands its `onSuccess`/`onError` here so the consumer
- * can wire per-mutation reactions (close a dialog, clear selection)
- * without re-implementing toast + invalidation. The opts struct mirrors
- * the mutation surface; callers pass only the hooks they need.
+ * Each mutation lands its `onSuccess`/`onError` here so the consumer can
+ * wire per-mutation reactions (close a dialog, clear selection) without
+ * re-implementing toast + invalidation. The opts struct mirrors the
+ * mutation surface; callers pass only the hooks they need.
  *
- * Per Copilot review on PR #2724 — dialogs must close from the success
- * path of their mutation, not inline at submit time, otherwise a failed
- * server call would still close the dialog and the user would lose their
- * input.
+ * Dialogs must close from the success path of their mutation, not inline
+ * at submit time, otherwise a failed server call would still close the
+ * dialog and the user would lose their input.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';

--- a/pillars/food/app/src/pages/data/conversions-tab/ConversionsTabContents.tsx
+++ b/pillars/food/app/src/pages/data/conversions-tab/ConversionsTabContents.tsx
@@ -1,7 +1,6 @@
 /**
- * Conversions tab (PRD-123 Phase C). Two-section page: Unit conversions
- * (top) + Ingredient weights (bottom). Each section is self-contained
- * (own queries, own filters, own dialogs); this file is only the layout.
+ * Conversions tab layout only. Each section is self-contained (own
+ * queries, own filters, own dialogs).
  */
 import { useTranslation } from 'react-i18next';
 

--- a/pillars/food/app/src/pages/data/conversions-tab/SeededBadge.tsx
+++ b/pillars/food/app/src/pages/data/conversions-tab/SeededBadge.tsx
@@ -1,7 +1,3 @@
-/**
- * Inline badge marking a conversion row as having come from PRD-113's
- * seed. Re-rendered on every row; kept tiny so it inlines cleanly.
- */
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@pops/ui';

--- a/pillars/food/app/src/pages/data/conversions-tab/UnitDialogs.tsx
+++ b/pillars/food/app/src/pages/data/conversions-tab/UnitDialogs.tsx
@@ -1,10 +1,8 @@
 /**
  * Create + edit dialogs for unit_conversions.
  *
- * The create dialog collects from / to / ratio / notes. The edit dialog
- * only mutates ratio + notes — `from_unit` and `to_unit` form the UNIQUE
- * key (PRD-123 Phase A) and changing them is "delete + re-create" by
- * intent; the PRD lists inline ratio + notes edit as the supported action.
+ * The edit dialog only mutates ratio + notes: `from_unit` and `to_unit`
+ * form the UNIQUE key, so changing them is delete + re-create, not an edit.
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/conversions-tab/__tests__/UnitsSection.test.tsx
+++ b/pillars/food/app/src/pages/data/conversions-tab/__tests__/UnitsSection.test.tsx
@@ -1,12 +1,8 @@
 /**
- * PRD-123 Phase D — UnitsSection smoke tests.
+ * Mocks the generated food SDK (src/food-api) so the section renders against
+ * controlled data without a live registry-mounted backend.
  *
- * Mocks the generated food SDK so the section renders against controlled
- * data and asserts:
- *   - the seeded badge + disabled delete render for seeded rows
- *   - the search input feeds into the listUnits query input
- *   - the create dialog submits via the SDK
- *   - server errors propagate to the dialog alert
+ * See pillars/food/docs/prds/conversion-table.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -61,7 +57,7 @@ beforeEach(() => {
   conversionsDeleteUnitMock.mockResolvedValue({ data: { ok: true } });
 });
 
-describe('PRD-123 Phase D — UnitsSection', () => {
+describe('UnitsSection', () => {
   it('renders the table with the seeded badge for seeded rows', async () => {
     seedList([
       row({ id: 1, fromUnit: 'cup', toUnit: 'ml', ratio: 240, seeded: true }),
@@ -125,7 +121,7 @@ describe('PRD-123 Phase D — UnitsSection', () => {
     await userEvent.type(within(dialog).getByLabelText(/^ratio$/i), '240');
     await userEvent.click(within(dialog).getByRole('button', { name: /save/i }));
     await waitFor(() => expect(conversionsCreateUnitMock).toHaveBeenCalledTimes(1));
-    // The mutation has not resolved yet — dialog must still be open.
+    // Dialog must stay open while the create mutation is in flight.
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
     resolveCreate?.({ data: { data: row({ id: 1 }) } });
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());

--- a/pillars/food/app/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
+++ b/pillars/food/app/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
@@ -1,12 +1,9 @@
 /**
- * PRD-123 Phase D — WeightsSection smoke tests.
+ * Mocks the generated food SDK (src/food-api) so the section renders against
+ * controlled data without a live registry-mounted backend. Variant labels are
+ * resolved via a separate ingredientsGet lookup, mocked independently here.
  *
- * Mocks the generated food SDK so the section renders against controlled
- * data and asserts:
- *   - rows render with the resolved ingredient + variant labels
- *   - the seeded badge + disabled delete render for seeded rows
- *   - the create dialog submits valid input through the SDK
- *   - the ingredient filter feeds into the listWeights query
+ * See pillars/food/docs/prds/conversion-table.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -94,7 +91,7 @@ beforeEach(() => {
   conversionsDeleteWeightMock.mockResolvedValue({ data: { ok: true } });
 });
 
-describe('PRD-123 Phase D — WeightsSection', () => {
+describe('WeightsSection', () => {
   it('renders rows with the ingredient name and any-variant label', async () => {
     seedIngredients([{ id: 100, name: 'Onion', slug: 'onion' }]);
     seedWeights([row({ id: 1 })]);

--- a/pillars/food/app/src/pages/data/conversions-tab/__tests__/useWeightRowViews.test.ts
+++ b/pillars/food/app/src/pages/data/conversions-tab/__tests__/useWeightRowViews.test.ts
@@ -1,6 +1,4 @@
 /**
- * PRD-123 Phase C — unit tests for the row-view projection helpers.
- *
  * Covers the pure `buildIngredientLookup` shape; the hook itself is
  * exercised end-to-end by the WeightsSection RTL suite.
  */
@@ -8,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildIngredientLookup } from '../useWeightRowViews';
 
-describe('PRD-123 Phase C — buildIngredientLookup', () => {
+describe('buildIngredientLookup', () => {
   it('indexes ingredients by id', () => {
     const lookup = buildIngredientLookup([
       { id: 1, name: 'Onion', slug: 'onion' },

--- a/pillars/food/app/src/pages/data/conversions-tab/types.ts
+++ b/pillars/food/app/src/pages/data/conversions-tab/types.ts
@@ -1,8 +1,7 @@
 /**
- * Wire-shape mirrors for the `food.conversions.*` endpoints (PRD-123
- * Phase D). Derived from the generated Hey API food SDK response types so
- * any schema change to the server output flows through to the UI without
- * manual updates.
+ * Wire-shape mirrors for the `food.conversions.*` endpoints, derived from
+ * the generated food SDK response types so any schema change to the server
+ * output flows through to the UI without manual updates.
  */
 import type {
   ConversionsListUnitsResponses,

--- a/pillars/food/app/src/pages/data/conversions-tab/useUnitMutations.ts
+++ b/pillars/food/app/src/pages/data/conversions-tab/useUnitMutations.ts
@@ -1,8 +1,7 @@
 /**
- * React Query mutations for unit_conversions (PRD-123 Phase D). Each
- * `submit*` returns the underlying mutation's promise so call sites can
- * chain `onSuccess` behaviour (close dialog, etc.) without racing the
- * synchronous-then-stale `errorMessage` state.
+ * React Query mutations for unit_conversions. Each `submit*` forwards an
+ * optional `onSuccess` so call sites can chain behaviour (close dialog,
+ * etc.) without racing the synchronous-then-stale `errorMessage` state.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';

--- a/pillars/food/app/src/pages/data/conversions-tab/useWeightMutations.ts
+++ b/pillars/food/app/src/pages/data/conversions-tab/useWeightMutations.ts
@@ -1,9 +1,9 @@
 /**
- * React Query mutations for ingredient_weights (PRD-123 Phase D). Same
- * shape as `useUnitMutations`; separate hook so each section owns its own
- * error state. Each `submit*` accepts an optional `onSuccess` callback the
- * call site can use to close its dialog AFTER the server confirms (avoids
- * the synchronous-state race where the dialog would close on every submit
+ * React Query mutations for ingredient_weights. Same shape as
+ * `useUnitMutations`; separate hook so each section owns its own error
+ * state. Each `submit*` accepts an optional `onSuccess` the call site uses
+ * to close its dialog AFTER the server confirms (avoids the
+ * synchronous-state race where the dialog would close on every submit
  * regardless of outcome).
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';

--- a/pillars/food/app/src/pages/data/ingredients-tab/ChangeParentDialog.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/ChangeParentDialog.tsx
@@ -1,8 +1,7 @@
 /**
- * Modal for changing an ingredient's parent. Wires
- * `food.ingredients.changeParent` which re-validates the parent chain (depth
- * ≤ 3 and acyclic per PRD-106). Self-as-parent is filtered out client-side
- * for clarity even though the service also rejects it.
+ * Modal for changing an ingredient's parent. The server re-validates the
+ * parent chain (depth ≤ 3 and acyclic). Self-as-parent is filtered out
+ * client-side for clarity even though the service also rejects it.
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/ingredients-tab/IngredientTagsEditor.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/IngredientTagsEditor.tsx
@@ -1,11 +1,10 @@
 /**
- * PRD-151 — Tags section embedded in PRD-122's ingredient detail panel.
+ * Tags section embedded in the ingredient detail panel.
  *
- * Chip list + an "+ Add tag" input wired to `food.ingredients.tags.distinct`
- * for autocomplete. The local draft is committed in one call via
- * `food.ingredients.tags.set` (full-set replacement, transactional). Errors
- * surface inline rather than through a thrown TRPCError — the router's
- * `set` procedure returns `{ ok: false, reason }` so the UI can map to
+ * Chip list + an "+ Add tag" input wired to the distinct-tags endpoint for
+ * autocomplete. The local draft is committed in one call (full-set
+ * replacement, transactional). Validation errors surface inline: the set
+ * endpoint returns `{ ok: false, reason }` so the UI maps the reason to
  * localised copy without a try/catch ladder.
  */
 import { useQuery } from '@tanstack/react-query';

--- a/pillars/food/app/src/pages/data/ingredients-tab/RecipeRefsSection.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/RecipeRefsSection.tsx
@@ -1,10 +1,9 @@
 /**
  * "Used by recipes" section of the ingredient detail panel.
  *
- * Queries `food.ingredients.recipeRefs` for the selected ingredient and
- * shows the count + a collapsible list of recipes. Recipe entries link to
- * `/food/recipes/<slug>` (the PRD-119 page; until that route exists the
- * link still renders but lands on a 404 placeholder).
+ * Queries the recipe-refs endpoint for the selected ingredient and shows the
+ * count + a collapsible list of recipes. Recipe entries link to the
+ * `/food/recipes/<slug>` detail page.
  */
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';

--- a/pillars/food/app/src/pages/data/ingredients-tab/RenameIngredientDialog.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/RenameIngredientDialog.tsx
@@ -1,11 +1,10 @@
 /**
  * Modal for renaming an ingredient's canonical slug.
  *
- * Calls `food.ingredients.rename` which atomically updates `ingredients.slug`
- * and `slug_registry.slug` (PRD-106 contract). Existing compiled `recipe_lines`
- * rows stay linked because they FK on `ingredient_id`, but recipe DSL bodies
- * referencing the old slug will fail on next compile — the description warns
- * the user about that.
+ * The rename atomically updates `ingredients.slug` and `slug_registry.slug`.
+ * Existing compiled `recipe_lines` rows stay linked because they FK on
+ * `ingredient_id`, but recipe DSL bodies referencing the old slug will fail
+ * on next compile — the description warns the user about that.
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/ingredients-tab/VariantFormDialog.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/VariantFormDialog.tsx
@@ -1,9 +1,5 @@
 /**
- * Modal for creating or editing a variant. Shared form fields:
- *   - slug, name, default unit
- *   - package size (g, optional)
- *   - shelf-life fridge / freezer (days, optional, PRD-108)
- *   - notes (optional)
+ * Modal for creating or editing a variant.
  *
  * Form-state + value helpers live in `variant-form-helpers.ts`; the actual
  * input rows in `VariantFormFields.tsx`. Errors come pre-mapped from

--- a/pillars/food/app/src/pages/data/ingredients-tab/__tests__/IngredientTagsEditor.test.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/__tests__/IngredientTagsEditor.test.tsx
@@ -1,13 +1,6 @@
 /**
- * PRD-151 — IngredientTagsEditor unit tests.
- *
  * Mocks the generated food SDK so the component is exercised against a
- * controlled stand-in. Covers:
- *   - initial render hydrates from the server-side list
- *   - adding a chip is local until Save
- *   - removing a chip toggles dirty + the Save button
- *   - autocomplete suggestions come from `distinct`
- *   - server-side BadTagFormat surfaces inline (no thrown error)
+ * controlled stand-in.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/pillars/food/app/src/pages/data/ingredients-tab/__tests__/IngredientsTab.test.tsx
+++ b/pillars/food/app/src/pages/data/ingredients-tab/__tests__/IngredientsTab.test.tsx
@@ -1,17 +1,6 @@
 /**
- * PRD-122-B / PRD-122-B2 — ingredients tab UI smoke tests.
- *
  * Mocks the generated food SDK so the tree renders against a controlled
- * dataset; asserts:
- *   - the tree groups children under their parents
- *   - selecting a node renders the detail panel
- *   - the create dialog opens and submits via the mutation
- *   - the create dialog surfaces a server error
- *   - rename / change-parent / delete flows wire to the right mutations
- *   - variant create + edit + delete flows wire to the right mutations
- *   - delete-with-blockers disables the destructive button and lists blockers
- *   - the `?focus=<slug>` deep-link selects + highlights the matching node
- *   - the not-found banner appears when `?focus` doesn't match anything
+ * dataset.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -146,7 +135,7 @@ beforeEach(() => {
   variantsDeleteMock.mockResolvedValue({ data: { ok: true } });
 });
 
-describe('PRD-122-B — IngredientsTab', () => {
+describe('IngredientsTab', () => {
   it('renders the tree with children nested under their parent', async () => {
     const fruit = row({ id: 1, slug: 'fruit', name: 'Fruit' });
     const banana = row({ id: 2, slug: 'banana', name: 'Banana', parentId: 1 });
@@ -232,7 +221,7 @@ describe('PRD-122-B — IngredientsTab', () => {
   });
 });
 
-describe('PRD-122-B2 — detail-panel CRUD', () => {
+describe('detail-panel CRUD', () => {
   function seedSelectedBanana(variants: readonly VariantRow[] = []) {
     const banana = row({ id: 5, slug: 'banana', name: 'Banana' });
     seedList([banana, row({ id: 6, slug: 'fruit', name: 'Fruit' })]);
@@ -378,7 +367,7 @@ describe('PRD-122-B2 — detail-panel CRUD', () => {
   });
 });
 
-describe('PRD-122-B2 — ?focus=<slug> deep-link', () => {
+describe('?focus=<slug> deep-link', () => {
   it('selects the matching ingredient and highlights its tree row', async () => {
     const apple = row({ id: 7, slug: 'apple', name: 'Apple' });
     seedList([apple]);

--- a/pillars/food/app/src/pages/data/ingredients-tab/useIngredientActions.ts
+++ b/pillars/food/app/src/pages/data/ingredients-tab/useIngredientActions.ts
@@ -3,7 +3,7 @@
  * ingredient row. State is fragmented per dialog so the parent component
  * can render only the controls relevant to the open modal.
  *
- * Each mutation invalidates the relevant tRPC caches on success so the
+ * Each mutation invalidates the relevant query caches on success so the
  * tree, detail panel, and blocker counts stay coherent.
  *
  * The mutation factories live in `useIngredientActionMutations.ts` to

--- a/pillars/food/app/src/pages/data/ingredients-tab/useTagsDraft.ts
+++ b/pillars/food/app/src/pages/data/ingredients-tab/useTagsDraft.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-151 — local-draft state for the ingredient Tags chip editor.
+ * Local-draft state for the ingredient Tags chip editor.
  *
  * Tracks the in-progress chip set independently of the server payload so
  * the user can add / remove tags freely and only commit on Save. The hook
@@ -10,8 +10,8 @@
  *   - dirty flag, save / reset wires, server-side error mapping
  *
  * Kept separate from `IngredientTagsEditor.tsx` so the component itself
- * stays under the per-function lint cap (60 lines) and so the draft
- * machinery is unit-testable in isolation.
+ * stays under the per-function lint cap and so the draft machinery is
+ * unit-testable in isolation.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';

--- a/pillars/food/app/src/pages/data/ingredients-tab/useVariantActions.ts
+++ b/pillars/food/app/src/pages/data/ingredients-tab/useVariantActions.ts
@@ -5,7 +5,7 @@
  * Errors:
  *   - CONFLICT on create  → slug-taken localised message
  *   - CONFLICT on delete  → FK reference (batch / line / sub / alias)
- *   - BAD_REQUEST         → invalid slug shape (PRD-106)
+ *   - BAD_REQUEST         → invalid slug shape
  */
 import { useCallback, useState } from 'react';
 

--- a/pillars/food/app/src/pages/data/ingredients-tab/variant-form-helpers.ts
+++ b/pillars/food/app/src/pages/data/ingredients-tab/variant-form-helpers.ts
@@ -63,9 +63,9 @@ function parsePositiveNumber(raw: string): number | null {
 function parseNonNegativeInt(raw: string): number | null {
   const n = parsePositiveNumber(raw);
   if (n === null) return null;
-  // Shelf-life columns are integers on the DB side (PRD-108) and the router
-  // validates with `z.number().int().nonnegative()` — coerce to int so decimal
-  // typos don't reach the backend as `BAD_REQUEST`.
+  // Shelf-life columns are integers on the DB side and the server validates
+  // with `z.number().int().nonnegative()` — coerce to int so decimal typos
+  // don't reach the backend as `BAD_REQUEST`.
   return Math.floor(n);
 }
 

--- a/pillars/food/app/src/pages/data/prep-states/AddPrepStateDialog.tsx
+++ b/pillars/food/app/src/pages/data/prep-states/AddPrepStateDialog.tsx
@@ -1,10 +1,10 @@
 /**
- * Add-prep-state dialog (PRD-122-C / Tab 3).
+ * Add-prep-state dialog (pillars/food/docs/prds/data-page).
  *
  * Prep states have heavy reference impact (every recipe_line references
  * one), so v1 only supports add — no rename, no delete. The dialog
- * collects a slug + name pair; submit fires `onSubmit` which is wired
- * to `food.prepStates.create` server-side.
+ * collects a slug + name pair; submit fires `onSubmit`, which the parent
+ * wires to the `POST /prep-states` REST endpoint.
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/data/prep-states/PrepStatesTab.stories.tsx
+++ b/pillars/food/app/src/pages/data/prep-states/PrepStatesTab.stories.tsx
@@ -1,11 +1,11 @@
 /**
  * Storybook stories for the Prep states tab's `AddPrepStateDialog`
- * (PRD-122-C / Tab 3).
+ * (pillars/food/docs/prds/data-page).
  *
  * The dialog is a pure-presentation component (slug + name inputs +
- * submit/cancel) that takes all data via props, so no tRPC mocking is
+ * submit/cancel) that takes all data via props, so no network mocking is
  * needed. Stories cover the open + submitting states; the full tab
- * (`PrepStatesTabContent`) consumes `trpc.food.prepStates.*` and is
+ * (`PrepStatesTabContent`) calls the prep-states REST endpoints and is
  * exercised in the RTL suite, not Storybook.
  */
 import { createInstance, type i18n } from 'i18next';

--- a/pillars/food/app/src/pages/data/prep-states/PrepStatesTabContent.tsx
+++ b/pillars/food/app/src/pages/data/prep-states/PrepStatesTabContent.tsx
@@ -1,11 +1,10 @@
 /**
- * `/food/data/prep-states` tab content (PRD-122-C / Tab 3).
+ * `/food/data/prep-states` tab content (pillars/food/docs/prds/data-page).
  *
  * Read-only list of all prep states (seeded + user-added) plus an Add
- * button. Per PRD-122 the delete affordance is deliberately omitted —
- * recipe_lines reference prep_states and cascade analysis is deferred
- * to a future PRD. The placeholder UI surfaces this via a disabled
- * delete button with a Tooltip explaining "not in v1".
+ * button. The delete affordance is deliberately omitted — recipe_lines
+ * reference prep_states and cascade analysis is deferred. The UI surfaces
+ * this via a disabled delete button with a Tooltip explaining "not in v1".
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';

--- a/pillars/food/app/src/pages/data/prep-states/__tests__/PrepStatesTabContent.test.tsx
+++ b/pillars/food/app/src/pages/data/prep-states/__tests__/PrepStatesTabContent.test.tsx
@@ -1,11 +1,6 @@
 /**
- * RTL coverage for `/food/data/prep-states` (PRD-122-C / Tab 3).
- *
- * The tab is read-only beyond Add; the test confirms:
- *   - description renders in the header
- *   - rows render in slug-sorted order
- *   - the row Delete button is disabled and the tooltip text is wired up
- *   - the Add dialog submits via `food.prepStates.create`
+ * RTL coverage for `/food/data/prep-states`, the read-only-beyond-Add Prep
+ * states tab. Spec: pillars/food/docs/prds/data-page.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -87,9 +82,8 @@ describe('PrepStatesTabContent', () => {
     ensure().items = [{ id: 1, slug: 'diced', name: 'Diced' }];
     renderTab();
     const del = (await screen.findAllByRole('button', { name: /delete disabled/i }))[0];
-    // Per the keyboard-accessibility fix: the button is focusable
-    // (`aria-disabled` instead of HTML `disabled`) so the tooltip can
-    // appear on focus. Click is no-op'd via onClick.
+    // The button stays focusable (`aria-disabled`, not HTML `disabled`) so the
+    // explanatory tooltip can appear on focus; click is no-op'd via onClick.
     expect(del.getAttribute('aria-disabled')).toBe('true');
     expect(del).not.toBeDisabled();
     expect(screen.getByLabelText(/delete disabled — see tooltip/i)).toBeInTheDocument();

--- a/pillars/food/app/src/pages/data/prep-states/index.ts
+++ b/pillars/food/app/src/pages/data/prep-states/index.ts
@@ -1,4 +1,1 @@
-/**
- * Barrel for the `/food/data/prep-states` tab (PRD-122-C).
- */
 export { PrepStatesTabContent } from './PrepStatesTabContent.js';

--- a/pillars/food/app/src/pages/data/substitutions-graph/EdgeDetailPanel.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/EdgeDetailPanel.tsx
@@ -1,10 +1,8 @@
 import { useTranslation } from 'react-i18next';
 /**
- * Side panel that opens when the user clicks an edge in the graph.
- *
- * Shows from → to (each clickable to refocus the radial view), the
- * substitution ratio with a verbal interpretation, context tags, scope,
- * notes, and an "Edit in table view" link back to PRD-122's CRUD tab.
+ * Side panel that opens when the user clicks an edge in the graph. The
+ * from/to labels refocus the radial view; "Edit in table view" links to
+ * the substitutions CRUD table.
  */
 import { Link } from 'react-router';
 

--- a/pillars/food/app/src/pages/data/substitutions-graph/RadialFocusView.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/RadialFocusView.tsx
@@ -3,9 +3,8 @@
  *
  * Centre node is the focused entity; outgoing edges fan to the right,
  * incoming edges fan in from the left. Edges are sorted radially by how
- * close the ratio is to 1.0 (PRD-148 spec). Pure SVG layout — keeps the
- * focused view light + screenshot-friendly without spinning up the
- * force-directed canvas.
+ * close the ratio is to 1.0. Pure SVG layout keeps the focused view light
+ * and screenshot-friendly without spinning up the force-directed canvas.
  */
 import { useTranslation } from 'react-i18next';
 

--- a/pillars/food/app/src/pages/data/substitutions-graph/SubGraphBody.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/SubGraphBody.tsx
@@ -1,8 +1,7 @@
 /**
- * Inner body of the PRD-148 graph explorer. Owns the layout-switch
- * between the force-directed canvas and the radial focus view, plus
- * the empty/loading/error states. Lifted out of `SubGraphPage.tsx` so
- * each file stays under the per-file lint cap.
+ * Inner body of the substitution graph explorer. Owns the layout-switch
+ * between the force-directed canvas and the radial focus view, plus the
+ * empty/loading/error states.
  */
 import { useTranslation } from 'react-i18next';
 

--- a/pillars/food/app/src/pages/data/substitutions-graph/SubGraphHeader.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/SubGraphHeader.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 /**
- * Header controls for the PRD-148 substitution graph explorer.
+ * Header controls for the substitution graph explorer.
  *
  * Scope toggle / context dropdown are controlled by URL state; the
- * search input owns local state and debounces its URL-sync by 200ms
- * (per PRD-148 spec) so per-keystroke typing doesn't churn the
- * tRPC query or the browser history. Deep links land with the URL's
- * `q` value pre-populated.
+ * search input owns local state and debounces its URL-sync by 200ms so
+ * per-keystroke typing doesn't churn the data query or the browser
+ * history. Deep links land with the URL's `q` value pre-populated.
  */
 import { Link } from 'react-router';
 

--- a/pillars/food/app/src/pages/data/substitutions-graph/SubGraphPage.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/SubGraphPage.tsx
@@ -1,16 +1,15 @@
 /**
- * `/food/data/substitutions/graph` — PRD-148.
+ * `/food/data/substitutions/graph`.
  *
  * Top-level page. Lifts header filters and side-panel selection into URL
  * search params so the page is shareable + back-navigable. The graphView
- * query (PRD-148) returns the minimum spanning subgraph for the
- * current filters; node/edge selection drives which side panel is shown.
+ * query returns the minimum spanning subgraph for the current filters;
+ * node/edge selection drives which side panel is shown.
  *
  * State model:
  *   - `?scope` (default `global`) drives header + query.
- *   - `?recipeId` is read but the picker UI ships disabled until PRD-119
- *     lands `food.recipes.list`. Selecting `scope=recipe` shows an empty
- *     state explaining the picker arrives with PRD-119.
+ *   - `?recipeId` is read but the recipe picker UI is not built yet;
+ *     selecting `scope=recipe` shows a placeholder instead of a graph.
  *   - `?contextTag` / `?q` drive the context dropdown + search box.
  *   - `?node=<slug>` triggers the radial focus view + node side panel.
  *   - `?edge=<id>` opens the edge side panel on load.

--- a/pillars/food/app/src/pages/data/substitutions-graph/__tests__/SubGraphPage.test.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-graph/__tests__/SubGraphPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-148 — SubGraphPage RTL suite.
+ * SubGraphPage RTL suite (pillars/food/docs/prds/substitution-graph-explorer).
  *
  * Drives the page through `createMemoryRouter` so the `useSearchParams`
  * + URL-state machinery exercises React Router's real resolution path.
@@ -214,7 +214,6 @@ describe('SubGraphPage', () => {
     };
     renderAt('/food/data/substitutions/graph?node=butter');
     expect(await screen.findByRole('img', { name: /radial view: butter/i })).toBeInTheDocument();
-    // The stub force graph should NOT be rendered in radial mode.
     expect(screen.queryByTestId('stub-force-graph')).toBeNull();
   });
 
@@ -251,8 +250,6 @@ describe('SubGraphPage', () => {
     expect(clear).toBeInTheDocument();
     fireEvent.click(clear);
     await waitFor(() => {
-      // After clearing, the filter pass-through (covered in another test)
-      // should see undefined contextTag + search.
       const input = lastGraphQuery();
       expect(input).toMatchObject({ scope: 'global' });
       expect(input.contextTag).toBeUndefined();
@@ -281,9 +278,8 @@ describe('SubGraphPage', () => {
     fireEvent.change(searchBox, { target: { value: 'b' } });
     fireEvent.change(searchBox, { target: { value: 'bu' } });
     fireEvent.change(searchBox, { target: { value: 'but' } });
-    // No URL/query update should have fired yet — the input is local.
+    // No query update should have fired yet — the search box is local state, not URL.
     expect(lastGraphQuery().search).toBeUndefined();
-    // Advance past the 200ms debounce; the latest value should land.
     vi.advanceTimersByTime(220);
     await vi.runAllTimersAsync();
     vi.useRealTimers();

--- a/pillars/food/app/src/pages/data/substitutions-graph/helpers.ts
+++ b/pillars/food/app/src/pages/data/substitutions-graph/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Pure utilities for the PRD-148 substitution graph explorer.
+ * Pure utilities for the substitution graph explorer.
  *
  * Kept free of React + i18n so each can be unit-tested in isolation and
  * reused across `ForceGraphCanvas`, `RadialFocusView`, and the side
@@ -18,8 +18,7 @@ export function nodeLabel(node: SubGraphNode): string {
 
 /**
  * Render slug for a node. For variants we use the `parent:variant` form
- * that matches the URL `?node=<slug>` convention the PRD specifies for
- * radial focus.
+ * that matches the URL `?node=<slug>` convention used for radial focus.
  */
 export function nodeSlug(node: SubGraphNode): string {
   if (node.kind === 'variant' && node.variantSlug !== null) {
@@ -44,8 +43,8 @@ export function findNodeBySlug(nodes: readonly SubGraphNode[], slug: string): Su
 
 /**
  * Map a ratio to one of three discrete "thickness buckets" — cosmetic
- * only. PRD-148 calls for a thick line when the ratio is non-trivial
- * (outside the 0.5..2.0 band) so the user spots non-1:1 subs at a glance.
+ * only. A non-trivial ratio (outside the 0.5..2.0 band) draws a thick
+ * line so the user spots non-1:1 subs at a glance.
  */
 export type EdgeThickness = 'thin' | 'normal' | 'thick';
 

--- a/pillars/food/app/src/pages/data/substitutions-graph/types.ts
+++ b/pillars/food/app/src/pages/data/substitutions-graph/types.ts
@@ -1,13 +1,11 @@
 /**
- * Local view-model types for the PRD-148 substitution graph explorer.
+ * Local view-model types for the substitution graph explorer.
  *
- * These mirror the wire shape produced by `food.substitutions.graphView`
- * (defined in `apps/pops-api/src/modules/food/routers/substitutions.ts`).
- * They are duplicated here intentionally so the page components remain a
- * self-contained unit for vitest + RTL — no cross-package type plumbing
- * between the page tests and the running pops-api router. The wire shape
- * itself is covered end-to-end by `substitutions-graph.test.ts` on the API
- * side; here we exercise rendering against the shape.
+ * These mirror the wire shape served by the food contract's graphView
+ * route (`pillars/food/src/contract/rest-substitutions.ts`, generated
+ * into `app/src/food-api/types.gen.ts`). They are duplicated here
+ * intentionally so the page components stay a self-contained unit for
+ * vitest + RTL; here we exercise rendering against the shape.
  */
 export interface SubGraphNode {
   id: string;

--- a/pillars/food/app/src/pages/data/substitutions-graph/useSubGraphState.ts
+++ b/pillars/food/app/src/pages/data/substitutions-graph/useSubGraphState.ts
@@ -1,7 +1,6 @@
 /**
- * URL-state hook for the PRD-148 graph explorer. Reads search params,
- * exposes derived filter values + setters. Extracted from `SubGraphPage`
- * to keep the page component under the per-function lint cap.
+ * URL-state hook for the graph explorer. Reads search params, exposes
+ * derived filter values + setters.
  */
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';

--- a/pillars/food/app/src/pages/data/substitutions-tab/__tests__/SubstitutionsTab.test.tsx
+++ b/pillars/food/app/src/pages/data/substitutions-tab/__tests__/SubstitutionsTab.test.tsx
@@ -93,7 +93,7 @@ beforeEach(() => {
   substitutionsDeleteMock.mockResolvedValue({ data: { ok: true } });
 });
 
-describe('PRD-122-D — SubstitutionsTab', () => {
+describe('pillars/food/docs/prds/substitution-model — SubstitutionsTab', () => {
   it('renders rows for each substitution returned by listHydrated', async () => {
     seedList([
       row({ id: 1, ratio: 1.25, contextTags: ['baking'] }),

--- a/pillars/food/app/src/pages/data/tab-config.ts
+++ b/pillars/food/app/src/pages/data/tab-config.ts
@@ -16,7 +16,7 @@ export const FOOD_DATA_TABS: readonly FoodDataTab[] = [
   { slug: 'prep-states', labelKey: 'data.tabs.prepStates' },
   { slug: 'substitutions', labelKey: 'data.tabs.substitutions' },
   { slug: 'conversions', labelKey: 'data.tabs.conversions' },
-  // PRD-151 — read-only vocabulary view; per-ingredient editing lives on the
+  // Read-only vocabulary view; per-ingredient editing lives on the
   // Ingredients tab's detail panel.
   { slug: 'tags', labelKey: 'data.tabs.tags' },
 ];

--- a/pillars/food/app/src/pages/data/tags-tab/TagsTab.tsx
+++ b/pillars/food/app/src/pages/data/tags-tab/TagsTab.tsx
@@ -1,15 +1,12 @@
 /**
- * PRD-151 — read-only Tags vocabulary tab at `/food/data/tags`.
+ * Read-only Tags vocabulary tab at `/food/data/tags`
+ * (pillars/food/docs/prds/store-section-taxonomy).
  *
  * Groups every distinct tag in the database by namespace (`store-section`,
  * `diet`, `allergen`, …) and tags without a `:` segment under
  * `(no namespace)`. Each row links into the drill-down panel which lists
  * the ingredients carrying the tag — useful for spotting drift
- * (`store-section:produce` vs `store-section:Produce`) before PRD-152's
- * generator surfaces the duplicate.
- *
- * v1 is read-only. Rename / merge / bulk operations are deferred to a
- * future PRD that introduces multi-select on the Ingredients tab too.
+ * (`store-section:produce` vs `store-section:Produce`).
  */
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';

--- a/pillars/food/app/src/pages/data/tags-tab/__tests__/TagsTab.test.tsx
+++ b/pillars/food/app/src/pages/data/tags-tab/__tests__/TagsTab.test.tsx
@@ -1,12 +1,6 @@
 /**
- * PRD-151 — TagsTab unit tests.
- *
- * Drives the read-only vocabulary view through synchronous tRPC stand-ins.
- * Asserts:
- *   - empty state when no tags
- *   - tags are grouped by namespace
- *   - `(no namespace)` bucket is rendered last
- *   - drill-down panel hits `findByTag` and lists the ingredients
+ * TagsTab unit tests: drives the read-only vocabulary view through mocked
+ * food-api REST clients (ingredientTagsDistinct / ingredientTagsByTag).
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -98,7 +92,6 @@ describe('TagsTab', () => {
         <TagsTab />
       </Wrapper>
     );
-    // Each namespace produces a heading; the (no namespace) bucket renders last.
     await waitFor(() => {
       const headings = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
       expect(headings).toEqual(['diet', 'store-section', '(no namespace)']);

--- a/pillars/food/app/src/pages/fridge/AddBatchModal.tsx
+++ b/pillars/food/app/src/pages/fridge/AddBatchModal.tsx
@@ -10,7 +10,7 @@ import { FormError } from './form-controls.js';
 import { useAddBatchForm } from './useAddBatchForm.js';
 
 /**
- * "+ Add batch" modal — PRD-147.
+ * "+ Add batch" modal.
  *
  * Form state + mutation live in `useAddBatchForm`. The JSX sub-sections
  * live in `AddBatchModal.sections.tsx`. This file just stitches them

--- a/pillars/food/app/src/pages/fridge/AdjustQtyModal.tsx
+++ b/pillars/food/app/src/pages/fridge/AdjustQtyModal.tsx
@@ -1,7 +1,7 @@
 /**
- * Adjust qty modal — PRD-147.
+ * Adjust qty modal.
  *
- * Records spoilage / waste / correction. PRD-145's `adjustBatchQty`
+ * Records spoilage / waste / correction. The `adjustBatchQty` service
  * enforces sign rules: spoiled + wasted require delta < 0; correction
  * allows either sign. NegativeQty surfaces if delta would push the
  * batch below zero.

--- a/pillars/food/app/src/pages/fridge/BatchRow.tsx
+++ b/pillars/food/app/src/pages/fridge/BatchRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Single batch row in the fridge sectioned list — PRD-147.
+ * Single batch row in the fridge sectioned list.
  *
  * Renders the variant / prep / qty / expiry line with a kebab menu
  * exposing Edit / Relocate / Adjust / Cook / Delete. The page owns

--- a/pillars/food/app/src/pages/fridge/CookNowPicker.tsx
+++ b/pillars/food/app/src/pages/fridge/CookNowPicker.tsx
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 /**
- * "Cook now" picker — PRD-147.
+ * "Cook now" picker.
  *
  * Lists recipes whose current version references this batch's variant.
- * The match is variant-only (not prep-aware) — a prep-aware solver
- * arrives in Epic 06. Clicking a recipe navigates to its detail page;
- * the cook flow takes over there.
+ * The match is variant-only, not prep-aware. Clicking a recipe navigates
+ * to its detail page; the cook flow takes over there.
  */
 import { type ReactElement } from 'react';
 import { Link, useNavigate } from 'react-router';

--- a/pillars/food/app/src/pages/fridge/DeleteBatchConfirm.tsx
+++ b/pillars/food/app/src/pages/fridge/DeleteBatchConfirm.tsx
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 /**
- * Soft-delete confirm — PRD-147.
+ * Soft-delete confirm.
  *
  * Distinguishes non-empty vs empty batches in the confirm copy. Calls
- * `food.batches.delete` (PRD-145 soft-delete via `deleted_at`).
+ * `batchesDelete`, which soft-deletes via `deleted_at`.
  */
 import { useEffect, useState, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/fridge/EditBatchModal.tsx
+++ b/pillars/food/app/src/pages/fridge/EditBatchModal.tsx
@@ -1,8 +1,8 @@
 /**
- * Edit batch modal — PRD-147.
+ * Edit batch modal.
  *
- * Edits expiry / notes / prepState only. Other fields delegated to
- * Relocate / Adjust qty per PRD-145's service split.
+ * Edits expiry / notes / prepState only. Other fields delegate to
+ * Relocate / Adjust qty, matching the batch service split.
  */
 import { type FormEvent, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/fridge/FridgeFilterBar.tsx
+++ b/pillars/food/app/src/pages/fridge/FridgeFilterBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Header filter row for the FridgePage — PRD-147.
+ * Header filter row for the FridgePage.
  *
  * Hosts the search box, location chips, expiring-soon / yielded-only
  * toggles, and the "show all" reveal for empty + soft-deleted batches.

--- a/pillars/food/app/src/pages/fridge/FridgePage.tsx
+++ b/pillars/food/app/src/pages/fridge/FridgePage.tsx
@@ -1,19 +1,10 @@
 /**
- * PRD-147 — `/food/fridge` page.
+ * The `/food/fridge` page.
  *
  * Sectioned list of every non-empty, non-deleted batch grouped by
  * location, then ingredient. Row-level Edit / Relocate / Adjust /
- * Cook / Delete actions delegate to PRD-145's `food.batches.*`
- * services. The filter / search / show-all controls feed
- * `food.fridge.view`.
- *
- * Deferred from v1:
- *   - URL-driven state (`?showAll=1`, `?add=1`, `?edit=<id>`, `?batch=<id>`
- *     scroll + highlight). Filter / modal state is local-only for now; a
- *     follow-up will sync to `useSearchParams` once the deep-link UX is
- *     designed (auto-expand showAll, auto-scroll target, pulse).
- *   - Sidebar badge for batches expiring within 3 days.
- *   - Mobile bottom-sheet modal variants.
+ * Cook / Delete actions delegate to the `batches*` REST endpoints. The
+ * filter / search / show-all controls feed `fridgeView`.
  */
 import { useEffect, useState, type ReactElement } from 'react';
 import { Link } from 'react-router';

--- a/pillars/food/app/src/pages/fridge/LocationSection.tsx
+++ b/pillars/food/app/src/pages/fridge/LocationSection.tsx
@@ -1,5 +1,5 @@
 /**
- * A single location section (Pantry / Fridge / Freezer / Other) — PRD-147.
+ * A single location section (Pantry / Fridge / Freezer / Other).
  *
  * Collapsible header + per-ingredient sub-groups of batch rows.
  */

--- a/pillars/food/app/src/pages/fridge/RelocateBatchModal.tsx
+++ b/pillars/food/app/src/pages/fridge/RelocateBatchModal.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 /**
- * Relocate batch modal — PRD-147.
+ * Relocate batch modal.
  *
- * Single-field modal: pick a new location and call
- * `food.batches.relocate`. The service recomputes default expiry when
- * the user hasn't overridden it (PRD-145).
+ * Single-field modal: pick a new location and call `batchesRelocate`.
+ * The service recomputes default expiry when the user hasn't overridden
+ * it.
  */
 import { useEffect, useState, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/fridge/__tests__/FridgePage.test.tsx
+++ b/pillars/food/app/src/pages/fridge/__tests__/FridgePage.test.tsx
@@ -1,8 +1,6 @@
 /**
- * RTL coverage for FridgePage — PRD-147.
+ * RTL coverage for FridgePage (pillars/food/docs/prds/fridge-view).
  *
- * Asserts the header renders, the empty state shows when there are no
- * batches, and a populated view renders sections with batch rows.
  * Heavier behavioural coverage (mutation flows, modal validation) lives
  * in the per-modal tests and the API integration tests.
  */
@@ -129,7 +127,7 @@ function viewWithOneTomato(): FridgeView {
   };
 }
 
-describe('FridgePage — PRD-147', () => {
+describe('FridgePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fridgeRecipesUsingBatchMock.mockResolvedValue({ data: { items: [] } });

--- a/pillars/food/app/src/pages/fridge/format.ts
+++ b/pillars/food/app/src/pages/fridge/format.ts
@@ -20,8 +20,8 @@ export function formatQty(qty: number, unit: BatchUnit): string {
 export function formatExpiry(expiresAt: string | null, daysToExpiry: number | null): string {
   if (expiresAt === null) return '—';
   const date = new Date(expiresAt);
-  // PRD-147 — date-only stamps come back as UTC midnight. We render in UTC
-  // so the visible day matches `daysToExpiry` (which is also UTC-anchored);
+  // Date-only stamps come back as UTC midnight. We render in UTC so the
+  // visible day matches `daysToExpiry` (which is also UTC-anchored);
   // showing the local-tz day would skew by one in negative offsets.
   const formatted = date.toLocaleDateString(undefined, {
     month: 'short',

--- a/pillars/food/app/src/pages/fridge/useFridgeView.ts
+++ b/pillars/food/app/src/pages/fridge/useFridgeView.ts
@@ -1,5 +1,5 @@
 /**
- * REST client wrapper for `fridge.view` — PRD-147.
+ * REST client wrapper for `fridgeView`.
  *
  * Owns the cache key for the fridge query so the mutation handlers in
  * the sibling modals can invalidate one place when a batch changes.
@@ -14,12 +14,12 @@ import type { FridgeViewResponses } from '../../food-api/types.gen.js';
 type FridgeViewOutput = FridgeViewResponses[200];
 
 /**
- * PRD-147's overview blurb mentions a prep-state filter, but the spec
- * body (filter chips, `fridge.view` schema) does not enumerate one.
- * Treating it as a documented deferral for v1 — re-instate by adding
- * `prepStateId` here, in the request body, and a SQL `prep_state_id =`
- * clause in `view-query.ts` once the design picks a single-select vs
- * multi-select shape.
+ * There is intentionally no prep-state filter: the
+ * `pillars/food/docs/prds/fridge-view` overview mentions one, but its
+ * filter-chip / `fridgeView` schema does not enumerate it. To add one,
+ * thread `prepStateId` here, into the request body, and into a
+ * `prep_state_id =` clause in
+ * `pillars/food/src/api/modules/fridge/view-query.ts`.
  */
 export interface FridgeFilterState {
   search: string;

--- a/pillars/food/app/src/pages/inbox/DraftRow.tsx
+++ b/pillars/food/app/src/pages/inbox/DraftRow.tsx
@@ -1,11 +1,7 @@
 /**
- * PRD-134 — single row in the Drafts tab list.
- *
- * Click anywhere on the row except the kind chip → navigate to
- * `/food/inbox/:sourceId` (the inspector, PRD-135). The kind chip itself
- * opens the source URL in a new tab for `url-*` kinds, or opens PRD-138's
- * `ViewSourceDialog` inline for text / screenshot kinds — so triagers can
- * peek before deciding to invest time.
+ * The kind chip stops row-click propagation: `url-*` kinds open the source
+ * in a new tab, text / screenshot kinds open `ViewSourceDialog` inline.
+ * The rest of the row navigates to the inspector at `/food/inbox/:sourceId`.
  */
 import { type ReactElement, useState } from 'react';
 import { Link } from 'react-router';

--- a/pillars/food/app/src/pages/inbox/DraftsFilters.tsx
+++ b/pillars/food/app/src/pages/inbox/DraftsFilters.tsx
@@ -1,11 +1,8 @@
 /**
- * PRD-134 — filter chip group + sort dropdown for the Drafts tab.
- *
- * All chips are multi-select; the band group defaults to all-selected so the
- * triagers see the full queue out of the box. The sort dropdown is
- * single-select with four documented orders. Parent owns the filter object
- * and decides where the state is persisted (this PRD wires it to the URL
- * hash via `drafts-filters.ts`).
+ * Filter chip group + sort dropdown for the Drafts tab. All chips are
+ * multi-select; the band group defaults to all-selected so triagers see the
+ * full queue out of the box. Parent owns the filter object; persistence to
+ * the URL hash lives in `drafts-filters.ts`.
  */
 import { type ChangeEvent, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/DraftsTab.tsx
+++ b/pillars/food/app/src/pages/inbox/DraftsTab.tsx
@@ -1,15 +1,6 @@
 /**
- * PRD-134 — Drafts tab body.
- *
- * Owns the filter object (defaulting to the URL-hash decoded state) and
- * surfaces:
- *   - the filter chip group + sort dropdown
- *   - the heuristic-sorted row list (one `DraftRow` per pending ingest)
- *   - empty states ("inbox is empty" vs "no rows match your filters")
- *   - loading / error pass-through
- *
- * The shell owns URL-hash sync via `InboxPage` so the URL stays a single
- * source of truth; this component just receives the initial state + an
+ * Drafts tab body. `InboxPage` owns URL-hash sync so the URL stays the single
+ * source of truth; this component receives the decoded filter state and an
  * `onFiltersChange` callback to push updates upward.
  */
 import { type ReactElement } from 'react';

--- a/pillars/food/app/src/pages/inbox/FailedFilters.tsx
+++ b/pillars/food/app/src/pages/inbox/FailedFilters.tsx
@@ -1,9 +1,7 @@
 /**
- * PRD-138 — filter chip group for the Failed-ingests tab.
- *
- * Error-code chip set is dynamic — auto-populated from
- * `food.inbox.failedErrorCodes` so newly emitted codes surface without a
- * UI change. Kind + sinceDays chips mirror the Rejected tab pattern.
+ * Filter chip group for the Failed-ingests tab. The error-code chip set is
+ * dynamic — `availableErrorCodes` comes from the `inboxFailedErrorCodes`
+ * endpoint so newly emitted codes surface without a UI change.
  */
 import { type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/FailedRow.tsx
+++ b/pillars/food/app/src/pages/inbox/FailedRow.tsx
@@ -1,9 +1,3 @@
-/**
- * PRD-138 — single row in the Failed-ingests tab.
- *
- * Pure presentational. Retry + ViewSource callbacks delegated to the
- * parent so the row's render shape doesn't change with the data layer.
- */
 import { type ReactElement } from 'react';
 
 import { Badge, Button } from '@pops/ui';

--- a/pillars/food/app/src/pages/inbox/FailedTab.tsx
+++ b/pillars/food/app/src/pages/inbox/FailedTab.tsx
@@ -1,8 +1,5 @@
 /**
- * PRD-138 — Failed-ingests tab body.
- *
- * Wraps the filter chips + row list + ViewSourceDialog. PRD-134's
- * `InboxLayout` mounts it when `?tab=failed` is selected.
+ * Failed-ingests tab body. `InboxPage` mounts it when `?tab=failed` is active.
  */
 import { type ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/InboxLayout.tsx
+++ b/pillars/food/app/src/pages/inbox/InboxLayout.tsx
@@ -1,12 +1,10 @@
 /**
- * PRD-134 — tab strip + page header for `/food/inbox`.
+ * Tab strip + page header for `/food/inbox` (Drafts / Rejected / Failed).
  *
- * Three tabs: Drafts / Rejected / Failed. Active tab state is mirrored in
- * the URL `?tab=` query param so refresh + shared links preserve context.
- * The pending-count badge for the sidebar is *not* rendered here — the
- * navigation rail is owned by `pops-shell` and lacks the badge surface
- * today. PRD-134's sidebar AC is deferred to a follow-up nav-rail
- * extension; the API hook is in place via `food.inbox.pendingCount`.
+ * The sidebar pending-count badge is not rendered here: the navigation rail
+ * is owned by the shell and has no badge surface, so that part is deferred
+ * (see pillars/food/docs/prds/review-queue-page). The count itself comes
+ * from the `inboxPendingCount` endpoint, surfaced as the header subtitle.
  */
 import { type ReactElement, type ReactNode } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/InboxPage.tsx
+++ b/pillars/food/app/src/pages/inbox/InboxPage.tsx
@@ -1,12 +1,7 @@
 /**
- * PRD-134 — top-level page for `/food/inbox`.
- *
- * Reads the `?tab=` query param + the URL hash, mounts the right tab body,
- * and pushes filter / tab updates back into the URL so refresh + shared
- * links keep the user in the same state.
- *
- * The Rejected + Failed tab content lands from PRD-138 (already on `main`).
- * This PRD owns the shell + the Drafts tab + the URL plumbing.
+ * Top-level page for `/food/inbox`. Reads the `?tab=` query param + the URL
+ * hash, mounts the right tab body, and pushes filter / tab updates back into
+ * the URL so refresh + shared links keep the user in the same state.
  */
 import { useQuery } from '@tanstack/react-query';
 import { type ReactElement, useCallback, useEffect } from 'react';

--- a/pillars/food/app/src/pages/inbox/QualityBandBadge.tsx
+++ b/pillars/food/app/src/pages/inbox/QualityBandBadge.tsx
@@ -1,11 +1,8 @@
 /**
- * PRD-134 — colour-coded pill that shows a draft's quality band + tooltip.
- *
- * Hover shows the top 3 signals from PRD-137's `scoreDraft` result so
- * triagers can see *why* a draft landed in a band without opening the
- * inspector. The pill itself is the band literal; the tooltip is a
- * native `title` attribute (Radix Tooltip would add a portal cost
- * disproportionate to a transient hover hint).
+ * Colour-coded pill showing a draft's quality band. Hover surfaces the top
+ * signals from `scoreDraft` so triagers see why a draft landed in a band
+ * without opening the inspector. The tooltip is a native `title` attribute,
+ * not a Radix Tooltip — a portal is disproportionate to a transient hover hint.
  */
 import { type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/RejectedFilters.tsx
+++ b/pillars/food/app/src/pages/inbox/RejectedFilters.tsx
@@ -1,10 +1,6 @@
 /**
- * PRD-138 — filter chip group for the Rejected tab.
- *
- * Three independent multi-/single-selects: reason (multi), kind (multi),
- * sinceDays (single, defaults to 30). Caller owns the filter object and
- * applies the change via React Router so URL hash drives the state per
- * PRD §Routes.
+ * Filter chip group for the Rejected tab: reason (multi), kind (multi),
+ * sinceDays (single). The caller owns the filter object.
  */
 import { type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/RejectedRow.tsx
+++ b/pillars/food/app/src/pages/inbox/RejectedRow.tsx
@@ -1,9 +1,7 @@
 /**
- * PRD-138 — single row in the Rejected tab.
- *
- * Pure presentational: parent owns the `undo` callback + the `isUndoing`
- * state. Title falls back to the synthetic `<no title>` placeholder per
- * the PRD when the version never had one assigned (rejected pre-extract).
+ * Single row in the Rejected tab. Title falls back to the synthetic
+ * `<no title>` placeholder when the version never had one assigned — a
+ * source rejected before extraction has no title.
  */
 import { type ReactElement } from 'react';
 import { Link } from 'react-router';

--- a/pillars/food/app/src/pages/inbox/RejectedTab.tsx
+++ b/pillars/food/app/src/pages/inbox/RejectedTab.tsx
@@ -1,10 +1,7 @@
 /**
- * PRD-138 — Rejected tab body.
- *
- * Self-contained component: mounts when PRD-134's tab shell selects the
- * `rejected` tab. Owns its own filter state internally; callers pass an
- * `initialFilters` prop (typically derived from a URL hash by PRD-134's
- * shell) so the URL→state plumbing belongs to whoever mounts this tab.
+ * Rejected tab body, mounted by `InboxPage` when the `rejected` tab is active.
+ * Owns its filter state internally; the URL→state plumbing belongs to whoever
+ * mounts this tab and passes `initialFilters`.
  */
 import { type ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/ViewSourceDialog.tsx
+++ b/pillars/food/app/src/pages/inbox/ViewSourceDialog.tsx
@@ -1,22 +1,13 @@
 /**
- * PRD-138 / PRD-134 — read-only dialog showing the original ingest input.
+ * Read-only dialog showing the original ingest input, rendered per kind:
+ *   - url-web / url-instagram → link + iframe preview, sandboxed to
+ *     `allow-same-origin` only (scripts disabled).
+ *   - text → a stub placeholder; the saved caption is not surfaced yet.
+ *   - screenshot → `<img>` from the source's screenshot endpoint.
  *
- * Per-kind rendering:
- *   - url-web / url-instagram → `<a>` link + sandboxed iframe preview
- *     (the `sandbox="allow-same-origin"` only — scripts disabled).
- *   - text → `<pre>` of the saved caption (fetched via inspection of the
- *     `ingest_sources.caption` column on the row; PRD-138 v1 receives
- *     this through a follow-up tRPC peek, but for now we render a stub
- *     copy explaining how to inspect via the source endpoint).
- *   - screenshot → `<img src="/food-api/ingest/source/<id>/screenshot">`.
- *
- * No DSL editor — there's no draft to edit at this point.
- *
- * Props accept a narrow `ViewSource` shape (sourceId / ingestKind /
- * sourceUrl / optional errorCode) so PRD-134's draft rows can mount the
- * dialog from an `InboxDraftRow` without paying for the full `FailedRow`
- * surface. PRD-138's `FailedTab` still passes a `FailedRow`; the dialog
- * just narrows the fields it needs.
+ * Props take a narrow `ViewSource` shape (sourceId / ingestKind / sourceUrl /
+ * optional errorCode) so draft rows can open it from an `InboxDraftRow`
+ * without the full `FailedRow` surface.
  */
 import { type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/inbox/__tests__/DraftsTab.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/DraftsTab.test.tsx
@@ -1,17 +1,3 @@
-/**
- * PRD-134 — RTL coverage for the Drafts tab.
- *
- *   - renders rows from the mocked SDK query, including band pill, title,
- *     kind chip, age string, sub-line counts, partialReason banner
- *   - filter chip toggle updates the query input (band, kind, partialReason)
- *   - Fresh-only toggle updates the query input
- *   - sort dropdown change updates the query input
- *   - clicking the kind chip on a text/screenshot row opens the dialog
- *     without firing the row's navigation
- *   - clicking elsewhere on the row navigates to the inspector route
- *   - empty (filtered) state surfaces the Clear-filters link
- *   - empty (no filters) state surfaces the "Inbox is empty" copy
- */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -104,7 +90,7 @@ beforeEach(() => {
   mockList([]);
 });
 
-describe('DraftsTab — PRD-134', () => {
+describe('DraftsTab', () => {
   it('renders one row per item including band pill, title, age, sub-line', async () => {
     mockList([makeRow(), makeRow({ versionId: 12, title: 'Lentil dahl', qualityBand: 'clean' })]);
     render(
@@ -159,7 +145,6 @@ describe('DraftsTab — PRD-134', () => {
       </Wrapper>
     );
     const user = userEvent.setup();
-    // Toggle a kind chip → filters now differ from default → filtered-empty.
     await user.click(screen.getByRole('button', { name: 'Web URL' }));
     expect(await screen.findByText(/No drafts match your filters/i)).toBeInTheDocument();
     expect(screen.getByTestId('drafts-clear-filters')).toBeInTheDocument();
@@ -173,8 +158,7 @@ describe('DraftsTab — PRD-134', () => {
       </Wrapper>
     );
     const user = userEvent.setup();
-    // Default: all 4 bands selected → wire is `undefined`. Toggling Clean off
-    // drops the chip to a 3-element list → wire ships an array.
+    // All bands selected collapses to `undefined` on the wire; dropping one ships the array.
     await user.click(screen.getByRole('button', { name: 'Clean' }));
     await vi.waitFor(() => {
       expect(Array.isArray(lastBody().bands)).toBe(true);

--- a/pillars/food/app/src/pages/inbox/__tests__/FailedTab.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/FailedTab.test.tsx
@@ -1,13 +1,3 @@
-/**
- * PRD-138 — RTL coverage for the Failed tab.
- *
- *   - renders rows from listFailed
- *   - filter chips auto-populated from failedErrorCodes
- *   - Retry → ingest.retry({ sourceId }) + optimistic remove + success toast
- *   - Retry failure → optimistic removal rolled back + error toast
- *   - View source opens ViewSourceDialog (per-kind body rendered)
- *   - empty state copy
- */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -96,7 +86,7 @@ beforeEach(() => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
-describe('FailedTab — PRD-138', () => {
+describe('FailedTab', () => {
   it('renders rows from listFailed', async () => {
     mockList([makeRow(), makeRow({ sourceId: 101, errorCode: 'Timeout' })]);
     mockCodes(['InstagramRateLimited', 'Timeout']);

--- a/pillars/food/app/src/pages/inbox/__tests__/InboxLayout.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/InboxLayout.test.tsx
@@ -1,10 +1,3 @@
-/**
- * PRD-134 — RTL coverage for the inbox shell.
- *
- *   - tab strip renders all three tabs + highlights the active one
- *   - clicking a tab fires `onTabChange` with the right key
- *   - pendingCount renders the live number; null → loading placeholder
- */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createInstance } from 'i18next';
@@ -65,7 +58,7 @@ function makeProps(over: Partial<Parameters<typeof InboxLayout>[0]> = {}) {
   };
 }
 
-describe('InboxLayout — PRD-134', () => {
+describe('InboxLayout', () => {
   it('renders the three tabs with active highlighting', () => {
     render(
       <I18nHost>

--- a/pillars/food/app/src/pages/inbox/__tests__/InboxPage.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/InboxPage.test.tsx
@@ -1,12 +1,3 @@
-/**
- * PRD-134 — RTL coverage for the page shell.
- *
- *   - default `?tab` → Drafts tab body
- *   - `?tab=rejected` → Rejected tab body
- *   - invalid `?tab` is normalised to `drafts` and the URL is updated
- *   - tab change pushes the new `?tab` into the URL
- *   - pendingCount renders from `inbox.pendingCount`
- */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -90,7 +81,7 @@ beforeEach(() => {
   inboxFailedErrorCodesMock.mockResolvedValue({ data: { items: [] } });
 });
 
-describe('InboxPage — PRD-134', () => {
+describe('InboxPage', () => {
   it('defaults to the Drafts tab when no ?tab is set', () => {
     render(<Wrapper initial="/food/inbox" />);
     expect(screen.getByTestId('drafts-tab')).toBeInTheDocument();

--- a/pillars/food/app/src/pages/inbox/__tests__/RejectedTab.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/RejectedTab.test.tsx
@@ -1,13 +1,3 @@
-/**
- * PRD-138 — RTL coverage for the Rejected tab.
- *
- *   - renders rows from the mocked SDK query
- *   - Undo invokes `inbox.unreject` with `{ versionId }` + surfaces
- *     a success toast on `{ ok: true }`
- *   - Undo failure rolls back the optimistic removal + surfaces an error toast
- *   - filter chip toggle updates the query input
- *   - empty state renders the recovery copy
- */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -96,7 +86,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('RejectedTab — PRD-138', () => {
+describe('RejectedTab', () => {
   it('renders rows from listRejected', async () => {
     mockList([makeRow(), makeRow({ versionId: 2, title: 'Lentil dahl' })]);
     render(

--- a/pillars/food/app/src/pages/inbox/__tests__/ViewSourceDialog.test.tsx
+++ b/pillars/food/app/src/pages/inbox/__tests__/ViewSourceDialog.test.tsx
@@ -1,12 +1,3 @@
-/**
- * PRD-138 — RTL coverage for the ViewSourceDialog.
- *
- *   - renders nothing when row is null
- *   - URL kinds render a clickable link + sandboxed iframe
- *   - screenshot kind renders an <img> pointing at the source endpoint
- *   - text kind renders the placeholder
- *   - Close button fires onClose
- */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createInstance } from 'i18next';
@@ -59,7 +50,7 @@ function renderDialog(r: FailedRow | null, onClose = () => {}): void {
   render(<Wrapper />);
 }
 
-describe('ViewSourceDialog — PRD-138', () => {
+describe('ViewSourceDialog', () => {
   it('renders nothing when row is null', () => {
     renderDialog(null);
     expect(screen.queryByTestId('view-source-dialog')).toBeNull();

--- a/pillars/food/app/src/pages/inbox/__tests__/drafts-filters.test.ts
+++ b/pillars/food/app/src/pages/inbox/__tests__/drafts-filters.test.ts
@@ -1,12 +1,3 @@
-/**
- * PRD-134 — unit tests for the filter URL-hash codec.
- *
- *   - default state encodes to the empty string (pristine URL)
- *   - encode → decode round-trips every documented filter axis
- *   - decode ignores unknown keys / bad arrays without throwing
- *   - decode falls back to the default state on malformed input
- *   - `toQueryInput` collapses the "all bands selected" UI default to `undefined`
- */
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -17,7 +8,7 @@ import {
   toQueryInput,
 } from '../drafts-filters.js';
 
-describe('PRD-134 — drafts URL-hash codec', () => {
+describe('drafts URL-hash codec', () => {
   it('encodes the default state to the empty string', () => {
     expect(encodeFiltersHash(DEFAULT_DRAFTS_FILTERS)).toBe('');
   });

--- a/pillars/food/app/src/pages/inbox/drafts-filters.ts
+++ b/pillars/food/app/src/pages/inbox/drafts-filters.ts
@@ -1,10 +1,10 @@
 /**
- * PRD-134 — Drafts-tab filter types + URL-hash codec.
+ * Drafts-tab filter types + URL-hash codec.
  *
  * Filter state lives in the URL hash (`#filters=<base64url(json)>`) so
- * sharing / refresh preserves context. We base64url-encode rather than
- * stuff the JSON in raw so the hash stays free of `%`-escaped characters
- * and so it survives the React Router pass-through unchanged.
+ * sharing / refresh preserves context. The JSON is base64url-encoded rather
+ * than stored raw so the hash stays free of `%`-escaped characters and
+ * survives the React Router pass-through unchanged.
  */
 import type { PartialReason } from '@pops/food/queue';
 
@@ -53,9 +53,8 @@ export function toQueryInput(filters: DraftsFiltersState): {
   sort?: DraftSort;
 } {
   return {
-    // PRD-134: the "all selected" UI default collapses to undefined on the
-    // wire so the SQL skips the WHERE-IN clause. Same shape PRD-140-B used
-    // for kind filters — Copilot R1 lessons captured.
+    // The "all selected" UI default collapses to undefined on the wire so the
+    // query skips the WHERE-IN clause entirely.
     bands: filters.bands.length === ALL_BANDS.length ? undefined : [...filters.bands],
     kinds: filters.kinds.length === 0 ? undefined : [...filters.kinds],
     partialReasons: filters.partialReasons.length === 0 ? undefined : [...filters.partialReasons],

--- a/pillars/food/app/src/pages/inbox/inbox-tabs.ts
+++ b/pillars/food/app/src/pages/inbox/inbox-tabs.ts
@@ -1,10 +1,7 @@
 /**
- * PRD-134 — shared tab-key constants for the `/food/inbox` shell.
- *
- * Three keys: `drafts` (default), `rejected`, `failed`. The `InboxPage`
- * reads `?tab=` and falls back to `drafts` for any unrecognised value,
- * normalising the URL via `router.replace` so the address bar reflects
- * the actual rendered tab.
+ * Shared tab-key constants for the `/food/inbox` shell. `InboxPage` reads
+ * `?tab=` and falls back to `drafts` for any unrecognised value, then
+ * normalises the URL so the address bar reflects the rendered tab.
  */
 export type InboxTabKey = 'drafts' | 'rejected' | 'failed';
 

--- a/pillars/food/app/src/pages/inbox/inbox-types.ts
+++ b/pillars/food/app/src/pages/inbox/inbox-types.ts
@@ -1,11 +1,8 @@
 import type { IngestSourceKind } from '../../food-api-shared-types.js';
 /**
- * PRD-138 — shared types + tiny helpers for the Rejected / Failed tabs.
- *
- * The row + filter shapes live here so the tab page, row component, filter
- * component, and stories all import from one place — and so the public
- * surface stays stable when the underlying tRPC procedure types are
- * regenerated.
+ * Shared types + tiny helpers for the Rejected / Failed tabs. The row + filter
+ * shapes live here so the tab page, row, filter, and stories import from one
+ * place, keeping the surface stable when the generated API types regenerate.
  */
 import type {
   InboxListFailedResponses,

--- a/pillars/food/app/src/pages/inbox/inspector/ApproveDialog.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/ApproveDialog.tsx
@@ -1,8 +1,3 @@
-/**
- * PRD-135 — approve confirmation dialog. Wraps PRD-136's
- * `food.inbox.approve` mutation. On success navigates to the promoted
- * recipe's detail page.
- */
 import { useMutation } from '@tanstack/react-query';
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/inspector/AutoCreateBanner.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/AutoCreateBanner.tsx
@@ -1,10 +1,6 @@
 /**
- * PRD-135 — auto-create banner.
- *
- * Lists each `InspectorResolverCreationRow` with a deep link into PRD-122's
- * `/food/data?focus=<slug>` route. Banner is purely informational —
- * approval is never gated on resolving auto-creations (Epic 03 key
- * decision).
+ * Banner is purely informational — approval is never gated on resolving
+ * auto-creations.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/inspector/DecisionPane.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/DecisionPane.tsx
@@ -1,12 +1,3 @@
-/**
- * PRD-135 — decision pane.
- *
- * Top-to-bottom: quality band card, auto-create banner, proposed-slug
- * list (with cursor-move callback), decision controls (Approve / Reject
- * or Undo for archived). Partial-draft sources surface a Re-run pipeline
- * button alongside Approve / Reject; `auth-dead` disables it with a
- * tooltip linking to the IG cookie runbook.
- */
 import { useMutation } from '@tanstack/react-query';
 import { type ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -183,13 +174,12 @@ function RerunPipelineButton({
   onRequeued: () => void;
 }): ReactElement {
   const { t } = useTranslation('food');
-  // PRD-135 §"Partial-draft retry variant" — `auth-dead` is disabled until
-  // the operator refreshes cookies out-of-band (see the IG cookie runbook).
+  // `auth-dead` stays disabled until the operator refreshes IG cookies
+  // out-of-band; nothing the UI can do recovers it.
   const isDisabled = partialReason === 'auth-dead';
   // `partial` is a terminal state, so the inspector's poll stops; without an
   // explicit invalidate after re-queue the UI sticks on the old partial draft
-  // until the user reloads. Bumping `onRequeued` invalidates the query
-  // (Copilot R1).
+  // until the user reloads. Bumping `onRequeued` invalidates the query.
   const mutation = useMutation({
     mutationFn: async (input: { sourceId: number }) => unwrap(await ingestRetry({ body: input })),
     onSuccess: () => {

--- a/pillars/food/app/src/pages/inbox/inspector/EditorPane.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/EditorPane.tsx
@@ -1,15 +1,7 @@
 /**
- * PRD-135 — editor pane.
- *
- * Two tabs: Editor (mounts PRD-120's `DslEditor`, debounced save) and
- * Renderer (lazy-loads PRD-121's `RecipeRenderer` via
- * `food.recipes.getForRendering`). Save fires `food.recipes.saveDraft`
- * and on success invalidates the inspector query so the band + signals +
- * proposed slugs refresh.
- *
  * Archived versions render the editor in `readOnly` mode and hide the
- * Save button; the renderer remains live for archived versions (a
- * frozen view of what was archived).
+ * Save button; the renderer stays live for archived versions, a frozen
+ * view of what was archived.
  */
 import { useMutation } from '@tanstack/react-query';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
@@ -46,8 +38,7 @@ export function EditorPane({ draft, onSaved, pendingCursor }: Props): ReactEleme
   // `draft.bodyDsl` (Save → invalidate, sibling-tab approve, etc.) — without
   // this, a stale `body` could overwrite the on-server DSL on the next Save.
   // The `lastSyncedDsl` ref prevents the user's in-flight unsaved edits from
-  // being clobbered by a refetch that returned the same value they last
-  // saved (Copilot R1).
+  // being clobbered by a refetch that returned the same value they last saved.
   const lastSyncedDsl = useRef(draft.bodyDsl);
   useEffect(() => {
     if (draft.bodyDsl === lastSyncedDsl.current) return;

--- a/pillars/food/app/src/pages/inbox/inspector/InspectorPage.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/InspectorPage.tsx
@@ -1,16 +1,12 @@
 /**
- * PRD-135 — `/food/inbox/:sourceId` per-draft inspector.
+ * `/food/inbox/:sourceId` per-draft inspector: three-pane layout
+ * (provenance / editor / decision) for an ingest source and its draft.
+ * The provenance pane is wrapped in an error boundary so a malformed
+ * `extracted_json` doesn't tank the editor + decision panes.
  *
- * Three-pane layout (provenance / editor / decision) for an ingest source
- * + its draft. Replaces PRD-134's stub route. Provenance pane is wrapped
- * in an error boundary so a malformed `extracted_json` doesn't tank the
- * editor + decision panes.
- *
- * Layout: tailwind `lg:` breakpoint switches between a single stacked
- * column (decision first so Approve is above the fold on mobile) and the
- * three-pane horizontal grid (25/45/30). Resizable pane widths + the
- * `localStorage` persistence the PRD spec describes are deferred — the
- * Gaps section on the PR tracks that follow-up.
+ * The `lg:` breakpoint switches between a single stacked column (decision
+ * first so Approve is above the fold on mobile) and the three-pane
+ * horizontal grid.
  */
 import { Component, type ReactElement, type ReactNode, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,8 +46,8 @@ function InspectorBody({ sourceId, t }: BodyProps): ReactElement {
   >(undefined);
   // Monotonic counter — `Date.now()` can collide on back-to-back clicks
   // (especially in tests with fake timers); a ref-backed integer always
-  // changes identity so `usePendingCursor` re-runs (Copilot R1). Lives
-  // before the early-return guards to honour the rules of hooks.
+  // changes identity so `usePendingCursor` re-runs. Lives before the
+  // early-return guards to honour the rules of hooks.
   const nonceRef = useRef(0);
 
   if (inspector.isLoading) return <LoadingState t={t} />;
@@ -111,9 +107,6 @@ function InspectorLayout({
   editor: ReactNode;
   decision: ReactNode;
 }): ReactElement {
-  // PRD-135 §Layout — `lg:` brings the three-pane horizontal split (25/45/30).
-  // On narrow screens the decision pane comes first so Approve is above the
-  // fold (vertical stack `flex-col-reverse`-style via explicit ordering).
   return (
     <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[1fr_1.8fr_1.2fr]">
       <div className="order-3 lg:order-1" data-testid="inspector-pane-provenance">

--- a/pillars/food/app/src/pages/inbox/inspector/InspectorRenderer.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/InspectorRenderer.tsx
@@ -1,10 +1,7 @@
 /**
- * PRD-135 — renderer tab body.
- *
- * Lazy-fetches PRD-121's `RecipeVersionWithCompiledData` via
- * `food.recipes.getForRendering` and mounts the read-only renderer. When
- * `compileStatus !== 'compiled'` we show a stub instead — the renderer is
- * only meaningful against materialised lines + steps.
+ * Lazy-fetches the joined render payload and mounts the read-only
+ * renderer. Uncompiled / failed versions show a stub instead — the
+ * renderer is only meaningful against materialised lines + steps.
  */
 import { useQuery } from '@tanstack/react-query';
 import { type ReactElement } from 'react';

--- a/pillars/food/app/src/pages/inbox/inspector/ProposedSlugsList.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/ProposedSlugsList.tsx
@@ -1,9 +1,6 @@
 /**
- * PRD-135 — proposed-slug list with cursor-move.
- *
- * Clicking an entry calls back into the parent with the `fromLoc` so the
- * decision pane can bump the editor's `pendingCursor` prop and move the
- * cursor to the source span (PRD-120's imperative cursor target).
+ * Clicking an entry calls back with its `fromLoc` so the editor's
+ * `pendingCursor` prop moves the cursor to the matching source span.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/inspector/ProvenancePane.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/ProvenancePane.tsx
@@ -1,15 +1,6 @@
 /**
- * PRD-135 — provenance pane.
- *
  * Dispatches to a per-kind body and renders the cost / extractor-version
- * footer. The bodies in v1 cover the always-on read surfaces — sandboxed
- * iframe for `url-web`, video + collapsible caption for `url-instagram`,
- * pre + copy for `text`, full-size `<img>` for `screenshot`. Image
- * zoom-on-click, the IG keyframe gallery, the STT transcript, and the
- * raw vision LLM output that the PRD calls out are deferred — they
- * depend on richer meta-JSON shapes than what handlers ship today.
- *
- * The pane is wrapped in an `ErrorBoundary` by the caller so a malformed
+ * footer. The caller wraps this pane in an `ErrorBoundary` so a malformed
  * `extracted_json` doesn't take down the editor or decision panes.
  */
 import { type ReactElement } from 'react';
@@ -87,11 +78,9 @@ function ProvenanceUrlInstagram({ source }: Props): ReactElement {
         </a>
       )}
       {/* eslint-disable-next-line jsx-a11y/media-has-caption --
-         IG reels we save have no native caption track and an empty <track>
-         element is worse than none (assistive tech may announce missing
-         captions exist). Real captions would come from PRD-130's STT
-         transcript — that pipeline is in flight; once stable we can wire
-         a generated VTT here and drop the suppression (Copilot R1). */}
+         IG reels we save have no native caption track, and an empty <track>
+         element is worse than none (assistive tech may announce that missing
+         captions exist). */}
       <video
         controls
         preload="metadata"

--- a/pillars/food/app/src/pages/inbox/inspector/QualityBandCard.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/QualityBandCard.tsx
@@ -1,9 +1,6 @@
 /**
- * PRD-135 — quality band card on the decision pane.
- *
- * Renders PRD-137's band pill (large), the integer score, and the full
- * signal list (NOT truncated to top-3 like the inbox row tooltip). Pure
- * presentation; no data fetching.
+ * Renders the band pill, the integer score, and the full signal list —
+ * NOT truncated to top-3 like the inbox row tooltip.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/inbox/inspector/RejectDialog.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/RejectDialog.tsx
@@ -1,9 +1,3 @@
-/**
- * PRD-135 — reject dialog. Reason picker (5-value enum) + optional note;
- * the note becomes required when reason is `other`. Wraps PRD-136's
- * `food.inbox.reject` mutation; navigates back to the inbox Drafts tab
- * on success.
- */
 import { useMutation } from '@tanstack/react-query';
 import { type ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -88,9 +82,9 @@ export function RejectDialog({ open, onOpenChange, versionId, onRejected }: Prop
             disabled={mutation.isPending || noteRequired}
             onClick={() => {
               // Trim before send so the persisted `note` matches what the
-              // client-side `noteRequired` check evaluated against (Copilot
-              // R1). Empty trimmed strings collapse to `undefined` so the
-              // server doesn't persist a whitespace-only note.
+              // client-side `noteRequired` check evaluated against. Empty
+              // trimmed strings collapse to `undefined` so the server doesn't
+              // persist a whitespace-only note.
               const trimmed = note.trim();
               mutation.mutate({
                 versionId,

--- a/pillars/food/app/src/pages/inbox/inspector/__tests__/InspectorPage.test.tsx
+++ b/pillars/food/app/src/pages/inbox/inspector/__tests__/InspectorPage.test.tsx
@@ -1,17 +1,9 @@
 /**
- * PRD-135 — RTL coverage for the per-draft inspector page.
+ * RTL coverage for the per-draft inspector page.
+ * Spec: pillars/food/docs/prds/draft-inspector
  *
- * Mocks the generated food SDK so the page renders against a synthetic
- * `inbox.getForReview` payload and asserts:
- *   - 404 renders for `{ ok: false, reason: 'SourceNotFound' }`
- *   - pending source (draft = null) shows the no-draft body
- *   - clean compiled draft surfaces the band card + Approve enabled +
- *     Approve dialog opens + confirm fires the mutation
- *   - Approve is disabled when the band is blocked / compile failed
- *   - Reject flow: `other` reason requires a note before submit enables
- *   - Archived draft renders the rejection details + Undo button + read-only editor
- *   - Re-run pipeline button shows for partial sources and is disabled for auth-dead
- *   - Clicking a proposed-slug entry sets `pendingCursor` on the DslEditor
+ * Mocks the food API client so the page renders against a synthetic
+ * `inboxGetForReview` payload.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -148,7 +140,6 @@ function Wrapper(): ReactElement {
   );
 }
 
-/** Resolve `inbox.getForReview` with the given `InspectorResult` envelope. */
 function mockReview(result: InspectorResult): void {
   inboxGetForReviewMock.mockResolvedValue({ data: result });
 }
@@ -168,7 +159,7 @@ beforeEach(() => {
   ingestRetryMock.mockResolvedValue({ data: { jobId: 'j1', queuedAt: '2026-06-10T16:00:00Z' } });
 });
 
-describe('InspectorPage — PRD-135', () => {
+describe('InspectorPage', () => {
   it('renders the not-found view for SourceNotFound', async () => {
     mockReview({ ok: false, reason: 'SourceNotFound' });
     render(<Wrapper />);

--- a/pillars/food/app/src/pages/inbox/inspector/inspector-wire-types.ts
+++ b/pillars/food/app/src/pages/inbox/inspector/inspector-wire-types.ts
@@ -1,10 +1,8 @@
 /**
- * Wire-derived view types for the inbox inspector (PRD-135).
- *
- * All projected from the generated food SDK's `inbox.getForReview`
- * response so the inspector UI stays in lockstep with the REST surface.
- * `InspectorResult` is the raw discriminated union; the rest narrow into
- * its `ok: true` member.
+ * Wire-derived view types for the inbox inspector. All projected from the
+ * generated food SDK's `inbox.getForReview` response so the inspector UI
+ * stays in lockstep with the REST surface. `InspectorResult` is the raw
+ * discriminated union; the rest narrow into its `ok: true` member.
  */
 import type { InboxGetForReviewResponses } from '../../../food-api/types.gen.js';
 

--- a/pillars/food/app/src/pages/inbox/inspector/useInspector.ts
+++ b/pillars/food/app/src/pages/inbox/inspector/useInspector.ts
@@ -1,14 +1,10 @@
 /**
- * PRD-135 — inspector data hook.
+ * Inspector data hook over `inbox.getForReview`, with conditional polling
+ * while the source's state is non-terminal (`pending` / `processing`).
+ * The Drafts tab only navigates to terminal sources, so the polling branch
+ * is reserved for direct URL navigation during an in-flight ingest.
  *
- * Mounts `inbox.getForReview` with conditional polling: 60 s while the
- * source's state is non-terminal (`pending` / `processing`), on-demand once
- * terminal. PRD-134's Drafts tab only navigates to terminal sources so the
- * polling branch is reserved for direct URL navigation during an in-flight
- * ingest.
- *
- * Exposes `invalidate()` so callers can refresh after Save, Approve, Reject,
- * Undo, or Re-run pipeline mutations.
+ * Exposes `invalidate()` so callers can refresh after a mutation.
  */
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 

--- a/pillars/food/app/src/pages/inbox/useDraftsTab.ts
+++ b/pillars/food/app/src/pages/inbox/useDraftsTab.ts
@@ -1,11 +1,7 @@
 /**
- * PRD-134 — React Query plumbing for the Drafts inbox tab.
- *
- * Splits the data hook out of `DraftsTab.tsx` so the page component stays
- * under the per-file line cap and the hook is testable on its own. Polling
- * runs every 60s so newly-completed ingests appear without a manual refresh
- * — React Query disables background polling automatically when the tab is
- * hidden.
+ * React Query plumbing for the Drafts inbox tab. Polls every 60s so
+ * newly-completed ingests appear without a manual refresh;
+ * `refetchIntervalInBackground: false` pauses polling when the tab is hidden.
  */
 import { useQuery } from '@tanstack/react-query';
 

--- a/pillars/food/app/src/pages/inbox/useFailedTab.ts
+++ b/pillars/food/app/src/pages/inbox/useFailedTab.ts
@@ -1,10 +1,8 @@
 /**
- * PRD-138 — data + retry mutation hook for the Failed-ingests tab.
- *
- * Wraps PRD-125's `ingest.retry` mutation. Optimistic update removes
- * the row from the cached page; on success the row is gone (the next
- * `listFailed` poll won't surface it because `error_code` is now NULL);
- * on failure the snapshot is restored.
+ * Data + retry mutation hook for the Failed-ingests tab. Wraps the
+ * `ingestRetry` endpoint. The optimistic update removes the row from the
+ * cached page; on success it stays gone (the next list poll won't surface it
+ * because `error_code` is now NULL); on failure the snapshot is restored.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';

--- a/pillars/food/app/src/pages/inbox/useRejectedTab.ts
+++ b/pillars/food/app/src/pages/inbox/useRejectedTab.ts
@@ -1,10 +1,7 @@
 /**
- * PRD-138 — data + mutation hook for the Rejected tab.
- *
- * Splits the React Query plumbing out of `RejectedTab.tsx` so the page
- * component stays under the per-file line cap and the hook is testable on
- * its own. Optimistic Undo removes the row from the cached list pages
- * before the mutation resolves; failure restores it and surfaces a toast.
+ * Data + mutation hook for the Rejected tab. Optimistic Undo removes the row
+ * from the cached list pages before the mutation resolves; failure restores it
+ * and surfaces a toast.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';

--- a/pillars/food/app/src/pages/plan/AddPlanEntryModal.tsx
+++ b/pillars/food/app/src/pages/plan/AddPlanEntryModal.tsx
@@ -1,10 +1,9 @@
 /**
- * PRD-143 — "Add plan entry" modal.
+ * "Add plan entry" modal: `(date, slot)` is pre-filled from the trigger;
+ * the form adds a recipe typeahead plus servings and notes. On success the
+ * caller's `onAdded` runs after the week query invalidates.
  *
- * Pre-filled `(date, slot)` from the trigger. Recipe picker uses
- * `food.recipes.list` typeahead; servings + notes round out the form.
- * Submit calls `food.plan.addEntry`; on success the caller's `onAdded`
- * runs after the week query invalidates.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/plan/PlanCell.tsx
+++ b/pillars/food/app/src/pages/plan/PlanCell.tsx
@@ -1,8 +1,10 @@
 /**
- * PRD-143 — one `(date, slot)` cell. Hosts the droppable target + the
- * sortable list of plan entries inside that cell + the `[+]` Add button.
- * Shared between the desktop week grid and the mobile day swiper so
- * drag-and-drop behaviour stays identical across viewports.
+ * One `(date, slot)` cell: the droppable target, the sortable list of plan
+ * entries inside it, and the `[+]` Add button. Shared between the desktop
+ * week grid and the mobile day swiper so drag-and-drop behaviour stays
+ * identical across viewports.
+ *
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';

--- a/pillars/food/app/src/pages/plan/PlanDaySwiper.tsx
+++ b/pillars/food/app/src/pages/plan/PlanDaySwiper.tsx
@@ -1,14 +1,14 @@
 /**
- * PRD-143 — mobile day-at-a-time swiper.
+ * Mobile day-at-a-time swiper: a vertical stack of slot sections for a
+ * single visible day, with prev / next arrows plus a touch swipe gesture to
+ * navigate between the seven days of the current ISO week. Shares the dnd
+ * context, cell rendering, and add / edit hooks with `PlanWeekGrid` so
+ * behaviour stays identical at narrow viewports — only the framing changes
+ * (one column of stacked cells instead of a 7-column table). The Mon→Sun
+ * index is internal state; the caller still owns the visible week via
+ * `weekStart`.
  *
- * Vertical stack of slot sections for a single visible day, with prev /
- * next arrows + a touch swipe gesture to navigate between the seven
- * days of the current ISO week. Shares the dnd context, cell
- * rendering, and add / edit hooks with `PlanWeekGrid` so behaviour
- * stays identical at narrow viewports — the only thing that changes is
- * the framing (one column of stacked cells instead of a 7-column
- * table). The Mon→Sun index is internal state; the caller still owns
- * the visible week via `weekStart`.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { DndContext } from '@dnd-kit/core';
 import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';

--- a/pillars/food/app/src/pages/plan/PlanEntryEditSheet.tsx
+++ b/pillars/food/app/src/pages/plan/PlanEntryEditSheet.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 /**
- * PRD-143 — plan entry edit sheet.
+ * Plan entry edit sheet: a right-side drawer on desktop, a bottom-sheet at
+ * narrow viewports (via `useIsMobile`). Surfaces servings, notes, a "Mark
+ * cooked" CTA that links into the cook flow
+ * (pillars/food/docs/prds/cook-event-recording), and delete. When the entry
+ * has a non-null `recipeRunId` the form is read-only and shows "Cooked on".
  *
- * Right-side drawer at `≥768px`; bottom-sheet at narrow viewports per the
- * PRD's mobile spec (`useIsMobile`). Surfaces servings + notes + "Mark
- * cooked" CTA (which links into PRD-144's cook flow) + delete. When the
- * entry has a non-null `recipe_run_id` the form is read-only and shows
- * "Cooked on".
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { useEffect, useState, type ReactElement } from 'react';
 import { Link } from 'react-router';

--- a/pillars/food/app/src/pages/plan/PlanEntryRow.tsx
+++ b/pillars/food/app/src/pages/plan/PlanEntryRow.tsx
@@ -1,10 +1,9 @@
 /**
- * PRD-143 — plan entry card row.
+ * One row per plan entry inside a cell: a servings badge, a status chip when
+ * cooked, and a drag handle that greys out when the entry is locked by a
+ * cook. Clicking the row body opens `PlanEntryEditSheet`.
  *
- * One row per plan entry inside a cell. Truncates title to 18 chars,
- * shows a servings badge when >1, a status chip when cooked, and a tiny
- * drag handle (greyed when locked by cook). Clicking the body opens
- * `PlanEntryEditSheet`.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';

--- a/pillars/food/app/src/pages/plan/PlanPage.tsx
+++ b/pillars/food/app/src/pages/plan/PlanPage.tsx
@@ -1,10 +1,11 @@
 /**
- * PRD-143 — top-level planning page mounted at `/food/plan`.
+ * Top-level planning page mounted at `/food/plan`. Reads `?week=…` from the
+ * URL (defaulting to the current ISO week), drives navigation buttons, and
+ * renders the grid plus the add modal, edit sheet, and slot drawer. At
+ * narrow viewports (via `useIsMobile`) the week grid swaps for a
+ * day-at-a-time swiper.
  *
- * Reads `?week=…` from the URL (defaulting to current ISO week), drives
- * navigation buttons, and renders the grid + add modal + edit sheet +
- * slot drawer. At `<768px` (the PRD's mobile breakpoint) the week grid
- * swaps for a day-at-a-time swiper.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { useCallback, useState, type ReactElement } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
@@ -130,7 +131,10 @@ interface HeaderProps {
   onToday: () => void;
   onDatePick: (date: string) => void;
   onManageSlots: () => void;
-  /** PRD-152 amendment — navigates to `/food/shopping/from-plan` with the current week pre-filled. */
+  /**
+   * Navigates to `/food/shopping/from-plan` with the current week pre-filled.
+   * Spec: pillars/food/docs/prds/plan-shopping-generator
+   */
   onMakeShoppingList: () => void;
 }
 

--- a/pillars/food/app/src/pages/plan/PlanWeekGrid.tsx
+++ b/pillars/food/app/src/pages/plan/PlanWeekGrid.tsx
@@ -1,11 +1,11 @@
 /**
- * PRD-143 — desktop week grid.
- *
- * 7-column × N-slot grid. Each cell hosts a sortable list of plan
- * entries. Drag across cells calls `moveEntry`; drag within a cell calls
- * `reorderSlot`. The mobile day-swiper variant lives in
- * `PlanDaySwiper.tsx`; `PlanPage` picks one or the other via
+ * Desktop week grid: a 7-column × N-slot table where each cell hosts a
+ * sortable list of plan entries. Dragging across cells calls `moveEntry`;
+ * dragging within a cell calls `reorderSlot`. The mobile day-swiper variant
+ * lives in `PlanDaySwiper.tsx`; `PlanPage` picks one or the other via
  * `useIsMobile`.
+ *
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { DndContext } from '@dnd-kit/core';
 

--- a/pillars/food/app/src/pages/plan/SlotManagementDrawer.tsx
+++ b/pillars/food/app/src/pages/plan/SlotManagementDrawer.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 /**
- * PRD-143 — slot management drawer.
- *
- * Lists `plan_slots` rows; default slots can be reordered but not
- * renamed or deleted, custom slots support inline rename + delete (when
- * not in use). "+ Add slot" form at the bottom validates the slug
+ * Slot management drawer: lists `plan_slots` rows. Default slots can be
+ * reordered but not renamed or deleted; custom slots support inline rename
+ * and delete (when not in use). The "+ Add slot" form validates the slug
  * grammar client-side before calling the API.
+ *
+ * Spec: pillars/food/docs/prds/plan-entry-model
  */
 import { useState, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/plan/SlotRow.tsx
+++ b/pillars/food/app/src/pages/plan/SlotRow.tsx
@@ -1,7 +1,9 @@
 /**
- * One row inside the slot-management drawer. Renders the slot name
- * (editable for custom slots), reorder up/down buttons, and a delete
- * affordance — defaults are locked per PRD-143 / PRD-111 invariants.
+ * One row inside the slot-management drawer: the slot name (editable for
+ * custom slots), reorder up/down buttons, and a delete affordance. Default
+ * slots are locked — they can be reordered but not renamed or deleted.
+ *
+ * Spec: pillars/food/docs/prds/plan-entry-model
  */
 import { useState, type ReactElement } from 'react';
 

--- a/pillars/food/app/src/pages/plan/__tests__/PlanPage.test.tsx
+++ b/pillars/food/app/src/pages/plan/__tests__/PlanPage.test.tsx
@@ -1,11 +1,8 @@
 /**
- * PRD-143 — RTL coverage for the planning page.
+ * RTL coverage for the planning page (spec: pillars/food/docs/prds/planning-page).
  *
- * Mocks the generated food SDK so the test pins exactly what every
- * endpoint returns and asserts the rendered grid, add modal, edit sheet,
- * and slot drawer wire the mutations correctly. The drag-and-drop
- * behavior is exercised at the @dnd-kit unit level via library coverage;
- * this test focuses on the wiring + happy paths the PRD calls out.
+ * Mocks the generated food SDK so every endpoint return is pinned. Drag-and-drop
+ * is covered at the @dnd-kit level, so this file focuses on wiring + happy paths.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, within } from '@testing-library/react';

--- a/pillars/food/app/src/pages/plan/useIsMobile.ts
+++ b/pillars/food/app/src/pages/plan/useIsMobile.ts
@@ -1,8 +1,8 @@
 /**
- * PRD-143 — tiny `matchMedia` hook that flips the planning surface to its
- * mobile layout at `<768px` (the PRD's mobile breakpoint). Returns `false`
- * in non-browser environments so SSR / unit tests render the grid by
- * default; tests that want the mobile view stub `window.matchMedia`.
+ * `matchMedia` hook that flips the planning surface to its mobile layout at
+ * the `MOBILE_QUERY` breakpoint. Returns `false` in non-browser environments
+ * so SSR and unit tests render the grid by default; tests that want the
+ * mobile view stub `window.matchMedia`.
  */
 import { useEffect, useState } from 'react';
 

--- a/pillars/food/app/src/pages/plan/usePlanDnd.ts
+++ b/pillars/food/app/src/pages/plan/usePlanDnd.ts
@@ -1,10 +1,11 @@
 /**
- * PRD-143 — shared drag-and-drop wiring for the planning surface.
+ * Shared drag-and-drop wiring for the planning surface: a single
+ * `DragEndEvent` handler plus the sensor and mutation stack used by both
+ * `PlanWeekGrid` (desktop) and `PlanDaySwiper` (mobile). Keeping it in one
+ * place means a touch tap on the mobile swiper resolves the same way it does
+ * on the desktop grid.
  *
- * Exposes a single `DragEndEvent` handler plus the sensor + mutation
- * stack used by both `PlanWeekGrid` (desktop) and `PlanDaySwiper`
- * (mobile). Keeping it in one place means a touch tap on the mobile
- * swiper resolves the same way it does on the desktop grid.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import {
   type DragEndEvent,

--- a/pillars/food/app/src/pages/plan/usePlanPage.ts
+++ b/pillars/food/app/src/pages/plan/usePlanPage.ts
@@ -1,9 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 /**
- * PRD-143 data hook for the planning page.
+ * Data hook for the planning page: polls the plan week view at
+ * `WEEK_POLL_INTERVAL_MS` and exposes mutation helpers that invalidate the
+ * week query on success.
  *
- * Wraps `plan.weekView` with 60s polling and exposes ergonomic mutation
- * helpers that invalidate the week query on success.
+ * Spec: pillars/food/docs/prds/planning-page
  */
 import { useCallback } from 'react';
 

--- a/pillars/food/app/src/pages/recipes/AutoCreatedBanner.stories.tsx
+++ b/pillars/food/app/src/pages/recipes/AutoCreatedBanner.stories.tsx
@@ -1,8 +1,3 @@
-/**
- * Storybook for the auto-created-ingredients banner from
- * `RecipeEditPage`. The links target `/food/data?focus=<slug>` per
- * PRD-122-B's deep-link contract.
- */
 import { createInstance } from 'i18next';
 import { useMemo } from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';

--- a/pillars/food/app/src/pages/recipes/AutoCreatedBanner.tsx
+++ b/pillars/food/app/src/pages/recipes/AutoCreatedBanner.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 /**
- * Shown after a save creates new ingredients/variants via PRD-115's
- * resolver `creations` flow. Links each new slug to
- * `/food/data?focus=<slug>` (PRD-122-B v1 owns the focus deep-link).
+ * Shown after a save auto-creates new ingredients/variants. Links each
+ * new slug to the data page's focus deep-link
+ * (`/food/data?focus=<slug>`, owned by pillars/food/docs/prds/data-page).
  * Dismissible — not persistent.
  */
 export function AutoCreatedBanner({ slugs }: Props): ReactElement | null {

--- a/pillars/food/app/src/pages/recipes/CookNowPortal.tsx
+++ b/pillars/food/app/src/pages/recipes/CookNowPortal.tsx
@@ -1,8 +1,6 @@
 /**
- * Thin mount wrapper for PRD-144's `CookModal`.
- *
- * Mirrors `SendToListPortal` — owns the success-toast presentation so
- * `RecipeDetailPage` stays declarative.
+ * Thin mount wrapper for `CookModal`. Mirrors `SendToListPortal` — owns
+ * the success-toast presentation so `RecipeDetailPage` stays declarative.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,8 +30,8 @@ export function CookNowPortal({ flow, versionId }: Props): ReactElement {
       onCookedSuccess={(result) => {
         if (result.yieldedBatchId !== null) {
           // Localise per chosen location instead of hardcoding "fridge"
-          // in the success copy (Copilot R1). i18n provides per-location
-          // strings; the `location` discriminator selects which one.
+          // in the success copy: i18n provides per-location strings; the
+          // `location` discriminator selects which one.
           const locKey = result.location ?? 'fridge';
           toast.success(t(`cook.modal.toast.success.${locKey}`), {
             action: {

--- a/pillars/food/app/src/pages/recipes/MissingCurrentVersionBanner.tsx
+++ b/pillars/food/app/src/pages/recipes/MissingCurrentVersionBanner.tsx
@@ -8,8 +8,8 @@ interface Props {
 }
 
 /**
- * Shown on the detail page when `recipes.current_version_id IS NULL`
- * (PRD-119 spec): links to the drafts page so the user can promote one.
+ * Shown on the detail page when `recipes.current_version_id IS NULL`:
+ * links to the drafts page so the user can promote one.
  */
 export function MissingCurrentVersionBanner({ slug }: Props): ReactElement {
   const { t } = useTranslation('food');

--- a/pillars/food/app/src/pages/recipes/RecipeActionMenu.stories.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeActionMenu.stories.tsx
@@ -1,8 +1,3 @@
-/**
- * Storybook for the recipe detail-page action menu. Forward-compat slot
- * showcased via `extraItems` — PRD-142 / PRD-144 will populate it for
- * Cook now / Send to shopping list.
- */
 import { createInstance } from 'i18next';
 import { useMemo } from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';

--- a/pillars/food/app/src/pages/recipes/RecipeActionMenu.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeActionMenu.tsx
@@ -9,8 +9,7 @@ import type { ReactNode } from 'react';
  * Item shape mirrored from `@pops/ui`'s wrapper component. We can't
  * re-import its `DropdownMenuItem` interface name because the same
  * identifier is also re-exported as the underlying Radix component, so
- * a `type` import collapses to the value. PRD-119-E can replace this
- * mirror with the direct interface once the UI barrel is detangled.
+ * a `type` import collapses to the value.
  */
 export interface RecipeActionMenuItem {
   label: string;
@@ -24,17 +23,15 @@ interface Props {
   slug: string;
   draftCount: number;
   onArchive: () => void;
-  /** PRD-142 + PRD-144 inject their menu items here at the slot between Drafts and Archive. */
+  /** Items injected at the slot between Drafts and Archive (Cook now, Send to list). */
   extraItems?: RecipeActionMenuItem[];
 }
 
 /**
- * Top-right action menu on the recipe detail page. Canonical final order
- * (per roadmap line 489):
+ * Top-right action menu on the recipe detail page. Canonical order:
  *   Edit / Drafts / Cook now... / Send to shopping list... / Archive.
- * 119-B ships only Edit / Drafts / Archive — PRD-142 and PRD-144 plug
- * into the `extraItems` slot to add their own entries between Drafts and
- * Archive when those PRDs land.
+ * Edit / Drafts / Archive are fixed here; the Cook now and Send-to-list
+ * entries arrive through the `extraItems` slot between Drafts and Archive.
  *
  * Built on `@pops/ui`'s Radix-backed `DropdownMenu` so we get focus
  * trap, roving focus, typeahead, click-outside, and Escape-to-close for

--- a/pillars/food/app/src/pages/recipes/RecipeArchiveDialog.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeArchiveDialog.tsx
@@ -12,10 +12,9 @@ interface Props {
 }
 
 /**
- * Type-to-confirm archive dialog. v1 uses a hand-rolled overlay rather
- * than `@pops/ui`'s Radix `AlertDialog` to keep the focus-trap surface
- * deliberately minimal — PRD-119-E will swap to the shared primitive
- * when the dialog gets keyboard-shortcut + animation polish.
+ * Type-to-confirm archive dialog. Uses a hand-rolled overlay rather than
+ * `@pops/ui`'s Radix `AlertDialog` to keep the focus-trap surface
+ * deliberately minimal.
  */
 export function RecipeArchiveDialog({
   open,

--- a/pillars/food/app/src/pages/recipes/RecipeDetailPage.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeDetailPage.tsx
@@ -20,8 +20,8 @@ import { useRecipeDetailData } from './useRecipeDetailData.js';
 /**
  * `/food/recipes/:slug` — read view of the current version.
  *
- * Wraps PRD-121's `RecipeRenderer variant='detail'` with the recipe-page
- * shell: action menu, scale provider (forward-compat for PRD-142/144),
+ * Wraps `RecipeRenderer variant='detail'` with the recipe-page shell:
+ * action menu, scale provider (feeds the Cook now / Send-to-list flows),
  * missing-current banner, and an archive confirm flow.
  */
 export function RecipeDetailPage(): ReactElement {
@@ -128,7 +128,7 @@ interface ErrorBranchArgs {
 }
 
 function renderErrorBranch({ slug, error, draftCount, archive, t }: ErrorBranchArgs): ReactElement {
-  // PRD-119-API throws NOT_FOUND with three distinct message shapes; we
+  // The API throws NOT_FOUND with three distinct message shapes; we
   // route "has no published version" to the missing-current banner so
   // the user isn't told "could not load recipe" when the cause is "no
   // version published yet" (drafts may still exist).

--- a/pillars/food/app/src/pages/recipes/RecipeEditPage.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeEditPage.tsx
@@ -28,7 +28,7 @@ type CompileResult = RecipesSaveDraftResponses[200]['compile'];
  * current version is published, a fresh draft is created on mount via
  * `createNewDraft` (idempotent: same draft returned if one exists).
  * Save / promote / discard map straight to the matching mutations;
- * compile-result errors flow back as PRD-120-C `issues`.
+ * compile-result errors flow back to the editor as `issues`.
  */
 export function RecipeEditPage(): ReactElement {
   const { t } = useTranslation('food');

--- a/pillars/food/app/src/pages/recipes/RecipeListCard.stories.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeListCard.stories.tsx
@@ -1,7 +1,3 @@
-/**
- * Storybook stories for the recipe list-page card. Pure-presentation —
- * no tRPC dependency, so the stories drive the variants directly.
- */
 import { MemoryRouter } from 'react-router';
 
 import { RecipeListCard } from './RecipeListCard';

--- a/pillars/food/app/src/pages/recipes/RecipeListCard.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeListCard.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 /**
- * Compact list-page card. NOT PRD-121's `RecipeRenderer` — that requires
- * the compiled lines + steps + JOINs. This card renders the wire-shape
+ * Compact list-page card. NOT `RecipeRenderer` — that requires the
+ * compiled lines + steps + JOINs. This card renders the wire-shape
  * `RecipeListItem` only and lets the user navigate to the detail page.
  */
 export function RecipeListCard({ item, t }: Props): ReactElement {
@@ -72,9 +72,8 @@ function Thumbnail({
       />
     );
   }
-  // PRD-124 stores hero_image_path as `<recipeId>/hero.<ext>`. The card
-  // variant lives at `<recipeId>/hero-card.webp`. Derive client-side per
-  // PRD-119's note: "thumbnail derivation is client-side".
+  // hero_image_path is stored as `<recipeId>/hero.<ext>`; the card
+  // variant lives at `<recipeId>/hero-card.webp`, derived client-side.
   const cardPath = heroImagePath.replace(/hero\.[^.]+$/, 'hero-card.webp');
   return (
     <img

--- a/pillars/food/app/src/pages/recipes/RecipeListPage.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeListPage.tsx
@@ -16,7 +16,7 @@ const SEARCH_DEBOUNCE_MS = 200;
 
 /**
  * `/food/recipes` — list page. Owns the local filter + cursor state;
- * the query hook handles tRPC + infinite-scroll mechanics.
+ * the query hook handles fetching + infinite-scroll mechanics.
  */
 export function RecipeListPage(): ReactElement {
   const { t } = useTranslation('food');

--- a/pillars/food/app/src/pages/recipes/RecipeNewPage.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeNewPage.tsx
@@ -40,7 +40,7 @@ export function RecipeNewPage(): ReactElement {
         toast.error(t('recipes.new.compileError'));
       }
       // Redirect in both paths — the draft exists either way, and the
-      // edit page surfaces compile errors inline via PRD-120-C `issues`.
+      // edit page surfaces compile errors inline via its `issues` prop.
       void navigate(`/food/recipes/${result.slug}/edit`);
     },
     onError: (err: Error) => {

--- a/pillars/food/app/src/pages/recipes/RecipeScaleProvider.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeScaleProvider.tsx
@@ -20,16 +20,11 @@ interface ProviderProps {
 }
 
 /**
- * Context shell for recipe-page scale state — PRD-119 B + amendments from
- * PRD-142 (send to shopping list) and PRD-144 (cook now). The detail page
- * mounts the provider; downstream PRDs consume `useRecipeScale()` to
- * scale the ingredient list, send a scaled list to a shopping list, or
- * pre-fill the cook modal.
- *
- * v1 ships scaleFactor=1 and a setter that downstream PRDs will wire to
- * a `<ScalePicker>` — no UI for changing scale yet (PRD-119 spec). The
- * provider is forward-compat scaffolding so 142 / 144 plug in without a
- * follow-up refactor of the detail page.
+ * Context shell for recipe-page scale state. The detail page mounts the
+ * provider; consumers call `useRecipeScale()` to scale the ingredient
+ * list, send a scaled list to a shopping list, or pre-fill the cook
+ * modal. No UI changes the scale yet — only the setter exists, defaulting
+ * to scaleFactor=1.
  */
 export function RecipeScaleProvider({
   children,

--- a/pillars/food/app/src/pages/recipes/RecipeVersionDetailPage.tsx
+++ b/pillars/food/app/src/pages/recipes/RecipeVersionDetailPage.tsx
@@ -73,7 +73,7 @@ function RecipeVersionDetailBody({ slug, versionNo }: BodyProps): ReactElement {
 
   if (isLoading) return <Status text={t('recipes.detail.loading')} />;
   if (error !== null) {
-    // PRD-119-API throws NOT_FOUND with message "Recipe \"<slug>\" has no
+    // The API throws NOT_FOUND with message "Recipe \"<slug>\" has no
     // version <n>" for an out-of-range versionNo and "Recipe \"<slug>\"
     // not found" for an unknown slug. Either way, the user is looking at
     // a non-existent version, so we show the same not-found copy.
@@ -142,16 +142,16 @@ function VersionDetailHeader({
 }
 
 /**
- * tRPC's `useQuery.error` is a `TRPCClientErrorLike` whose `.data.code`
- * carries the structured status. Match on the code so the not-found
- * detection doesn't depend on the human-readable message.
+ * Detect a not-found from the query error. Prefers a structured `code`
+ * field when the error carries one, so detection doesn't depend on the
+ * human-readable message.
  */
 function isVersionLookupNotFound(err: unknown): boolean {
   if (err === null || typeof err !== 'object') return false;
   const data = (err as { data?: { code?: unknown } }).data;
   if (data && typeof data === 'object' && data.code === 'NOT_FOUND') return true;
-  // Fallback for non-tRPC errors (e.g. mocked test errors): match on the
-  // two server-side message shapes.
+  // Fallback (e.g. mocked test errors): match on the two server-side
+  // message shapes.
   if (err instanceof Error) {
     return /has no version|not found/i.test(err.message);
   }

--- a/pillars/food/app/src/pages/recipes/SendToListPortal.tsx
+++ b/pillars/food/app/src/pages/recipes/SendToListPortal.tsx
@@ -1,9 +1,7 @@
 /**
- * Thin mount wrapper for PRD-142's `SendToListModal`.
- *
- * Owns the success-toast presentation so `RecipeDetailPage` can stay
- * declarative and under the per-file lint cap. Mirrors the
- * `ArchiveDialogPortal` pattern.
+ * Thin mount wrapper for `SendToListModal`. Owns the success-toast
+ * presentation so `RecipeDetailPage` can stay declarative and under the
+ * per-file lint cap. Mirrors the `ArchiveDialogPortal` pattern.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/recipes/__tests__/AutoCreatedBanner.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/AutoCreatedBanner.test.tsx
@@ -30,7 +30,7 @@ function Wrapper({ children }: { children: ReactElement }): ReactElement {
   );
 }
 
-describe('PRD-119-C — AutoCreatedBanner', () => {
+describe('recipe-crud-pages — AutoCreatedBanner', () => {
   it('renders nothing when the slug list is empty', () => {
     const { container } = render(
       <Wrapper>

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeActionMenu.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeActionMenu.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
   navigateMock.mockReset();
 });
 
-describe('PRD-119-B — RecipeActionMenu', () => {
+describe('recipe-crud-pages — RecipeActionMenu', () => {
   it('opens the menu when the trigger is clicked', async () => {
     const user = userEvent.setup();
     wrap();
@@ -38,7 +38,7 @@ describe('PRD-119-B — RecipeActionMenu', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('renders the canonical 119-B order: Edit, Drafts, Archive (without Cook now/Send)', async () => {
+  it('renders the canonical order: Edit, Drafts, Archive (without Cook now/Send)', async () => {
     const user = userEvent.setup();
     wrap();
     await user.click(screen.getByRole('button', { name: /actions/i }));

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeDetailPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeDetailPage.test.tsx
@@ -123,7 +123,7 @@ beforeEach(() => {
   recipesListDraftsMock.mockResolvedValue({ data: { drafts: [] } });
 });
 
-describe('PRD-119-B — RecipeDetailPage', () => {
+describe('recipe-crud-pages — RecipeDetailPage', () => {
   it('shows the loading state while the query resolves', () => {
     recipesGetForRenderingMock.mockReturnValue(new Promise(() => {}));
     render(

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeDraftEditPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeDraftEditPage.test.tsx
@@ -92,7 +92,7 @@ beforeEach(() => {
   currentParams = { slug: 'pancakes', draftNo: '2' };
 });
 
-describe('PRD-119-D — RecipeDraftEditPage', () => {
+describe('recipe-crud-pages — RecipeDraftEditPage', () => {
   it('alerts when the URL is missing slug or draftNo', () => {
     currentParams = { slug: undefined, draftNo: undefined };
     render(

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeDraftsPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeDraftsPage.test.tsx
@@ -92,7 +92,7 @@ beforeEach(() => {
   navigateMock.mockReset();
 });
 
-describe('PRD-119-D — RecipeDraftsPage', () => {
+describe('recipe-crud-pages — RecipeDraftsPage', () => {
   it('shows the loading state while drafts are fetching', () => {
     recipesListDraftsMock.mockReturnValue(new Promise(() => {}));
     render(

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
@@ -1,8 +1,10 @@
 /**
- * PRD-124 follow-up — verifies the `RecipeEditPage` recipe edit shell
- * mounts the `HeroImageUploader` with the recipe's id + heroImagePath,
- * and that the upload/remove callbacks invalidate the rendering query
- * so the new path round-trips into the editor surface.
+ * Verifies the `RecipeEditPage` recipe edit shell mounts the
+ * `HeroImageUploader` with the recipe's id + heroImagePath, and that the
+ * upload/remove callbacks invalidate the rendering query so the new path
+ * round-trips into the editor surface.
+ *
+ * Spec: pillars/food/docs/prds/hero-image-upload
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -119,7 +121,7 @@ beforeEach(() => {
   recipesListProposedSlugsMock.mockResolvedValue({ data: { items: [] } });
 });
 
-describe('PRD-124 follow-up — RecipeEditPage hero uploader mount', () => {
+describe('hero-image-upload — RecipeEditPage hero uploader mount', () => {
   it('mounts HeroImageUploader with recipe.id + heroImagePath once the draft opens', async () => {
     render(
       <Wrapper>

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeListCard.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeListCard.test.tsx
@@ -34,7 +34,7 @@ function wrap(item: RecipeListItemView = baseItem) {
   );
 }
 
-describe('PRD-119-A — RecipeListCard', () => {
+describe('recipe-crud-pages — RecipeListCard', () => {
   it('renders the title and links to the detail route', () => {
     wrap();
     expect(screen.getByRole('link', { name: /banana pancakes/i })).toHaveAttribute(

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeListPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeListPage.test.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
   resolvePage([]);
 });
 
-describe('PRD-119-A — RecipeListPage', () => {
+describe('recipe-crud-pages — RecipeListPage', () => {
   it('renders the empty state CTA when there are zero rows', async () => {
     resolvePage([]);
     render(

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeNewPage.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeNewPage.test.tsx
@@ -69,7 +69,7 @@ beforeEach(() => {
   navigateMock.mockReset();
 });
 
-describe('PRD-119-C — RecipeNewPage', () => {
+describe('recipe-crud-pages — RecipeNewPage', () => {
   it('renders the editor + save CTA', () => {
     render(
       <Wrapper>

--- a/pillars/food/app/src/pages/recipes/__tests__/RecipeScaleProvider.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/RecipeScaleProvider.test.tsx
@@ -16,7 +16,7 @@ function ScaleProbe() {
   );
 }
 
-describe('PRD-119-B — RecipeScaleProvider', () => {
+describe('recipe-crud-pages — RecipeScaleProvider', () => {
   it('defaults scaleFactor to 1', () => {
     render(
       <RecipeScaleProvider>
@@ -35,7 +35,7 @@ describe('PRD-119-B — RecipeScaleProvider', () => {
     expect(screen.getByTestId('scale')).toHaveTextContent('2.5');
   });
 
-  it('exposes a setter to downstream consumers (PRD-142/144 forward-compat)', async () => {
+  it('exposes a setter to downstream cook-flow consumers (forward-compat)', async () => {
     render(
       <RecipeScaleProvider>
         <ScaleProbe />

--- a/pillars/food/app/src/pages/recipes/__tests__/accessibility.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/accessibility.test.tsx
@@ -1,14 +1,16 @@
 import { render } from '@testing-library/react';
 /**
- * PRD-119-E — axe-core accessibility sweep across the leaf components
- * of the recipe-CRUD flow. Each test renders a static (non-interactive)
- * variant and asserts zero a11y violations.
+ * axe-core accessibility sweep across the leaf components of the
+ * recipe-CRUD flow. Each test renders a static (non-interactive) variant
+ * and asserts zero a11y violations.
  *
  * Page-level components are intentionally NOT covered here because they
- * pull in tRPC mutations + async state machines that would require
+ * pull in REST mutations + async state machines that would require
  * heavyweight mocks for marginal value — the leaf components are where
  * a11y regressions actually surface (badges, labels, focus order, role
  * hierarchy). Page-level a11y is verified via Storybook addon-a11y.
+ *
+ * Spec: pillars/food/docs/prds/recipe-crud-pages
  */
 import axeCore from 'axe-core';
 import { createInstance } from 'i18next';
@@ -77,7 +79,7 @@ async function assertNoViolations(container: HTMLElement): Promise<void> {
   expect(results.violations).toEqual([]);
 }
 
-describe('PRD-119-E — leaf component accessibility', () => {
+describe('recipe-crud-pages — leaf component accessibility', () => {
   it('RecipeListCard — Default', async () => {
     const { container } = render(
       <Wrapper>

--- a/pillars/food/app/src/pages/recipes/__tests__/compile-result-issues.test.ts
+++ b/pillars/food/app/src/pages/recipes/__tests__/compile-result-issues.test.ts
@@ -4,7 +4,7 @@ import { buildEditorIssues } from '../compile-result-issues.js';
 
 const SPAN = { startLine: 3, startCol: 1, endLine: 3, endCol: 8 };
 
-describe('PRD-119-C — compile-result-issues', () => {
+describe('recipe-crud-pages — compile-result-issues', () => {
   it('returns an empty array when no compile result and no proposed slugs', () => {
     expect(buildEditorIssues(null, [])).toEqual([]);
   });

--- a/pillars/food/app/src/pages/recipes/__tests__/mobile-layout.test.tsx
+++ b/pillars/food/app/src/pages/recipes/__tests__/mobile-layout.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-119-E — mobile-viewport layout sanity check.
+ * Mobile-viewport layout sanity check.
  *
  * jsdom doesn't really lay out CSS, but we can assert the structural
  * primitives (action menus stay tappable; cards stack via the
@@ -7,6 +7,8 @@
  * survive a 375px viewport. The real responsive audit is delivered via
  * Storybook + manual review — these tests guard against regressions on
  * the contracts the page-level code depends on.
+ *
+ * Spec: pillars/food/docs/prds/recipe-crud-pages
  */
 import { render, screen } from '@testing-library/react';
 import { createInstance } from 'i18next';
@@ -68,7 +70,7 @@ afterEach(() => {
   Object.defineProperty(window, 'innerWidth', { writable: true, value: ORIGINAL_INNER_WIDTH });
 });
 
-describe('PRD-119-E — mobile viewport (375px) layout contracts', () => {
+describe('recipe-crud-pages — mobile viewport (375px) layout contracts', () => {
   it('RecipeListCard — caps visible tags at 4 + overflow indicator', () => {
     render(
       <Wrapper>

--- a/pillars/food/app/src/pages/recipes/__tests__/useDebounce.test.ts
+++ b/pillars/food/app/src/pages/recipes/__tests__/useDebounce.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('PRD-119-A — useDebounce', () => {
+describe('recipe-crud-pages — useDebounce', () => {
   it('returns the initial value synchronously', () => {
     const { result } = renderHook(({ v }: { v: string }) => useDebounce(v, 200), {
       initialProps: { v: 'hello' },

--- a/pillars/food/app/src/pages/recipes/compile-result-issues.ts
+++ b/pillars/food/app/src/pages/recipes/compile-result-issues.ts
@@ -20,9 +20,9 @@ interface PossiblyLocatedError {
 }
 
 /**
- * Convert PRD-116's `CompileResult` + PRD-119's `listProposedSlugs` into
- * the diagnostic shape PRD-120-C's `DslEditor` consumes via its `issues`
- * prop. Errors are `severity='error'`; proposed slugs are `severity='info'`.
+ * Convert a `CompileResult` + the proposed-slug rows into the diagnostic
+ * shape `DslEditor` consumes via its `issues` prop. Errors are
+ * `severity='error'`; proposed slugs are `severity='info'`.
  *
  * `MaterialiseError` has no `loc` (it fires deep in the DB write path);
  * pin it to file-origin so the gutter marker still appears.

--- a/pillars/food/app/src/pages/recipes/send-to-list/ListChoiceRow.tsx
+++ b/pillars/food/app/src/pages/recipes/send-to-list/ListChoiceRow.tsx
@@ -1,10 +1,8 @@
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 /**
- * Single row in the existing-list picker — PRD-142 §UI.
+ * Single row in the existing-list picker (pillars/food/docs/prds/send-to-list).
  *
- * Shows name + item count + last-updated relative time + an inline badge
- * when the recipe was already sent to this list previously (soft warning,
- * never blocks selection).
+ * The already-sent badge is a soft warning — it never blocks selection.
  */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/recipes/send-to-list/SendToListModal.tsx
+++ b/pillars/food/app/src/pages/recipes/send-to-list/SendToListModal.tsx
@@ -1,17 +1,14 @@
 /**
- * Send-to-list modal — PRD-142.
+ * Send-to-list modal (pillars/food/docs/prds/send-to-list).
  *
- * Wraps `food.recipes.prepareSendToList` + `food.recipes.sendToList`. The
- * detail page mounts this under PRD-119's `RecipeScaleProvider` so the
- * scale factor flows in via `useRecipeScale()`.
- *
- * Per PRD §UI:
+ * The detail page mounts this under `RecipeScaleProvider` so the scale
+ * factor flows in via `useRecipeScale()`. Behaviour:
  *  - existing-list radio defaults selected when at least one shopping list
  *    exists; otherwise the modal auto-selects "create new"
  *  - the create-new name prefills `Shopping list — yyyy-MM-dd`
  *  - send button label dynamically shows the item count
- *  - closing mid-flight does NOT cancel the server work (PRD §Business
- *    Rules) — onOpenChange just hides the modal
+ *  - closing mid-flight does NOT cancel the server work — onOpenChange just
+ *    hides the modal
  */
 import { useEffect, useRef, useState, type FormEvent, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -57,10 +54,9 @@ export function SendToListModal({
   const { scaleFactor } = useRecipeScale();
   const data = useSendToListData({ versionId, scaleFactor, enabled: open });
   const [form, setForm] = useState<FormState>(initialForm);
-  // Track whether we've seeded the form for this open. We seed ONCE the
-  // first time the lists query resolves (or settles as empty) — re-seeding
-  // on every shoppingLists.length change would override a user who clicked
-  // "Create new" before a list-list refetch finished, per Copilot R1.
+  // Seed the form ONCE per open, the first time the lists query resolves (or
+  // settles as empty). Re-seeding on every shoppingLists.length change would
+  // override a user who clicked "Create new" before a refetch finished.
   const seededRef = useRef(false);
   useEffect(() => {
     if (!open) {
@@ -80,8 +76,8 @@ export function SendToListModal({
       onOpenChange(false);
     },
   });
-  // Clear stale server-error state when the modal closes so reopening
-  // doesn't surface yesterday's failure (Copilot R1).
+  // Clear stale server-error state on close so reopening doesn't surface a
+  // prior failure.
   useEffect(() => {
     if (!open) mutation.clearError();
   }, [open, mutation]);

--- a/pillars/food/app/src/pages/recipes/send-to-list/SendToListPreview.tsx
+++ b/pillars/food/app/src/pages/recipes/send-to-list/SendToListPreview.tsx
@@ -1,10 +1,11 @@
 /**
- * Preview pane for the send-to-list modal — PRD-142.
+ * Preview pane for the send-to-list modal
+ * (pillars/food/docs/prds/send-to-list).
  *
- * Shows the canonical items (post-aggregation, post-scale) and the
- * unconverted items in two grouped lists with a `…N more` collapser that
- * expands inline. PRD §UI shows first 5 + "…N more"; using 6 here keeps
- * the section readable on tall recipes without an immediate cutoff.
+ * Shows canonical items (post-aggregation, post-scale) and unconverted items
+ * in two grouped lists with a `…N more` collapser that expands inline. The
+ * collapse threshold sits one above the spec's "first 5" to keep tall
+ * recipes readable without an immediate cutoff.
  */
 import { useState, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -48,10 +49,10 @@ interface Row {
 }
 
 function toRow(item: PrepareOutput['canonicalItems'][number]): Row {
-  // First sourceLineId is unique per preview row — canonical items aggregate
-  // multiple lines but the first id is stable across renders, and unconverted
-  // items each have exactly one line id. Beats label-as-key (collisions on
-  // identical text) and idx (lint: no-array-index-key).
+  // First sourceLineId is unique per preview row and stable across renders:
+  // canonical items aggregate multiple lines but the first id is stable,
+  // unconverted items have exactly one line id. Label-as-key collides on
+  // identical text, so it's only the fallback when no line id exists.
   return { key: String(item.sourceLineIds[0] ?? item.label), label: item.label };
 }
 

--- a/pillars/food/app/src/pages/recipes/send-to-list/SendToListTargetPicker.tsx
+++ b/pillars/food/app/src/pages/recipes/send-to-list/SendToListTargetPicker.tsx
@@ -1,5 +1,6 @@
 /**
- * Target-picker section for the send-to-list modal — PRD-142 §UI.
+ * Target-picker section for the send-to-list modal
+ * (pillars/food/docs/prds/send-to-list).
  *
  * Renders two radio choices: "Add to existing" (a scrollable list of
  * shopping lists with name + item count + last-updated) and "Create

--- a/pillars/food/app/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
+++ b/pillars/food/app/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-142 — RTL coverage for the send-to-list modal.
+ * RTL coverage for the send-to-list modal (pillars/food/docs/prds/send-to-list).
  *
  * Mocks the food Hey API SDK (prepare + send) and the lists Hey API SDK
  * (the cross-pillar `GET /lists` read) so all three calls are controllable

--- a/pillars/food/app/src/pages/recipes/send-to-list/format-prefill-name.ts
+++ b/pillars/food/app/src/pages/recipes/send-to-list/format-prefill-name.ts
@@ -1,7 +1,8 @@
 /**
- * Default name for the "Create new list" radio per PRD-142 §UI:
- * `"Shopping list — <yyyy-MM-dd>"`. Pulled out so the test suite can
- * inject a stable clock without freezing the whole modal.
+ * Default name for the "Create new list" radio
+ * (pillars/food/docs/prds/send-to-list): `"Shopping list — <yyyy-MM-dd>"`.
+ * Pulled out so the test suite can inject a stable clock without freezing
+ * the whole modal.
  */
 import { format } from 'date-fns';
 

--- a/pillars/food/app/src/pages/recipes/send-to-list/index.ts
+++ b/pillars/food/app/src/pages/recipes/send-to-list/index.ts
@@ -1,5 +1,2 @@
-/**
- * PRD-142 — send-to-list modal barrel.
- */
 export { SendToListModal } from './SendToListModal.js';
 export type { SendToListModalProps } from './SendToListModal.js';

--- a/pillars/food/app/src/pages/recipes/send-to-list/types.ts
+++ b/pillars/food/app/src/pages/recipes/send-to-list/types.ts
@@ -1,8 +1,9 @@
 /**
- * Local UI shapes for the send-to-list modal — PRD-142.
+ * Local UI shapes for the send-to-list modal.
  *
- * The wire-shape `SendPreview` is inferred from `food.recipes.prepareSendToList`
- * via tRPC; this module exposes the form-state shape the modal manages.
+ * The wire shapes come from the generated REST client (see
+ * `./useSendToListData.ts`); this module exposes the form-state shape the
+ * modal manages.
  */
 export type TargetKind = 'existing' | 'new';
 

--- a/pillars/food/app/src/pages/recipes/send-to-list/useSendToListData.ts
+++ b/pillars/food/app/src/pages/recipes/send-to-list/useSendToListData.ts
@@ -1,13 +1,14 @@
 /**
- * Combined data hook for the send-to-list modal — PRD-142.
+ * Combined data hook for the send-to-list modal
+ * (pillars/food/docs/prds/send-to-list).
  *
- * Fetches the preview (`recipes.sendToList.prepare`) from the food SDK and
- * the available shopping lists (`GET /lists`) from the lists SDK in
- * parallel; the modal renders once both resolve. Both queries are scoped
- * to enabled=open so the modal pays nothing while closed.
+ * Fetches the preview (`sendToListPrepare`, food REST client) and the
+ * available shopping lists (`listListAggregate`, lists REST client) in
+ * parallel; the modal renders once both resolve. Both queries are scoped to
+ * `enabled=open` so the modal pays nothing while closed.
  *
  * The shopping-list read is a cross-pillar call to the lists pillar through
- * app-food's generated lists client (wire contract only — no monolith).
+ * food's generated lists client.
  */
 import { useQuery } from '@tanstack/react-query';
 

--- a/pillars/food/app/src/pages/recipes/send-to-list/useSendToListMutation.ts
+++ b/pillars/food/app/src/pages/recipes/send-to-list/useSendToListMutation.ts
@@ -1,10 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 /**
- * Mutation hook for the send-to-list modal — PRD-142.
+ * Mutation hook for the send-to-list modal
+ * (pillars/food/docs/prds/send-to-list).
  *
  * Surfaces a structured local error string (the modal renders inline; the
- * mutation itself never throws) and an `onSuccess(listId, listName)`
- * callback hook for the modal to close + toast.
+ * mutation itself never throws) and an `onSuccess(outcome)` callback for the
+ * modal to close + toast.
  */
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/recipes/use-cook-flow.ts
+++ b/pillars/food/app/src/pages/recipes/use-cook-flow.ts
@@ -1,11 +1,11 @@
 /**
- * Cook-now integration helpers for `RecipeDetailPage` — PRD-144.
+ * Cook-now integration helpers for `RecipeDetailPage`.
  *
- * Mirrors `use-send-flow.ts` from PRD-142: open/close state, a "can cook
- * this version" decider, and a builder that wires both into the action
- * menu's `extraItems` slot (between Drafts and Send-to-list).
+ * Mirrors `use-send-flow.ts`: open/close state, a "can cook this version"
+ * decider, and a builder that wires both into the action menu's
+ * `extraItems` slot (between Drafts and Send-to-list).
  *
- * Per the PRD-119 canonical menu order:
+ * Canonical menu order:
  *   Edit / Drafts / Cook now... / Send to shopping list... / Archive
  */
 import { useCallback, useState } from 'react';

--- a/pillars/food/app/src/pages/recipes/use-send-flow.ts
+++ b/pillars/food/app/src/pages/recipes/use-send-flow.ts
@@ -1,5 +1,5 @@
 /**
- * Send-to-list integration helpers for `RecipeDetailPage` — PRD-142.
+ * Send-to-list integration helpers for `RecipeDetailPage`.
  *
  * Extracted from the page so the page stays under the per-file lint cap.
  * `useSendFlow` owns the modal open/close state; `canSendRecipe` is the

--- a/pillars/food/app/src/pages/recipes/useDebounce.ts
+++ b/pillars/food/app/src/pages/recipes/useDebounce.ts
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 
 /**
  * Debounce a fast-changing value (e.g. search input keystrokes) so the
- * downstream React Query doesn't refetch on every character. 200 ms is
- * the PRD-119 spec.
+ * downstream query doesn't refetch on every character.
  */
 export function useDebounce<T>(value: T, ms: number): T {
   const [debounced, setDebounced] = useState(value);

--- a/pillars/food/app/src/pages/recipes/useRecipeDetailData.ts
+++ b/pillars/food/app/src/pages/recipes/useRecipeDetailData.ts
@@ -26,8 +26,8 @@ export interface RecipeDetailState {
 }
 
 /**
- * Combine the two reads PRD-119-B's detail page needs: the heavy compile
- * payload (via `recipes.getForRendering`) and the draft count (via
+ * Combine the two reads the detail page needs: the heavy compile payload
+ * (via `recipes.getForRendering`) and the draft count (via
  * `recipes.listDrafts`). Drafts is keyed off the slug only so it
  * stays cached across version-no navigation, AND its fetch is gated by
  * `includeDrafts` so the historic-version page doesn't pay for a count

--- a/pillars/food/app/src/pages/shopping/FromPlanHeader.tsx
+++ b/pillars/food/app/src/pages/shopping/FromPlanHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * Date-range picker header for the FromPlanPage — PRD-152.
+ * Date-range picker header for the FromPlanPage.
  *
  * Two date inputs + a "↺ This week" button that snaps to the current ISO
  * Mon–Sun. Live plan-entry count caption. Disabled feedback messaging when

--- a/pillars/food/app/src/pages/shopping/FromPlanItem.tsx
+++ b/pillars/food/app/src/pages/shopping/FromPlanItem.tsx
@@ -1,6 +1,3 @@
-/**
- * One row in the shopping preview — PRD-152.
- */
 import { type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';

--- a/pillars/food/app/src/pages/shopping/FromPlanPage.tsx
+++ b/pillars/food/app/src/pages/shopping/FromPlanPage.tsx
@@ -1,11 +1,12 @@
 /**
- * PRD-152 — `/food/shopping/from-plan`.
+ * `/food/shopping/from-plan`.
  *
  * Pre-fills the date range from `?start=YYYY-MM-DD&end=YYYY-MM-DD` query
- * parameters when present (linked from PRD-143's plan-header button),
- * otherwise defaults to today + 6 days. Drives a server-side preview and
- * gates a Generate mutation that writes a new shopping list + navigates
- * to `/lists/:id` on success.
+ * parameters when present (linked from the planning page's plan-header
+ * button — see pillars/food/docs/prds/planning-page), otherwise defaults
+ * to today + 6 days. Drives a server-side preview and gates a Generate
+ * mutation that writes a new shopping list + navigates to `/lists/:id` on
+ * success.
  */
 import { useCallback, useState, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/pillars/food/app/src/pages/shopping/__tests__/FromPlanPage.test.tsx
+++ b/pillars/food/app/src/pages/shopping/__tests__/FromPlanPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-152 — RTL coverage for the FromPlanPage.
+ * Spec: pillars/food/docs/prds/plan-shopping-generator
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/pillars/food/app/src/pages/shopping/default-list-name.ts
+++ b/pillars/food/app/src/pages/shopping/default-list-name.ts
@@ -3,7 +3,7 @@
  * server-side default used when the user accepts whatever's in the input
  * box.
  *
- * Format mirrors `apps/pops-api/src/modules/food/shopping/list-name.ts`.
+ * Format mirrors `pillars/food/src/api/modules/shopping/list-name.ts`.
  */
 const MONTHS_SHORT = [
   'Jan',

--- a/pillars/food/app/src/pages/shopping/format-qty.ts
+++ b/pillars/food/app/src/pages/shopping/format-qty.ts
@@ -3,7 +3,7 @@
  * integer → plain; otherwise toFixed(2) + trailing-zero strip.
  *
  * Kept in lockstep with the server-side `formatQty` in
- * `apps/pops-api/src/modules/food/shopping/generate.ts` so the preview
+ * `pillars/food/src/api/modules/shopping/generate.ts` so the preview
  * label matches the row inserted in the generated list.
  */
 export function formatQty(qty: number): string {

--- a/pillars/food/app/src/pages/shopping/range-helpers.ts
+++ b/pillars/food/app/src/pages/shopping/range-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Date-range helpers for the FromPlanPage — PRD-152.
+ * Date-range helpers for the FromPlanPage.
  *
  * Keeps the date math out of the component so the tests can exercise the
  * "↺ This week" snap, the +6 default, and the > 90-day client-side gate
@@ -27,7 +27,7 @@ export function defaultRange(today: Date = new Date()): { start: string; end: st
 }
 
 export function isoMondayFor(today: Date = new Date()): string {
-  // toISOString is in UTC; map to ISO Monday by walking back to dow=1.
+  // Normalise to UTC midnight so DST/TZ never shifts the weekday, then walk back to ISO Monday (dow=1).
   const utc = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
   const dow = utc.getUTCDay(); // 0=Sun..6=Sat
   const offset = dow === 0 ? -6 : 1 - dow;

--- a/pillars/food/app/src/pages/shopping/types.ts
+++ b/pillars/food/app/src/pages/shopping/types.ts
@@ -1,7 +1,6 @@
 /**
  * Wire types for the shopping FromPlanPage — derived from the generated
- * food SDK so they stay in lockstep with the `/shopping/*` REST surface
- * (PRD-152).
+ * food SDK so they stay in lockstep with the `/shopping/*` REST surface.
  */
 import type {
   ShoppingGenerateResponses,

--- a/pillars/food/app/src/pages/shopping/useFromPlanPage.ts
+++ b/pillars/food/app/src/pages/shopping/useFromPlanPage.ts
@@ -1,8 +1,8 @@
 /**
- * Data hook for the FromPlanPage — PRD-152.
+ * Data hook for the FromPlanPage.
  *
- * Drives `food.shopping.previewFromPlan` from the user-picked range and
- * exposes `generateFromPlan` so the page stays free of tRPC plumbing.
+ * Drives `shoppingPreview` from the user-picked range and exposes
+ * `shoppingGenerate` as a mutation.
  *
  * No polling — the preview is a snapshot at range-change time.
  */

--- a/pillars/food/app/src/pages/solve/SolveFilters.tsx
+++ b/pillars/food/app/src/pages/solve/SolveFilters.tsx
@@ -1,14 +1,14 @@
 /**
- * Header filter bar for `/food/solve` — PRD-150.
+ * Header filter bar for `/food/solve`.
  *
  * Four controls: a "No substitutions" toggle, multi-select recipe-type
  * chips, multi-select tag chips, and a max-time dropdown. Every filter
  * is optional; clearing them all is the equivalent of unfiltered.
  *
- * Tag suggestions come from `food.recipes.distinctTags` if/when that
- * surface lands — for v1 the input takes a comma-separated string the
- * user types directly. Keeps the page shippable without a dependency
- * on a tag taxonomy that doesn't exist yet.
+ * The tags control is a free-text comma-separated input: there is no
+ * tag-taxonomy read surface, so the user types tags directly. Replacing
+ * it with a discoverable chip group is tracked in
+ * pillars/food/docs/ideas/solver-tag-taxonomy-filter.md.
  */
 import { useTranslation } from 'react-i18next';
 

--- a/pillars/food/app/src/pages/solve/SolvePage.tsx
+++ b/pillars/food/app/src/pages/solve/SolvePage.tsx
@@ -1,5 +1,5 @@
 /**
- * `/food/solve` — PRD-150.
+ * `/food/solve` — see pillars/food/docs/prds/cook-solver.
  *
  * Discovery surface: walks every compiled, non-archived recipe against
  * the current pantry + substitution graph and lists the cookable

--- a/pillars/food/app/src/pages/solve/SolveRecipeCard.tsx
+++ b/pillars/food/app/src/pages/solve/SolveRecipeCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 /**
- * Per-recipe card on `/food/solve` — PRD-150.
+ * Per-recipe card on `/food/solve`.
  *
  * Icon (📗 clean / ⚠ subs needed) + title + status line + sub
  * breakdown + "Cook this" button. The whole card title links to the

--- a/pillars/food/app/src/pages/solve/SubBreakdownExpander.tsx
+++ b/pillars/food/app/src/pages/solve/SubBreakdownExpander.tsx
@@ -1,5 +1,5 @@
 /**
- * Sub-breakdown expander — PRD-150.
+ * Sub-breakdown expander.
  *
  * For recipes with one sub needed, the breakdown line is inlined into
  * the card so the user sees `soy sauce → tamari` without an extra

--- a/pillars/food/app/src/pages/solve/__tests__/SolvePage.test.tsx
+++ b/pillars/food/app/src/pages/solve/__tests__/SolvePage.test.tsx
@@ -1,17 +1,3 @@
-/**
- * RTL coverage for SolvePage — PRD-150.
- *
- * Asserts that:
- *   - header renders + count caption reflects the query data
- *   - cookable recipes render in the order the server returned
- *   - clean (subsNeeded=0) cards label "No subs needed"
- *   - one-sub recipes inline the breakdown
- *   - multi-sub recipes hide subs behind an expander
- *   - clicking "Cook this" navigates to /food/recipes/:slug
- *   - excludeSubs toggle flips the input to the query and the
- *     resulting empty state surfaces a "Clear filters" affordance
- *   - bare-pantry empty state surfaces the Open-fridge link
- */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -114,7 +100,7 @@ function render150(): void {
   );
 }
 
-describe('SolvePage — PRD-150', () => {
+describe('SolvePage — pillars/food/docs/prds/cook-solver', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/pillars/food/app/src/pages/solve/useSolveResult.ts
+++ b/pillars/food/app/src/pages/solve/useSolveResult.ts
@@ -1,7 +1,8 @@
 /**
- * tRPC client wrapper for `food.solver.canICook` — PRD-150.
+ * Query wrapper for the food REST SDK's `solverCanICook` endpoint.
  *
- * Polls every 60s while the page is visible (PRD-150 §Polling). The
+ * Polls every 60s while the page is visible (see the Polling section of
+ * pillars/food/docs/prds/cook-solver). The
  * `refetchIntervalInBackground: false` flag pauses the timer when
  * `document.visibilityState !== 'visible'` so a backgrounded tab
  * doesn't burn solver budget.

--- a/pillars/food/app/src/prompts/ig-vision.ts
+++ b/pillars/food/app/src/prompts/ig-vision.ts
@@ -1,13 +1,13 @@
 /**
- * Prompt template for PRD-130 (Instagram STT + vision pipeline).
+ * Instagram Reel ingest prompts (see pillars/food/docs/prds/instagram-stt-vision).
  *
  * Primary path: ffmpeg keyframes + faster-whisper transcript → Claude
- * vision. Fallback text-only variant ships as a separate version
- * (`PROMPT_VERSION_IG_VISION_TEXT_FALLBACK`) — both are registered with
- * the food prompt viewer (PRD-133).
+ * vision. The text-only variant (`PROMPT_VERSION_IG_VISION_TEXT_FALLBACK`)
+ * covers a failed vision call. Both are registered with the food prompt
+ * viewer (pillars/food/docs/prds/ai-usage-prompts).
  *
- * Bump version on any template change so `ai_inference_log` rows remain
- * reproducible.
+ * Bump the version constant on any template change so `ai_inference_log`
+ * rows stay reproducible.
  */
 export const PROMPT_VERSION_IG_VISION = 'ig-vision-v0.1';
 

--- a/pillars/food/app/src/prompts/screenshot.ts
+++ b/pillars/food/app/src/prompts/screenshot.ts
@@ -1,9 +1,9 @@
 /**
- * Prompt template for PRD-131 (Screenshot ingest).
+ * Screenshot ingest prompt (see pillars/food/docs/prds/screenshot-ingest).
  *
  * Single image → Claude vision. Registered with the food prompt viewer
- * (PRD-133). Bump the version on every template edit so logged rows
- * remain reproducible.
+ * (pillars/food/docs/prds/ai-usage-prompts). Bump the version constant on
+ * every template edit so logged rows stay reproducible.
  */
 export const PROMPT_VERSION_SCREENSHOT = 'screenshot-v0.1';
 

--- a/pillars/food/app/src/prompts/text.ts
+++ b/pillars/food/app/src/prompts/text.ts
@@ -1,5 +1,5 @@
 /**
- * Prompt template for PRD-132 (Text ingest).
+ * Text ingest prompt (see pillars/food/docs/prds/text-ingest).
  *
  * Supports two modes:
  *
@@ -8,7 +8,8 @@
  *     and wants Claude to flesh it out into a usable starter.
  *
  * Both modes share one prompt — the model decides based on the input
- * shape. Registered with the food prompt viewer (PRD-133).
+ * shape. Registered with the food prompt viewer
+ * (pillars/food/docs/prds/ai-usage-prompts).
  */
 export const PROMPT_VERSION_TEXT = 'text-v0.1';
 

--- a/pillars/food/app/src/prompts/web-llm.ts
+++ b/pillars/food/app/src/prompts/web-llm.ts
@@ -1,14 +1,14 @@
 /**
- * Prompt template for PRD-128 (Web URL LLM fallback extraction).
+ * Web URL LLM fallback prompt (see pillars/food/docs/prds/web-llm-fallback).
  *
- * Used when JSON-LD recipe data is absent on a recipe page (PRD-127's
- * deterministic extractor failed). Sends readability-extracted page text
- * to Claude and asks for a structured DSL recipe.
+ * Used when JSON-LD recipe data is absent on a recipe page (the
+ * deterministic extractor in pillars/food/docs/prds/web-jsonld returns
+ * `JsonLdMissing`). Sends readability-extracted page text to Claude and
+ * asks for a structured DSL recipe.
  *
- * The handler implementation lands with PRD-128; this template is the
- * v1 starting point and is registered with the food prompt viewer
- * (PRD-133). Bump `PROMPT_VERSION_WEB_LLM` whenever the template
- * changes.
+ * Registered with the food prompt viewer
+ * (pillars/food/docs/prds/ai-usage-prompts). Bump `PROMPT_VERSION_WEB_LLM`
+ * whenever the template changes.
  */
 export const PROMPT_VERSION_WEB_LLM = 'web-llm-v0.1';
 

--- a/pillars/food/app/src/routes.tsx
+++ b/pillars/food/app/src/routes.tsx
@@ -4,11 +4,10 @@ import { Navigate } from 'react-router';
 import type { RouteObject } from 'react-router';
 
 /**
- * Local mirror of the shell's `IconName` union. The shell owns the canonical
- * vocabulary in `@pops/navigation/src/types.ts`; this copy is kept in sync
- * because depending on `@pops/navigation` would re-introduce a build cycle
- * with `@pops/api`. If a new icon ships in
- * `@pops/navigation`, mirror it here when this package needs to reference it.
+ * Local mirror of the shell's `IconName` union. The canonical vocabulary lives
+ * in `@pops/navigation` (libs/navigation/src/types.ts); this copy is mirrored to
+ * avoid a build cycle. When a new icon ships there, mirror it here if this
+ * package needs to reference it.
  */
 type IconName =
   | 'Activity'
@@ -165,21 +164,17 @@ export const routes: RouteObject[] = [
       { path: 'aliases', element: <AliasesTab /> },
       { path: 'prep-states', element: <PrepStatesTab /> },
       { path: 'substitutions', element: <SubstitutionsTab /> },
-      // PRD-148: graph visualisation lives at /food/data/substitutions/graph.
       // Declared as a sibling under `data` (not nested under `substitutions`)
       // so the active-tab resolver in FoodDataLayout still highlights the
       // Substitutions tab while the graph subroute is open.
+      // (pillars/food/docs/prds/substitution-graph-explorer)
       { path: 'substitutions/graph', element: <SubGraphPage /> },
       { path: 'conversions', element: <ConversionsTab /> },
-      // PRD-151 — read-only Tags vocabulary view. The per-ingredient
-      // chip editor lives inside the Ingredients tab's detail panel.
+      // Read-only vocabulary view; the per-ingredient chip editor lives inside
+      // the Ingredients tab's detail panel.
       { path: 'tags', element: <TagsTab /> },
     ],
   },
-  // PRD-119 — recipe CRUD pages. 119-A mounts the list page + placeholders
-  // for routes that 119-B/C/D will fill (detail, new, edit, drafts,
-  // historic versions). Wiring the routes up-front keeps internal links
-  // from breaking during the staged rollout.
   { path: 'recipes', element: <RecipeListPage /> },
   { path: 'recipes/new', element: <RecipeNewPage /> },
   { path: 'recipes/:slug', element: <RecipeDetailPage /> },
@@ -188,17 +183,11 @@ export const routes: RouteObject[] = [
   { path: 'recipes/:slug/drafts', element: <RecipeDraftsPage /> },
   { path: 'recipes/:slug/drafts/:draftNo', element: <RecipeDraftEditPage /> },
   { path: 'prompts', element: <PromptViewerPage /> },
-  // I5-prep scaffolds — `PlanPage` (PRD-143) + `FridgePage` (PRD-147)
-  // render `null` until their owning PRDs wire real UI. Routes mounted
-  // up-front so navConfig links + cross-PRD imports resolve today.
   { path: 'plan', element: <PlanPage /> },
   { path: 'fridge', element: <FridgePage /> },
-  // PRD-150 — `/food/solve` what-can-I-cook discovery surface.
   { path: 'solve', element: <SolvePage /> },
-  // PRD-152 — plan-derived shopping list generator.
   { path: 'shopping/from-plan', element: <FromPlanPage /> },
-  // PRD-134 — review queue page. PRD-135 — `:sourceId` per-draft inspector
-  // (three-pane provenance / editor / decision view).
   { path: 'inbox', element: <InboxPage /> },
+  // `:sourceId` opens the three-pane provenance / editor / decision inspector.
   { path: 'inbox/:sourceId', element: <InspectorPage /> },
 ];

--- a/pillars/food/app/src/storage/__tests__/hero-paths.test.ts
+++ b/pillars/food/app/src/storage/__tests__/hero-paths.test.ts
@@ -1,6 +1,3 @@
-/**
- * PRD-124 — hero-paths unit tests.
- */
 import { resolve, sep } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -127,11 +124,8 @@ describe('hero-paths', () => {
       expect(resolveServablePath(7, 'evil.gif')).toBeNull();
     });
     it('rejects traversal attempts via recipe id', () => {
-      // Numeric path traversal cannot escape because the guard rejects
-      // non-integers — assertValidRecipeId throws before any join happens.
-      // resolveServablePath wraps the throw and returns null for the
-      // filename case, but the recipeId guard raises. Both shape it as
-      // "no path returned".
+      // assertValidRecipeId rejects non-positive-integers before any path join,
+      // so an out-of-range id throws rather than escaping the root.
       expect(() => resolveServablePath(-1, 'hero.jpg')).toThrow();
     });
   });

--- a/pillars/food/app/src/storage/__tests__/ingest-paths.test.ts
+++ b/pillars/food/app/src/storage/__tests__/ingest-paths.test.ts
@@ -1,6 +1,3 @@
-/**
- * PRD-110 — path helper unit tests.
- */
 import { resolve } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/pillars/food/app/src/storage/hero-paths.node.ts
+++ b/pillars/food/app/src/storage/hero-paths.node.ts
@@ -2,10 +2,6 @@
  * Node-only hero-image path helpers. Split from `./hero-paths.ts` because
  * the browser-bound `HeroImageUploader` imports constants from that file
  * and Vite cannot resolve `node:path` or read `process.env`.
- *
- * The same layout is mirrored at `apps/pops-api/src/modules/food/
- * hero-image/paths.ts` — pops-api doesn't depend on `@pops/app-food` at
- * runtime, so keep both sources in sync.
  */
 import { resolve, sep } from 'node:path';
 

--- a/pillars/food/app/src/storage/hero-paths.ts
+++ b/pillars/food/app/src/storage/hero-paths.ts
@@ -14,14 +14,9 @@
  *
  * `recipes.hero_image_path` stores the relative path of the original
  * (`<recipe_id>/hero.<ext>`); thumbnail paths are derived at read time.
- *
- * The same constants are mirrored inside
- * `apps/pops-api/src/modules/food/hero-image/paths.ts` — pops-api does not
- * depend on `@pops/app-food` at runtime, so the absolute-path helpers are
- * duplicated there. Keep both in sync if the layout ever changes.
  */
 
-/** Hard-coded default — kept in sync with `apps/pops-api/.env.example`. */
+/** Hard-coded default for `FOOD_RECIPES_DIR`. */
 export const DEFAULT_FOOD_RECIPES_DIR = './data/food/recipes';
 
 /** File extensions allowed for the original hero upload. */
@@ -104,7 +99,6 @@ export function heroImageUrl(
   variant: HeroImageVariant = 'original'
 ): string | null {
   if (!currentPath) return null;
-  // Split on POSIX separator — the column is always written with `/`.
   const match = /^(\d+)\/hero\.(jpg|jpeg|png|webp)$/.exec(currentPath);
   if (!match) return null;
   const recipeId = match[1] ?? '';

--- a/pillars/food/app/src/storage/ingest-paths.ts
+++ b/pillars/food/app/src/storage/ingest-paths.ts
@@ -10,7 +10,7 @@
  */
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 
-/** Hard-coded default — kept in sync with `apps/pops-api/.env.example`. */
+/** Hard-coded default for `FOOD_INGEST_DIR`. */
 export const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
 
 /**


### PR DESCRIPTION
## Wave 5 — agent-first comment hygiene (food pillar — **frontend**) · 5b/12

The frontend half of the food comment-hygiene pass (`@pops/app-food`, `pillars/food/app`). Backend (`@pops/food`) is the sibling PR (5a, #3564). Split for Copilot reviewability (food is ~535 changed files total).

**Litmus per comment:** *"does this tell a future agent something the code/types/tests don't already say — and is it still true?"* Keep live intent/invariants/cross-refs/resolvable spec-anchors; delete narration/restating-code/banners; **correct-or-delete** history/migration narration and anything now false.

### Result (this PR — frontend)
- **274 files** of comment-only changes.
- `PRD-NNN` removed from comments (slugs where useful, fully-qualified); migration/`tRPC` narration deleted; stale claims corrected.
- **Comments/labels only** — 0 logic changes, 0 functional-string changes (adversarially verified per-module via `git diff`).
- Validated across the whole food package: typecheck, **951 tests**, format, lint — green.

### Deferred (functional, not comments)
`PRD-NNN` survives in functional/asserted strings — the `prompt-registry` `prd:` field + format-asserting test, and an asserted i18n UI string (`recipePickerPending`) — left for the dedicated user-facing-string pass. Note: `@pops/app-food` has a pre-existing flaky test (`CookModal.test.tsx`); unrelated to comment edits — re-run if it trips.
