### PR TITLE
chore(contacts): agent-first comment hygiene (Wave 5, pillar 8/12)

### DIFF
--- a/pillars/contacts/src/config.rs
+++ b/pillars/contacts/src/config.rs
@@ -1,8 +1,8 @@
 //! Environment-resolved runtime configuration for the contacts pillar.
 //!
 //! Every knob has a deterministic default so the binary boots with zero env
-//! in local/dev and CI. Production overrides arrive via the docker-compose
-//! service definition (a later node wires that).
+//! in local/dev and CI. Production overrides arrive via the contacts service
+//! definition in `infra/docker-compose.yml`.
 
 use std::env;
 
@@ -10,7 +10,7 @@ use std::env;
 ///
 /// `3008` is the `ai` pillar and `3009` is the orchestrator, so contacts
 /// takes the next free slot. Kept in lock-step with `PILLAR_UPSTREAMS`
-/// (`apps/pops-shell/scripts/generate-nginx-conf.ts`).
+/// (`pillars/shell/scripts/generate-nginx-conf.ts`).
 pub const DEFAULT_PORT: u16 = 3010;
 
 /// Default on-disk SQLite location. Overridden in-cluster by
@@ -22,10 +22,8 @@ pub const DEFAULT_SQLITE_PATH: &str = "contacts.db";
 pub const DEFAULT_VERSION: &str = "0.0.0-dev";
 
 /// Registry base URL used when neither `POPS_REGISTRY_URL` nor `CORE_URL` is
-/// set. Matches the TS SDK fallback (`bootstrap/bootstrap.ts`) and the
-/// `registry-api` compose service name (the pillar formerly named `core`).
-/// During the core→registry rename window the registry container also answers
-/// to the legacy `core-api` alias, so an un-rebuilt deploy resolves either.
+/// set. Matches the TS SDK fallback (`libs/sdk/src/bootstrap/bootstrap.ts`)
+/// and the `registry-api` compose service name.
 pub const DEFAULT_REGISTRY_URL: &str = "http://registry-api:3001";
 
 /// Resolved configuration for one process lifetime.

--- a/pillars/contacts/src/db.rs
+++ b/pillars/contacts/src/db.rs
@@ -1,9 +1,9 @@
 //! SQLite connection pool boot + migration application.
 //!
-//! N0 opens the pool, sets the durability/concurrency pragmas every pillar
+//! Opens the pool, sets the durability/concurrency pragmas every pillar
 //! DB runs with (WAL journaling, enforced foreign keys, a busy timeout so
 //! concurrent writers retry rather than error), and applies the committed
-//! migration journal on boot. The entities schema arrives in N1.
+//! migration journal on boot.
 
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{ConnectOptions, SqlitePool};

--- a/pillars/contacts/src/entities/model.rs
+++ b/pillars/contacts/src/entities/model.rs
@@ -2,18 +2,16 @@
 //!
 //! The wire [`Entity`] is camelCase JSON with `aliases`/`defaultTags` as string
 //! arrays; the stored [`EntityRow`] is snake_case with `aliases` as opaque CSV
-//! and `default_tags` as opaque JSON text. The two array columns are encoded
-//! exactly as core's TS service encodes them (`join(', ')` for aliases,
-//! `JSON.stringify` for tags) so a migrated row round-trips byte-for-byte and a
-//! contact created here reads identically in any other consumer.
+//! (`join(', ')`) and `default_tags` as opaque JSON text (`JSON.stringify`).
+//! Both array columns are decoded only when projecting to the wire shape, and
+//! the encoding is stable so a row round-trips byte-for-byte.
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-/// The entity discriminator. Mirrors `ENTITY_TYPES` in core's contract; a
-/// contact is the superset of core's + finance's entities so the full set is
-/// accepted. Stored verbatim as the `type` column (no enum coercion at the DB
-/// layer — validation happens at the route boundary).
+/// The accepted entity discriminators. Stored verbatim as the `type` column
+/// (no enum coercion at the DB layer — validation happens at the route
+/// boundary).
 pub const ENTITY_TYPES: [&str; 7] = [
     "company",
     "person",
@@ -24,13 +22,12 @@ pub const ENTITY_TYPES: [&str; 7] = [
     "organisation",
 ];
 
-/// Default `type` applied when a create omits it. Matches the core column
-/// default and the TS `CreateEntityBody` default.
+/// Default `type` applied when a create omits it.
 pub const DEFAULT_ENTITY_TYPE: &str = "company";
 
-/// The wire shape served by every entities route — the `toEntity` projection.
-/// `notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed
-/// (internal/integration columns), matching core's `EntitySchema`.
+/// The wire shape served by every entities route. `notionId`, `ownerUri`, and
+/// `ownerUriStaleAt` are deliberately NOT exposed (internal/integration
+/// columns).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {
@@ -104,8 +101,8 @@ impl From<EntityLookupRow> for EntityLookup {
     }
 }
 
-/// Decode the CSV `aliases` column into a trimmed, empty-filtered vector.
-/// Mirrors core's `parseAliases`: split on `,`, trim, drop empties.
+/// Decode the CSV `aliases` column into a trimmed, empty-filtered vector:
+/// split on `,`, trim, drop empties.
 pub fn decode_aliases(raw: Option<&str>) -> Vec<String> {
     let Some(raw) = raw else {
         return Vec::new();
@@ -118,7 +115,7 @@ pub fn decode_aliases(raw: Option<&str>) -> Vec<String> {
 }
 
 /// Encode an alias vector to the CSV column value (`join(', ')`), or `None`
-/// when empty — matching core's `aliases?.length ? aliases.join(', ') : null`.
+/// when empty.
 pub fn encode_aliases(aliases: &[String]) -> Option<String> {
     if aliases.is_empty() {
         None
@@ -137,7 +134,7 @@ pub fn decode_default_tags(raw: Option<&str>) -> Vec<String> {
 }
 
 /// Encode a tag vector to the JSON column value (`JSON.stringify`), or `None`
-/// when empty — matching core's `defaultTags?.length ? JSON.stringify(...) : null`.
+/// when empty.
 pub fn encode_default_tags(tags: &[String]) -> Option<String> {
     if tags.is_empty() {
         None

--- a/pillars/contacts/src/entities/repo.rs
+++ b/pillars/contacts/src/entities/repo.rs
@@ -1,16 +1,11 @@
 //! Data access for the entities domain.
 //!
 //! Every query is parameterized — values are bound, never interpolated into
-//! SQL — so the layer is injection-safe. (The N1 node uses sqlx's runtime
-//! query API rather than the compile-time `query!` macros: the macros require
-//! a build-time database or a committed `.sqlx/` offline cache, and neither the
-//! offline cache nor `sqlx-cli` lands until the Phase 6 toolchain node. The
-//! conversion to compile-time-checked queries rides that node.)
+//! SQL — so the layer is injection-safe.
 //!
-//! Create/update semantics mirror core's `entities/service.ts` exactly:
-//! name-uniqueness raises a conflict, `last_edited_time` is bumped to the
-//! current instant on create and on any non-empty update, and ordering is
-//! case-insensitive by name.
+//! Create/update semantics: name-uniqueness raises a conflict,
+//! `last_edited_time` is bumped to the current instant on create and on any
+//! non-empty update, and ordering is case-insensitive by name.
 
 use sqlx::{Row, SqlitePool};
 

--- a/pillars/contacts/src/main.rs
+++ b/pillars/contacts/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(%addr, "contacts pillar listening");
 
     // Graceful shutdown drains in-flight requests on the first SIGTERM/SIGINT;
-    // the lifecycle then deregisters best-effort so core drops the route
+    // the lifecycle then deregisters best-effort so the registry drops the route
     // immediately rather than waiting for the missed-heartbeat eviction.
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())

--- a/pillars/contacts/src/registry/transport.rs
+++ b/pillars/contacts/src/registry/transport.rs
@@ -2,16 +2,15 @@
 //!
 //! ## Path resolution (slash-first, legacy fallback)
 //!
-//! One logical registry operation is reachable at two HTTP paths during the
-//! `core→registry` rename's rolling-deploy window: the canonical slash form
-//! (`/registry/register`) and the legacy dotted form (`/core.registry.register`).
-//! This transport tries the canonical path first and falls back to the legacy
-//! path on a **404 only** — a faithful port of the SDK's `resolveWithFallback`
-//! (`packages/pillar-sdk/src/registry-path-resolver.ts`):
+//! The registry serves one logical operation at two HTTP paths: the canonical
+//! slash form (`/registry/register`) and the legacy dotted alias
+//! (`/core.registry.register`). This transport tries the canonical path first
+//! and falls back to the dotted alias on a **404 only** — a faithful port of
+//! the SDK's `resolveWithFallback` (`libs/sdk/src/registry-path-resolver.ts`):
 //!
 //!   - 2xx → remember the winning path so steady state issues one request, and
 //!     return.
-//!   - 404 on the cached winner (e.g. core rolled back to legacy-only) →
+//!   - 404 on the cached winner (e.g. the slash form stops being served) →
 //!     invalidate the hint and fall through to the other candidate IN THIS
 //!     call, so a single 404 self-heals without a failed heartbeat.
 //!   - any non-404 error (5xx / network) → surface immediately; "up but broken"
@@ -25,7 +24,8 @@
 //! [`RegistryError::retriable`] is `true` for a network failure or a `>= 500`
 //! response, `false` for a 4xx (a rejected manifest, a malformed pillar id).
 //! The lifecycle uses this to fail fast on a non-retriable register rejection
-//! and to back off on a transient one — matching the SDK's `register.ts`.
+//! and to back off on a transient one — matching the SDK's
+//! `libs/sdk/src/bootstrap/register.ts`.
 
 use std::future::Future;
 use std::sync::Mutex;
@@ -40,8 +40,8 @@ pub const RESOLVER_PRIMARY_PATHS: RegistryPaths = RegistryPaths {
     deregister: "/registry/deregister",
 };
 
-/// Legacy (dotted, tRPC-vestigial) registry paths — the 404 fallback kept alive
-/// across the rename's rolling-deploy window. These are what core mounts today.
+/// Legacy (dotted, tRPC-vestigial) registry paths — the 404 fallback. The
+/// registry serves these as an alias alongside the canonical slash paths.
 pub const RESOLVER_LEGACY_PATHS: RegistryPaths = RegistryPaths {
     register: "/core.registry.register",
     heartbeat: "/core.registry.heartbeat",
@@ -102,37 +102,37 @@ impl std::error::Error for RegistryError {}
 
 /// Outcome of a heartbeat that reached the registry (HTTP 2xx).
 ///
-/// Core's heartbeat route soft-fails with `{ ok: false, reason: 'not-registered' }`
-/// at HTTP 200 when the pillar has no registration row (e.g. it was evicted, or
-/// the initial register never succeeded). Distinguishing this from an
-/// acknowledged heartbeat lets the lifecycle re-register instead of
-/// heartbeating into the void forever.
+/// The registry's heartbeat route soft-fails with
+/// `{ ok: false, reason: 'not-registered' }` at HTTP 200 when the pillar has no
+/// registration row (e.g. it was evicted, or the initial register never
+/// succeeded). Distinguishing this from an acknowledged heartbeat lets the
+/// lifecycle re-register instead of heartbeating into the void forever.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HeartbeatOutcome {
     /// `{ ok: true, … }` — the registration is live.
     Acknowledged,
-    /// `{ ok: false, reason: 'not-registered' }` — core has no row for us.
+    /// `{ ok: false, reason: 'not-registered' }` — the registry has no row for us.
     NotRegistered,
 }
 
 /// The registry operations a pillar drives over its lifetime. A trait so the
 /// lifecycle loop can be exercised against an in-process fake (the integration
-/// tests) without a live core.
+/// tests) without a live registry.
 ///
 /// Methods return `impl Future + Send` (rather than the bare `async fn in
 /// trait` sugar) because the lifecycle spawns the loop onto the tokio
 /// multi-thread runtime, which requires the futures be `Send`.
 pub trait RegistryTransport: Send + Sync {
     /// Register this pillar. `manifest` is the validated capability document;
-    /// `base_url` is the origin core records for it.
+    /// `base_url` is the origin the registry records for it.
     fn register(
         &self,
         base_url: &str,
         manifest: &Value,
     ) -> impl Future<Output = Result<(), RegistryError>> + Send;
     /// Report liveness for `pillar_id`. A transport error is a failure to
-    /// reach/parse the registry; an `Ok(NotRegistered)` means core answered but
-    /// has no row for us (re-register).
+    /// reach/parse the registry; an `Ok(NotRegistered)` means the registry
+    /// answered but has no row for us (re-register).
     fn heartbeat(
         &self,
         pillar_id: &str,
@@ -222,8 +222,9 @@ where
                     return Err(err);
                 }
                 // 404 on the first candidate when a winner was cached on a
-                // prior call → drop the hint so the cycle self-heals after a
-                // core rollback, then fall through to the next candidate.
+                // prior call → drop the hint so the cycle self-heals after the
+                // winning path stops being served, then fall through to the
+                // next candidate.
                 if index == 0 && leg.had_hint() {
                     leg.invalidate();
                 }
@@ -455,8 +456,8 @@ mod tests {
             .unwrap();
         assert_eq!(leg.candidates()[0], "/registry/register");
 
-        // Core rolls back to legacy-only: the cached canonical now 404s, the
-        // call must fall through to legacy WITHIN the same invocation.
+        // The registry stops serving the slash form: the cached canonical now
+        // 404s, the call must fall through to legacy WITHIN the same invocation.
         let seen = RefCell::new(Vec::new());
         resolve_with_fallback(&leg, |path| {
             seen.borrow_mut().push(path);

--- a/pillars/contacts/tests/registry.rs
+++ b/pillars/contacts/tests/registry.rs
@@ -4,9 +4,7 @@
 //! This complements the unit tests (which use an in-process fake): here the
 //! actual `reqwest`-backed `HttpRegistryTransport` makes real TCP requests, so
 //! the slash-first → legacy-404 fallback, the JSON body shape, and the
-//! register/heartbeat/deregister envelopes are all exercised end-to-end. It
-//! mirrors the plan's Gate G2 ("spin a mock registry and assert contacts POSTs
-//! a schema-valid manifest, heartbeats, deregisters").
+//! register/heartbeat/deregister envelopes are all exercised end-to-end.
 
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Wave 5 — agent-first comment hygiene (contacts pillar — Rust) · 8/12

The lone Rust pillar (`.rs`, axum + OpenAPI). Same litmus as the registry template (#3560), applied to `//` / `///` / `//!` doc comments.

- **7 files, net -11.** 4 comments deleted, 18 corrected (stale/migration narration -> present-tense truth).
- **Comments only** — 0 logic / 0 functional changes (adversarial verify + Rust non-comment-diff scan = 0). No PRD-NNN tags were present in comments.
- Green: `cargo fmt --check`, `cargo test` (all suites pass). Clean run, 0 verify issues.
