### PR TITLE
fix(contacts): regenerate OpenAPI snapshot after #3568 doc-comment hygiene

### DIFF
--- a/pillars/contacts/openapi/contacts.openapi.json
+++ b/pillars/contacts/openapi/contacts.openapi.json
@@ -42,7 +42,7 @@
         "type": "object"
       },
       "Entity": {
-        "description": "The wire shape served by every entities route — the `toEntity` projection.\n`notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed\n(internal/integration columns), matching core's `EntitySchema`.",
+        "description": "The wire shape served by every entities route. `notionId`, `ownerUri`, and\n`ownerUriStaleAt` are deliberately NOT exposed (internal/integration\ncolumns).",
         "properties": {
           "abn": {
             "nullable": true,

--- a/pillars/finance/app/contracts/contacts.openapi.json
+++ b/pillars/finance/app/contracts/contacts.openapi.json
@@ -42,7 +42,7 @@
         "type": "object"
       },
       "Entity": {
-        "description": "The wire shape served by every entities route — the `toEntity` projection.\n`notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed\n(internal/integration columns), matching core's `EntitySchema`.",
+        "description": "The wire shape served by every entities route. `notionId`, `ownerUri`, and\n`ownerUriStaleAt` are deliberately NOT exposed (internal/integration\ncolumns).",
         "properties": {
           "abn": {
             "nullable": true,

--- a/pillars/finance/app/src/contacts-api/types.gen.ts
+++ b/pillars/finance/app/src/contacts-api/types.gen.ts
@@ -19,9 +19,9 @@ export type CreateEntityBody = {
 };
 
 /**
- * The wire shape served by every entities route — the `toEntity` projection.
- * `notionId`, `ownerUri`, and `ownerUriStaleAt` are deliberately NOT exposed
- * (internal/integration columns), matching core's `EntitySchema`.
+ * The wire shape served by every entities route. `notionId`, `ownerUri`, and
+ * `ownerUriStaleAt` are deliberately NOT exposed (internal/integration
+ * columns).
  */
 export type Entity = {
   abn?: string | null;


### PR DESCRIPTION
## fix(contacts): regenerate OpenAPI snapshot

The Wave 5 comment hygiene PR (#3568) reworded an entities-schema `///` doc comment (correctly dropping a stale "matching core's EntitySchema" reference). In Rust those `///` doc comments are the **source of the generated OpenAPI `description`**, so the committed `openapi/contacts.openapi.json` snapshot went out of date — the contacts contract-drift check went red on main.

This regenerates the snapshot (`cargo run --bin emit-openapi`) to match — a 1-line description change. Restores main green.

_(Root cause: #3568 auto-merged over a non-required failing rust check. Fixing the merge gate to never merge over a CI failure for the remaining pillars.)_
