### PR TITLE
chore(ai): agent-first comment hygiene (Wave 5, pillar 9/12)

### DIFF
--- a/pillars/ai/app/src/ai-api-helpers.ts
+++ b/pillars/ai/app/src/ai-api-helpers.ts
@@ -6,8 +6,7 @@
  *
  * `unwrap` turns a Hey API `{ data, error, response }` result into its
  * data payload, throwing `AiApiError` (carrying the HTTP status)
- * on failure. The status lets call sites reproduce the pillar-sdk UX
- * distinctions that used to come from `usePillarQuery`:
+ * on failure. The status lets call sites distinguish:
  *   - 404            → "not found"   (isNotFoundError)
  *   - 5xx / no status → "unavailable" (isUnavailableError)
  */

--- a/pillars/ai/app/src/manifest.ts
+++ b/pillars/ai/app/src/manifest.ts
@@ -1,13 +1,11 @@
 import { navConfig, routes } from './routes';
 
 /**
- * AI Ops frontend module manifest (PRD-055).
+ * AI Ops frontend module manifest.
  *
- * **App surface of the first-class `ai` pillar.** AI Ops was extracted out of
- * core into its own `pops-ai-api` container (port 3008); this dashboard's
- * generated client targets the `/ai-api` proxy. The shell loads this manifest
- * via `@pops/app-ai` in `WORKSPACE_BUNDLE_MAP` and mounts the routes under
- * `/ai/*`.
+ * **App surface of the `ai` pillar.** This dashboard's generated client targets
+ * the `/ai-api` proxy. The shell loads this manifest via `@pops/app-ai` in
+ * `WORKSPACE_BUNDLE_MAP` and mounts the routes under `/ai/*`.
  */
 import type { ModuleManifest } from '@pops/types';
 

--- a/pillars/ai/src/api/__tests__/ai-alerts.test.ts
+++ b/pillars/ai/src/api/__tests__/ai-alerts.test.ts
@@ -1,19 +1,13 @@
 /**
- * Integration tests for the `ai-alerts.*` REST surface (PRD-092 US-07),
- * driven through the real Express app via supertest.
- *
- * Mirrors the legacy tRPC coverage on the REST transport across the nested
- * rule CRUD + seeding, fired-alert listing/acknowledgement, and the
- * evaluation trigger:
+ * Integration tests for the `ai-alerts.*` REST surface, driven through the real
+ * Express app via supertest, across the nested rule CRUD + seeding, fired-alert
+ * listing/acknowledgement, and the evaluation trigger:
  *   - rules: create → get → list → update → setEnabled → delete, seedDefaults
- *   - rules.get / acknowledge 404 on unknown id (preserving the tRPC NOT_FOUND)
+ *   - rules.get / acknowledge 404 on unknown id
  *   - the literal `/rules/seed-defaults` route wins over `/rules/:id`
  *   - list fired alerts with the acknowledged filter (string-coerced boolean)
  *   - runNow returns evaluation counters (no rules → no dispatch, no network)
  *   - validation 400 at the contract boundary (bad type, non-positive threshold)
- *
- * Auth gating is intentionally NOT asserted: REST runs under docker-net trust
- * (non-identity domain), so there is no `ctx.user` to bounce on.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/__tests__/ai-budgets.test.ts
+++ b/pillars/ai/src/api/__tests__/ai-budgets.test.ts
@@ -1,15 +1,10 @@
 /**
- * Integration tests for the `ai-budgets.*` REST surface (`core.aiBudgets.*`),
- * driven through the real Express app via supertest.
- *
- * Mirrors the legacy tRPC service coverage on the REST transport: upsert
- * round-trips (including global-scope canonicalisation of `scopeValue` to
- * null), list, and live status (percentage-used + projected-exhaustion) with
- * usage seeded into `ai_inference_log`. Validation 400 is asserted at the
- * contract boundary (bad scopeType / empty id).
- *
- * Auth gating is intentionally NOT asserted: REST runs under docker-net trust
- * (non-identity domain), so there is no `ctx.user` to bounce on.
+ * Integration tests for the `ai-budgets.*` REST surface, driven through the real
+ * Express app via supertest: upsert round-trips (including global-scope
+ * canonicalisation of `scopeValue` to null), list, and live status
+ * (percentage-used + projected-exhaustion) with usage seeded into
+ * `ai_inference_log`. Validation 400 is asserted at the contract boundary
+ * (bad scopeType / empty id).
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/__tests__/ai-observability.test.ts
+++ b/pillars/ai/src/api/__tests__/ai-observability.test.ts
@@ -1,15 +1,9 @@
 /**
- * Integration tests for the `ai-observability.*` REST surface
- * (`core.aiObservability.*`), driven through the real Express app via
- * supertest.
- *
- * Mirrors the legacy tRPC service coverage on the REST transport: stats
- * totals + breakdowns, history grouping, latency percentiles + slow queries,
- * per-model quality metrics, and the filter query (provider scoping). All
- * usage is seeded into `ai_inference_log`.
- *
- * Auth gating is intentionally NOT asserted: REST runs under docker-net trust
- * (non-identity domain), so there is no `ctx.user` to bounce on.
+ * Integration tests for the `ai-observability.*` REST surface, driven through
+ * the real Express app via supertest: stats totals + breakdowns, history
+ * grouping, latency percentiles + slow queries, per-model quality metrics, and
+ * the filter query (provider scoping). All usage is seeded into
+ * `ai_inference_log`.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/__tests__/ai-providers.test.ts
+++ b/pillars/ai/src/api/__tests__/ai-providers.test.ts
@@ -1,15 +1,10 @@
 /**
- * Integration tests for the `ai-providers.*` REST surface
- * (`core.aiProviders.*`), driven through the real Express app via supertest.
- *
- * Mirrors the legacy tRPC service coverage on the REST transport: upsert
- * (provider + nested model pricing), list, get (including the NULLABLE
- * unknown-id contract — null body, NOT 404), and health checks (success +
- * failure, with `fetch` mocked so no real network is hit). Validation 400 is
- * asserted at the contract boundary (bad type / empty id).
- *
- * Auth gating is intentionally NOT asserted: REST runs under docker-net trust
- * (non-identity domain), so there is no `ctx.user` to bounce on.
+ * Integration tests for the `ai-providers.*` REST surface, driven through the
+ * real Express app via supertest: upsert (provider + nested model pricing),
+ * list, get (including the NULLABLE unknown-id contract — null body, NOT 404),
+ * and health checks (success + failure, with `fetch` mocked so no real network
+ * is hit). Validation 400 is asserted at the contract boundary (bad type /
+ * empty id).
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/__tests__/ai-usage.test.ts
+++ b/pillars/ai/src/api/__tests__/ai-usage.test.ts
@@ -1,15 +1,10 @@
 /**
  * Integration tests for the `ai-usage.*` REST surface, driven through the real
- * Express app via supertest.
- *
- * Mirrors the legacy tRPC coverage on the REST transport: stats aggregation
- * (zeros, single entry, cache-hit-rate over the inference log's `cached`
- * column) and date-range history filtering. The AI-entity disk cache surface
- * stayed in core (finance-categorizer state, re-homed to finance later), so its
- * stats/prune/clear endpoints are not part of the ai pillar's telemetry slice.
- *
- * Auth gating is intentionally NOT asserted: REST runs under docker-net trust
- * (non-identity domain), so there is no `ctx.user` to bounce on.
+ * Express app via supertest: stats aggregation (zeros, single entry,
+ * cache-hit-rate over the inference log's `cached` column) and date-range
+ * history filtering. The AI-entity disk cache surface is owned by the finance
+ * pillar, so its stats/prune/clear endpoints are not part of the ai pillar's
+ * telemetry slice.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/__tests__/ingest-record.test.ts
+++ b/pillars/ai/src/api/__tests__/ingest-record.test.ts
@@ -4,7 +4,7 @@
  * Express app via supertest against a temp SQLite (the ai pillar's own
  * baseline migration).
  *
- * Covers the GATE-P1 acceptance: internal-token gate (403 without the token),
+ * Covers: internal-token gate (403 without the token),
  * a valid record writes exactly one `ai_inference_log` row with the field
  * mapping applied (cached 0|1, promptVersion→metadata.prompt_version,
  * contextId→context_id), an invalid/malformed domain 400s, the handler is

--- a/pillars/ai/src/api/ai-manifest.ts
+++ b/pillars/ai/src/api/ai-manifest.ts
@@ -1,13 +1,13 @@
 /**
- * Hand-rolled ai pillar manifest payload (PRD-055 US-01).
+ * Hand-rolled ai pillar manifest payload.
  *
  * Lives in its own module (not inline in `server.ts`) so tests can import the
  * builder without triggering `server.ts`'s boot side-effects (`openAiDb`,
  * `app.listen`, signal handlers).
  *
- * The ai pillar is backend-serving; its UI (`@pops/app-ai`, the moved AI usage
- * dashboard) is loaded by the shell via the in-repo `WORKSPACE_BUNDLE_MAP`, so
- * — like core — this manifest omits the optional `nav`/`pages` dimensions.
+ * The ai pillar is backend-serving; its UI (`@pops/app-ai`) is loaded by the
+ * shell via its `bundle-map.tsx`, so this manifest omits the optional
+ * `nav`/`pages` dimensions.
  *
  * `contract.package` MUST be `@pops/ai` — the collapsed-pillar form the manifest
  * validator requires for pillar id `ai`, matching the npm package name.

--- a/pillars/ai/src/api/modules/ai-alerts/__tests__/evaluator.test.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/__tests__/evaluator.test.ts
@@ -1,11 +1,10 @@
 /**
- * Tests for the AI alert evaluator + dispatchers (ported from
- * `apps/pops-api/src/modules/core/ai-alerts/evaluator.test.ts`).
+ * Tests for the AI alert evaluator + dispatchers.
  *
- * Runs against an in-memory `core.db` opened per-test; usage + budget rows
- * are seeded via the relocated services. The nudge dispatcher calls the
- * cerebrum REST SDK — tests stub the injectable nudge sink, so no cerebrum
- * db (in-memory or otherwise) is involved.
+ * Each test opens a fresh ai-pillar SQLite db on a temp path and seeds
+ * usage + budget rows via the ai services. The nudge dispatcher reaches
+ * cerebrum through an injectable {@link NudgeSink}, which tests stub, so
+ * no cerebrum db is ever involved.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/pillars/ai/src/api/modules/ai-alerts/dispatch.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/dispatch.ts
@@ -5,7 +5,7 @@
  * sequentially, catching per-channel failures so a misconfigured channel
  * doesn't block delivery on the others.
  *
- * The default channel matrix matches PRD-092 US-07:
+ * Default channel matrix (see pillars/ai/docs/prds/ai-observability):
  *   - in-app nudges always receive every alert (warning + critical)
  *   - Telegram receives only `critical` alerts unless an env override is set
  *     (POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS=1)

--- a/pillars/ai/src/api/modules/ai-alerts/dispatchers/nudge.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/dispatchers/nudge.ts
@@ -1,12 +1,11 @@
 /**
- * Cerebrum nudge dispatcher (PRD-092 US-07, PRD-084).
+ * Cerebrum nudge dispatcher.
  *
  * Surfaces the alert as a cerebrum nudge by calling the cerebrum REST SDK
  * (`pillar('cerebrum').nudges.create`, which maps to `POST /nudges` — the
- * "alert-driven single insert, no dedup" write). The nudge type is the
- * fixed string `insight` since PRD-084 reserves the four canonical detector
- * types and these nudges are observability events, not engram
- * recommendations (hence no engram IDs).
+ * alert-driven single insert, no dedup). The nudge type is the fixed string
+ * `insight` because the canonical detector types are reserved for engram
+ * recommendations; these nudges are observability events (hence no engram IDs).
  *
  * Best-effort / fire-and-forget: cerebrum being unavailable (a non-`ok`
  * `CallResult`) is logged and swallowed so an alert dispatch never throws.
@@ -18,7 +17,7 @@ import { logger } from '../../../shared/logger.js';
 
 import type { FiredAlert } from '../types.js';
 
-/** The cerebrum `nudges.create` request body (see `rest-nudges.ts`). */
+/** The cerebrum `nudges.create` request body (see `pillars/cerebrum/src/contract/rest-nudges.ts`). */
 export interface CerebrumNudgeCreateBody {
   type?: 'consolidation' | 'staleness' | 'pattern' | 'insight';
   title: string;
@@ -62,9 +61,8 @@ export interface DispatchNudgeOptions {
 /**
  * Build the cerebrum `nudges.create` body for a fired alert.
  *
- * The alert metadata that the legacy direct-write stored on the nudge's
- * `actionParams` is preserved on the `action.params` field so the cerebrum
- * nudge surface keeps the same provenance.
+ * Alert provenance (ids, rule, type, severity) rides on `action.params` so the
+ * cerebrum nudge surface can trace each nudge back to its originating alert.
  */
 export function buildNudgeBody(alert: FiredAlert): CerebrumNudgeCreateBody {
   const body = alert.scopeDetail ? `${alert.message} (${alert.scopeDetail})` : alert.message;

--- a/pillars/ai/src/api/modules/ai-alerts/dispatchers/telegram.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/dispatchers/telegram.ts
@@ -1,5 +1,5 @@
 /**
- * Telegram dispatcher for AI alerts (PRD-092 US-07, PRD-088).
+ * Telegram dispatcher for AI alerts.
  *
  * Pushes a message to the Moltbot Telegram chat using the Bot API directly.
  * The bot token + chat ID are read from environment variables:
@@ -8,8 +8,7 @@
  *   POPS_ALERTS_TELEGRAM_CHAT_ID     the chat ID to deliver to
  *
  * When either variable is unset the dispatcher is treated as not configured
- * and silently skips delivery — this matches the PRD note "If Moltbot is not
- * configured, skip Telegram delivery silently."
+ * and silently skips delivery.
  */
 import { logger } from '../../../shared/logger.js';
 

--- a/pillars/ai/src/api/modules/ai-alerts/evaluator.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/evaluator.ts
@@ -1,19 +1,15 @@
 /**
- * Alert rule evaluator orchestrator (PRD-092 US-07).
+ * Alert rule evaluator orchestrator (see pillars/ai/docs/prds/ai-observability).
  *
  * Loads enabled rules, delegates to per-type evaluator functions, dedupes,
  * persists, and dispatches via channel handlers. The actual evaluation
- * logic lives in `./evaluators/*` to keep each file within the project
- * max-lines lint budget and to make each rule type independently testable.
+ * logic lives in `./evaluators/*` so each rule type is independently testable.
  *
- * In the monolith the orchestrator is invoked from the BullMQ scheduled
- * worker every 5 minutes. In the core pillar it is exposed via the
- * `core.aiAlerts.runNow` mutation and (optionally) the env-gated in-process
- * scheduler — see `./scheduler.ts`.
+ * Triggered by the `runNow` REST route handler and (optionally) the env-gated
+ * in-process scheduler — see `./scheduler.ts`.
  *
- * Reads + writes resolve against the request-scoped core drizzle handle
- * threaded in by the caller; the per-rule evaluator helpers receive the same
- * handle for ergonomics.
+ * Reads + writes resolve against the AiDb drizzle handle threaded in by the
+ * caller; the per-rule evaluator helpers receive the same handle.
  */
 import { eq } from 'drizzle-orm';
 

--- a/pillars/ai/src/api/modules/ai-alerts/evaluators/budget.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/evaluators/budget.ts
@@ -1,5 +1,5 @@
 /**
- * Budget-threshold rule evaluator (PRD-092 US-07).
+ * Budget-threshold rule evaluator (see pillars/ai/docs/prds/ai-observability).
  *
  * Iterates every configured `ai_budgets` row, computes current-month usage
  * against the row's cost or token limit, and fires a candidate when the

--- a/pillars/ai/src/api/modules/ai-alerts/evaluators/error-spike.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/evaluators/error-spike.ts
@@ -1,5 +1,5 @@
 /**
- * Error-spike rule evaluator (PRD-092 US-07).
+ * Error-spike rule evaluator (see pillars/ai/docs/prds/ai-observability).
  *
  * Counts rows in the rolling window matching the rule's optional provider /
  * model scope and fires a candidate when the error rate (status in

--- a/pillars/ai/src/api/modules/ai-alerts/evaluators/latency.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/evaluators/latency.ts
@@ -1,5 +1,5 @@
 /**
- * Latency-degradation rule evaluator (PRD-092 US-07).
+ * Latency-degradation rule evaluator (see pillars/ai/docs/prds/ai-observability).
  *
  * Computes the P95 latency for each model in the rolling window (filtered to
  * `success` + non-cached + latencyMs > 0) and fires a candidate per model
@@ -14,11 +14,10 @@ import { rollingWindowStart } from './shared.js';
 import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
 
 /**
- * Nearest-rank percentile. The previous implementation used
- * `Math.floor(p * n)` which selects the *max* element for common sample
- * sizes (e.g. `p=0.95`, `n=20` → idx 19), overstating P95 and producing
- * false-positive alerts. We use the standard nearest-rank formula:
- * `ceil(p * n) - 1`, clamped to the array bounds.
+ * Nearest-rank percentile via `ceil(p * n) - 1`, clamped to the array bounds.
+ * `floor(p * n)` is wrong here: for common sample sizes (e.g. `p=0.95`,
+ * `n=20` → idx 19) it selects the *max* element, overstating P95 and
+ * producing false-positive alerts.
  */
 export function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;

--- a/pillars/ai/src/api/modules/ai-alerts/scheduler.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/scheduler.ts
@@ -1,17 +1,10 @@
 /**
- * In-process, env-gated scheduler for the AI alert evaluator (PRD-092 US-07).
+ * In-process, env-gated scheduler for the AI alert evaluator
+ * (see pillars/ai/docs/prds/ai-observability).
  *
- * The monolith registers this as a repeatable BullMQ job on the
- * `pops-default` queue every 5 minutes (see
- * `apps/pops-api/src/modules/core/ai-alerts/scheduler.ts`). The core pillar
- * has no BullMQ worker or Redis dependency, so this provides a self-contained
- * `setInterval` loop that calls `runEvaluation` directly against the pillar's
- * own core.db handle. It is OFF by default and only starts when
- * `AI_ALERTS_SCHEDULER_ENABLED=true`.
- *
- * TODO(core-pillar runbook — "ai-alerts scheduler"): once the pillar has a
- * durable job runner, replace this interval loop with a proper cron-scheduled
- * job (every 5 minutes) so timing matches the monolith.
+ * A self-contained `setInterval` loop that calls `runEvaluation` directly
+ * against the pillar's own AiDb handle every 5 minutes. It is OFF by default
+ * and only starts when `AI_ALERTS_SCHEDULER_ENABLED=true`.
  */
 import { type AiDb } from '../../../db/index.js';
 import { logger } from '../../shared/logger.js';
@@ -19,7 +12,7 @@ import { runEvaluation } from './evaluator.js';
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
-/** Default cadence: every 5 minutes (mirrors the monolith cron). */
+/** Default cadence: every 5 minutes. */
 export const AI_ALERTS_SCHEDULER_INTERVAL_MS = FIVE_MINUTES_MS;
 
 export interface AlertsSchedulerOptions {

--- a/pillars/ai/src/api/modules/ai-alerts/service.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/service.ts
@@ -1,10 +1,10 @@
 /**
- * CRUD service for `ai_alert_rules` (PRD-092 US-07).
+ * CRUD service for `ai_alert_rules` (see pillars/ai/docs/prds/ai-observability).
  *
- * Exposes pure functions used by the tRPC router and seeding scripts.
+ * Exposes pure functions consumed by the REST handlers and seeding scripts.
  *
- * Reads + writes resolve against the request-scoped core drizzle handle
- * threaded in by the caller.
+ * Reads + writes resolve against the AiDb drizzle handle threaded in by the
+ * caller.
  */
 import { eq } from 'drizzle-orm';
 
@@ -101,7 +101,8 @@ export function deleteRule(db: AiDb, id: number): { success: boolean } {
 }
 
 /**
- * Idempotently seed default alert rules per PRD-092 US-07.
+ * Idempotently seed default alert rules
+ * (see pillars/ai/docs/prds/ai-observability).
  *
  * Returns the number of rules created. Only types that are not already
  * represented in the table are inserted, so the function can backfill a

--- a/pillars/ai/src/api/modules/ai-alerts/types.ts
+++ b/pillars/ai/src/api/modules/ai-alerts/types.ts
@@ -1,5 +1,6 @@
 /**
- * Public types for the AI alert subsystem (PRD-092 US-07).
+ * Public types for the AI alert subsystem
+ * (see pillars/ai/docs/prds/ai-observability).
  *
  * Rule type strings map 1:1 to evaluator implementations under `evaluators/`;
  * adding a new rule type requires both an entry here and a matching evaluator

--- a/pillars/ai/src/api/modules/ai-budgets/__tests__/service.test.ts
+++ b/pillars/ai/src/api/modules/ai-budgets/__tests__/service.test.ts
@@ -1,12 +1,3 @@
-/**
- * Tests for the AI budgets service + enforcement helpers (ported from
- * `apps/pops-api/src/modules/core/ai-budgets/service.test.ts`).
- *
- * Runs against an in-memory `core.db` opened per-test via `openAiDb`.
- * Usage / settings / providers are seeded through the relocated service
- * layer (or raw drizzle for the provider+pricing join) rather than the
- * monolith's `seedAiUsage` / `seedSetting` raw-SQL helpers.
- */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/pillars/ai/src/api/modules/ai-budgets/enforcement.ts
+++ b/pillars/ai/src/api/modules/ai-budgets/enforcement.ts
@@ -1,15 +1,10 @@
 /**
- * Pre-call budget enforcement helpers (PRD-092 US-04).
+ * Pre-call budget enforcement helpers for the inference path.
  *
- * Split out of `service.ts` so the read-side CRUD/status code (mounted on
- * `core.aiBudgets`) and the inference-enforcement path can each stay
- * under the project's max-lines lint budget.
- *
- * Routing: `listApplicableBudgets`, the per-scope usage aggregation, the
+ * `listApplicableBudgets`, the per-scope usage aggregation, the
  * conflict-detection read in `migrateLegacyBudgetSettings`, and the
  * `findFallbackProvider` join over `ai_providers` + `ai_model_pricing`
- * all run against the request-scoped core drizzle handle threaded in by
- * the caller — both joined tables live in the relocated core db.
+ * all run against the pillar's `AiDb` handle threaded in by the caller.
  */
 import { and, asc, desc, eq } from 'drizzle-orm';
 

--- a/pillars/ai/src/api/modules/ai-budgets/service.ts
+++ b/pillars/ai/src/api/modules/ai-budgets/service.ts
@@ -1,13 +1,11 @@
 /**
- * AI budgets module — CRUD + budget status for `core.aiBudgets.*`.
+ * AI budgets module — CRUD + budget status.
  *
- * Every read and write goes through the relocated `aiUsageService`
- * resolved against the request-scoped core drizzle handle (`ctx.coreDb`),
- * so `listBudgets`, `getBudgetStatus`, and `upsertBudget` all land on
- * `core.db`. Per-budget usage aggregation (`sumInferenceLogUsage`) reads
- * from the same store the inference writes land on, so usage reflects
- * every recorded call immediately — there is no read/write staleness
- * window.
+ * `listBudgets`, `getBudgetStatus`, and `upsertBudget` go through
+ * `aiUsageService` against the pillar's `AiDb` handle. Per-budget usage
+ * aggregation (`sumInferenceLogUsage`) reads from the same DB the inference
+ * writes land on, so usage reflects every recorded call immediately — there
+ * is no read/write staleness window.
  */
 import { aiUsageService, type AiBudgetRow, type AiDb } from '../../../db/index.js';
 
@@ -61,16 +59,16 @@ function computeProjectedExhaustion(
 }
 
 /**
- * READ — forwards to `aiUsageService.listBudgets` against `core.db`.
+ * READ — forwards to `aiUsageService.listBudgets`.
  */
 export function listBudgets(db: AiDb): Budget[] {
   return aiUsageService.listBudgets(db);
 }
 
 /**
- * WRITE — upsert lands on `core.db` via `aiUsageService.upsertBudget`.
- * Returns the persisted row including the canonicalised `scopeValue`
- * (`null` for global scope regardless of the supplied value).
+ * WRITE — upsert via `aiUsageService.upsertBudget`. Returns the persisted
+ * row including the canonicalised `scopeValue` (`null` for global scope
+ * regardless of the supplied value).
  */
 export function upsertBudget(db: AiDb, input: UpsertBudgetInput): Budget {
   return aiUsageService.upsertBudget(db, {
@@ -85,7 +83,7 @@ export function upsertBudget(db: AiDb, input: UpsertBudgetInput): Budget {
 
 /**
  * READ — budgets come from `aiUsageService.listBudgets`; per-budget usage
- * comes from `aiUsageService.sumInferenceLogUsage` against `core.db`.
+ * comes from `aiUsageService.sumInferenceLogUsage`.
  */
 export function getBudgetStatus(db: AiDb): BudgetStatus[] {
   const start = monthStart();

--- a/pillars/ai/src/api/modules/ai-observability/__tests__/observability.test.ts
+++ b/pillars/ai/src/api/modules/ai-observability/__tests__/observability.test.ts
@@ -1,12 +1,9 @@
 /**
  * Tests for the AI observability service, retention rollup, daily summary
- * and the env-gated scheduler (ported/condensed from the monolith's
- * service.test.ts / summary.test.ts / retention.test.ts).
+ * and the env-gated scheduler.
  *
- * Runs against an in-memory `core.db` opened per-test; the request-scoped
- * drizzle handle is threaded explicitly. Usage rows are seeded via the
- * relocated `aiUsageService.createInferenceLog` rather than the monolith's
- * raw-SQL `seedAiUsage`.
+ * Runs against a temp-dir SQLite DB opened per-test; the drizzle handle is
+ * threaded explicitly. Usage rows are seeded via `aiUsageService.createInferenceLog`.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -343,7 +340,6 @@ describe('startObservabilityScheduler', () => {
     delete process.env[ENV_KEY];
     const stop = startObservabilityScheduler(db, { intervalMs: 1 });
     stop();
-    // No summary should have been written.
     expect(settingsService.getSettingOrNull(db, OBSERVABILITY_SUMMARY_SETTING_KEY)).toBeNull();
   });
 

--- a/pillars/ai/src/api/modules/ai-observability/history.ts
+++ b/pillars/ai/src/api/modules/ai-observability/history.ts
@@ -1,10 +1,9 @@
 /**
  * History endpoint helpers — UNIONs the recent rows in `ai_inference_log`
- * with the historical aggregates in `ai_inference_daily` (PRD-092 US-08)
- * so the dashboard sees a continuous timeline regardless of the retention
- * boundary.
+ * with the historical aggregates in `ai_inference_daily` so the dashboard
+ * sees a continuous timeline regardless of the retention boundary.
  *
- * Split out of `service.ts` to keep both files under the file-size lint cap.
+ * Spec: pillars/ai/docs/prds/ai-observability
  */
 import { and, gte, lte, sql } from 'drizzle-orm';
 

--- a/pillars/ai/src/api/modules/ai-observability/retention-types.ts
+++ b/pillars/ai/src/api/modules/ai-observability/retention-types.ts
@@ -1,5 +1,5 @@
 /**
- * Type declarations for the inference log retention job (PRD-092 US-08).
+ * Type declarations for the inference log retention job.
  *
  * Kept in their own module to avoid an import cycle between the main
  * `retention` orchestrator and the SQL helpers in `retention-db`.

--- a/pillars/ai/src/api/modules/ai-observability/retention.ts
+++ b/pillars/ai/src/api/modules/ai-observability/retention.ts
@@ -1,13 +1,11 @@
 /**
- * Inference log retention + daily aggregation (PRD-092 US-08).
+ * Inference log retention + daily aggregation.
  *
  * Pure-ish service module:
  *  - `aggregateRowsToDaily` is a pure function over input rows used by the
  *    unit tests.
  *  - `runRetention` performs the full cycle (read → aggregate → upsert →
- *    delete) against the supplied core drizzle handle — every
- *    `ai_inference_log` read, `ai_inference_daily` upsert, and
- *    `ai_inference_log` delete lands on `core.db`.
+ *    delete) against the supplied ai-pillar drizzle handle.
  *
  * The job is idempotent: a re-run with no aged-out rows returns zero
  * deletions, and re-running over the same horizon adds to existing daily
@@ -149,8 +147,8 @@ export interface RunRetentionOptions {
  * Each batch runs in its own drizzle transaction: aggregation upsert + delete
  * are atomic per-batch. If a batch fails partway, only that batch rolls back;
  * the next invocation re-processes it. The transaction handle is passed
- * through to the package helpers so writes target the same `core.db`
- * connection that opened the batch.
+ * through to the `retention-db` helpers so writes target the same connection
+ * that opened the batch.
  */
 export function runRetention(db: AiDb, opts: RunRetentionOptions = {}): RetentionResult {
   const retentionDays = opts.retentionDays ?? getRetentionDays(db);

--- a/pillars/ai/src/api/modules/ai-observability/scheduler.ts
+++ b/pillars/ai/src/api/modules/ai-observability/scheduler.ts
@@ -1,25 +1,17 @@
 /**
- * In-process, env-gated schedulers for the AI observability summary
- * (PRD-092 US-05) and inference-log retention (PRD-092 US-08) jobs.
+ * In-process, env-gated schedulers for the AI observability summary and
+ * inference-log retention jobs.
  *
- * The monolith registers these as repeatable BullMQ jobs on the
- * `pops-default` queue (see
- * `apps/pops-api/src/modules/core/ai-observability/{summary-,}scheduler.ts`).
- * The core pillar container has no BullMQ worker or Redis dependency, so
- * porting the queue registration as-is would drag Redis/BullMQ across the
- * pillar boundary — not an additive change.
+ * A self-contained `setInterval` loop calls the idempotent `runSummary` /
+ * `runRetention` service functions directly against the pillar's own DB
+ * handle. It is OFF by default and only starts when
+ * `AI_OBSERVABILITY_SCHEDULER_ENABLED=true`.
  *
- * Instead this provides a self-contained `setInterval` loop that calls the
- * idempotent `runSummary` / `runRetention` service functions directly
- * against the pillar's own core.db handle. It is OFF by default and only
- * starts when `AI_OBSERVABILITY_SCHEDULER_ENABLED=true`, mirroring the
- * boot-time registration in the monolith but env-gated.
+ * The pillar has no durable job runner, so this fires on a relative
+ * interval rather than cron at fixed UTC times (e.g. 03:00 summary, 04:00
+ * retention); add cron scheduling once one exists.
  *
- * TODO(core-pillar runbook — "ai-observability-summary / ai-log-retention
- * scheduler"): once the pillar has a durable job runner, replace this
- * interval loop with proper cron-scheduled jobs (03:00 UTC summary, 04:00
- * UTC retention) so timing matches the monolith rather than relative
- * intervals.
+ * Spec: pillars/ai/docs/prds/ai-observability
  */
 import { type AiDb } from '../../../db/index.js';
 import { logger } from '../../shared/logger.js';

--- a/pillars/ai/src/api/modules/ai-providers/__tests__/service.test.ts
+++ b/pillars/ai/src/api/modules/ai-providers/__tests__/service.test.ts
@@ -1,11 +1,3 @@
-/**
- * Tests for the AI providers service (ported from
- * `apps/pops-api/src/modules/core/ai-providers/service.test.ts`).
- *
- * Runs against an in-memory `core.db` opened per-test via `openAiDb`;
- * the request-scoped drizzle handle is threaded explicitly into every
- * service call. `fetch` is stubbed per-test for the health-check paths.
- */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/pillars/ai/src/api/pillars/env.ts
+++ b/pillars/ai/src/api/pillars/env.ts
@@ -1,13 +1,5 @@
 /**
- * `POPS_PILLARS` environment variable parser inside the ai-api process.
- *
- * Functionally identical to `apps/pops-inventory-api/src/pillars/env.ts`
- * (and the original in `apps/pops-api/src/modules/core/pillars/env.ts`)
- * — kept as a local copy so ai-api can boot without a runtime
- * dependency on pops-api. The two implementations should be promoted
- * into a shared `packages/core-contract` (or `@pops/types`) package once
- * the pillar split stabilises; until then contract guard tests in
- * pops-api keep this behaviour pinned.
+ * `POPS_PILLARS` environment variable parser inside the ai pillar process.
  *
  * Format: `id:baseUrl[,id:baseUrl,...]`
  *   - `id` lowercase kebab-case pillar slug (`food`, `finance`, …)

--- a/pillars/ai/src/api/pillars/registry.ts
+++ b/pillars/ai/src/api/pillars/registry.ts
@@ -1,9 +1,8 @@
 /**
- * Pillar registry view served by ai-api.
+ * Pillar registry view served by the ai pillar.
  *
- * Wraps the local copy of `parsePillarsEnv` with a process-level cache
- * (same pattern pops-api / inventory-api use). Adds the synthetic `ai`
- * entry so the shell sees the host pillar in the `/pillars` listing
+ * Wraps `parsePillarsEnv` with a process-level cache. Adds the synthetic
+ * `ai` entry so the shell sees the host pillar in the `/pillars` listing
  * without having to special-case the call site.
  */
 import { parseBareOrigin, parsePillarsEnv } from './env.js';

--- a/pillars/ai/src/api/rest/ai-alerts-handlers.ts
+++ b/pillars/ai/src/api/rest/ai-alerts-handlers.ts
@@ -1,12 +1,11 @@
 /**
- * Handlers for the `ai-alerts.*` sub-router.
+ * Handlers for the ai-alerts contract.
  *
- * Wraps the existing `ai-alerts/service.ts` (rule CRUD + seeding) and the
+ * Wraps `ai-alerts/service.ts` (rule CRUD + seeding) and the
  * `ai-alerts/evaluator.ts` re-exports (`listAlerts`, `acknowledgeAlert`,
- * `runEvaluation`). The tRPC router threw `NOT_FOUND` when `getRule` /
- * `acknowledgeAlert` returned `null`; the REST handlers throw `NotFoundError`
- * → 404 to preserve that. `update` / `setEnabled` merge the path `id` back
- * into the service input (the tRPC input carried `id` in the body).
+ * `runEvaluation`). When `getRule` / `acknowledgeAlert` return `null` the
+ * handler throws `NotFoundError` → 404. `updateRule` / `setRuleEnabled` merge
+ * the path `id` into the service input, which expects `id` in its payload.
  */
 import { type AiDb } from '../../db/index.js';
 import { acknowledgeAlert, listAlerts, runEvaluation } from '../modules/ai-alerts/evaluator.js';

--- a/pillars/ai/src/api/server.ts
+++ b/pillars/ai/src/api/server.ts
@@ -1,12 +1,12 @@
 /**
- * Entry point for the ai pillar HTTP server (PRD-055).
+ * Entry point for the ai pillar HTTP server.
  *
  * Opens its OWN `ai.db` via `openAiDb`, serves the AI-ops telemetry surface +
  * the cross-pillar ingest, and (when `POPS_REGISTRY_ENABLED=true`) registers
- * with core's registry via `bootstrapPillar` — the same handshake every pillar
- * uses. The two AI-ops schedulers (observability rollup + alert evaluation) are
- * env-gated OFF by default and run queue-free. SIGTERM/SIGINT stop the
- * schedulers, deregister, then close the HTTP server and DB.
+ * with the registry pillar via `bootstrapPillar` — the same handshake every
+ * pillar uses. The two AI-ops schedulers (observability rollup + alert
+ * evaluation) are env-gated OFF by default and run queue-free. SIGTERM/SIGINT
+ * stop the schedulers, deregister, then close the HTTP server and DB.
  */
 import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 

--- a/pillars/ai/src/api/shared/errors.ts
+++ b/pillars/ai/src/api/shared/errors.ts
@@ -1,9 +1,9 @@
 /**
- * HTTP-shaped domain errors used by ai-api router handlers.
+ * HTTP-shaped domain errors thrown by the REST handlers and translated into
+ * the wire envelope by `mapHttpError` in `../rest/error-mapping.ts`.
  *
- * The per-pillar container stands alone of every other pillar in the
- * dependency graph. The subset reproduced here is whatever the migrated
- * routers need.
+ * This pillar stands alone of every other pillar in the dependency graph, so
+ * these errors are defined locally rather than shared.
  */
 export class HttpError extends Error {
   constructor(

--- a/pillars/ai/src/contract/manifest.ts
+++ b/pillars/ai/src/contract/manifest.ts
@@ -1,9 +1,6 @@
 /**
- * Structural `ModuleManifest` for the ai pillar — the source the module
- * registry's discovery walk consumes (PRD-241) via the package's `./manifest`
- * export. Previously inlined in the registry pillar's (formerly `@pops/core`)
- * contract package while AI Ops lived inside it; now owned here as a
- * first-class pillar (PRD-055).
+ * Structural `ModuleManifest` for the ai pillar — the source the registry
+ * pillar's discovery walk consumes via the package's `./manifest` export.
  *
  * `surfaces: ['app']` — the AI usage dashboard (`@pops/app-ai`) is the pillar's
  * UI surface, loaded by the shell via the in-repo bundle map.

--- a/pillars/ai/src/contract/rest-ai-alerts.ts
+++ b/pillars/ai/src/contract/rest-ai-alerts.ts
@@ -1,32 +1,20 @@
 /**
- * `ai-alerts.*` sub-router — AI alert rules + fired alerts (PRD-092 US-07).
- *
- * The legacy tRPC router nests a `rules` sub-router plus top-level
- * list/acknowledge/runNow. Mapping:
- *
- *   rules.list        (query)               → GET    /ai-alerts/rules
- *   rules.seedDefaults(mutation, no input)  → POST   /ai-alerts/rules/seed-defaults
- *   rules.get         (query, id)           → GET    /ai-alerts/rules/:id
- *   rules.create      (mutation, body)      → POST   /ai-alerts/rules
- *   rules.update      (mutation, id+body)   → PATCH  /ai-alerts/rules/:id
- *   rules.setEnabled  (mutation, id+enabled)→ PATCH  /ai-alerts/rules/:id/enabled
- *   rules.delete      (mutation, id)        → DELETE /ai-alerts/rules/:id
- *   list              (query, filters)      → GET    /ai-alerts
- *   acknowledge       (mutation, id)        → POST   /ai-alerts/:id/acknowledge
- *   runNow            (mutation, no input)  → POST   /ai-alerts/run
+ * `aiAlerts` sub-router — AI alert rules + fired alerts.
  *
  * Non-obvious choices:
- *   - `seedDefaults` is declared BEFORE `get`/`update`/`delete` so its literal
- *     `/rules/seed-defaults` path is registered ahead of the `/rules/:id`
- *     param route and wins the match (ts-rest registers in contract-key order).
- *   - `update`/`setEnabled` move `id` from the tRPC body into the path; the
- *     handler merges the path id back into the service input.
- *   - `rules.get` and `acknowledge` returned `null` → `NOT_FOUND` in tRPC; the
- *     handlers throw `NotFoundError` → 404 to preserve that contract.
+ *   - `seedDefaultRules` is declared BEFORE `getRule`/`updateRule`/`deleteRule`
+ *     so its literal `/ai-alerts/rules/seed-defaults` path is registered ahead
+ *     of the `/ai-alerts/rules/:id` param route and wins the match (ts-rest
+ *     registers in contract-key order).
+ *   - `updateRule`/`setRuleEnabled` carry `id` in the path; the handler merges
+ *     the path id back into the service input.
+ *   - `getRule` and `acknowledge` throw `NotFoundError` → 404 (via `runHttp`)
+ *     when the id resolves to nothing.
  *   - the `acknowledged` list filter is a boolean; on the wire it arrives as a
  *     string, so it's modelled as a `'true' | 'false'` enum the handler coerces.
  *
- * Output shapes mirror `ai-alerts/types.ts` + the service/evaluator returns.
+ * Output shapes mirror `api/modules/ai-alerts/types.ts` + the service/evaluator
+ * returns.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -39,7 +27,7 @@ const AlertRuleType = z.enum(['budget-threshold', 'error-spike', 'latency-degrad
 const AlertSeverity = z.enum(['warning', 'critical']);
 const AlertChannel = z.enum(['telegram', 'nudge']);
 
-/** Mirrors `AlertRule` in `ai-alerts/types.ts`. */
+/** Mirrors `AlertRule` in `api/modules/ai-alerts/types.ts`. */
 const AlertRuleSchema = z.object({
   id: z.number(),
   type: AlertRuleType,
@@ -52,7 +40,7 @@ const AlertRuleSchema = z.object({
   updatedAt: z.string(),
 });
 
-/** Mirrors `FiredAlert` in `ai-alerts/types.ts`. */
+/** Mirrors `FiredAlert` in `api/modules/ai-alerts/types.ts`. */
 const FiredAlertSchema = z.object({
   id: z.number(),
   ruleId: z.number().nullable(),
@@ -72,7 +60,7 @@ const DispatchedAlertSchema = FiredAlertSchema.extend({
   channels: z.array(AlertChannel),
 });
 
-/** Mirrors `RunEvaluationResult` in `ai-alerts/evaluator.ts`. */
+/** Mirrors `RunEvaluationResult` in `api/modules/ai-alerts/evaluator.ts`. */
 const RunEvaluationResultSchema = z.object({
   rulesEvaluated: z.number(),
   candidates: z.number(),

--- a/pillars/ai/src/contract/rest-ai-budgets.ts
+++ b/pillars/ai/src/contract/rest-ai-budgets.ts
@@ -1,15 +1,9 @@
 /**
- * `ai-budgets.*` sub-router — AI budget config + live status
- * (`core.aiBudgets.*`).
+ * `aiBudgets` sub-router — AI budget config + live status.
  *
- * Mapping from the legacy tRPC router:
- *   - `list`            (query, no input) → `GET  /ai-budgets`
- *   - `getBudgetStatus` (query, no input) → `GET  /ai-budgets/status`
- *   - `upsert`          (mutation, body)  → `POST /ai-budgets`
- *
- * `upsert` carries its `id` in the body (the tRPC input shape), so it stays a
- * `POST` with that body rather than a path-id `PUT`. Output shapes mirror
- * `Budget` / `BudgetStatus` from `ai-budgets/service.ts` exactly.
+ * `upsert` carries its `id` in the body, so it stays a `POST` with that body
+ * rather than a path-id `PUT`. Output shapes mirror `Budget` / `BudgetStatus`
+ * from `api/modules/ai-budgets/service.ts` exactly.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -18,7 +12,7 @@ import { ERR_RESPONSES, NonEmptyString } from './rest-schemas.js';
 
 const c = initContract();
 
-/** Mirrors `Budget` in `ai-budgets/service.ts`. */
+/** Mirrors `Budget` in `api/modules/ai-budgets/service.ts`. */
 const BudgetSchema = z.object({
   id: z.string(),
   scopeType: z.string(),
@@ -30,7 +24,7 @@ const BudgetSchema = z.object({
   updatedAt: z.string(),
 });
 
-/** Mirrors `BudgetStatus` in `ai-budgets/service.ts`. */
+/** Mirrors `BudgetStatus` in `api/modules/ai-budgets/service.ts`. */
 const BudgetStatusSchema = BudgetSchema.extend({
   currentTokenUsage: z.number(),
   currentCostUsage: z.number(),

--- a/pillars/ai/src/contract/rest-ai-observability.ts
+++ b/pillars/ai/src/contract/rest-ai-observability.ts
@@ -1,23 +1,16 @@
 /**
- * `ai-observability.*` sub-router — AI observability dashboards
- * (`core.aiObservability.*`).
+ * `aiObservability` sub-router — AI observability dashboards.
  *
- * Mapping from the legacy tRPC router (all `query`, all carrying only the
- * optional `ObservabilityFilters` — provider/model/domain/operation +
- * start/end date — so each maps to a `GET` with those as query params):
- *   - `getStats`          → `GET /ai-observability/stats`
- *   - `getHistory`        → `GET /ai-observability/history`
- *   - `getLatencyStats`   → `GET /ai-observability/latency`
- *   - `getQualityMetrics` → `GET /ai-observability/quality`
- *
- * Output shapes mirror `ai-observability/types.ts` exactly.
+ * Every route is a `GET` carrying the optional `ObservabilityFilters`
+ * (provider/model/domain/operation + start/end date) as query params. Output
+ * shapes mirror `api/modules/ai-observability/types.ts` exactly.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
 
 const c = initContract();
 
-/** Mirrors `observabilityFiltersSchema` in `ai-observability/types.ts`. */
+/** Mirrors `observabilityFiltersSchema` in `api/modules/ai-observability/types.ts`. */
 const ObservabilityFilters = z.object({
   provider: z.string().optional(),
   model: z.string().optional(),

--- a/pillars/ai/src/contract/rest-ai-providers.ts
+++ b/pillars/ai/src/contract/rest-ai-providers.ts
@@ -1,18 +1,10 @@
 /**
- * `ai-providers.*` sub-router — provider + model-pricing config and health
- * checks (`core.aiProviders.*`).
+ * `aiProviders` sub-router — provider + model-pricing config and health checks.
  *
- * Mapping from the legacy tRPC router:
- *   - `list`        (query, no input)      → `GET  /ai-providers`
- *   - `get`         (query, providerId)    → `GET  /ai-providers/:providerId`
- *   - `upsert`      (mutation, body)       → `POST /ai-providers`
- *   - `healthCheck` (mutation, providerId) → `POST /ai-providers/:providerId/health-check`
- *
- * `get` preserves the tRPC contract's NULLABLE 200 (an unknown providerId
- * resolves to `null`, NOT a 404) so the wire behaviour is identical. `upsert`
- * carries its `id` in the body (the tRPC input shape), so it stays a `POST`
- * rather than a path-id `PUT`. Output shapes mirror `ProviderWithModels` from
- * `ai-providers/service.ts` exactly.
+ * `get` returns a NULLABLE 200: an unknown providerId resolves to `null`, NOT a
+ * 404. `upsert` carries its `id` in the body, so it stays a `POST` rather than a
+ * path-id `PUT`. Output shapes mirror `ProviderWithModels` from
+ * `api/modules/ai-providers/service.ts` exactly.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
@@ -21,7 +13,7 @@ import { ERR_RESPONSES, NonEmptyString } from './rest-schemas.js';
 
 const c = initContract();
 
-/** Mirrors `ModelPricing` in `ai-providers/service.ts`. */
+/** Mirrors `ModelPricing` in `api/modules/ai-providers/service.ts`. */
 const ModelPricingSchema = z.object({
   id: z.number(),
   modelId: z.string(),
@@ -32,7 +24,7 @@ const ModelPricingSchema = z.object({
   isDefault: z.boolean(),
 });
 
-/** Mirrors `ProviderWithModels` in `ai-providers/service.ts`. */
+/** Mirrors `ProviderWithModels` in `api/modules/ai-providers/service.ts`. */
 const ProviderWithModelsSchema = z.object({
   id: z.string(),
   name: z.string(),

--- a/pillars/ai/src/contract/rest-ai-usage.ts
+++ b/pillars/ai/src/contract/rest-ai-usage.ts
@@ -1,17 +1,8 @@
 /**
- * `ai-usage.*` sub-router — AI usage analytics + cache maintenance
- * (`core.aiUsage.*`).
+ * `aiUsage` sub-router — AI usage analytics reads.
  *
- * Mapping from the legacy tRPC router:
- *   - `getStats`        (query, no input)      → `GET  /ai-usage/stats`
- *   - `getHistory`      (query, date range)    → `GET  /ai-usage/history` (query params)
- *   - `cacheStats`      (query, no input)      → `GET  /ai-usage/cache`
- *   - `clearStaleCache` (mutation, maxAgeDays) → `POST /ai-usage/cache/prune` (body)
- *   - `clearAllCache`   (mutation, no input)   → `DELETE /ai-usage/cache`
- *
- * Response shapes mirror `ai-usage/service.ts` + `ai-usage/cache.ts` exactly.
- * `clearStaleCache` carries a body, so it must be POST (a GET can't carry one);
- * `clearAllCache` is a bodyless purge of the whole cache, so it's a DELETE.
+ * `getStats` is bodyless; `getHistory` takes an optional date range as query
+ * params. Response shapes mirror `api/modules/ai-usage/service.ts` exactly.
  */
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';

--- a/pillars/ai/src/contract/rest.ts
+++ b/pillars/ai/src/contract/rest.ts
@@ -1,12 +1,11 @@
 /**
  * The ai pillar's ts-rest contract — the canonical wire surface served by the
- * `pops-ai` container (PRD-055).
+ * `pops-ai` container.
  *
- * Composes the AI-ops telemetry routers moved out of core (usage reads,
- * observability, providers, budgets, alerts) plus the two routes this pillar
- * OWNS: the cross-pillar ingest `POST /ai-usage/record` (`aiIngest`) and the
- * pricing read `GET /ai-pricing/:p/:m` (`aiPricing`), and the per-pillar
- * `settings.*` RU+reset surface for its own `ai.*` keys.
+ * Composes the AI-ops telemetry routers (usage reads, observability, providers,
+ * budgets, alerts), the cross-pillar ingest `POST /ai-usage/record`
+ * (`aiIngest`), the pricing read `GET /ai-pricing/:p/:m` (`aiPricing`), and the
+ * per-pillar `settings.*` RU+reset surface for its own `ai.*` keys.
  */
 import { initContract } from '@ts-rest/core';
 

--- a/pillars/ai/src/db/__tests__/ai-model-pricing.test.ts
+++ b/pillars/ai/src/db/__tests__/ai-model-pricing.test.ts
@@ -1,9 +1,8 @@
 /**
  * Invariant tests for the ai-model-pricing cache against an in-memory
- * SQLite seeded with the `ai_model_pricing` schema inline. The table
- * has no core-db migration file yet (PRD-186 sibling cutover owns
- * that), so the test boots the schema directly from the canonical
- * shape.
+ * SQLite. The `ai_model_pricing` schema is booted inline here rather
+ * than from the pillar migration so the cache contract is exercised in
+ * isolation from the rest of the baseline schema.
  *
  * Cache-hit + cache-miss + TTL invalidation + DB-error fallback are
  * driven via the `now` injection point so the test is deterministic

--- a/pillars/ai/src/db/index.ts
+++ b/pillars/ai/src/db/index.ts
@@ -2,9 +2,8 @@
  * Backend-safe barrel for the ai pillar's persistence layer.
  *
  * Hosts the AI-ops observability slice (`ai_inference_log`/
- * `ai_inference_daily`/budgets/alerts/providers/pricing) extracted out of
- * `core` (PRD-055), plus the flat `settings` table backing the pillar's
- * own `ai.*` keys.
+ * `ai_inference_daily`/budgets/alerts/providers/pricing), plus the flat
+ * `settings` table backing the pillar's own `ai.*` keys.
  */
 export * from './errors.js';
 export * from './row-types.js';

--- a/pillars/ai/src/db/schema.ts
+++ b/pillars/ai/src/db/schema.ts
@@ -3,8 +3,8 @@
  *
  * Canonical definitions for the AI-ops observability slice
  * (`ai_inference_log`/`ai_inference_daily`/budgets/alerts/providers/
- * pricing) extracted out of `core` (PRD-055). The flat `settings` table
- * backs `@pops/pillar-settings` for the pillar's own `ai.*` keys.
+ * pricing). The flat `settings` table backs `@pops/pillar-settings` for
+ * the pillar's own `ai.*` keys.
  */
 export { aiAlertRules } from './schema/ai-alert-rules.js';
 export { aiAlerts } from './schema/ai-alerts.js';

--- a/pillars/ai/src/db/schema/ai-alert-rules.ts
+++ b/pillars/ai/src/db/schema/ai-alert-rules.ts
@@ -1,6 +1,6 @@
 /**
- * `ai_alert_rules` (PRD-092 US-07) — configurable rules that the alert
- * evaluator job runs every 5 minutes to decide whether to fire an alert.
+ * `ai_alert_rules` (see pillars/ai/docs/prds/ai-observability) — configurable
+ * rules that the alert evaluator job runs to decide whether to fire an alert.
  *
  * - `type` is one of `budget-threshold`, `error-spike`, `latency-degradation`.
  * - `threshold_value` semantics depend on type:

--- a/pillars/ai/src/db/schema/ai-alerts.ts
+++ b/pillars/ai/src/db/schema/ai-alerts.ts
@@ -1,9 +1,11 @@
 /**
- * `ai_alerts` (PRD-092 US-07) — fired alerts produced by the evaluator job.
+ * `ai_alerts` (see pillars/ai/docs/prds/ai-observability) — fired alerts
+ * produced by the evaluator job.
  *
  * `scope_detail` is a human-readable scope identifier used both for display
  * and for deduplication; the evaluator suppresses inserts when an alert with
- * the same `(type, scope_detail)` was created within the last hour.
+ * the same `(type, scope_detail)` was created within the dedupe window
+ * (`idx_ai_alerts_dedupe` covers that lookup).
  */
 import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 

--- a/pillars/ai/src/db/schema/ai-inference-daily.ts
+++ b/pillars/ai/src/db/schema/ai-inference-daily.ts
@@ -3,10 +3,11 @@ import { index, integer, real, sqliteTable, text, uniqueIndex } from 'drizzle-or
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
 /**
- * Daily aggregation table for AI inference logs (PRD-092 US-08).
+ * Daily aggregation table for AI inference logs
+ * (see pillars/ai/docs/prds/ai-observability).
  *
- * Once raw `ai_inference_log` rows pass the retention horizon (default 90 days),
- * a scheduled job rolls them up into one row per
+ * Once raw `ai_inference_log` rows pass the retention horizon, a scheduled job
+ * rolls them up into one row per
  * `(date, provider, model, operation, domain)` tuple and deletes the originals.
  *
  * The table is append-mostly — written exclusively by the retention job,
@@ -38,9 +39,8 @@ export const aiInferenceDaily = sqliteTable(
     budgetBlockedCount: integer('budget_blocked_count').notNull().default(0),
   },
   (table) => [
-    // Unique on the natural aggregation key so upserts can target it. SQLite
-    // treats NULLs as distinct, so we always store a sentinel empty string
-    // when domain is null (handled in the service layer).
+    // Unique on the natural aggregation key so upserts can target it (relies on
+    // the `domain` NULL-sentinel coercion noted on the column above).
     uniqueIndex('idx_ai_inference_daily_key').on(
       table.date,
       table.provider,

--- a/pillars/ai/src/db/services/ai-model-pricing.ts
+++ b/pillars/ai/src/db/services/ai-model-pricing.ts
@@ -8,12 +8,6 @@
  * cache TTL (default 5 minutes) bounds staleness when ops edit pricing
  * via the dashboard.
  *
- * Per `docs/themes/13-pillar-finale/notes/infra-hot-path-migration.md`
- * row 5 the `ai_model_pricing` table is owned by the core pillar (per
- * PRD-186). This module is the SDK surface for that ownership; the
- * physical table cutover from the shared `pops.db` into `core.db` lands
- * with the PRD-186 sibling PR.
- *
  * Cache invariants:
  *   - Each `(providerId, modelId)` key remembers the timestamp at which
  *     it was populated.
@@ -56,17 +50,17 @@ const DEFAULT_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_FALLBACK: ModelPrice = { input: 1.0, output: 5.0 };
 
 /**
- * Build a process-local pricing lookup bound to the given core DB
+ * Build a process-local pricing lookup bound to the given ai pillar DB
  * handle. Each call to `lookup(provider, model)` either hits the cache
  * or refreshes the entire pricing table from SQLite.
  *
- * @param db - Core drizzle handle. Captured by closure; the same handle
- *   is used for every refresh against this cache.
+ * @param db - ai pillar drizzle handle. Captured by closure; the same
+ *   handle is used for every refresh against this cache.
  * @param options.ttlMs - Cache freshness window in milliseconds.
  *   Defaults to 5 minutes.
  * @param options.fallback - Returned when the cache is empty AND a
  *   refresh fails OR the requested key is unknown. Defaults to
- *   `{ input: 1.0, output: 5.0 }` to preserve historical behaviour.
+ *   `{ input: 1.0, output: 5.0 }`.
  * @param options.now - Optional clock override; tests use this to drive
  *   the TTL deterministically. Defaults to `Date.now`.
  */

--- a/pillars/ai/src/db/services/ai-usage-dashboard.ts
+++ b/pillars/ai/src/db/services/ai-usage-dashboard.ts
@@ -6,7 +6,7 @@
  * `getStats` / `getHistory`) need a cached-aware split: cached rows
  * count toward cache-hit tallies but never contribute to cost or token
  * spend. These helpers encapsulate the CASE-based aggregation so the
- * pops-api layer keeps a thin pass-through service.
+ * REST handler service stays a thin pass-through.
  */
 import { and, desc, gte, lt, sql, type SQL } from 'drizzle-orm';
 
@@ -51,7 +51,7 @@ function coalesceDashboardStats(
 
 /**
  * Dashboard-shaped variant of `sumInferenceLogUsage`. Returns the
- * 5-field cached-aware stats shape consumed by `core.aiUsage.getStats`.
+ * 5-field cached-aware stats shape consumed by `aiUsage.getStats`.
  * Cached rows contribute to `totalCacheHits` only; everything else is
  * summed across non-cached rows.
  */
@@ -115,7 +115,7 @@ function buildDateWindowCondition(filter: GroupInferenceLogByDateFilter): SQL | 
  * Dashboard-shaped daily roll-up of `ai_inference_log`. Returns one row
  * per UTC date in `[startDate, endDate]` (both inclusive, both
  * optional) newest-first. Mirrors {@link summarizeInferenceLogStats}'s
- * cached split per bucket. Used by `core.aiUsage.getHistory` to drive
+ * cached split per bucket. Used by `aiUsage.getHistory` to drive
  * the timeline chart.
  */
 export function groupInferenceLogByDate(

--- a/pillars/ai/src/db/services/ai-usage.ts
+++ b/pillars/ai/src/db/services/ai-usage.ts
@@ -1,34 +1,22 @@
 /**
- * AI usage persistence against the core pillar's SQLite via drizzle.
+ * AI usage persistence against the ai pillar's SQLite via drizzle.
  *
- * Carries the three hot tables behind `core.aiUsage.*`:
+ * Carries the three hot tables behind `aiUsage.*`:
  *   - `ai_inference_log` — append-only per-call record written by the
  *     inference middleware on every provider invocation. The dashboard
  *     reads it for stats + history.
  *   - `ai_inference_daily` — aggregate roll-up written by the retention
- *     job (PRD-092 US-08) once raw rows pass the 90-day horizon. The
- *     dashboard reads it for the continuous timeline across the retention
- *     boundary. Helpers live in `./ai-usage-retention.ts`.
+ *     job once raw rows pass the 90-day horizon. The dashboard reads it
+ *     for the continuous timeline across the retention boundary. Helpers
+ *     live in `./ai-usage-retention.ts`.
  *   - `ai_budgets` — small CRUD surface that gates AI calls. Budgets are
  *     scoped global / per-provider / per-operation; consulted on the hot
  *     path before the middleware fires. CRUD lives in
  *     `./ai-usage-budgets.ts`.
  *
  * Services take a `AiDb` handle as their first argument; the calling
- * layer (pops-api modules) is responsible for resolving the singleton or
- * transaction handle to pass in. Mirrors `@pops/finance-db`'s service
- * signature pattern.
- *
- * Post-PRD-186 PR 3 + PR 3 follow-up: the hot inference-log write path,
- * the retention rollup, and the AI Ops `core.aiUsage` dashboard reads
- * (`getStats` / `getHistory`) all route through this module against
- * `getCoreDrizzle()`. A handful of `ai-observability` read paths
- * (`history.ts`, `group-stats.ts`, `summary.ts`, plus
- * `findFallbackProvider`) still query `ai_inference_log` /
- * `ai_inference_daily` directly via `getDrizzle()` and migrate in
- * subsequent PRs. The boot-time `pops.db -> core.db` backfill bridges
- * any pre-cutover rows; PR 4 drops the legacy `ai_*` tables from the
- * shared journal once those last read sites move over.
+ * REST handler layer resolves the singleton or transaction handle to
+ * pass in.
  */
 import { and, desc, gte, lte, sql, type SQL } from 'drizzle-orm';
 


### PR DESCRIPTION
## Wave 5 — agent-first comment hygiene (ai pillar) · 9/12

Same pass as the registry template (#3560).

- **50 files, net -157.** 18 comments deleted, 72 corrected.
- **PRD-NNN removed from comments** (25 dropped, 14 to fully-qualified resolvable doc anchors). ADR-NNN kept.
- **Comments/labels only** — 0 logic / 0 functional-string changes (adversarial verify + non-comment-diff scan = 0). A verify agent had stripped a PRD token from a `SettingsManifest` field *description* (user-facing functional string); reverted to keep this PR comment-only — that token is deferred to the user-facing-string pass.
- Green: typecheck, 189 tests, format, lint.
