### PR TITLE
chore(shell): agent-first comment hygiene (Wave 5, pillar 10/12)

### DIFF
--- a/pillars/shell/e2e/ai-rules-create-edit.spec.ts
+++ b/pillars/shell/e2e/ai-rules-create-edit.spec.ts
@@ -1,16 +1,15 @@
 /**
  * E2E tests — AI rules: create + preview, edit + verify updated preview.
  *
- * Closes:
- *   - #2119  Tier 2 — create a new rule and confirm preview matches against
- *            seeded transactions.
- *   - #2135  Tier 3 — edit an existing rule's pattern and confirm the
- *            updated preview reflects the new match set, then save and
- *            assert persistence across reload.
+ * Two flows:
+ *   - Create a new rule and confirm preview matches against seeded
+ *     transactions.
+ *   - Edit an existing rule's pattern, confirm the updated preview reflects
+ *     the new match set, then save and assert persistence across reload.
  *
- * Both flows run against the real `/ai/rules` page, hitting the seeded `e2e`
- * SQLite environment via the standard `useRealApi` helper. The seeded data
- * (see `apps/pops-api/src/db/seeder.ts`) provides:
+ * Both flows run against the real `/cerebrum/admin/rules` page, hitting the
+ * seeded `e2e` SQLite environment via the standard `useRealApi` helper. The
+ * seeded data provides:
  *   - 16 transactions including `Woolworths Metro`, `Woolworths`,
  *     `Netflix Subscription`, `Shell Service Station`, `Coles Local`
  *   - 2 corrections: `WOOLWORTHS%` (contains, Groceries) and
@@ -124,9 +123,7 @@ test.describe('AI rules — manual create/edit + preview', () => {
     expect(realConsoleErrors).toHaveLength(0);
   });
 
-  test('#2119 — creates a rule and confirms preview matches seeded transactions', async ({
-    page,
-  }) => {
+  test('creates a rule and confirms preview matches seeded transactions', async ({ page }) => {
     // Use a regex matchType so the unique (pattern,matchType) tuple won't
     // collide with the seeded `WOOLWORTHS%`/contains correction even after
     // pattern normalisation — letting the test run idempotently against the
@@ -164,7 +161,7 @@ test.describe('AI rules — manual create/edit + preview', () => {
     });
   });
 
-  test('#2135 — edits an existing rule and verifies the updated preview, then persists', async ({
+  test('edits an existing rule and verifies the updated preview, then persists', async ({
     page,
   }) => {
     // Create a rule we can then edit. Two reasons:

--- a/pillars/shell/e2e/ai-usage-stats.spec.ts
+++ b/pillars/shell/e2e/ai-usage-stats.spec.ts
@@ -1,18 +1,18 @@
 /**
- * Smoke test — AI usage stats page (#2120)
+ * Smoke test — AI usage stats page
  *
- * Tier 2 minimum: navigating to `/ai` loads the AI Observability page, the
+ * Navigating to `/cerebrum/admin` loads the AI Observability page, the
  * usage-stats KPI panel renders, at least one numeric metric is non-empty,
  * and the page does not throw.
  *
- * Uses the real API against the seeded `e2e` SQLite environment. The seeder
+ * Uses the real API against the seeded `e2e` SQLite environment. The seed
  * inserts 3 `ai_inference_log` rows (2 live calls + 1 cache hit) so the
- * `core.aiObservability.getStats` endpoint returns non-zero totals — no
- * mocking is needed. Design note: we deliberately avoid `page.route()` mocks
- * here because real data exercises the full stack (router → service → DB
- * aggregation → KPI derivation) and catches regressions mocks would hide.
+ * `getStats` endpoint returns non-zero totals — no mocking is needed. We
+ * deliberately avoid `page.route()` mocks here because real data exercises the
+ * full stack (service → DB aggregation → KPI derivation) and catches
+ * regressions mocks would hide.
  *
- * Seeded totals (see apps/pops-api/src/db/seeder.ts "AI Usage" block):
+ * Seeded totals:
  *   totalCalls      = 3
  *   totalCostUsd    = 0.0006   → rendered as "$0.0006"
  *   cacheHitRate    = 1/3      → rendered as "33.3%"

--- a/pillars/shell/e2e/budgets-period-filter.spec.ts
+++ b/pillars/shell/e2e/budgets-period-filter.spec.ts
@@ -1,14 +1,14 @@
 /**
- * Tier 3 — Finance budgets period filter (#2123)
+ * Finance budgets period filter
  *
  * Exercises the period filter on `/finance/budgets` with exact row counts and
  * per-row badge verification against the real API seeded with 8 budgets
- * (7 Monthly + 1 Yearly). Complements the Tier 1 smoke test
+ * (7 Monthly + 1 Yearly). Complements the smoke test
  * (`finance-budgets.spec.ts`) — instead of only asserting that a single row is
  * visible/hidden per filter state, this suite asserts the full list is
  * correctly narrowed and restored.
  *
- * Seed snapshot (see `apps/pops-api/src/db/seeder.ts`):
+ * Seed snapshot:
  *   Monthly (7): Groceries, Transport, Entertainment, Shopping,
  *                Home & Garden, Utilities, Subscriptions
  *   Yearly  (1): Holiday Fund

--- a/pillars/shell/e2e/finance-budgets-spending-progress.spec.ts
+++ b/pillars/shell/e2e/finance-budgets-spending-progress.spec.ts
@@ -1,9 +1,9 @@
 /**
- * E2E — Finance budgets spending progress (#2108 / #2186)
+ * E2E — Finance budgets spending progress
  *
- * Tier 2 flow: prove the freshly-built `Spent` / `% Progress` columns light
- * up after a matching transaction is created, end-to-end against the seeded
- * `e2e` SQLite environment.
+ * Prove the `Spent` / `% Progress` columns light up after a matching
+ * transaction is created, end-to-end against the seeded `e2e` SQLite
+ * environment.
  *
  * Steps:
  *   1. Navigate to /finance/budgets and confirm the page loads.
@@ -13,10 +13,8 @@
  *   3. Confirm the new budget renders with a 0% progress (no transactions
  *      yet match its category tag).
  *   4. Create a matching transaction directly via the tRPC create mutation
- *      against the same `e2e` env (the transactions list page does not yet
- *      expose a CRUD UI — see in-flight branch #2185 for the matching
- *      front-end work). The transaction is dated today so it falls inside
- *      the Monthly MTD window the API computes.
+ *      against the same `e2e` env. The transaction is dated today so it falls
+ *      inside the Monthly MTD window the API computes.
  *   5. Reload /finance/budgets and assert the new budget's row now shows a
  *      non-zero `%` and a non-zero `$` Spent amount.
  *   6. Delete the budget via the row-level Delete action and confirm the
@@ -123,7 +121,7 @@ function budgetRow(page: Page, category: string) {
   return page.getByRole('row').filter({ hasText: category });
 }
 
-test.describe('Finance — budgets spending progress (#2108 / #2186)', () => {
+test.describe('Finance — budgets spending progress', () => {
   let pageErrors: string[] = [];
   let consoleErrors: string[] = [];
   let category = '';
@@ -208,8 +206,8 @@ test.describe('Finance — budgets spending progress (#2108 / #2186)', () => {
     await expect(row.getByText('0%')).toBeVisible();
 
     // ---- Step 4: create a matching transaction via the API ---------------
-    // The transactions list page has no create UI yet (#2185), so we POST
-    // straight to the tRPC procedure under the same `e2e` env.
+    // POST straight to the tRPC procedure under the same `e2e` env rather than
+    // driving the list UI, so this assertion targets the budget math only.
     const txn = await createMatchingTransaction(request, category);
     expect(txn.id).toBeTruthy();
 

--- a/pillars/shell/e2e/finance-transactions-crud.spec.ts
+++ b/pillars/shell/e2e/finance-transactions-crud.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E test — Finance transactions CRUD (#2106)
+ * E2E test — Finance transactions CRUD
  *
  * Exercises the full create → confirm → edit (amount + entity) → confirm →
  * delete → confirm flow at `/finance/transactions` against the seeded e2e

--- a/pillars/shell/e2e/helpers/use-real-api.ts
+++ b/pillars/shell/e2e/helpers/use-real-api.ts
@@ -1,20 +1,21 @@
 /**
- * Helpers for routing Playwright browser requests to the real pops-api
- * using the named 'e2e' environment (isolated seeded SQLite DB).
+ * Helpers for routing Playwright browser requests to the named 'e2e'
+ * environment (an isolated seeded SQLite DB selected via the `?env=e2e`
+ * query param). The helpers intercept matching requests with `page.route`,
+ * re-fetch them with `env` appended, and fulfil the browser with the result.
  *
- * How it works:
- *   Browser → /trpc/... → page.route() intercepts → route.fetch() re-sends with ?env=e2e
- *   → Vite proxy → pops-api :3000 → envContextMiddleware → e2e SQLite DB
- *
- * This avoids needing a second API port or changes to vite.config.ts.
+ * The API surface these helpers target no longer exists: this suite was
+ * written against the deleted `apps/pops-api` tRPC monolith and is gated to
+ * `workflow_dispatch` only (see playwright.config.ts) pending a rewrite
+ * against the REST pillars.
  */
 import type { Page } from '@playwright/test';
 
 const E2E_ENV = 'e2e';
 
 /**
- * Route ALL tRPC calls through the real API using the e2e environment.
- * Use this in beforeEach for fully integrated tests (no mocks).
+ * Route every matched request through the real API using the e2e
+ * environment. Use this in beforeEach for fully integrated tests (no mocks).
  */
 export async function useRealApi(page: Page): Promise<void> {
   await page.route('/trpc/**', async (route) => {
@@ -26,10 +27,10 @@ export async function useRealApi(page: Page): Promise<void> {
 }
 
 /**
- * Route only a specific tRPC procedure through the real API.
- * All other procedures fall through to whatever mocks are set up.
+ * Route only requests matching `pattern` through the real API. Everything
+ * else falls through to whatever mocks are set up.
  *
- * @param pattern - Regex string matching the procedure path, e.g. 'transactions\\.list'
+ * @param pattern - Regex string matching the request path, e.g. 'transactions\\.list'
  */
 export async function useRealEndpoint(page: Page, pattern: string): Promise<void> {
   await page.route(new RegExp(`/trpc/${pattern}`), async (route) => {

--- a/pillars/shell/e2e/import-duplicate-detection.spec.ts
+++ b/pillars/shell/e2e/import-duplicate-detection.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Integration test — finance import: duplicate detection workflow (#2122).
+ * Integration test — finance import: duplicate detection workflow.
  *
- * Tier 3: real API against an isolated seeded SQLite environment.
+ * Real API against an isolated seeded SQLite environment.
  *
  * Flow covered:
  *   Phase 1 — upload CSV A (3 unique rows), walk the wizard, commit.
@@ -100,7 +100,7 @@ async function commitAndReachSummary(page: Page): Promise<void> {
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Finance import — duplicate detection workflow (#2122)', () => {
+test.describe('Finance import — duplicate detection workflow', () => {
   let pageErrors: string[] = [];
   let consoleErrors: string[] = [];
 

--- a/pillars/shell/e2e/import-entity-matching.spec.ts
+++ b/pillars/shell/e2e/import-entity-matching.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Integration test — finance import: real entity matching against seeded DB (#2121).
+ * Integration test — finance import: real entity matching against seeded DB.
  *
- * Tier 3: real API against an isolated seeded SQLite environment.
+ * Real API against an isolated seeded SQLite environment.
  *
  * Flow covered:
  *   Upload a CSV with 3 merchant descriptions and assert that the Review step
@@ -35,8 +35,8 @@
  * Persistence:
  *   The test only walks the wizard up to Review and asserts on the in-memory
  *   processed output. It deliberately does NOT commit — the goal is to verify
- *   the matcher's classification, not to exercise commit semantics (#2122
- *   already covers that).
+ *   the matcher's classification, not to exercise commit semantics
+ *   (`import-duplicate-detection.spec.ts` already covers that).
  */
 import { expect, test, type Page, type APIRequestContext } from '@playwright/test';
 
@@ -114,7 +114,7 @@ async function walkToReview(page: Page, content: string, fileName: string): Prom
   });
 }
 
-test.describe('Finance import — real entity matching against seeded DB (#2121)', () => {
+test.describe('Finance import — real entity matching against seeded DB', () => {
   let pageErrors: string[] = [];
   let consoleErrors: string[] = [];
 

--- a/pillars/shell/e2e/import-wizard-happy-path.spec.ts
+++ b/pillars/shell/e2e/import-wizard-happy-path.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Smoke test — Finance import wizard happy path (#2101)
+ * Smoke test — Finance import wizard happy path
  *
- * Tier 1 minimum: walks the full 8-step import wizard end-to-end with a
+ * Walks the full 8-step import wizard end-to-end with a
  * 2-transaction CSV where the backend is fully mocked via `page.route()`:
  *
  *   1. Upload CSV         → parsed client-side (no REST call)

--- a/pillars/shell/e2e/import-wizard-integration.spec.ts
+++ b/pillars/shell/e2e/import-wizard-integration.spec.ts
@@ -11,7 +11,7 @@
  *   - imports.createEntity → returns a fake entity ID
  *   - corrections.createOrUpdate → returns success
  *
- * Entity matching relies on seeded entities (from src/db/seeder.ts):
+ * Entity matching relies on seeded entities:
  *   - "Woolworths" (aliases: "Woolies, WOW, Woolworths Metro")
  *   - "Netflix" (aliases: "Netflix.com")
  *   - "Shell" (aliases: "Shell Coles Express, Shell Service Station")

--- a/pillars/shell/e2e/install-set-switching.spec.ts
+++ b/pillars/shell/e2e/install-set-switching.spec.ts
@@ -1,11 +1,11 @@
 /**
- * Install-set boundary E2E (PRD-101 US-11).
+ * Install-set boundary E2E.
  *
  * Why 404 vs NotInstalledPage matter as distinct surfaces: operators must
  * be able to tell a typo from an excluded module at a glance. Full
- * install-set switching across two shell builds is deferred — the install
- * set is baked into `MODULES` at registry build time, so two-suite
- * switching needs harness changes (see the linked US doc).
+ * install-set switching across two shell builds is not covered here — the
+ * install set is `POPS_APPS`-gated at build time, so two-suite switching
+ * would need harness changes.
  *
  * The known-but-not-installed boundary is exercised here via `/ego`: the
  * `ego` module is in `KNOWN_MODULES` but exposes only an overlay surface

--- a/pillars/shell/e2e/inventory-connections.spec.ts
+++ b/pillars/shell/e2e/inventory-connections.spec.ts
@@ -1,7 +1,7 @@
 /**
- * E2E test — Inventory connections between items (#2127)
+ * E2E test — Inventory connections between items
  *
- * Tier 3 flow: link two seeded inventory items via the Connect dialog, verify
+ * Link two seeded inventory items via the Connect dialog, verify
  * the relationship is visible on both item detail pages, then delete the
  * connection from item A and verify it disappears from both sides.
  *
@@ -29,7 +29,7 @@
  *     share a single state transition; they must run in order.
  *   - pageerror + console-error listeners are registered before navigation
  *     and asserted in afterEach so every test enforces the no-crash
- *     requirement from the issue.
+ *     requirement.
  */
 import { expect, test, type Page } from '@playwright/test';
 

--- a/pillars/shell/e2e/inventory-document-upload.spec.ts
+++ b/pillars/shell/e2e/inventory-document-upload.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Tier 3 — Inventory: document upload, download link, and delete on item (#2126)
+ * Inventory: document upload, download link, and delete on item
  *
  * Flow:
  *   1. Pre-clean: remove any uploaded documents previously attached to the
@@ -55,7 +55,7 @@ async function purgeDocuments(req: APIRequestContext): Promise<void> {
   }
 }
 
-test.describe('Inventory — document upload, download, delete (#2126)', () => {
+test.describe('Inventory — document upload, download, delete', () => {
   test.beforeEach(async ({ page, request }) => {
     await purgeDocuments(request);
     await useRealApi(page);

--- a/pillars/shell/e2e/inventory-item-lifecycle.spec.ts
+++ b/pillars/shell/e2e/inventory-item-lifecycle.spec.ts
@@ -1,8 +1,8 @@
 /**
- * E2E test — Inventory item lifecycle (#2111)
+ * E2E test — Inventory item lifecycle
  *
  * Walks the full create → view → edit → delete flow at `/inventory` against the
- * seeded e2e SQLite environment. Complements the Tier 1 smoke test
+ * seeded e2e SQLite environment. Complements the smoke test
  * (inventory-items.spec.ts), which only verifies seeded data renders.
  *
  * Design notes:

--- a/pillars/shell/e2e/inventory-photo-upload-reorder.spec.ts
+++ b/pillars/shell/e2e/inventory-photo-upload-reorder.spec.ts
@@ -1,13 +1,13 @@
 /**
- * Tier 3 — Inventory: photo upload, reorder, and delete on item (#2125)
+ * Inventory: photo upload, reorder, and delete on item
  *
  * Flow:
  *   1. Pre-clean: remove any photos previously attached to the test item.
  *   2. Navigate to the item edit page (the only place upload UI is exposed).
  *   3. Upload two small PNG fixtures via the hidden <input type="file">.
  *      The form's photo section uploads immediately on file select — no Save
- *      Changes click is needed, so the WebKit reset() bug (#2175) and the
- *      navigation drop bug (#2157) are both side-stepped.
+ *      Changes click is needed, side-stepping the WebKit form-reset and
+ *      post-save navigation-drop bugs that bite the Save Changes path.
  *   4. Wait for both photos to appear in the SortablePhotoGrid (`role="listitem"`).
  *   5. Navigate to the detail page and confirm both thumbnail cells render
  *      in the gallery's reorder grid.
@@ -111,7 +111,7 @@ async function getPhotoFilePath(page: Page, index: number): Promise<string> {
   return decodeURIComponent(last);
 }
 
-test.describe('Inventory — photo upload, reorder, delete (#2125)', () => {
+test.describe('Inventory — photo upload, reorder, delete', () => {
   test.beforeEach(async ({ page, request }) => {
     await purgePhotos(request);
     await useRealApi(page);

--- a/pillars/shell/e2e/inventory-reports-value-by-location.spec.ts
+++ b/pillars/shell/e2e/inventory-reports-value-by-location.spec.ts
@@ -1,7 +1,7 @@
 /**
- * E2E — Inventory reports: value breakdown by location (#2128)
+ * E2E — Inventory reports: value breakdown by location
  *
- * Tier 3: navigate to `/inventory/reports`, confirm the Value by Location
+ * Navigate to `/inventory/reports`, confirm the Value by Location
  * widget renders, at least one seeded location shows a non-zero replacement
  * value, and the sum across all locations equals the overall replacement
  * value shown in the items list summary.
@@ -29,7 +29,7 @@
  *   without hovering. Recharts does not render the totals anywhere in the
  *   static DOM today.
  *
- * Seeded value snapshot (from apps/pops-api/src/db/seeder.ts):
+ * Seeded value snapshot:
  *   All 20 inventory items carry a location_id, so `getValueByLocation`
  *   produces no "Unassigned" bucket and its SUM equals the unfiltered items
  *   list `totalReplacementValue`. With the current seed that total is
@@ -43,10 +43,7 @@ import { expect, test, type APIRequestContext } from '@playwright/test';
 
 import { useRealApi } from './helpers/use-real-api';
 
-/**
- * tRPC batch GET URL shape for an input-less query.
- * Mirrors the format used by apps/pops-api/src/middleware/env-context.integration.test.ts.
- */
+/** tRPC batch GET URL shape for an input-less query. */
 const NO_INPUT_BATCH = encodeURIComponent(JSON.stringify({ '0': null }));
 
 interface BreakdownEntry {

--- a/pillars/shell/e2e/inventory-warranties.spec.ts
+++ b/pillars/shell/e2e/inventory-warranties.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Smoke test — Inventory warranties list with expiry flagging (#2113)
+ * Smoke test — Inventory warranties list with expiry flagging
  *
- * Tier 2 — confirm the warranty tracking page loads seeded items, renders
+ * Confirm the warranty tracking page loads seeded items, renders
  * future-expiry items in the Active section with a "N days" remaining badge,
  * and visually flags past-expiry items in a dedicated "Expired" section
  * containing "Xd ago" muted text.
@@ -9,7 +9,7 @@
  * Crash detection is wired into beforeEach/afterEach so every test in this
  * suite verifies the page does not crash (no separate crash test needed).
  *
- * Seeded warranty items (from apps/pops-api/src/db/seeder.ts):
+ * Seeded warranty items:
  *   Active  (future expiry): MacBook Pro 16-inch → 2027-11-15,
  *                            Sony WH-1000XM5    → 2027-02-02,
  *                            USB-C Hub          → 2026-11-15,

--- a/pillars/shell/e2e/media-compare-arena.spec.ts
+++ b/pillars/shell/e2e/media-compare-arena.spec.ts
@@ -1,12 +1,12 @@
 /**
- * E2E — Media compare arena: record one comparison pair (#2118)
+ * E2E — Media compare arena: record one comparison pair
  *
- * Tier 2 flow: navigate to /media/compare, wait for a seeded pair to render,
+ * Navigate to /media/compare, wait for a seeded pair to render,
  * pick a winner, confirm the outcome is recorded (session-count badge ticks
  * to 1), then visit /media/rankings and confirm both movies appear with a
  * score cell.
  *
- * Seed context (see apps/pops-api/src/db/seeder.ts):
+ * Seed context:
  *   Smart-pair candidates are the intersection of watched movies and the
  *   non-watchlisted pool, which in the e2e seed reduces to five watched
  *   titles: Shawshank, Godfather, Dark Knight, Pulp Fiction, LOTR. The seed

--- a/pillars/shell/e2e/media-quick-pick.spec.ts
+++ b/pillars/shell/e2e/media-quick-pick.spec.ts
@@ -1,12 +1,12 @@
 /**
- * E2E — Media quick pick: generate picks and add one to watchlist (#2130)
+ * E2E — Media quick pick: generate picks and add one to watchlist
  *
- * Tier 3 flow: navigate to `/media/quick-pick`, confirm cards render, change
+ * Navigate to `/media/quick-pick`, confirm cards render, change
  * the count selector and verify the displayed card count tracks it, then pick
  * one card, navigate to its detail page via the "Watch This" button, add it
  * to the watchlist, and confirm it appears on `/media/watchlist`.
  *
- * Seed context (apps/pops-api/src/db/seeder.ts):
+ * Seed context:
  *   `quickPick` filters out movies with completed watch_history rows. The
  *   seeded pool starts at 5 unwatched movies (Forrest Gump, Fight Club, The
  *   Matrix, Interstellar, Spider-Verse), but other specs running earlier in
@@ -64,7 +64,7 @@ function countButton(page: Page, n: number) {
   return page.getByRole('group', { name: 'Number of picks' }).getByRole('button', { name: `${n}` });
 }
 
-test.describe('Media — quick pick generate and add to watchlist (#2130)', () => {
+test.describe('Media — quick pick generate and add to watchlist', () => {
   test.describe.configure({ mode: 'serial' });
 
   let pageErrors: string[] = [];

--- a/pillars/shell/e2e/media-tier-list.spec.ts
+++ b/pillars/shell/e2e/media-tier-list.spec.ts
@@ -1,7 +1,7 @@
 /**
- * E2E — Media tier list: create dimension, drag movies into tiers, save, reload (#2131 + #2190)
+ * E2E — Media tier list: create dimension, drag movies into tiers, save, reload
  *
- * Tier 3 flow: navigate to `/media/tier-list`, create a fresh comparison
+ * Navigate to `/media/tier-list`, create a fresh comparison
  * dimension via the page's empty-state CTA (or the header "+ New" button),
  * confirm the unranked pool populates from the seeded library, drag two
  * movies into tiers via dnd-kit's pointer sensor, submit the tier list,
@@ -76,7 +76,7 @@ async function findDimensionIdByName(req: APIRequestContext, name: string): Prom
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Media — tier list create, drag, save, reload (#2131, #2190)', () => {
+test.describe('Media — tier list create, drag, save, reload', () => {
   let pageErrors: string[] = [];
   let consoleErrors: string[] = [];
   let createdDimensionId: number | null = null;
@@ -120,16 +120,15 @@ test.describe('Media — tier list create, drag, save, reload (#2131, #2190)', (
   });
 
   /**
-   * Scope note (see #2195):
+   * Scope note:
    * The full "drag movies into tiers, submit, reload, assert persistence"
    * flow can't run end-to-end against a freshly created dimension because
    * the unranked pool query (`fetchEligibleRows`) filters by
    * `media_scores.dimension_id` — and a brand-new dimension has zero score
    * rows until comparisons are recorded for it. Until that gap is closed
    * (either seed `media_scores` on dimension create, or fall back to
-   * defaults in the eligibility query), this test verifies the part of
-   * the feature that PR #2190 actually delivers: the empty-state CTA →
-   * create-dimension dialog → chip activation flow surfaced by the page.
+   * defaults in the eligibility query), this test verifies only the
+   * empty-state CTA → create-dimension dialog → chip activation flow.
    */
   test('creates a new dimension from the empty-state CTA and selects it', async ({ page }) => {
     // Timestamp the name to dodge ConflictError from prior runs against the

--- a/pillars/shell/e2e/media-watch-history.spec.ts
+++ b/pillars/shell/e2e/media-watch-history.spec.ts
@@ -1,11 +1,11 @@
 /**
- * E2E — Media watch history: log a watch event (#2117)
+ * E2E — Media watch history: log a watch event
  *
- * Tier 2 flow: navigate to a seeded movie detail page (Interstellar), click
+ * Navigate to a seeded movie detail page (Interstellar), click
  * "Mark as Watched", visit /media/history, and confirm the movie appears as a
  * recent watch entry with a timestamp.
  *
- * Seed context (see apps/pops-api/src/db/seeder.ts):
+ * Seed context:
  *   Seeded watch_history rows include Shawshank, Godfather, Dark Knight,
  *   Pulp Fiction, LOTR — so Interstellar is NOT pre-watched and is the
  *   natural candidate for "log a new watch event".

--- a/pillars/shell/e2e/media-watchlist-add-remove.spec.ts
+++ b/pillars/shell/e2e/media-watchlist-add-remove.spec.ts
@@ -1,12 +1,12 @@
 /**
- * E2E — Media watchlist: add and remove an item (#2116)
+ * E2E — Media watchlist: add and remove an item
  *
- * Tier 2 flow: navigate to a seeded movie detail page, click "Add to
+ * Navigate to a seeded movie detail page, click "Add to
  * Watchlist", visit /media/watchlist, confirm the movie appears, then remove
  * it via the detail page toggle and confirm it no longer appears in the
  * watchlist list.
  *
- * Seed context (see apps/pops-api/src/db/seeder.ts):
+ * Seed context:
  *   The seeded watchlist contains Matrix, Interstellar, Fight Club (movies)
  *   and Shogun (TV). Forrest Gump is NOT seeded onto the watchlist and NOT in
  *   watch_history, so it is the natural candidate for "add a fresh item".

--- a/pillars/shell/e2e/pops-apps-finance-only-not-installed.spec.ts
+++ b/pillars/shell/e2e/pops-apps-finance-only-not-installed.spec.ts
@@ -1,6 +1,5 @@
 /**
- * Install-set switching E2E — finance-only build (PRD-101 US-11
- * follow-up, issue #2595).
+ * Install-set switching E2E — finance-only build.
  *
  * A regression here means an operator-selected install set no longer
  * isolates uninstalled modules behind `NotInstalledPage`, blurring the

--- a/pillars/shell/e2e/pops-apps-finance-only-search.spec.ts
+++ b/pillars/shell/e2e/pops-apps-finance-only-search.spec.ts
@@ -1,6 +1,5 @@
 /**
- * Install-set switching E2E — search results narrow with the install set
- * (PRD-101 US-11 follow-up, issue #2595).
+ * Install-set switching E2E — search results narrow with the install set.
  *
  * A regression here means the `isInstalledModule` filter has broken or
  * the finance-only shell is consuming the wrong registry snapshot —

--- a/pillars/shell/e2e/settings-persistence.spec.ts
+++ b/pillars/shell/e2e/settings-persistence.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Tier 3 — Settings change, save, and persistence (#2136)
+ * Settings change, save, and persistence
  *
  * Navigates to /settings, deep-links to the media.rotation section, changes
  * a non-critical capacity setting ("Target Free Space (GB)") via the auto-save

--- a/pillars/shell/e2e/transactions-date-range-filter.spec.ts
+++ b/pillars/shell/e2e/transactions-date-range-filter.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Tier 3 — Finance transactions date range filter (#2124)
+ * Finance transactions date range filter
  *
  * Exercises the date range filter on `/finance/transactions` against the real
- * API seeded with 16 transactions (see `apps/pops-api/src/db/seeder.ts`).
+ * API seeded with 16 transactions.
  *
  * Filter mechanism:
  *   `TRANSACTION_TABLE_FILTERS` (pillars/finance/app/src/pages/transactions/columns.tsx)

--- a/pillars/shell/e2e/transactions-integration.spec.ts
+++ b/pillars/shell/e2e/transactions-integration.spec.ts
@@ -10,7 +10,7 @@
  *     we test the UI flow and request payload, not the DB write.
  *   - Read operations (transactions.list, suggestTags) are fully real.
  *
- * Seeded data reference (from src/db/seeder.ts):
+ * Seeded data reference:
  *   - txn-001: "Salary Payment", Bank Account, Income, tags: ["Salary"]
  *   - txn-003: "Woolworths Metro", Credit Card, Expense, tags: ["Groceries"]
  *   - txn-006: "Netflix Subscription", Credit Card, Expense, tags: ["Entertainment","Subscriptions"]

--- a/pillars/shell/e2e/wishlist-crud.spec.ts
+++ b/pillars/shell/e2e/wishlist-crud.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E test — Finance wish list CRUD (#2110)
+ * E2E test — Finance wish list CRUD
  *
  * Exercises the full create → confirm → edit priority → confirm → delete → confirm
  * flow at `/finance/wishlist` against the seeded e2e SQLite environment.

--- a/pillars/shell/nginx.conf
+++ b/pillars/shell/nginx.conf
@@ -9,8 +9,8 @@ server {
     # load time for literal `proxy_pass <name>`), letting nginx boot
     # even when an optional pillar container is missing. Every `proxy_pass`
     # in this file uses the variable form so the shell always boots — a
-    # registry-driven boot-render (PRD-255) must never hard-fail on an
-    # absent pillar — and new upstreams must adopt the same form.
+    # registry-driven boot-render must never hard-fail on an absent
+    # pillar — and new upstreams must adopt the same form.
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Gzip compression
@@ -140,10 +140,10 @@ server {
     #
     # Variable-form `proxy_pass` (like every other upstream here) so the
     # shell boots even when media-api is unreachable — a registry-driven
-    # boot-render must never hard-fail the image on an absent pillar
-    # (PRD-255). The location prefix matches the upstream path, so the bare
-    # host:port variable plus the unchanged `$request_uri` reproduces the
-    # previous literal `http://media-api:3003/media/images/` target.
+    # boot-render must never hard-fail the image on an absent pillar.
+    # The location prefix matches the upstream path, so the bare host:port
+    # variable plus the unchanged `$request_uri` resolves to the
+    # `http://media-api:3003/media/images/` target.
     location /media/images/ {
         set $media_images_upstream http://media-api:3003;
         proxy_pass $media_images_upstream;
@@ -194,7 +194,7 @@ server {
         proxy_send_timeout 10s;
     }
 
-    # Registry pillar SSE stream (PRD-163). `GET /registry/subscribe`
+    # Registry pillar SSE stream. `GET /registry/subscribe`
     # is a plain-HTTP Server-Sent-Events endpoint on the registry pillar (NOT
     # a tRPC subscription). Proxy buffering is disabled and the read
     # timeout is long so the stream stays open; the handler already sets
@@ -236,7 +236,7 @@ server {
         proxy_send_timeout 10s;
     }
 
-    # API docs browser — Theme 13 PRD-219.
+    # API docs browser.
     #
     # `pops-docs` is a tiny static nginx image serving Stoplight Elements
     # pointed at every contract package's OpenAPI snapshot. Variable-form

--- a/pillars/shell/scripts/build-registry-snapshot.ts
+++ b/pillars/shell/scripts/build-registry-snapshot.ts
@@ -1,35 +1,33 @@
 #!/usr/bin/env tsx
 /**
- * Build a runtime-only registry snapshot for E2E install-set switching
- * (PRD-101 US-11 follow-up, issue #2595).
+ * Build a runtime-only registry snapshot for E2E install-set switching.
  *
  * The canonical `pnpm registry:build` emits a TypeScript source file at
- * `packages/module-registry/src/generated.ts` that requires `tsc` to
- * compile. That pipeline is well suited to the single-build, committed-
- * output workflow it was designed for, but the Playwright harness needs
- * to spin up two shell builds in the same `pnpm test:e2e` run with
- * different `POPS_APPS` values without mutating the committed registry.
+ * `libs/module-registry/src/generated.ts` that requires `tsc` to
+ * compile. That pipeline suits the single-build, committed-output
+ * workflow it was designed for, but the Playwright harness needs to spin
+ * up two shell builds in the same `pnpm test:e2e` run with different
+ * `POPS_APPS` values without mutating the committed registry.
  *
  * This script bypasses the `generated.ts → tsc` path entirely. It uses
  * the same pure pipeline pieces the registry build does
  * (`discoverManifestSources`, `ALWAYS_INSTALLED_IDS`, `resolveInstalledIds`,
  * `validateManifests`, `project`) to compute the same `MODULES`
- * projection the canonical build would produce, then emits a single
- * plain-JS module file ready to be `resolve.alias`-pointed at by Vite.
+ * projection the canonical build produces, then emits a single plain-JS
+ * module file ready to be `resolve.alias`-pointed at by Vite.
  *
- * Output shape mirrors `@pops/module-registry`'s public surface that
- * the shell actually imports (`KNOWN_MODULES`, `MODULES`, `findModule`,
- * `isModuleId`, plus `INSTALLED_MODULES` / `isInstalledModule` from the
- * PRD-218 US-01 runtime shim). Settings sub-exports are intentionally
- * not emitted — the shell does not consume them at runtime; only the
- * API does, and the API does not switch install sets per Playwright
- * project.
+ * Output shape mirrors `@pops/module-registry`'s public surface that the
+ * shell actually imports (`KNOWN_MODULES`, `MODULES`, `findModule`,
+ * `isModuleId`, plus `INSTALLED_MODULES` / `isInstalledModule`). Settings
+ * sub-exports are intentionally not emitted — the shell does not consume
+ * them at runtime; only the API does, and the API does not switch install
+ * sets per Playwright project.
  *
  * Usage:
  *   tsx scripts/build-registry-snapshot.ts <output-file>
  *
  * The script reads `POPS_APPS` and `POPS_OVERLAYS` from `process.env`,
- * matching the build-time contract documented in PRD-100.
+ * matching the build-time install-set contract.
  */
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';

--- a/pillars/shell/scripts/bundle-nginx-tools.ts
+++ b/pillars/shell/scripts/bundle-nginx-tools.ts
@@ -2,7 +2,8 @@
 /**
  * Bundle the nginx render + watcher CLIs into standalone ESM so the
  * production `nginx:alpine` image can run them with a bare node binary
- * and **no** `node_modules` (Theme 13 PRD-255 US-02/US-03).
+ * and **no** `node_modules`
+ * (docs/themes/federation/prds/prod-registry-driven-nginx).
  *
  * The generator (`generate-nginx-conf.ts`) and watcher
  * (`watch-registry-and-reload-cli.ts`) import `@pops/pillar-sdk`, which

--- a/pillars/shell/scripts/docker-entrypoint.test.ts
+++ b/pillars/shell/scripts/docker-entrypoint.test.ts
@@ -12,10 +12,11 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ENTRYPOINT = resolve(SCRIPT_DIR, '..', 'docker-entrypoint.sh');
 
 /**
- * The boot entrypoint (PRD-255) is the only thing standing between a
- * registry outage and a dead shell. These guards pin the load-bearing
- * invariants so a future edit can't quietly break the "always boots"
- * contract or the supervision shape.
+ * The boot entrypoint
+ * (docs/themes/federation/prds/prod-registry-driven-nginx) is the only
+ * thing standing between a registry outage and a dead shell. These guards
+ * pin the load-bearing invariants so a future edit can't quietly break
+ * the "always boots" contract or the supervision shape.
  */
 describe('docker-entrypoint.sh', () => {
   it('declares a strict shell and errexit/nounset', async () => {

--- a/pillars/shell/scripts/generate-nginx-conf.test.ts
+++ b/pillars/shell/scripts/generate-nginx-conf.test.ts
@@ -109,7 +109,7 @@ describe('generate-nginx-conf', () => {
   describe('rendered output structure', () => {
     const rendered = renderNginxConf();
 
-    it('renders no per-pillar /trpc-<id>/ dispatcher blocks (G6 cut — pillars no longer serve /trpc)', () => {
+    it('renders no per-pillar /trpc-<id>/ dispatcher blocks (pillars serve REST, not /trpc)', () => {
       for (const id of PILLARS) {
         expect(rendered).not.toContain(`location /trpc-${id}/ {`);
       }
@@ -178,9 +178,9 @@ describe('generate-nginx-conf', () => {
       expect(rendered).toContain('set $registry_api_upstream http://registry-api:3001;');
     });
 
-    it('no longer emits the transitional /core-api alias (core→registry rename complete)', () => {
-      // The shell's registry client now posts to `/registry-api/`; the legacy
-      // `/core-api/` alias block is fully removed.
+    it('emits no /core-api alias — the registry pillar is reached at /registry-api', () => {
+      // The shell's registry client posts to `/registry-api/`; there is no
+      // `/core-api/` alias block.
       expect(rendered).not.toContain('location /core-api/ {');
       expect(rendered).not.toContain('core-api');
     });
@@ -230,12 +230,12 @@ describe('generate-nginx-conf', () => {
       );
     });
 
-    it('no longer renders the legacy /trpc → pops-api catch-all (02 decommission)', () => {
+    it('renders no /trpc → pops-api monolith catch-all', () => {
       expect(rendered).not.toContain('location /trpc {');
       expect(rendered).not.toMatch(/proxy_pass http:\/\/pops-api:3000/);
     });
 
-    it('routes the relocated raw routes to their new pillars (02 R1/R2)', () => {
+    it('routes the relocated raw routes (Up Bank webhook, inventory byte routes) to their pillars', () => {
       expect(rendered).toMatch(
         /location \/webhooks\/up \{[\s\S]*?set \$up_webhook_upstream http:\/\/finance-api:3004;/
       );
@@ -320,7 +320,7 @@ describe('generate-nginx-conf', () => {
     });
   });
 
-  describe('resolveUpstreamForEntry (PRD-232)', () => {
+  describe('resolveUpstreamForEntry', () => {
     it('returns the canonical PILLAR_UPSTREAMS host:port for known pillars regardless of baseUrl', () => {
       const entry: Pick<DiscoveredPillar, 'pillarId' | 'baseUrl'> = {
         pillarId: 'finance',
@@ -365,7 +365,7 @@ describe('generate-nginx-conf', () => {
     });
   });
 
-  describe('orderUpstreams (PRD-232)', () => {
+  describe('orderUpstreams', () => {
     it('places known pillars first in PILLAR_RENDER_ORDER, then unknowns alphabetically', () => {
       const upstreams: PillarUpstream[] = [
         { pillarId: 'plugin-z', host: 'z', port: 1 },
@@ -378,7 +378,7 @@ describe('generate-nginx-conf', () => {
     });
   });
 
-  describe('renderNginxConfFromUpstreams (PRD-232)', () => {
+  describe('renderNginxConfFromUpstreams', () => {
     it('renders zero pillar blocks for an empty registry but keeps head + tail', () => {
       const rendered = renderNginxConfFromUpstreams([]);
       expect(rendered).not.toMatch(/location \/trpc-[a-z]/);
@@ -428,7 +428,7 @@ describe('generate-nginx-conf', () => {
     });
   });
 
-  describe('renderNginxConfDynamic (PRD-232)', () => {
+  describe('renderNginxConfDynamic', () => {
     it('emits a config that mirrors the static output when the registry advertises every known pillar', async () => {
       const transport = makeTransport(
         PILLARS.map((id) => ({
@@ -440,7 +440,7 @@ describe('generate-nginx-conf', () => {
       expect(rendered).toBe(renderNginxConf());
     });
 
-    it('emits zero pillar blocks for an empty registry (snapshot)', async () => {
+    it('emits zero pillar blocks for an empty registry', async () => {
       const rendered = await renderNginxConfDynamic('http://registry-api:3001', makeTransport([]));
       for (const id of PILLARS) {
         expect(rendered).not.toContain(`location /${id}-api/ {`);
@@ -486,7 +486,7 @@ describe('generate-nginx-conf', () => {
     });
   });
 
-  describe('parseCliArgs (PRD-232)', () => {
+  describe('parseCliArgs', () => {
     it('defaults: static mode, default output, default registry url', () => {
       const opts = parseCliArgsForGenerator([]);
       expect(opts.dynamic).toBe(false);

--- a/pillars/shell/scripts/generate-nginx-conf.ts
+++ b/pillars/shell/scripts/generate-nginx-conf.ts
@@ -2,22 +2,22 @@
 /**
  * Generate `pillars/shell/nginx.conf` from a single source of truth.
  *
- * Theme 13 PRD-217 + PRD-232. Two render modes share the same template:
+ * See docs/themes/federation/prds/nginx-config-generator. Two render
+ * modes share the same template:
  *
  *   - **Static** (default) — reads `PILLARS` from `@pops/pillar-sdk` and
  *     `PILLAR_UPSTREAMS` below. Used at image-build time so the committed
  *     `nginx.conf` is reproducible without a live registry-api. The drift
  *     test guards this output.
  *
- *   - **Dynamic** (`--dynamic`) — PRD-232, Wave 6 BE-lego. Reads the
- *     live `pillar_registry` via the SDK's `HttpDiscoveryTransport`,
- *     which currently fetches `GET /core.registry.list` (the route core
- *     mounts today; the canonical `GET /registry/pillars` is introduced
- *     in a later phase and is not live yet), and emits one
- *     `/<pillar>-api/` REST block per registered pillar.
- *     Used at boot-time inside the cluster: an init container (or a future
- *     subscription-bus watcher, PRD-163) runs the script with
- *     `--dynamic` so newly-registered external pillars (PRD-228) pick
+ *   - **Dynamic** (`--dynamic`) — reads the live registry via the SDK's
+ *     `HttpDiscoveryTransport`, which fetches the canonical
+ *     `GET /registry/pillars` (falling back to the legacy
+ *     `GET /core.registry.list` on a 404 during a rolling deploy), and
+ *     emits one `/<pillar>-api/` REST block per registered pillar. Used
+ *     at boot-time inside the cluster: an init container (or the
+ *     subscription-bus watcher, watch-registry-and-reload.ts) runs the
+ *     script with `--dynamic` so newly-registered external pillars pick
  *     up routing without a fresh shell image.
  *
  *     Known core pillars (those in `PILLAR_UPSTREAMS`) keep their
@@ -39,8 +39,8 @@
  *   tsx generate-nginx-conf.ts --dynamic --out … --registry-url=http://registry-api:3001
  *
  * The event-driven `nginx -s reload` wrapper that re-runs the dynamic
- * mode on each registry subscription event (`GET /registry/subscribe`) is
- * intentionally NOT shipped here; see PRD-163 follow-up.
+ * mode on each registry subscription event (`GET /registry/subscribe`)
+ * lives in watch-registry-and-reload.ts, not here.
  */
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -60,17 +60,17 @@ import { DEFAULT_REGISTRY_URL, resolveRegistryUrl } from './registry-url-env.ts'
 
 /**
  * In-tree pillar id, keyed off the curated `PILLARS` value (NOT the SDK's
- * `KnownPillarId` type, which RD-9 widened to `string`). This local literal
- * union is what `PILLAR_UPSTREAMS` is keyed on, so the exhaustiveness guard —
- * "every curated pillar ships a port" — survives the type-widening: a new
- * entry in `PILLARS` without a matching `PILLAR_UPSTREAMS` port still fails
- * typecheck here.
+ * `KnownPillarId`, which is a plain `string`). This local literal union is
+ * what `PILLAR_UPSTREAMS` is keyed on, so the exhaustiveness guard —
+ * "every curated pillar ships a port" — holds despite the widened SDK
+ * type: a new entry in `PILLARS` without a matching `PILLAR_UPSTREAMS`
+ * port still fails typecheck here.
  */
 type BuildPillarId = (typeof PILLARS)[number];
 
 /**
- * Internal port assignment for each pillar's API container. Matches every
- * `proxy_pass` in the pre-generator hand-written `nginx.conf`.
+ * Internal port assignment for each pillar's API container, fed into the
+ * `proxy_pass` upstream of every rendered `/<pillar>-api/` block.
  *
  * `Record<BuildPillarId, …>` forces every pillar in the curated `PILLARS`
  * value (in `@pops/pillar-sdk`) to ship a port here; missing entries fail
@@ -102,9 +102,9 @@ function knownUpstream(pillarId: string): { host: string; port: number } | undef
 }
 
 /**
- * Stable ordering for the rendered `/<id>-api/` blocks. Matches the
- * order PRD-190 shipped in the hand-written conf so the generator's
- * first run produces a byte-identical (modulo header comment) file.
+ * Stable ordering for the rendered `/<id>-api/` blocks. Load-bearing:
+ * the drift test compares the rendered output byte-for-byte against the
+ * committed `nginx.conf`, so reordering this changes the committed file.
  */
 export const PILLAR_RENDER_ORDER: readonly BuildPillarId[] = [
   'registry',
@@ -188,8 +188,7 @@ export function renderNginxConf(order: readonly BuildPillarId[] = PILLAR_RENDER_
 /**
  * Pure renderer (dynamic mode). Takes an explicit list of upstreams in
  * the order they should appear in the output. Empty input is valid and
- * produces a config with zero per-pillar `/<pillar>-api/` REST blocks (the
- * monolith catch-all was removed in the 02 decommission).
+ * produces a config with zero per-pillar `/<pillar>-api/` REST blocks.
  */
 export function renderNginxConfFromUpstreams(upstreams: readonly PillarUpstream[]): string {
   if (upstreams.length === 0) {

--- a/pillars/shell/scripts/nginx-cli-args.ts
+++ b/pillars/shell/scripts/nginx-cli-args.ts
@@ -1,7 +1,7 @@
 /**
- * CLI argument parser for `generate-nginx-conf.ts` (Theme 13 PRD-217 +
- * PRD-232). Split out so the generator's renderer stays small and the
- * complexity budget of `parseCliArgs` does not grow with every new flag.
+ * CLI argument parser for `generate-nginx-conf.ts`. Split out so the
+ * generator's renderer stays small and the complexity budget of
+ * `parseCliArgs` does not grow with every new flag.
  *
  * The parser is intentionally hand-written (no commander/yargs) because
  * the surface is tiny and pulling in a CLI framework for four flags is

--- a/pillars/shell/scripts/nginx-cli-main.ts
+++ b/pillars/shell/scripts/nginx-cli-main.ts
@@ -1,8 +1,7 @@
 /**
- * CLI entry-point helpers for `generate-nginx-conf.ts` (Theme 13 PRD-217
- * + PRD-232). Lives in a sibling file so the renderer module stays under
- * the 200-line budget and so the main-loop logic can be unit-tested
- * without forking a subprocess.
+ * CLI entry-point helpers for `generate-nginx-conf.ts`. Lives in a
+ * sibling file so the renderer module stays under the 200-line budget and
+ * so the main-loop logic can be unit-tested without forking a subprocess.
  */
 import { readFile, writeFile } from 'node:fs/promises';
 

--- a/pillars/shell/scripts/nginx-conf-template.ts
+++ b/pillars/shell/scripts/nginx-conf-template.ts
@@ -21,8 +21,8 @@ export const NGINX_CONF_HEAD = `server {
     # load time for literal \`proxy_pass <name>\`), letting nginx boot
     # even when an optional pillar container is missing. Every \`proxy_pass\`
     # in this file uses the variable form so the shell always boots — a
-    # registry-driven boot-render (PRD-255) must never hard-fail on an
-    # absent pillar — and new upstreams must adopt the same form.
+    # registry-driven boot-render must never hard-fail on an absent
+    # pillar — and new upstreams must adopt the same form.
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Gzip compression
@@ -80,10 +80,10 @@ export const NGINX_CONF_TAIL = `    # Relocated raw routes (02): Up Bank webhook
     #
     # Variable-form \`proxy_pass\` (like every other upstream here) so the
     # shell boots even when media-api is unreachable — a registry-driven
-    # boot-render must never hard-fail the image on an absent pillar
-    # (PRD-255). The location prefix matches the upstream path, so the bare
-    # host:port variable plus the unchanged \`$request_uri\` reproduces the
-    # previous literal \`http://media-api:3003/media/images/\` target.
+    # boot-render must never hard-fail the image on an absent pillar.
+    # The location prefix matches the upstream path, so the bare host:port
+    # variable plus the unchanged \`$request_uri\` resolves to the
+    # \`http://media-api:3003/media/images/\` target.
     location /media/images/ {
         set $media_images_upstream http://media-api:3003;
         proxy_pass $media_images_upstream;
@@ -134,7 +134,7 @@ export const NGINX_CONF_TAIL = `    # Relocated raw routes (02): Up Bank webhook
         proxy_send_timeout 10s;
     }
 
-    # Registry pillar SSE stream (PRD-163). \`GET /registry/subscribe\`
+    # Registry pillar SSE stream. \`GET /registry/subscribe\`
     # is a plain-HTTP Server-Sent-Events endpoint on the registry pillar (NOT
     # a tRPC subscription). Proxy buffering is disabled and the read
     # timeout is long so the stream stays open; the handler already sets
@@ -176,7 +176,7 @@ export const NGINX_CONF_TAIL = `    # Relocated raw routes (02): Up Bank webhook
         proxy_send_timeout 10s;
     }
 
-    # API docs browser — Theme 13 PRD-219.
+    # API docs browser.
     #
     # \`pops-docs\` is a tiny static nginx image serving Stoplight Elements
     # pointed at every contract package's OpenAPI snapshot. Variable-form

--- a/pillars/shell/scripts/nginx-event-reload.test.ts
+++ b/pillars/shell/scripts/nginx-event-reload.test.ts
@@ -374,7 +374,7 @@ describe('createReloadHandler', () => {
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
-  it('preserves pre-PRD-228 behaviour when validateConfig is omitted', async () => {
+  it('runs regen then reload with no validate gate when validateConfig is omitted', async () => {
     const calls: string[] = [];
     const regenerate = vi.fn(async () => {
       calls.push('regen');

--- a/pillars/shell/scripts/nginx-event-reload.ts
+++ b/pillars/shell/scripts/nginx-event-reload.ts
@@ -1,7 +1,9 @@
 /**
- * Event-driven nginx regen + reload (Theme 13 PRD-228 US-03).
+ * Event-driven nginx regen + reload
+ * (docs/themes/federation/prds/dynamic-pillar-registration).
  *
- * Subscribes to the registry SSE event bus (PRD-163) and, on each
+ * Subscribes to the registry SSE event bus
+ * (docs/themes/federation/prds/subscription-model) and, on each
  * `pillar.registered` / `pillar.deregistered` / `pillar.health-changed`
  * frame, regenerates the dynamic dispatcher conf and signals nginx to
  * reload. A trailing 250ms debounce coalesces bursts (multi-pillar

--- a/pillars/shell/scripts/nginx-generator-health.ts
+++ b/pillars/shell/scripts/nginx-generator-health.ts
@@ -1,7 +1,8 @@
 /**
- * Health surface for the event-driven nginx reloader (Theme 13 PRD-228
- * US-03). Exposes `nginx_generator_last_error_at` so the registry — or
- * any operator dashboard — can detect a stuck dispatcher generator.
+ * Health surface for the event-driven nginx reloader
+ * (docs/themes/federation/prds/dynamic-pillar-registration). Exposes
+ * `nginx_generator_last_error_at` so the registry — or any operator
+ * dashboard — can detect a stuck dispatcher generator.
  *
  * State model:
  *   - On every successful regen + validate + reload, `lastError` clears

--- a/pillars/shell/scripts/register-with-registry.ts
+++ b/pillars/shell/scripts/register-with-registry.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env tsx
 /**
  * Ops CLI: register the running shell with `pops-registry`'s pillar
- * registry (Theme 13 PRD-228 US-01 + ADR-035).
+ * registry (docs/themes/federation/prds/dynamic-pillar-registration +
+ * ADR-035).
  *
  * The shell's production image is `nginx:alpine` — there is no Node
  * runtime at request time. This script is invoked from outside the

--- a/pillars/shell/scripts/registry-sse-client.ts
+++ b/pillars/shell/scripts/registry-sse-client.ts
@@ -1,6 +1,7 @@
 /**
- * Minimal Node-side SSE consumer for `GET /registry/subscribe` (Theme
- * 13 PRD-163), used by the event-driven nginx reloader (PRD-228 US-03).
+ * Minimal Node-side SSE consumer for `GET /registry/subscribe`
+ * (docs/themes/federation/prds/subscription-model), used by the
+ * event-driven nginx reloader.
  *
  * Uses global `fetch` + `ReadableStream` so the script has no runtime
  * dependency beyond Node 22+ (the pinned engine). Parses just enough of

--- a/pillars/shell/scripts/registry-url-env.ts
+++ b/pillars/shell/scripts/registry-url-env.ts
@@ -1,6 +1,6 @@
 /**
  * Resolve the registry base URL from the environment for the nginx
- * render + watcher paths (Theme 13 PRD-255).
+ * render + watcher paths.
  *
  * `POPS_REGISTRY_URL` is the repo-wide convention (orchestrator, mcp,
  * the SDK bootstrap, and the shell's self-registration all read it), so

--- a/pillars/shell/scripts/watch-registry-and-reload-cli.ts
+++ b/pillars/shell/scripts/watch-registry-and-reload-cli.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env tsx
 /**
- * CLI entrypoint for the Theme 13 PRD-228 US-03 nginx event-reload
- * watcher. Reads env, wires up the optional health endpoint, and runs
- * the watcher until SIGINT/SIGTERM. Kept thin so the watcher core
+ * CLI entrypoint for the nginx event-reload watcher
+ * (docs/themes/federation/prds/dynamic-pillar-registration). Reads env,
+ * wires up the optional health endpoint, and runs the watcher until
+ * SIGINT/SIGTERM. Kept thin so the watcher core
  * (`watchRegistryAndReload`) stays test-friendly.
  */
 import { fileURLToPath } from 'node:url';

--- a/pillars/shell/scripts/watch-registry-and-reload.e2e.test.ts
+++ b/pillars/shell/scripts/watch-registry-and-reload.e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * End-to-end integration test for the PRD-228 US-03 watcher.
+ * End-to-end integration test for the nginx event-reload watcher.
  *
  * Spins up the SHELL watcher (`watchRegistryAndReload`) against a fake
  * in-process SSE registry, fires `pillar.registered` + `pillar.deregistered`
@@ -12,9 +12,10 @@
  *     `nginx_generator_last_error_at` health surface flips to degraded.
  *   - On the next successful cycle, the error clears.
  *
- * Mirrors the in-process e2e in `pillars/registry` US-05 — same shape,
- * but exercised THROUGH the watcher rather than against the registry's
- * mutation handlers directly.
+ * Mirrors the in-process e2e in
+ * `pillars/registry/src/api/__tests__/external-pillar-e2e.test.ts` — same
+ * shape, but exercised THROUGH the watcher rather than against the
+ * registry's mutation handlers directly.
  */
 import { createServer, type Server } from 'node:http';
 

--- a/pillars/shell/scripts/watch-registry-and-reload.ts
+++ b/pillars/shell/scripts/watch-registry-and-reload.ts
@@ -1,6 +1,8 @@
 /**
- * Long-running watcher that ties PRD-163's registry SSE stream to
- * PRD-232's dynamic nginx generator (Theme 13 PRD-228 US-03).
+ * Long-running watcher that ties the registry SSE stream
+ * (docs/themes/federation/prds/subscription-model) to the dynamic nginx
+ * generator (docs/themes/federation/prds/nginx-config-generator). Part of
+ * docs/themes/federation/prds/dynamic-pillar-registration.
  *
  * Opens `GET <registry-url>/registry/subscribe`, ignores the initial
  * `pillar.snapshot` frame, and on every subsequent registered /

--- a/pillars/shell/src/app/IndexRedirect.tsx
+++ b/pillars/shell/src/app/IndexRedirect.tsx
@@ -6,7 +6,7 @@ import { Navigate } from 'react-router';
 import { useRegisteredApps } from './BootRegistryProvider';
 
 /**
- * `/` redirect that respects the installed-modules manifest (PRD-100).
+ * `/` redirect that respects the installed-modules manifest.
  * Picks the first installed app from the LIVE `registeredApps` (manifest
  * `nav.order` ascending, lexicographic tiebreak — see `nav/registry.ts`);
  * falls back to `/settings` if no apps are installed.

--- a/pillars/shell/src/app/boot-online-render.test.tsx
+++ b/pillars/shell/src/app/boot-online-render.test.tsx
@@ -1,14 +1,12 @@
 /**
- * Online-path render test (P7-T03 / RD-3, MUST-FIX 2).
+ * Online-path render test for the registry-driven boot branch.
  *
- * The registry-driven boot branch is this PR's entire purpose, yet it had no
- * rendered coverage: the gated Playwright suite (workflow_dispatch only — it
- * targets the deleted tRPC monolith) never runs in PR CI, and even when it
- * did, dev Vite had no `/registry-api` proxy and the e2e harness swaps a
- * build-time `@pops/module-registry` snapshot, so the boot fetch 404s and the
- * shell silently soft-falls to `[]` → the static floor. Every e2e therefore
- * exercises ONLY the floor; a regression that breaks only the live mount would
- * pass all CI green and surface only in production.
+ * That branch has no rendered coverage from the gated Playwright suite
+ * (workflow_dispatch only): dev Vite has no `/registry-api` proxy and the e2e
+ * harness swaps a build-time `@pops/module-registry` snapshot, so the boot
+ * fetch 404s and the shell silently soft-falls to `[]` → the static floor.
+ * Every e2e therefore exercises ONLY the floor; a regression that breaks only
+ * the live mount would pass all CI green and surface only in production.
  *
  * This drives the real online pipeline end-to-end in jsdom: a stubbed `fetch`
  * serves a NON-EMPTY snapshot (one in-repo pillar + one external pillar) →

--- a/pillars/shell/src/app/bundle-map.tsx
+++ b/pillars/shell/src/app/bundle-map.tsx
@@ -2,40 +2,35 @@ import { useEffect } from 'react';
 
 /**
  * Workspace bundle map — single source enumerating in-repo pillar ids in the
- * shell (PRD-243 US-03).
+ * shell.
  *
  * The shell discovers each in-repo pillar's UI surface (nav + pages +
- * capture overlay) by walking this map. For external pillars (PRD-228)
- * the registry advertises an `assetsBaseUrl` and the wire-shaped `nav` /
- * `pages` descriptors; those never appear in this map (ADR-002 keeps the
- * in-repo FE a single static SPA). They reach the shell through the
- * runtime loader in `external-ui.tsx`, which lazy-`import()`s the remote
- * bundle (PRD-243 US-05, Option A).
+ * capture overlay) by walking this map. For external pillars the registry
+ * advertises an `assetsBaseUrl` and the wire-shaped `nav` / `pages`
+ * descriptors; those never appear in this map (ADR-002 keeps the in-repo FE
+ * a single static SPA). They reach the shell through the runtime loader in
+ * `external-ui.tsx`, which lazy-`import()`s the remote bundle (Option A).
  *
  * Each entry carries:
  *
  *   - `manifest`              — the frontend `ModuleManifest` re-exported
  *                               by the pillar's `@pops/app-*` workspace
  *                               package. Provides `frontend.routes`
- *                               (lazy `RouteObject[]`), the legacy
- *                               `navConfig`, and (PRD-246 US-03) the
+ *                               (lazy `RouteObject[]`), `navConfig`, and the
  *                               `frontend.captureOverlay` descriptor.
  *                               Bound by static import because the
  *                               current shell consumer surface is
  *                               synchronous.
  *   - `navOrder`              — mirrors `nav.order` from the pillar's
  *                               wire-format manifest payload
- *                               (`apps/pops-<id>-api/src/manifest.ts`).
- *                               Values follow the reconciled sparse
- *                               scheme (finance=10, media=20,
- *                               inventory=30, food=40, lists=50,
- *                               cerebrum=60, ai=70) so the app rail
- *                               renders the same seven entries in the
- *                               same order as the pre-PR `registeredApps`
- *                               literal.
+ *                               (`pillars/<id>/src/api/manifest.ts`).
+ *                               Values follow the sparse scheme (finance=10,
+ *                               media=20, inventory=30, food=40, lists=50,
+ *                               cerebrum=60, ai=70) so the app rail renders
+ *                               the seven entries in that order.
  *   - `captureOverlayBundles` — kebab-case bundle slot → component +
  *                               (optional) hook reference. The shell's
- *                               `CaptureModal` (PRD-246 US-03) resolves
+ *                               `CaptureModal` resolves
  *                               `manifest.frontend.captureOverlay.bundleSlot`
  *                               through this record to obtain the React
  *                               component to mount. Cerebrum binds
@@ -48,7 +43,7 @@ import { useEffect } from 'react';
  *
  * Adding a new in-repo pillar = adding one entry here. External pillars
  * never appear in this map; they reach the shell via the registry walk and
- * the asset-URL loading path in `external-ui.tsx` (PRD-243 US-05).
+ * the asset-URL loading path in `external-ui.tsx`.
  */
 import { manifest as aiManifest } from '@pops/app-ai';
 import { IngestForm, manifest as cerebrumManifest, useIngestPageModel } from '@pops/app-cerebrum';

--- a/pillars/shell/src/app/capture/CaptureHotkeyHost.test.tsx
+++ b/pillars/shell/src/app/capture/CaptureHotkeyHost.test.tsx
@@ -1,8 +1,3 @@
-/**
- * PRD-246 US-03: CaptureHotkeyHost no longer reads cerebrum's
- * CEREBRUM_CAPTURE_HOTKEY setting — it reads the active overlay's
- * descriptor hotkey from the manifest registry walk.
- */
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -48,7 +43,7 @@ function syntheticOverlay(hotkey: string | undefined): ActiveCaptureOverlay {
   };
 }
 
-describe('CaptureHotkeyHost (PRD-246 US-03)', () => {
+describe('CaptureHotkeyHost', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.activeCaptureOverlay.mockReturnValue(null);

--- a/pillars/shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/pillars/shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -1,18 +1,14 @@
 /**
- * CaptureHotkeyHost — owns the global capture hotkey binding (PRD-081
- * US-09, rewritten under PRD-246 US-03 to close audit H8/H9).
+ * CaptureHotkeyHost — owns the global capture hotkey binding.
  *
  * Reads the active capture overlay's `hotkey` descriptor from the
- * registry walk and binds it via `useCaptureHotkey`. The previous
- * implementation read the hotkey from cerebrum's
- * `CEREBRUM_CAPTURE_HOTKEY` core setting at runtime — that path is gone.
- * Pillars that want a different hotkey publish a different
- * `captureOverlay.hotkey` value on their manifest.
+ * registry walk and binds it via `useCaptureHotkey`. Pillars that want
+ * a different hotkey publish a different `captureOverlay.hotkey` value
+ * on their manifest.
  *
- * When no manifest contributes a `captureOverlay` (e.g. cerebrum is
- * not in the install set and no successor pillar declared the
- * dimension), the host renders the modal anyway — the modal handles
- * the empty surface — but does not bind any hotkey.
+ * When no manifest contributes a `captureOverlay`, the host renders the
+ * modal anyway — the modal handles the empty surface — but does not bind
+ * any hotkey.
  */
 import { useCallback, useMemo, useState } from 'react';
 

--- a/pillars/shell/src/app/capture/CaptureModal.test.tsx
+++ b/pillars/shell/src/app/capture/CaptureModal.test.tsx
@@ -1,10 +1,3 @@
-/**
- * PRD-246 US-03: CaptureModal mounts the bundle resolved from the
- * registry walk and falls back to an empty surface when no overlay is
- * registered. The cerebrum coupling that previously sat at the top of
- * the file is gone — these tests prove the modal works with synthetic
- * bundles.
- */
 import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { describe, expect, it } from 'vitest';
@@ -42,7 +35,7 @@ function syntheticOverlay(props: {
   };
 }
 
-describe('CaptureModal (PRD-246 US-03)', () => {
+describe('CaptureModal', () => {
   it('renders the resolved bundle inside the dialog when open', () => {
     render(
       withI18n(

--- a/pillars/shell/src/app/capture/CaptureModal.tsx
+++ b/pillars/shell/src/app/capture/CaptureModal.tsx
@@ -1,11 +1,9 @@
 /**
- * CaptureModal — global capture surface rendered as a Dialog (PRD-081
- * US-09, rewritten under PRD-246 US-03 to close audit findings H8/H9).
+ * CaptureModal — global capture surface rendered as a Dialog.
  *
  * Discovers the active capture overlay by walking the registry
  * (`activeCaptureOverlay()` over `installedFrontendManifests()` +
- * `WORKSPACE_BUNDLE_MAP`) rather than hard-importing cerebrum's
- * `IngestForm` + `useIngestPageModel`. The selection rule lives in
+ * `WORKSPACE_BUNDLE_MAP`). The selection rule lives in
  * `./capture-registry.ts`; this file is responsible for:
  *
  *   - Mounting the resolved bundle's `Mount` component inside the

--- a/pillars/shell/src/app/capture/capture-hotkey-helpers.ts
+++ b/pillars/shell/src/app/capture/capture-hotkey-helpers.ts
@@ -1,6 +1,6 @@
 /**
- * Pure helpers for the global capture hotkey (PRD-081 US-09). Extracted
- * so the suppression logic can be unit-tested without rendering a hook.
+ * Pure helpers for the global capture hotkey. Extracted so the
+ * suppression logic can be unit-tested without rendering a hook.
  */
 
 const IGNORE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);

--- a/pillars/shell/src/app/capture/capture-registry.test.ts
+++ b/pillars/shell/src/app/capture/capture-registry.test.ts
@@ -8,10 +8,10 @@ import {
 } from './capture-registry';
 
 /**
- * PRD-246 US-03 unit tests for the capture-overlay registry walk.
- * Exercises the selection rule (sort by order, tiebreak by pillarId)
- * and the bundle-map resolution edge cases (no overlay registered,
- * unknown bundleSlot).
+ * Unit tests for the capture-overlay registry walk. Exercises the
+ * selection rule (sort by order, tiebreak by pillarId) and the
+ * bundle-map resolution edge cases (no overlay registered, unknown
+ * bundleSlot).
  */
 import type { ComponentType } from 'react';
 

--- a/pillars/shell/src/app/capture/capture-registry.ts
+++ b/pillars/shell/src/app/capture/capture-registry.ts
@@ -1,15 +1,15 @@
 import { WORKSPACE_BUNDLE_MAP, type BundleEntry, type CaptureOverlayBundle } from '../bundle-map';
 /**
- * Capture-overlay registry walk (PRD-246 US-03).
+ * Capture-overlay registry walk.
  *
  * Projects `installedFrontendManifests()` onto the
- * `frontend.captureOverlay` dimension, applies the selection rule from
- * the spec (sort ascending by `order`, ties broken alphabetically by
- * pillar id, pick head), and resolves the descriptor's `bundleSlot`
- * through the workspace bundle map to obtain the React component the
- * shell's `CaptureModal` will mount.
+ * `frontend.captureOverlay` dimension, applies the selection rule (sort
+ * ascending by `order`, ties broken alphabetically by pillar id, pick
+ * head), and resolves the descriptor's `bundleSlot` through the
+ * workspace bundle map to obtain the React component the shell's
+ * `CaptureModal` will mount.
  *
- * Failure modes mirror PRD-243 US-03's `pages` resolution edge cases:
+ * Failure modes mirror the `pages` resolution edge cases:
  *
  *   - No manifest contributes a `captureOverlay` → returns `null`; the
  *     modal renders an empty state (`captureModal.empty`).
@@ -51,13 +51,13 @@ function compareRanked(a: RankedCaptureOverlay, b: RankedCaptureOverlay): number
 }
 
 /**
- * Selection rule from the spec. Exported for unit tests.
+ * Selection rule. Exported for unit tests.
  *
  * Returns every manifest whose `frontend.captureOverlay` is defined,
  * sorted ascending by `order` with ties broken alphabetically by
- * `pillarId`. The shell consumes only the head element today — the
- * full list is exposed so the spec's "duplicate hotkey" warning has
- * the full set to diff against (handled in `useCaptureOverlay`).
+ * `pillarId`. The shell consumes only the head element — the full list
+ * is exposed so the "duplicate hotkey" warning has the full set to diff
+ * against (handled in `warnOnDuplicateHotkeys`).
  */
 export function rankCaptureOverlays(
   manifests: readonly FrontendManifest[]
@@ -95,13 +95,13 @@ export function resolveCaptureOverlay(
 
 /**
  * The head of the ranked list, resolved against the workspace bundle
- * map. Returns `null` (and logs a `debug` line) when no manifest
+ * map. Returns `null` (and logs a structured warning) when no manifest
  * contributes a `captureOverlay` — the modal renders the empty-state
  * surface in that case.
  *
- * Exported for unit tests; the live consumer is `useCaptureOverlay()`
- * which threads the same call through React and additionally emits the
- * duplicate-hotkey warning across the full ranked list.
+ * Exported for unit tests; the live consumer is `activeCaptureOverlay()`
+ * below, which additionally emits the duplicate-hotkey warning across
+ * the full ranked list.
  */
 export function selectActiveCaptureOverlay(
   manifests: readonly FrontendManifest[],

--- a/pillars/shell/src/app/capture/useCaptureHotkey.ts
+++ b/pillars/shell/src/app/capture/useCaptureHotkey.ts
@@ -1,9 +1,9 @@
 /**
  * useCaptureHotkey — keyboard shortcut that opens the global capture
- * modal (PRD-081 US-09, generalised under PRD-246 US-03).
+ * modal.
  *
- * Accepts both legacy single-key shortcuts (`'c'`) and the wire-format
- * chord shape declared on `frontend.captureOverlay.hotkey` (e.g.
+ * Accepts both single-key shortcuts (`'c'`) and the wire-format chord
+ * shape declared on `frontend.captureOverlay.hotkey` (e.g.
  * `'cmd+shift+k'`). When a chord with modifiers is supplied the modifier
  * suppression in `capture-hotkey-helpers.ts` is bypassed for the chord
  * itself — focus-inside-input suppression still applies for both shapes.

--- a/pillars/shell/src/app/external-ui.test.tsx
+++ b/pillars/shell/src/app/external-ui.test.tsx
@@ -1,5 +1,5 @@
 /**
- * PRD-243 US-05 — external-pillar UI loading (Option A) unit tests.
+ * External-pillar UI loading (Option A) unit tests.
  *
  * Exercises the runtime loader end to end against a fake remote bundle so
  * no network round-trip is needed:
@@ -131,7 +131,7 @@ describe('synthesizeExternalBundleEntry — descriptor → bundle entry', () => 
   });
 });
 
-describe('external pillar UI — runtime mount (US-05 Option A)', () => {
+describe('external pillar UI — runtime mount (Option A)', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });

--- a/pillars/shell/src/app/external-ui.tsx
+++ b/pillars/shell/src/app/external-ui.tsx
@@ -1,14 +1,14 @@
 /**
- * External-pillar UI loading (PRD-243 US-05, Option A).
+ * External-pillar UI loading (Option A).
  *
  * In-repo pillars reach the shell through the static `WORKSPACE_BUNDLE_MAP`
  * (`./bundle-map.tsx`) — a build-time import graph that ADR-002 keeps as a
  * single static Vite SPA. This module covers the orthogonal case: a pillar
- * the build does not know about, registered at runtime (PRD-228), whose
- * manifest advertises an `assetsBaseUrl`.
+ * the build does not know about, registered at runtime, whose manifest
+ * advertises an `assetsBaseUrl`.
  *
- * The mechanism is the one US-05 recommends (Option A, not Module
- * Federation): the shell `import()`s the pillar's single ESM entry from the
+ * The mechanism is Option A (not Module Federation): the shell `import()`s
+ * the pillar's single ESM entry from the
  * URL it advertises and resolves each `PageDescriptor.bundleSlot` to a React
  * component the remote bundle exports. The nav rail comes off the wire
  * (`NavConfigDescriptor`) so it renders synchronously at boot; the remote

--- a/pillars/shell/src/app/installed-modules.ts
+++ b/pillars/shell/src/app/installed-modules.ts
@@ -1,32 +1,26 @@
 /**
  * Shell-side aggregator that resolves the shell's install set against the
  * workspace bundle map (`./bundle-map.tsx`) — the single place the shell
- * enumerates in-repo pillar ids per PRD-243 US-03.
+ * enumerates in-repo pillar ids. Every installed pillar id resolves through
+ * the workspace bundle map.
  *
- * Prior to PRD-243 this file hand-imported each pillar's frontend
- * manifest by name. The registry walk replaces that: every installed
- * pillar id resolves through the workspace bundle map.
+ * Install-set source: the live registry snapshot is the source of truth for
+ * which pillars mount, not the build-time `MODULES` / `INSTALLED_MODULES`
+ * constants. The async boot path (`main.tsx` → `boot-snapshot.ts`) fetches
+ * the snapshot and walks {@link bootEntries}; if the registry is unreachable
+ * the shell falls back to {@link staticFloorEntries} (the in-repo bundle-map
+ * pillars) so it never bricks. `installedFrontendManifests()` is that static
+ * floor — the synchronous in-repo set the boot path degrades to, and the
+ * source the capture-overlay / manifest-validation tests read.
  *
- * Install-set source (P7-T03 / RD-3): the live registry snapshot is now
- * the source of truth for which pillars mount, not the build-time
- * `MODULES` / `INSTALLED_MODULES` constants. The async boot path
- * (`main.tsx` → `boot-snapshot.ts`) fetches the snapshot and walks
- * {@link bootEntries}; if the registry is unreachable the shell falls
- * back to {@link staticFloorEntries} (the in-repo bundle-map pillars) so
- * it never bricks. `installedFrontendManifests()` is that static floor —
- * the synchronous in-repo set the boot path degrades to, and the source
- * the capture-overlay / manifest-validation tests read.
+ * External pillars that the registry advertises via `assetsBaseUrl` are
+ * absent from the workspace bundle map by design (ADR-002 keeps the in-repo
+ * FE a single static SPA). For those the walk takes the runtime path
+ * (Option A): it lazily `import()`s the pillar's ESM bundle from the
+ * advertised URL and mounts it like an in-repo module. A failed remote load
+ * degrades to skipping the pillar's UI, never crashing the shell.
  *
- * External pillars (PRD-228) that the registry advertises via
- * `assetsBaseUrl` are absent from the workspace bundle map by design
- * (ADR-002 keeps the in-repo FE a single static SPA). For those the walk
- * takes the runtime path (PRD-243 US-05, Option A): it lazily `import()`s
- * the pillar's ESM bundle from the advertised URL and mounts it like an
- * in-repo module. A failed remote load degrades to skipping the pillar's
- * UI, never crashing the shell.
- *
- * See `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-03-shell-registry-walk.md`
- * and `us-05-external-pillar-ui-loading.md`.
+ * See `docs/themes/federation/prds/registry-driven-shell-ui`.
  */
 import { isInstalledModule } from '@pops/module-registry';
 
@@ -86,16 +80,16 @@ export class ExternalUiLoadError extends Error {
 
 /**
  * Minimal "registry entry" shape the shell walks. Mirrors the
- * `PillarSnapshot` projection `discoverSettings()` reads (PRD-240) but
- * carries only the fields PRD-243 needs to decide which UI surface to
- * mount: the pillar id, and — for external pillars (PRD-228) absent from
- * the workspace bundle map — the `assetsBaseUrl` plus the wire-shaped
- * `nav` / `pages` descriptors the runtime loader (US-05) consumes.
+ * `PillarSnapshot` projection `discoverSettings()` reads but carries only
+ * the fields needed to decide which UI surface to mount: the pillar id,
+ * and — for external pillars absent from the workspace bundle map — the
+ * `assetsBaseUrl` plus the wire-shaped `nav` / `pages` descriptors the
+ * runtime loader consumes.
  *
  * In-repo pillars carry only `pillarId`: their UI surface comes from the
  * static bundle map, never the wire. Sourced from the live registry
- * snapshot via {@link bootEntries} (P7-T03), or from the in-repo bundle
- * map via {@link staticFloorEntries} when the registry is unreachable.
+ * snapshot via {@link bootEntries}, or from the in-repo bundle map via
+ * {@link staticFloorEntries} when the registry is unreachable.
  */
 export interface RegistryEntry {
   readonly pillarId: string;
@@ -106,20 +100,19 @@ export interface RegistryEntry {
 
 /**
  * The static install-set floor: the in-repo pillars the shell renders when
- * the live registry is unreachable (the never-brick fallback, P7-T03), and
- * the synchronous source `installedFrontendManifests()` walks.
+ * the live registry is unreachable (the never-brick fallback), and the
+ * synchronous source `installedFrontendManifests()` walks.
  *
  * The floor is the workspace bundle map narrowed by the runtime install
  * shim `isInstalledModule` (the `@pops/module-registry` projection of the
  * build-time `POPS_APPS` contract). The LIVE install set comes from the
  * registry snapshot (`bootEntries`) and is the source of truth; this floor
- * only governs the offline path. Honouring the install shim here keeps that
- * path identical to the pre-P7-T03 behaviour — so an operator's `POPS_APPS`
- * selection still narrows the shell when the registry is down (and the
- * finance-only install-set e2e stays meaningful) — without the shell
- * consulting the build-time `MODULES` superset for the live install set. In-
- * repo pillars carry only `pillarId`; their UI surface comes from the static
- * bundle map.
+ * only governs the offline path. Honouring the install shim here means an
+ * operator's `POPS_APPS` selection still narrows the shell when the registry
+ * is down (and the finance-only install-set e2e stays meaningful) — without
+ * the shell consulting the build-time `MODULES` superset for the live
+ * install set. In-repo pillars carry only `pillarId`; their UI surface comes
+ * from the static bundle map.
  */
 export function staticFloorEntries(): readonly RegistryEntry[] {
   return Object.keys(WORKSPACE_BUNDLE_MAP)
@@ -129,8 +122,8 @@ export function staticFloorEntries(): readonly RegistryEntry[] {
 
 /**
  * Map a live registry snapshot onto the registry-entry list the walk
- * consumes (P7-T03 / RD-3). Only `registered` pillars contribute. For
- * each, the wire `manifest` carries the external-UI surface
+ * consumes. Only `registered` pillars contribute. For each, the wire
+ * `manifest` carries the external-UI surface
  * (`assetsBaseUrl` / `nav` / `pages`); in-repo pillars omit `assetsBaseUrl`
  * and resolve through the static bundle map instead. The snapshot is the
  * sole truth for which pillars mount — backend-only pillars (no bundle-map
@@ -192,14 +185,12 @@ function resolveExternalManifest(
  *
  *   - Bundle map hit → emit the in-repo workspace manifest (ADR-002:
  *     statically bundled, unchanged).
- *   - Bundle map miss + `assetsBaseUrl` set → external pillar (PRD-228).
- *     Synthesize a manifest whose routes lazy-`import()` the remote bundle
- *     (PRD-243 US-05, Option A). A bad descriptor is logged and skipped;
- *     a remote bundle that fails to load later is contained by the
- *     per-route error boundary, not here.
+ *   - Bundle map miss + `assetsBaseUrl` set → external pillar. Synthesize a
+ *     manifest whose routes lazy-`import()` the remote bundle (Option A). A
+ *     bad descriptor is logged and skipped; a remote bundle that fails to
+ *     load later is contained by the per-route error boundary, not here.
  *   - Bundle map miss + no `assetsBaseUrl` → backend-only pillar, drop
- *     silently. Mirrors the pre-PRD-243 behaviour where backend-only
- *     ids simply weren't in `KNOWN_FRONTEND_MANIFESTS`.
+ *     silently.
  *
  * `importer` is injectable for tests; production omits it so the external
  * loader uses the real dynamic `import()`.
@@ -224,11 +215,9 @@ export function walkRegistry(
       if (manifest !== null) out.push(manifest);
       continue;
     }
-    // Backend-only pillars (e.g. `core`) sit in `MODULES` but contribute
+    // Backend-only pillars (e.g. `registry`) sit in `MODULES` but contribute
     // no UI. They never appear in the bundle map and they never advertise
-    // an `assetsBaseUrl`, so the walk drops them silently — mirroring the
-    // pre-PRD-243 behaviour where they simply weren't in
-    // `KNOWN_FRONTEND_MANIFESTS`.
+    // an `assetsBaseUrl`, so the walk drops them silently.
   }
   return out;
 }
@@ -247,9 +236,9 @@ let testOverride: readonly FrontendManifest[] | null = null;
  * The static install-set floor as frontend manifests: every in-repo
  * pillar in the workspace bundle map, walked through {@link walkRegistry}.
  *
- * This is the synchronous in-repo set the live install-set (P7-T03)
- * degrades to when the registry is unreachable, and the source the
- * capture-overlay walk and manifest-validation tests read. The live,
+ * This is the synchronous in-repo set the live install-set degrades to when
+ * the registry is unreachable, and the source the capture-overlay walk and
+ * manifest-validation tests read. The live,
  * snapshot-driven install set is built by the async boot path
  * (`boot-snapshot.ts`), not here.
  */

--- a/pillars/shell/src/app/layout/BuildVersion.tsx
+++ b/pillars/shell/src/app/layout/BuildVersion.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Truncate a version label to a short SHA. Build hashes are 40 chars and
- * blow out the topbar; sequential CI numbers used to be short enough to
- * show in full but the build now stamps the full git SHA. We keep the
- * one-letter prefix (`f` / `a`) and the first 7 hex chars — full value is
- * still available via the title attribute for copy/paste.
+ * Truncate a version label to a short SHA so a 40-char build hash does not
+ * blow out the topbar. Keeps the one-letter prefix (`f` / `a`) and the first
+ * 7 hex chars; the full value stays available via the title attribute for
+ * copy/paste.
  */
 export function shortVersion(raw: string | null | undefined): string | null {
   if (!raw) return null;
@@ -16,7 +15,6 @@ export function shortVersion(raw: string | null | undefined): string | null {
   return `${prefix}${(sha ?? '').slice(0, 7)}`;
 }
 
-/** Faded mono build version label showing frontend and API versions. */
 export function BuildVersion() {
   const [apiVersion, setApiVersion] = useState<string | null>(null);
 

--- a/pillars/shell/src/app/layout/ChatFab.tsx
+++ b/pillars/shell/src/app/layout/ChatFab.tsx
@@ -3,9 +3,9 @@ import { useUIStore } from '@/store/uiStore';
 import { EgoFab } from '@pops/overlay-ego';
 
 /**
- * Shell wiring for the Ego overlay's floating action button (PRD-099).
- * Visual + behaviour live in `@pops/overlay-ego`; this file binds toggle
- * state to the shell's `useUIStore` (PRD-101 US-07 generic overlay map).
+ * Shell wiring for the Ego overlay's floating action button. Visual +
+ * behaviour live in `@pops/overlay-ego`; this file binds toggle state to the
+ * shell's `useUIStore` generic overlay map.
  */
 const EGO_MODULE_ID = 'ego';
 

--- a/pillars/shell/src/app/layout/PageNav.tsx
+++ b/pillars/shell/src/app/layout/PageNav.tsx
@@ -2,13 +2,12 @@ import { useRegisteredApps } from '@/app/BootRegistryProvider';
 import { iconMap } from '@/app/nav/icon-map';
 import { findActiveApp, findActiveItem } from '@/app/nav/path-utils';
 /**
- * Page navigation panel
+ * Page navigation panel.
  *
- * Renders page links for the currently active app, determined by URL.
- * Designed to sit alongside the AppRail (tb-030) in the two-level
- * navigation layout defined by PRD-003.
- *
- * Colour is inherited from --app-accent CSS variable set on the shell root.
+ * Renders page links for the currently active app, determined by URL. Sits
+ * alongside the AppRail in the two-level navigation layout
+ * (pillars/shell/docs/prds/app-switcher). Colour is inherited from the
+ * --app-accent CSS variable set on the shell root.
  */
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router';

--- a/pillars/shell/src/app/layout/RootLayout.tsx
+++ b/pillars/shell/src/app/layout/RootLayout.tsx
@@ -5,14 +5,15 @@ import { useUIStore } from '@/store/uiStore';
 import { Outlet, useLocation } from 'react-router';
 
 /**
- * Root layout — top bar + two-level navigation + content area
+ * Root layout — top bar + two-level navigation + content area.
  *
- * Desktop (≥1024px): AppRail (icons) + PageNav (page links) push content
- * Tablet (768–1023px): AppRail visible, PageNav as overlay on app icon click
- * Mobile (<768px): Hamburger opens Sidebar overlay with all pages
+ * Desktop (≥1024px): AppRail (icons) + PageNav (page links) push content.
+ * Tablet (768–1023px): AppRail visible, PageNav as overlay on app icon click.
+ * Mobile (<768px): Hamburger opens Sidebar overlay with all pages.
  *
- * Overlays (PRD-101 US-07) are mounted from the module registry via
- * `OverlayHost` — `RootLayout` itself does not import overlay components.
+ * Overlays are mounted from the module registry via `OverlayHost`; `RootLayout`
+ * itself does not import overlay components
+ * (docs/themes/foundation/prds/overlay-surfaces).
  */
 import { AppContextProvider } from '@pops/navigation';
 import { cn, ErrorBoundary } from '@pops/ui';
@@ -73,14 +74,13 @@ export function RootLayout() {
         <CaptureHotkeyHost />
 
         {/*
-         * One host per known chrome slot (PRD-101 US-07). Each host mounts
-         * only the overlays whose manifest declares that slot, so slot
-         * declarations actually drive placement rather than being purely
-         * informational. Positioning is intentionally bare — overlays own
-         * their own visual chrome (fixed positioning, z-index, etc.); the
-         * host wrappers are anchors so future slot-specific layout (e.g.
-         * a notification stack region) can replace these without touching
-         * overlay packages.
+         * One host per known chrome slot. Each host mounts only the overlays
+         * whose manifest declares that slot, so slot declarations actually
+         * drive placement rather than being purely informational. Positioning
+         * is intentionally bare — overlays own their own visual chrome (fixed
+         * positioning, z-index, etc.); the host wrappers are anchors so future
+         * slot-specific layout (e.g. a notification stack region) can replace
+         * these without touching overlay packages.
          */}
         <div data-overlay-slot="assistant">
           <OverlayHost slot="assistant" />

--- a/pillars/shell/src/app/layout/SearchInput.test.ts
+++ b/pillars/shell/src/app/layout/SearchInput.test.ts
@@ -4,11 +4,12 @@
  * The SearchResultsPanel component is tested comprehensively in the navigation
  * package (sections, ordering, context distinction, close behaviour, show-more
  * button rendering). These tests cover the helper functions and pure logic used
- * to transform tRPC API sections into panel-ready sections.
+ * to transform the federated-search orchestrator's `POST /search` response
+ * sections into panel-ready sections.
  */
 import { describe, expect, it } from 'vitest';
 
-/** Replicated from SearchInput — must stay in sync. */
+/** Replicated from `@pops/navigation` SearchInput — must stay in sync. */
 function domainToLabel(domain: string): string {
   return domain
     .split('-')
@@ -67,11 +68,9 @@ describe('showMore offset calculation', () => {
     const firstBatch = [{ uri: 'c' }, { uri: 'd' }];
     const secondBatch = [{ uri: 'e' }];
 
-    // Simulate first show-more
     extraHits[domain] = [...(extraHits[domain] ?? []), ...firstBatch];
     expect(extraHits[domain]).toHaveLength(2);
 
-    // Simulate second show-more
     extraHits[domain] = [...(extraHits[domain] ?? []), ...secondBatch];
     expect(extraHits[domain]).toHaveLength(3);
   });

--- a/pillars/shell/src/app/layout/top-bar/NudgeIndicator.tsx
+++ b/pillars/shell/src/app/layout/top-bar/NudgeIndicator.tsx
@@ -1,15 +1,14 @@
 /**
- * NudgeIndicator — notification bell showing pending nudge count (#2244).
+ * NudgeIndicator — notification bell showing pending nudge count.
  *
- * Polls the cerebrum pillar's `POST /nudges/search` REST endpoint (opId
- * `nudges.list`) through the shell's `/cerebrum-api` proxy and displays a
- * badge on the bell icon when there are pending nudges. Clicking navigates
- * to the cerebrum nudges page.
+ * Polls the cerebrum pillar's `POST /nudges/search` REST endpoint through the
+ * shell's `/cerebrum-api` proxy and displays a badge on the bell icon when
+ * there are pending nudges. Clicking navigates to the cerebrum nudges page.
  *
- * The proxy (vite in dev, nginx in prod) strips the `/cerebrum-api` prefix
- * so the pillar sees `/nudges/search`. Mirrors the federated-search surface
- * (`@pops/navigation` useSearchInputData → `/orchestrator-api/search`): a
- * plain `fetch` + React Query, no tRPC and no pillar-sdk transport.
+ * The proxy (vite in dev, nginx in prod) strips the `/cerebrum-api` prefix so
+ * the pillar sees `/nudges/search`. Mirrors the federated-search surface
+ * (`@pops/navigation` useSearchInputData → `/orchestrator-api/search`): a plain
+ * `fetch` + React Query.
  */
 import { useQuery } from '@tanstack/react-query';
 import { Bell } from 'lucide-react';
@@ -20,11 +19,6 @@ import { Button } from '@pops/ui';
 const POLL_BASE_MS = 60_000;
 const MAX_FAILURES = 5;
 
-/**
- * Shell path the dev Vite proxy / production nginx rewrites onto the cerebrum
- * pillar's nudges list (`POST /nudges/search`). The proxy strips the
- * `/cerebrum-api` prefix so the pillar sees `/nudges/search`.
- */
 const NUDGES_SEARCH_URL = '/cerebrum-api/nudges/search';
 
 /** Failure carrying the HTTP status so the bell can hide on 404 / unavailable. */
@@ -36,10 +30,9 @@ class NudgeFetchError extends Error {
 }
 
 /**
- * Exponential backoff for the nudges poller.
- * Uses fetchFailureCount (resets to 0 on success) so the interval recovers
- * automatically after the endpoint starts returning 200s.
- * Intervals: 60s → 2m → 4m → 8m → 16m → stop.
+ * Exponential backoff for the nudges poller. Keys off fetchFailureCount (which
+ * resets to 0 on success) so the interval recovers automatically once the
+ * endpoint starts returning 200s again, and stops polling past MAX_FAILURES.
  */
 export function nudgeRefetchInterval(query: {
   state: { fetchFailureCount: number };
@@ -79,7 +72,7 @@ export function NudgeIndicator() {
   });
 
   // Hide the bell when cerebrum is unreachable / not-found rather than render a
-  // broken indicator (matches the previous pillar-sdk hidden-on-unavailable UX).
+  // broken indicator.
   if (isError) return null;
 
   const pendingCount = data ?? 0;

--- a/pillars/shell/src/app/nav/registry.test.ts
+++ b/pillars/shell/src/app/nav/registry.test.ts
@@ -10,10 +10,9 @@ describe('nav registry', () => {
     expect(registeredApps.length).toBeGreaterThan(0);
   });
 
-  // Parity gate — the seven in-repo pillars must render in the same order
-  // as the pre-PRD-243 hand-curated `registeredApps` literal. Drift here
-  // means audit H5's observable behaviour has regressed.
-  it('preserves the pre-PRD-243 app-rail order', () => {
+  // Parity gate — the seven in-repo pillars must render in this exact
+  // order; drift here is an observable app-rail regression.
+  it('renders the seven in-repo pillars in their pinned order', () => {
     expect(registeredApps.map((app) => app.id)).toEqual([
       'finance',
       'media',

--- a/pillars/shell/src/app/nav/registry.ts
+++ b/pillars/shell/src/app/nav/registry.ts
@@ -1,19 +1,11 @@
 /**
- * App-rail registry — derived from a registry walk over the workspace
- * bundle map (PRD-243 US-03).
+ * App-rail registry — derived from a walk over the workspace bundle map.
  *
- * Replaces the pre-PRD-243 hand-curated `registeredApps` literal that
- * imported each `@pops/app-*` package's `navConfig` by name. The walk
- * iterates the workspace bundle map, picks up each entry's
- * `manifest.frontend.navConfig`, and sorts by the manifest-level
- * `navOrder` (mirrors `nav.order` on the pillar's wire-format manifest
- * payload, per PRD-243 US-02). Ties break lexicographically on the nav
- * `id` so authoring order is deterministic without tight numbering.
- *
- * Today every workspace bundle map entry that contributes a `navConfig`
- * is in-repo. External pillars (PRD-228, US-05 deferred) will join the
- * walk via the same path once their assets-base-url loading mechanism
- * lands; for now their bundle map entries do not exist.
+ * The walk iterates the workspace bundle map, picks up each entry's
+ * `manifest.frontend.navConfig`, and sorts by the entry-level `navOrder`
+ * (mirrors `nav.order` on the pillar's wire-format manifest payload). Ties
+ * break lexicographically on the nav `id` so authoring order is
+ * deterministic without tight numbering.
  */
 import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from '../bundle-map';
 
@@ -40,9 +32,9 @@ function compareRankedNav(a: RankedNavConfig, b: RankedNavConfig): number {
 }
 
 /**
- * Build the app-rail registry from a bundle map snapshot. Exported so
- * the US-03 test suite can exercise the walk against a synthetic bundle
- * map without mutating the live `WORKSPACE_BUNDLE_MAP` singleton.
+ * Build the app-rail registry from a bundle map snapshot. Exported so the
+ * test suite can exercise the walk against a synthetic bundle map without
+ * mutating the live `WORKSPACE_BUNDLE_MAP` singleton.
  */
 export function buildRegisteredAppsFromBundleMap(
   bundleMap: Readonly<Record<string, BundleEntry>>
@@ -61,13 +53,13 @@ export function buildRegisteredAppsFromBundleMap(
  * The static app-rail floor: every in-repo pillar in the workspace bundle
  * map, sorted by `navOrder` ascending with a stable lexicographic tiebreak
  * on `id`. The display order (`finance, media, inventory, food, lists,
- * cerebrum, ai`) follows the reconciled sparse scheme in `bundle-map.tsx`.
+ * cerebrum, ai`) follows the sparse `navOrder` scheme in `bundle-map.tsx`.
  *
- * P7-T03 / RD-3: the LIVE app rail no longer reads this constant — it reads
- * the boot-resolved install set from `BootRegistryProvider`
+ * The live app rail does not read this constant — it reads the
+ * boot-resolved install set from `BootRegistryProvider`
  * (`useRegisteredApps()`), which is the registry snapshot (or this floor
- * when the registry is unreachable). This export remains as the floor the
- * boot path falls back to and the order parity gate pins.
+ * when the registry is unreachable). This export is the floor the boot
+ * path falls back to and the order the parity gate pins.
  */
 export const registeredApps: AppNavConfig[] =
   buildRegisteredAppsFromBundleMap(WORKSPACE_BUNDLE_MAP);

--- a/pillars/shell/src/app/overlays/OverlayHost.test.tsx
+++ b/pillars/shell/src/app/overlays/OverlayHost.test.tsx
@@ -1,6 +1,6 @@
 import { useUIStore } from '@/store/uiStore';
 /**
- * Tests for `OverlayHost` (PRD-101 US-07).
+ * Tests for `OverlayHost` (docs/themes/foundation/prds/overlay-surfaces).
  *
  * Three scenarios:
  *   1. Default — an installed overlay declares the `assistant` slot;
@@ -14,9 +14,10 @@ import { useUIStore } from '@/store/uiStore';
  *      is mocked to return no overlays; the host renders nothing.
  *
  * Each test mocks `./registry` with a synthetic overlay rather than relying
- * on the real `@pops/overlay-ego` package. The real overlay drags Zustand,
- * tRPC, and a large chat surface into the cold-vitest module graph; loading
- * it on the first lazy-mount blows past the test timeout intermittently.
+ * on the real `@pops/overlay-ego` package. The real overlay drags React
+ * Query, a generated REST client, and a large chat surface into the
+ * cold-vitest module graph; loading it on the first lazy-mount blows past
+ * the test timeout intermittently.
  * The slot-matching + Suspense-unwrap mechanics under test are the same
  * regardless of which component sits behind the loader.
  */

--- a/pillars/shell/src/app/overlays/OverlayHost.tsx
+++ b/pillars/shell/src/app/overlays/OverlayHost.tsx
@@ -16,9 +16,10 @@ export interface OverlayComponentProps {
 type OverlayComponent = ComponentType<OverlayComponentProps>;
 
 /**
- * Known chrome slots the shell layout exposes (PRD-101 US-07). The shell
- * mounts overlays whose `chromeSlot` matches one of these; unknown slots
- * are skipped at runtime and warned about (the registry build also warns).
+ * Known chrome slots the shell layout exposes
+ * (docs/themes/foundation/prds/overlay-surfaces). The shell mounts overlays
+ * whose `chromeSlot` matches one of these; unknown slots are skipped at
+ * runtime and warned about (the registry build also warns).
  */
 export const KNOWN_CHROME_SLOTS = ['assistant', 'notification', 'command'] as const;
 
@@ -104,7 +105,7 @@ const SLOT_MOUNTS = buildSlotMounts();
  * `slot` prop. Lazy-loaded via `React.lazy` so absent overlays never
  * appear in the shell bundle. `RootLayout` renders one `OverlayHost` per
  * known slot region so overlays land where their manifest says they
- * belong (PRD-101 US-07).
+ * belong (docs/themes/foundation/prds/overlay-surfaces).
  */
 export function OverlayHost({ slot }: OverlayHostProps) {
   const mounts = useMemo(() => SLOT_MOUNTS[slot], [slot]);

--- a/pillars/shell/src/app/overlays/registry.test.ts
+++ b/pillars/shell/src/app/overlays/registry.test.ts
@@ -1,12 +1,13 @@
 /**
- * Tests for the shell-level overlay registry (PRD-101 US-07).
+ * Tests for the shell-level overlay registry
+ * (docs/themes/foundation/prds/overlay-surfaces).
  *
  * The runtime export `installedOverlays` is the join of the live overlay
- * manifests and the runtime `INSTALLED_MODULES` install set (PRD-218
- * US-01: `POPS_APPS` / `POPS_OVERLAYS` are re-evaluated at module load).
- * The pure helper `selectInstalledOverlays` is exposed so we can exercise
- * both the "installed" and "absent" branches without mocking the
- * generated module registry.
+ * manifests and the runtime `INSTALLED_MODULES` install set (`POPS_APPS` /
+ * `POPS_OVERLAYS` are re-evaluated at module load). The pure helper
+ * `selectInstalledOverlays` is exposed so we can exercise both the
+ * "installed" and "absent" branches without mocking the generated module
+ * registry.
  */
 import { describe, expect, it } from 'vitest';
 

--- a/pillars/shell/src/app/overlays/registry.ts
+++ b/pillars/shell/src/app/overlays/registry.ts
@@ -1,19 +1,11 @@
 import { INSTALLED_MODULES } from '@pops/module-registry';
 /**
- * Shell-level overlay registry (PRD-101 US-07).
+ * Shell-level overlay registry (docs/themes/foundation/prds/overlay-surfaces).
  *
  * Joins the build-time module registry (`@pops/module-registry`) with each
  * overlay package's live manifest export. The build-time registry tells us
  * which overlays are installed (`POPS_OVERLAYS` may narrow the set); the
  * live manifest carries the lazy `component` loader the shell mounts.
- *
- * To add a new overlay module:
- *   1. Implement it as a `packages/overlay-<name>/` workspace package that
- *      exports a `ModuleManifest` with `surfaces: ['overlay']` and a
- *      `frontend.overlay.component` loader.
- *   2. Add the manifest to `SHELL_OVERLAY_MANIFESTS` below.
- *   3. Ensure the module id appears in `packages/module-registry`'s
- *      `MANIFEST_SOURCES` so it survives env filtering.
  */
 import { manifest as egoManifest } from '@pops/overlay-ego';
 
@@ -47,7 +39,8 @@ function projectOverlay(manifest: ModuleManifest): InstalledOverlay | null {
 /**
  * Filter a list of known overlay manifests by an install set. Pure so tests
  * can inject either real `MODULES` ids or a synthetic set to exercise the
- * absent-module path (PRD-101 US-07 acceptance criterion).
+ * absent-module path
+ * (docs/themes/foundation/prds/overlay-surfaces acceptance criterion).
  */
 export function selectInstalledOverlays(
   manifests: readonly ModuleManifest[],
@@ -64,9 +57,9 @@ export function selectInstalledOverlays(
 
 /**
  * Overlay modules that are both registered in this shell build AND in the
- * runtime install set emitted by `@pops/module-registry` (PRD-218 US-01:
- * the `INSTALLED_MODULES` shim re-evaluates `POPS_APPS` / `POPS_OVERLAYS`
- * at module load against the build-time `KNOWN_MODULES` superset).
+ * runtime install set emitted by `@pops/module-registry`: the
+ * `INSTALLED_MODULES` shim re-evaluates `POPS_APPS` / `POPS_OVERLAYS` at
+ * module load against the build-time `KNOWN_MODULES` superset.
  */
 export const installedOverlays: readonly InstalledOverlay[] = selectInstalledOverlays(
   SHELL_OVERLAY_MANIFESTS,

--- a/pillars/shell/src/app/overlays/useOverlayShortcuts.test.ts
+++ b/pillars/shell/src/app/overlays/useOverlayShortcuts.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for the shell-centralised overlay shortcut wiring (PRD-101 US-07).
+ * Tests for the shell-centralised overlay shortcut wiring
+ * (docs/themes/foundation/prds/overlay-surfaces).
  *
  * The hook itself is render-time only, so we test the pure shortcut
  * matcher (the part with all the branching) directly. Acceptance

--- a/pillars/shell/src/app/overlays/useOverlayShortcuts.ts
+++ b/pillars/shell/src/app/overlays/useOverlayShortcuts.ts
@@ -95,9 +95,10 @@ function compileBindings(): readonly ShortcutBinding[] {
 
 /**
  * Bind per-overlay keyboard shortcuts declared in module manifests.
- * Centralised in the shell (PRD-101 US-07) so individual overlay packages
- * don't each install their own listener — easier to audit conflicts and
- * easier to disable in non-shell hosts (tests, storybook).
+ * Centralised in the shell (docs/themes/foundation/prds/overlay-surfaces) so
+ * individual overlay packages don't each install their own listener — easier
+ * to audit conflicts and easier to disable in non-shell hosts (tests,
+ * storybook).
  */
 export function useOverlayShortcuts(): void {
   const toggleOverlay = useUIStore((state) => state.toggleOverlay);

--- a/pillars/shell/src/app/pages/NotInstalledPage.test.tsx
+++ b/pillars/shell/src/app/pages/NotInstalledPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * NotInstalledPage tests (PRD-101 US-03).
+ * NotInstalledPage tests.
  *
  * The page renders for catch-all matches; the requested module id is
  * derived from the URL's first path segment. These tests confirm the

--- a/pillars/shell/src/app/pages/NotInstalledPage.tsx
+++ b/pillars/shell/src/app/pages/NotInstalledPage.tsx
@@ -5,18 +5,18 @@ import { Button } from '@pops/ui';
 
 /**
  * Fallback for routes whose owning module isn't in the deployment's
- * `POPS_APPS` / `POPS_OVERLAYS` set (PRD-100, PRD-101 US-03). Distinct
- * from 404 — the URL's first segment names a known module id, the module
- * just isn't installed in this build.
+ * `POPS_APPS` / `POPS_OVERLAYS` set. Distinct from 404 — the URL's first
+ * segment names a known module id, the module just isn't installed in this
+ * build. Rendered by the router's catch-all `UnmatchedRoute`, which only
+ * picks this over `NotFoundPage` when the leading segment is in
+ * `KNOWN_MODULES` but absent from the live install set.
  *
- * Mounted by the shell router as a catch-all under `/:moduleId/*` after
- * every installed module's routes; the catch-all only triggers when no
- * installed module owns the leading segment.
+ * See pillars/shell/docs/prds/shell.
  */
 export function NotInstalledPage() {
   const { pathname } = useLocation();
-  // First non-empty path segment is the requested module id (the catch-all
-  // route binds `:moduleId` to it). Strip leading slash + trailing path.
+  // First non-empty path segment is the requested module id; the component
+  // derives it from the pathname directly (the catch-all binds no route param).
   const moduleId = pathname.split('/').find((s) => s.length > 0) ?? '';
 
   return (

--- a/pillars/shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/pillars/shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -7,13 +7,12 @@ import { usePillarSdkOptions } from '@pops/pillar-sdk/react';
  * Drives the per-section "Test" button. The button's `procedure` string is
  * supplied by a settings manifest at runtime in the shape
  * `pillarId.routerName.procName`, so the SDK's typed proxy can't be used
- * directly — `pillar(id).callDynamic(router, proc, input, kind)` (PRD-204
- * + PR #3131) is the supported escape hatch.
+ * directly — `pillar(id).callDynamic(router, proc, input, kind)` is the
+ * supported escape hatch for a path only known at runtime.
  *
- * The pillar's tRPC HTTP transport doesn't differentiate query vs mutation
- * on the wire, so a `query` call always succeeds against either kind; the
- * `'query'` kind is the safe default and is reserved for future routing
- * instrumentation.
+ * The `kind` argument is ignored by the SDK proxy: every `callDynamic`
+ * dispatch is the same body-carrying REST POST regardless of kind, so the
+ * `'query'` default works against any procedure.
  */
 export function useTestActionHandler() {
   const sdkOptions = usePillarSdkOptions();

--- a/pillars/shell/src/app/pillars/manifest-pillar.test.ts
+++ b/pillars/shell/src/app/pillars/manifest-pillar.test.ts
@@ -7,9 +7,10 @@ import { pillarIdForModule, REGISTRY_PILLAR_ID } from './manifest-pillar';
 
 describe('pillarIdForModule', () => {
   it('returns the platform registry pillar for every known module today', () => {
-    // Unmigrated modules fall back to the platform `registry` pillar. The list
-    // is pulled from `installed-modules.ts`'s known frontend manifests; if a
-    // module migrates, this test failure is the prompt to update the mapping.
+    // Modules without a dedicated mapping resolve to the platform `registry`
+    // pillar. This list mirrors the known frontend manifests in
+    // `installed-modules.ts`; give a module its own pillar and this assertion
+    // is the prompt to update the mapping.
     const knownModules = [
       'ai',
       'cerebrum',

--- a/pillars/shell/src/app/pillars/manifest-pillar.ts
+++ b/pillars/shell/src/app/pillars/manifest-pillar.ts
@@ -1,32 +1,19 @@
 /**
- * Static mapping from shell module id → pillar id (ADR-026 P3).
+ * Maps a shell module id to the pillar id that owns its backend (ADR-026 P3).
  *
- * Historically the entire backend was the `core` pillar — now renamed to
- * `registry` (the platform registry / discovery / settings host). As mature
- * pillars migrated, the corresponding module's mapping flipped to the
- * pillar's id and routes started observing its health; the remaining
- * unmapped modules fall back to the platform `registry` pillar.
- *
- * **`ai` is a permanent exception** — it folded into the platform pillar
- * during Phase γ (Track I, 2026-06-10). `pillarIdForModule('ai')` therefore
- * returns the platform pillar id and stays that way.
- *
- * Keeping the mapping in a single function rather than on the manifest
- * itself is deliberate: per-pillar migrations land in the
- * CI-never-breaks PR sequence and the manifest doesn't need to know
- * about pillars until its owning pillar actually exists.
+ * Every module currently resolves to the platform `registry` pillar (the
+ * discovery / settings host). To route a module's health at its own pillar,
+ * special-case its id here.
  */
 
-/** The canonical platform-pillar id, shared with `registry-api`'s `/health` response. */
+/** The canonical platform-pillar id, shared with the `registry` pillar's `/health` response. */
 export const REGISTRY_PILLAR_ID = 'registry';
 
 /**
  * Returns the pillar id that owns the backend for a given module id.
  *
- * Unknown module ids return the platform `registry` pillar id: a freshly-built
- * shell with a module not yet known to this mapping falls back to the platform
- * pillar. The PR that migrates a module to its own pillar updates this function
- * in the same change.
+ * Module ids without a dedicated mapping resolve to the platform `registry`
+ * pillar.
  */
 export function pillarIdForModule(_moduleId: string): string {
   return REGISTRY_PILLAR_ID;

--- a/pillars/shell/src/app/registry-walk.test.ts
+++ b/pillars/shell/src/app/registry-walk.test.ts
@@ -1,17 +1,17 @@
 /**
- * PRD-243 US-03 + US-05 — registry-walk unit tests.
+ * Registry-walk unit tests.
  *
  * Exercises the bundle-map-driven discovery path with synthetic data
  * instead of the live `WORKSPACE_BUNDLE_MAP` / `MODULES` constants. The
- * existing override-based `installed-modules.test.ts` covers the
- * production wiring; this file pins the walk's contract:
+ * override-based `installed-modules.test.ts` covers the production wiring;
+ * this file pins the walk's contract:
  *
  *   - Two synthetic pillars produce two nav configs.
  *   - Frontend manifests joined through the walk preserve `frontend.routes`.
  *   - Pillars omitting both `nav` and `pages` are skipped from the rail.
  *   - An external pillar (absent from the bundle map) that advertises an
  *     `assetsBaseUrl` plus `nav` / `pages` is loaded via the runtime path
- *     (US-05, Option A) and contributes a mounted manifest.
+ *     (Option A) and contributes a mounted manifest.
  *   - A structurally broken external descriptor is logged once and skipped
  *     (no crash).
  *   - Sort order respects `navOrder` ascending with a lexicographic
@@ -124,7 +124,7 @@ describe('walkRegistry', () => {
     expect(apps.map((a) => a.id)).toEqual(['finance']);
   });
 
-  it('mounts an external pillar (no bundle map entry) via the runtime loader (US-05 Option A)', () => {
+  it('mounts an external pillar (no bundle map entry) via the runtime loader (Option A)', () => {
     const externalNav: NavConfigDescriptor = {
       id: 'external-pillar',
       label: 'External Pillar',

--- a/pillars/shell/src/app/router.tsx
+++ b/pillars/shell/src/app/router.tsx
@@ -2,15 +2,13 @@
  * Shell route table — composed from the boot-resolved install set
  * (`boot-snapshot.ts` → resolved `FrontendManifest[]`).
  *
- * PRD-101 US-03 removed the per-module hand-coded `<Route>` list: route
- * entries derive from the install set, the runtime `RequireModule` guard is
- * gone, and direct navigation to an absent module's URL renders
- * `NotInstalledPage` via the catch-all.
+ * App route entries derive from the install set; direct navigation to an
+ * absent module's URL renders `NotInstalledPage` via the catch-all.
  *
- * P7-T03 / RD-3 moved the install-set source from the build-time `MODULES`
- * constant to the live registry snapshot, resolved before first render. The
- * router is therefore built by {@link buildRouter} (called from `App.tsx`
- * with the boot-resolved manifests) rather than a module-eval constant.
+ * The install-set source is the live registry snapshot, resolved before
+ * first render — not the build-time `MODULES` constant. The router is built
+ * by {@link buildRouter} (called from `App.tsx` with the boot-resolved
+ * manifests) rather than a module-eval constant.
  */
 import { Suspense } from 'react';
 import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-router';
@@ -37,9 +35,8 @@ import type { RouteObject } from 'react-router';
  * every in-repo pillar manifest — the right "could-ship" set, broader than
  * the per-deploy install set (`POPS_APPS`-gated) so the "not installed"
  * message fires for an excluded-but-buildable module while truly unknown
- * paths still get a proper 404. RD-9 re-sourced this off the SDK's frozen
- * `ALL_MODULE_IDS` tuple onto this runtime set so adding a pillar needs no
- * SDK type edit.
+ * paths still get a proper 404. Sourcing it off this runtime set (not a
+ * frozen SDK tuple) means adding a pillar needs no SDK type edit.
  */
 function UnmatchedRoute() {
   const { pathname } = useLocation();
@@ -75,10 +72,10 @@ function withSuspense(routes: readonly RouteObject[]): RouteObject[] {
  * the subtree renders the `PillarUnavailableRoute` placeholder when the
  * owning pillar's health is `'unavailable'` (ADR-026 P3).
  *
- * Unmigrated modules map to the platform `registry` pillar via
- * `pillarIdForModule`; the guard is a no-op for healthy/unknown statuses. As
- * mature pillars migrate, their module's mapping flips and routes start
- * observing the pillar's reported health.
+ * `pillarIdForModule` currently maps every module to the platform `registry`
+ * pillar; the guard is a no-op for healthy/unknown statuses. To route a
+ * module's health at its own pillar, special-case its id in
+ * `pillarIdForModule`.
  */
 function appRouteEntries(manifests: readonly FrontendManifest[]): RouteObject[] {
   return filterAppManifests(manifests).map((manifest) => {
@@ -110,9 +107,9 @@ const ErrorElement = (
 
 /**
  * Build the shell's browser router from the boot-resolved install set. Called
- * once from `App.tsx` after the boot snapshot resolves (P7-T03): the app
- * routes derive from `manifests`, the rest of the table (index redirect,
- * legacy redirects, settings/features, catch-all) is fixed.
+ * once from `App.tsx` after the boot snapshot resolves: the app routes derive
+ * from `manifests`, the rest of the table (index redirect, legacy redirects,
+ * settings/features, catch-all) is fixed.
  */
 export function buildRouter(
   manifests: readonly FrontendManifest[]
@@ -125,10 +122,9 @@ export function buildRouter(
       children: [
         { index: true, element: <IndexRedirect /> },
         ...appRouteEntries(manifests),
-        // Legacy /cerebrum/admin/* redirects — keep bookmarks pointing into
-        // the old in-cerebrum admin surface working after the AI app moved
-        // back to its own top-level /ai/* nav (#2618). Reverses the redirects
-        // added in #2333.
+        // Legacy /cerebrum/admin/* redirects keep old bookmarks working now
+        // that the admin surface lives under the top-level /ai/* and
+        // /finance/* navs.
         { path: 'cerebrum/admin', element: <Navigate to="/ai" replace /> },
         { path: 'cerebrum/admin/prompts', element: <Navigate to="/finance/prompts" replace /> },
         { path: 'cerebrum/admin/rules', element: <Navigate to="/finance/rules" replace /> },

--- a/pillars/shell/src/components/settings/SectionRenderer.tsx
+++ b/pillars/shell/src/components/settings/SectionRenderer.tsx
@@ -11,7 +11,7 @@ interface SectionRendererProps {
   manifest: SettingsManifest;
   /** The pillar that owns this section's settings; resolves the transport. */
   ownerPillar?: string;
-  /** Live `capabilities.settings` flag — routes to the pillar when true, else core. */
+  /** Live `capabilities.settings` flag — routes to the owning pillar when true, else `registry`. */
   hasFederatedSettings?: boolean;
   optionsLoaders?: Record<string, () => Promise<{ value: string; label: string }[]>>;
   onTestAction?: (procedure: string) => Promise<void>;
@@ -35,10 +35,9 @@ function applyDynamicOptions(
 
 /**
  * Renders one settings section and routes its read/write to the OWNING pillar
- * (capability-gated) via `useSectionState` (settings-federation S3). When the
- * owning pillar has not advertised the `settings` capability the transport
- * falls back to the platform `registry` pillar (formerly `core`), so an
- * un-upgraded pillar keeps working.
+ * (capability-gated) via `useSectionState`. When the owning pillar has not
+ * advertised the `settings` capability the transport falls back to the
+ * `registry` pillar, so an un-upgraded pillar keeps working.
  */
 export function SectionRenderer({
   manifest,
@@ -69,9 +68,8 @@ export function SectionRenderer({
   );
 
   // `isLoading` is true only on the genuine first fetch; a failed load (pillar
-  // unavailable / drifted contract) reports `isError` instead, so we fall
-  // through and render the groups with their static defaults rather than hang
-  // on a skeleton.
+  // unavailable / drifted contract) falls through to render the groups with
+  // their static defaults rather than hang on a skeleton.
   if (isLoading) {
     return (
       <div className="space-y-3">

--- a/pillars/shell/src/components/settings/section-renderer/useDynamicOptionsLoaders.ts
+++ b/pillars/shell/src/components/settings/section-renderer/useDynamicOptionsLoaders.ts
@@ -14,7 +14,8 @@ type Loaders = Record<string, () => Promise<Options>>;
  * at runtime in the shape `pillarId.routerName.procName`, so a generated
  * per-pillar client can't express the call — the path isn't known at build
  * time. This stays on the generic REST SDK escape hatch
- * `pillar(id).callDynamic(router, proc, input)` (PRD-204 + PR #3131).
+ * `pillar(id).callDynamic(router, proc, input)` (see
+ * docs/themes/federation/prds/client-surface).
  *
  * The procedure is expected to return `{ data: Record<string, unknown>[] }`.
  */

--- a/pillars/shell/src/lib/network-error.ts
+++ b/pillars/shell/src/lib/network-error.ts
@@ -13,13 +13,13 @@ function messageLooksLikeNetworkFailure(err: object): boolean {
 
 /**
  * Heuristic: is this error a network/transport-level failure (server
- * unreachable, request aborted, fetch threw) rather than a tRPC error
- * returned by the server with a real status code?
+ * unreachable, request aborted, fetch threw) rather than an error the
+ * server returned with a real status code?
  *
- * Server-returned errors have a `data` field with `httpStatus`. Network
- * failures don't make it that far — they bubble up as a TRPCClientError
- * wrapping a fetch error, an AbortError, or a `DOMException` (which is
- * not an `Error` subclass in browsers).
+ * Server-returned errors carry a `data` field with status detail. Network
+ * failures don't make it that far — they bubble up wrapping a fetch error,
+ * an AbortError, or a `DOMException` (which is not an `Error` subclass in
+ * browsers).
  */
 export function isNetworkError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;

--- a/pillars/shell/src/lib/register-with-registry.ts
+++ b/pillars/shell/src/lib/register-with-registry.ts
@@ -1,6 +1,6 @@
 /**
- * Shell self-registration with `pops-registry`'s pillar registry
- * (Theme 13 PRD-228 US-01 + ADR-035 UI-pillar variant).
+ * Shell self-registration with the `registry` pillar
+ * (docs/themes/federation/prds/registry-driven-shell-ui + ADR-035 UI-pillar variant).
  *
  * The shell is the first **UI pillar** to register itself: a pillar that
  * owns no data, exposes no procedures, and ships an empty manifest
@@ -22,8 +22,7 @@
  * registry is unreachable, slow, or returns an error, the shell still
  * boots: a UI pillar that fails to announce itself is degraded, not
  * broken. Missing env vars short-circuit before the network call (the
- * same `INVENTORY_BASE_URL`-style discipline applied to the data
- * pillars in PRD-187).
+ * same base-URL discipline the data pillars apply).
  */
 import type { ManifestPayload } from '@pops/pillar-sdk';
 
@@ -45,9 +44,9 @@ export const SHELL_CONTRACT_TAG = `contract-${SHELL_PILLAR_ID}@v${SHELL_PILLAR_V
 /**
  * The empty manifest a UI pillar publishes. Every capability array is
  * empty; healthcheck still points at `/health` because the registry's
- * heartbeat checker (PRD-228 US-02) probes it. `sinks` is intentionally
- * omitted — it is optional in the manifest schema and a UI pillar
- * neither emits nor consumes federated events directly.
+ * heartbeat checker probes it. `sinks` is intentionally omitted — it is
+ * optional in the manifest schema and a UI pillar neither emits nor
+ * consumes federated events directly.
  */
 export function buildShellManifest(): ManifestPayload {
   return {

--- a/pillars/shell/src/lib/settings-client.ts
+++ b/pillars/shell/src/lib/settings-client.ts
@@ -1,14 +1,12 @@
 /**
- * Capability-gated, per-pillar settings transport for the admin Settings UI
- * (settings-federation S3; see `docs/plans/02-settings-federation.md` §7.2).
+ * Capability-gated, per-pillar settings transport for the admin Settings UI.
  *
  * The shell renders one settings section per federated pillar and routes each
  * section's read/write to the OWNING pillar's `/<id>-api/settings/*` surface —
  * EXCEPT when the pillar has not yet advertised the live `settings` capability,
  * in which case the transport falls back to `/registry-api/settings`. The
- * fallback still works because the federation backfill COPIED (not moved) each
- * pillar's keys into the registry pillar, so it holds the values until the
- * rollout completes (the compat-shim removal is the later S5 node).
+ * fallback works because the registry pillar holds a copy of each pillar's keys
+ * for un-upgraded pillars.
  *
  * This is a HAND-WRITTEN raw-`fetch` client, NOT a generated hey-api client,
  * precisely so it can be keyed dynamically by `ownerPillar` at runtime. It

--- a/pillars/shell/src/registry-api-helpers.ts
+++ b/pillars/shell/src/registry-api-helpers.ts
@@ -6,8 +6,7 @@
  *
  * `unwrap` turns a Hey API `{ data, error, response }` result into its data
  * payload, throwing `RegistryApiError` (carrying the HTTP status) on failure.
- * The status lets call sites reproduce the pillar-sdk UX distinctions that
- * used to come from `usePillarQuery`:
+ * The status lets call sites distinguish UX outcomes:
  *   - 404            → "not found"   (isNotFoundError)
  *   - 5xx / no status → "unavailable" (isUnavailableError)
  */

--- a/pillars/shell/src/store/uiStore.ts
+++ b/pillars/shell/src/store/uiStore.ts
@@ -1,7 +1,3 @@
-/**
- * UI store - manages UI state like sidebar open/close
- * Persisted to localStorage
- */
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
@@ -10,8 +6,7 @@ interface UIState {
   railOpen: boolean;
   pageNavOpen: boolean;
   /**
-   * Open state for each installed overlay, keyed by module id (PRD-101 US-07).
-   * Replaces the previous per-overlay `chatOverlayOpen` flag so the shell can
+   * Open state for each installed overlay, keyed by module id, so the shell can
    * mount any registered overlay without growing a new field per module.
    */
   overlays: Record<string, boolean>;

--- a/pillars/shell/src/tests/SearchPage.test.ts
+++ b/pillars/shell/src/tests/SearchPage.test.ts
@@ -16,8 +16,6 @@ function shouldSearchTv(query: string, mode: SearchMode): boolean {
   return query.length > 0 && (mode === 'tv' || mode === 'both');
 }
 
-// ── useDebouncedValue logic (extracted for testability) ──────────────
-
 /**
  * Simulates the debounce behavior used by SearchPage.
  * Uses callbacks to avoid microtask timing issues with fake timers.
@@ -75,7 +73,6 @@ describe('SearchPage debounce logic', () => {
     debounce('second', (v) => results.push(v));
     vi.advanceTimersByTime(300);
 
-    // Only the second value should resolve (first was cancelled)
     expect(results).toEqual(['second']);
   });
 
@@ -93,8 +90,6 @@ describe('SearchPage debounce logic', () => {
     expect(results).toEqual(['abc']);
   });
 });
-
-// ── URL param persistence logic ──────────────────────────────────────
 
 describe('SearchPage URL param logic', () => {
   it('should produce ?q= param for non-empty query', () => {
@@ -123,8 +118,6 @@ describe('SearchPage URL param logic', () => {
   });
 });
 
-// ── Clear button state logic ──────────────────────────────────────────
-
 describe('SearchPage clear button logic', () => {
   it('should show clear button when query has text', () => {
     const query = 'test';
@@ -144,14 +137,11 @@ describe('SearchPage clear button logic', () => {
 
   it('should reset query to empty on clear', () => {
     const _before = 'some search';
-    // Simulate onClear callback — previous query (_before) is discarded
     const query = '';
     expect(query).toBe('');
     expect(_before).toBeDefined();
   });
 });
-
-// ── Empty query behavior ──────────────────────────────────────────────
 
 describe('SearchPage empty query behavior', () => {
   it('should not enable search when query is empty', () => {
@@ -179,17 +169,8 @@ describe('SearchPage empty query behavior', () => {
   });
 });
 
-// ── Request cancellation logic ──────────────────────────────────────
-
 describe('SearchPage request cancellation', () => {
-  it('tRPC/React Query cancels previous request when query key changes', () => {
-    // When debouncedQuery changes, React Query automatically aborts
-    // the previous request via its built-in AbortController support.
-    // The useQuery hook's query key includes the query string —
-    // when it changes, React Query cancels the in-flight request.
-    //
-    // Verification: { query: debouncedQuery } is passed as the query input,
-    // which becomes part of the query key. React Query handles cancellation.
+  it('changing the debounced query produces a distinct React Query key', () => {
     const queryKey1 = { query: 'bat' };
     const queryKey2 = { query: 'batman' };
     expect(queryKey1).not.toEqual(queryKey2);

--- a/pillars/shell/src/tests/manifests.test.ts
+++ b/pillars/shell/src/tests/manifests.test.ts
@@ -1,11 +1,11 @@
 /**
- * PRD-098/099 frontend module manifests — structural validation.
+ * Frontend module manifests — structural validation.
  *
- * PRD-243 US-04 migrated this test off the per-pillar named-import literal
- * (audit finding M7). The manifest set is now derived from
- * `installedFrontendManifests()` — the same registry-walk getter the
- * shell uses at boot — so adding a new in-repo pillar requires no edit
- * here.
+ * The manifest set is derived from `installedFrontendManifests()` — the same
+ * registry-walk getter the shell uses at boot — so adding a new in-repo pillar
+ * requires no edit here.
+ *
+ * See `docs/themes/federation/prds/registry-driven-shell-ui`.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -29,7 +29,7 @@ const overlayModules: LabelledManifest[] = allManifests.filter(([, m]) =>
   m.surfaces.includes('overlay')
 );
 
-describe('PRD-098/099 frontend module manifests', () => {
+describe('frontend module manifests', () => {
   it('the registry walk surfaces at least one installed manifest', () => {
     expect(allManifests.length).toBeGreaterThan(0);
   });

--- a/pillars/shell/src/tests/synthetic-pillar.integration.test.tsx
+++ b/pillars/shell/src/tests/synthetic-pillar.integration.test.tsx
@@ -1,10 +1,10 @@
 /**
- * PRD-243 US-04 — registry-driven shell UI integration test.
+ * Registry-driven shell UI integration test.
  *
- * Closes audit M7. Proves the lego: a synthetic pillar that ships
- * **no** patch to `WORKSPACE_BUNDLE_MAP`, `installed-modules.ts`,
- * `nav/registry.ts`, the router, or any real `@pops/app-*` package
- * still flows through the shell's registry walk and mounts:
+ * Proves the lego: a synthetic pillar that ships **no** patch to
+ * `WORKSPACE_BUNDLE_MAP`, `installed-modules.ts`, `nav/registry.ts`,
+ * the router, or any real `@pops/app-*` package still flows through
+ * the shell's registry walk and mounts:
  *
  *   - its `nav.navConfig` into the app rail (via `buildRegisteredAppsFromBundleMap`),
  *   - its `frontend.routes` into the route tree (via `walkRegistry`),
@@ -14,6 +14,8 @@
  * The synthetic pillar's manifest, nav config, route fixture, and bundle
  * entry are all declared **inline in this test file**, so the test would
  * fail if any of those structures required a per-pillar source edit.
+ *
+ * See `docs/themes/federation/prds/registry-driven-shell-ui`.
  */
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router';
@@ -103,7 +105,7 @@ function mountManifestRoutes(manifest: FrontendManifest, initialPath: string): v
   );
 }
 
-describe('PRD-243 US-04 — synthetic pillar mounts via registry (audit M7)', () => {
+describe('synthetic pillar mounts via registry', () => {
   it('app rail nav surfaces the synthetic pillar at the navOrder-derived position', () => {
     const apps = buildRegisteredAppsFromBundleMap(bundleMapWithSynthetic());
     const ids = apps.map((app) => app.id);
@@ -160,7 +162,7 @@ describe('PRD-243 US-04 — synthetic pillar mounts via registry (audit M7)', ()
     expect(manifests.map((m) => m.id)).not.toContain(SYNTHETIC_ID);
   });
 
-  it('an external registry entry (no bundle map entry) mounts via the runtime loader (US-05)', () => {
+  it('an external registry entry (no bundle map entry) mounts via the runtime loader', () => {
     const entries: RegistryEntry[] = [
       {
         pillarId: SYNTHETIC_ID,


### PR DESCRIPTION
## Wave 5 — agent-first comment hygiene (shell pillar — UI host) · 10/12

Same pass as the registry template (#3560).

- **89 files, net -103.** 41 comments deleted, 111 corrected.
- **All PRD-NNN removed** (63 dropped, 27 to fully-qualified resolvable doc anchors). grep PRD-[0-9] shell = 0. ADR-NNN kept.
- **Comments/labels only** — 0 logic / 0 functional-string changes (adversarial verify + non-comment-diff scan = 0).
- Green: typecheck, 612 tests, format, lint. Clean run, 0 verify issues.
