### PR TITLE
chore(orchestrator): agent-first comment hygiene (Wave 5, pillar 11/12)

### DIFF
--- a/pillars/orchestrator/src/__tests__/ai-tools.app.test.ts
+++ b/pillars/orchestrator/src/__tests__/ai-tools.app.test.ts
@@ -33,7 +33,8 @@ describe('GET /ai/tools', () => {
   });
 
   it('returns 200 with an empty list when no pillar declares ai.tools yet', async () => {
-    // No pillar ships PRD-200 ai.tools descriptors today, so the SDK
+    // No pillar ships ai.tools descriptors
+    // (docs/themes/federation/prds/ai-tool-manifest) today, so the SDK
     // projection is empty. The registry is hosted and ready; this asserts
     // the honest empty-but-200 contract, not a faked tool.
     const buildToolList: BuildToolList = vi.fn(async (): Promise<readonly Tool[]> => []);

--- a/pillars/orchestrator/src/ai-tools/index.ts
+++ b/pillars/orchestrator/src/ai-tools/index.ts
@@ -1,14 +1,14 @@
 /**
- * Orchestrator AI-tool registry handler (precursor C2 / epic 07).
+ * Orchestrator AI-tool registry handler. See
+ * `pillars/orchestrator/docs/prds/ai-tool-registry`.
  *
- * Epic 07's deliverable: the orchestrator HOSTS the aggregated AI-tool
- * registry. The aggregation itself already lives in the SDK —
- * `@pops/pillar-sdk`'s `buildToolList()` (PRD-201) pulls the current
- * registry snapshot from the shared discovery cache (PRD-159), projects
- * each registered pillar's `manifest.ai.tools` slot (PRD-200) into a flat
- * list, and drops pillars that aren't healthy. This module wires that
- * aggregation onto an HTTP surface and nothing more — it deliberately does
- * not reimplement the projection.
+ * The orchestrator hosts the aggregated AI-tool registry; the aggregation
+ * itself lives in the SDK. `@pops/pillar-sdk`'s `buildToolList()` pulls the
+ * current registry snapshot from the shared discovery cache, projects each
+ * registered pillar's `manifest.ai.tools` slot into a flat list, and drops
+ * pillars that aren't healthy. This module wires that aggregation onto an
+ * HTTP surface and nothing more — it deliberately does not reimplement the
+ * projection.
  *
  * Registry source: `buildToolList` reads the in-process discovery cache
  * (the same central registry the orchestrator registers itself with via
@@ -20,10 +20,8 @@
  *
  * Best-effort: a registry read failure (e.g. `RegistryUnreachableError`
  * on a cold, empty cache) degrades to `{ tools: [] }` rather than a 500.
- * An empty list is also the correct STEADY-STATE result today: no pillar
- * ships PRD-200 `ai.tools` descriptors yet, so the projection is empty
- * until they adopt them. The value delivered now is that the registry is
- * hosted and ready — tools appear as pillars declare them.
+ * An empty list is also a valid steady state: a pillar that ships no
+ * `ai.tools` descriptors contributes nothing to the projection.
  */
 import { buildToolList as sdkBuildToolList, type Tool } from '@pops/pillar-sdk';
 

--- a/pillars/orchestrator/src/pillars/env.ts
+++ b/pillars/orchestrator/src/pillars/env.ts
@@ -1,11 +1,8 @@
 /**
  * `POPS_PILLARS` environment-variable parser inside the orchestrator process.
  *
- * Functionally identical to the copies that live in each pillar's
- * `src/api/pillars/env.ts` (and `apps/pops-core-api/src/pillars/env.ts`) —
- * kept as a local copy so the orchestrator can boot without a runtime
- * dependency on any one pillar. The shape is the established federation
- * convention; promotion into a shared package is tracked separately.
+ * A local copy of the parser each pillar carries at `src/api/pillars/env.ts`,
+ * so the orchestrator can boot without a runtime dependency on any one pillar.
  *
  * Format: `id:baseUrl[,id:baseUrl,...]`
  *   - `id` lowercase kebab-case pillar slug (`food`, `finance`, …)

--- a/pillars/orchestrator/src/search/__tests__/domain-app-mapping.test.ts
+++ b/pillars/orchestrator/src/search/__tests__/domain-app-mapping.test.ts
@@ -10,10 +10,10 @@ describe('getDomainApp', () => {
     expect(getDomainApp('contacts')).toBe('contacts');
   });
 
-  it('keeps the monolith fine-grained adapter domains mapped', () => {
+  it('keeps the fine-grained adapter domains mapped', () => {
     expect(getDomainApp('transactions')).toBe('finance');
     expect(getDomainApp('budgets')).toBe('finance');
-    // Entities are owned by the contacts pillar (PRD-163).
+    // Entities are owned by the contacts pillar (pillars/contacts/docs/prds/entities).
     expect(getDomainApp('entities')).toBe('contacts');
     expect(getDomainApp('inventory-items')).toBe('inventory');
   });

--- a/pillars/orchestrator/src/search/domain-app-mapping.ts
+++ b/pillars/orchestrator/src/search/domain-app-mapping.ts
@@ -1,22 +1,19 @@
 /**
- * Domain-to-app mapping for search context section ordering.
- *
- * Relocated from the monolith engine
- * (`apps/pops-api/src/modules/core/search/domain-app-mapping.ts`). Maps each
- * search section domain to the app it belongs to so the federator can mark
- * "context sections" (belonging to the currently active app) and order them
- * first.
+ * Domain-to-app mapping for search context section ordering. Maps each search
+ * section domain to the app it belongs to so the federator can mark "context
+ * sections" (belonging to the currently active app) and order them first.
  *
  * Carries BOTH granularities:
- *   - the monolith's fine-grained adapter domains (`transactions`, `budgets`,
- *     …) so the mapping stays correct if a section is ever decorated at
- *     adapter granularity again, and
- *   - the pillar-level section domains the federation source emits today
+ *   - fine-grained adapter domains (`transactions`, `budgets`, …) so the
+ *     mapping stays correct if a section is ever decorated at adapter
+ *     granularity, and
+ *   - the pillar-level section domains the federation source emits
  *     (`finance`, `inventory`, `contacts`) — one section per pillar, because a
  *     pillar's `/search` returns a single flat hit list.
  *
- * The `entities` adapter domain now belongs to the contacts pillar (PRD-163);
- * a `contacts` pillar-level key is added alongside it.
+ * The `entities` adapter domain belongs to the contacts pillar (see
+ * pillars/contacts/docs/prds/entities); a `contacts` pillar-level key sits
+ * alongside it.
  */
 
 const DOMAIN_APP_MAP: Record<string, string> = {

--- a/pillars/orchestrator/src/search/engine.ts
+++ b/pillars/orchestrator/src/search/engine.ts
@@ -1,21 +1,17 @@
 /**
- * Federated search engine — the monolith fan-out engine
- * (`apps/pops-api/src/modules/core/search/engine.ts`) with a PLUGGABLE hit
- * source.
+ * Federated search engine with a PLUGGABLE hit source.
  *
- * The monolith engine owned both the fan-out (calling each in-process
- * `adapter.search()`) AND the merge/rank/section-ordering. In the orchestrator
- * the fan-out moves over the network: each pillar's `/search` endpoint returns
- * an already-ranked flat hit list, and the federation source
- * (`federation.ts`) is responsible for issuing those HTTP calls and decorating
- * each pillar's hits with `domain`/`icon`/`color`/`isContextSection`.
+ * The fan-out runs over the network: each pillar's `/search` endpoint returns
+ * an already-ranked flat hit list, and the federation source (`federation.ts`)
+ * issues those HTTP calls and decorates each pillar's hits with
+ * `domain`/`icon`/`color`/`isContextSection`.
  *
  * This module keeps the PURE half: given the source's per-pillar result
  * groups, it sorts hits within each group, caps them per section, drops empty
  * groups, and orders context sections (current app) first then by top score.
- * The `source` option is the analogue of the monolith engine's `adapters?`
- * override seam — production callers pass {@link federationSource}; tests pass
- * a stub that returns fixed groups with no network.
+ * The `source` option is the injection seam — production callers pass the
+ * federation source; tests pass a stub that returns fixed groups with no
+ * network.
  */
 import { z } from 'zod';
 
@@ -41,8 +37,8 @@ export interface PillarSearchGroup {
 
 /**
  * Pluggable hit source. Resolves every search-capable pillar's group for the
- * query — best-effort: a down pillar is omitted, never throws. Production:
- * {@link import('./federation.js').federationSource}. Tests: a stub.
+ * query — best-effort: a down pillar is omitted, never throws. Production: the
+ * federation source from `./federation.js`. Tests: a stub.
  */
 export type SearchSource = (query: Query, context: SearchContext) => Promise<PillarSearchGroup[]>;
 
@@ -76,10 +72,9 @@ export const HITS_PER_SECTION = 5;
 
 export interface SearchAllOptions {
   /**
-   * Hit source override. Production callers pass the federation source; tests
-   * pass a stub. Required here (unlike the monolith's optional `adapters`)
-   * because the orchestrator has no in-process default adapter registry — the
-   * route handler injects {@link import('./federation.js').federationSource}.
+   * Hit source. Production callers pass the federation source; tests pass a
+   * stub. Required because there is no in-process default adapter registry —
+   * the route handler injects the federation source from `./federation.js`.
    */
   source: SearchSource;
 }

--- a/pillars/orchestrator/src/search/federation.ts
+++ b/pillars/orchestrator/src/search/federation.ts
@@ -1,14 +1,10 @@
 /**
  * Federation hit source — the production {@link SearchSource} for the engine.
  *
- * Replaces the monolith's in-process adapter registry: instead of calling each
- * `adapter.search(query, context)` in-process, it POSTs the same
- * `{ query, context }` envelope to every search-capable pillar's `/search`
- * endpoint over the pillar SDK (`pillar(id).search.search(...)`, REST
- * transport) and decorates each pillar's returned hits with the
- * `domain`/`icon`/`color` metadata the monolith's per-adapter descriptors
- * carried (`apps/pops-api/src/modules/search-adapters.ts` + each module's
- * `search-adapter.ts`).
+ * POSTs the `{ query, context }` envelope to every search-capable pillar's
+ * `/search` endpoint over the pillar SDK (`pillar(id).search.search(...)`, REST
+ * transport) and decorates each pillar's returned hits with `domain`/`icon`/
+ * `color` section metadata.
  *
  * One section per pillar: a pillar's `/search` returns a single flat ranked
  * hit list (finance concatenates its transactions/budgets/wishlist adapters
@@ -17,7 +13,7 @@
  *
  * Best-effort: a pillar that is `unavailable`, errors, or returns a non-ok
  * SDK result is LOGGED and SKIPPED — federation never fails the whole search
- * because one pillar is down (epic 06).
+ * because one pillar is down.
  *
  * Pillar discovery (registry-as-truth): the search-capable set is derived from
  * the LIVE registry snapshot — every registered, healthy pillar whose manifest
@@ -28,10 +24,10 @@
  *
  * Presentation metadata (the section `icon`/`color`/`domain`) is NOT carried by
  * the manifest's `search` slot — that slot describes adapter mechanics
- * (`name`/`entityType`/`queryShape`/`procedurePath`), not section chrome. The
- * monolith's per-section icon/color descriptors have no manifest equivalent, so
- * they stay in the small static {@link SEARCH_SECTION_META} table keyed by
- * pillar id. A search-capable pillar with no entry there is still federated,
+ * (`name`/`entityType`/`queryShape`/`procedurePath`), not section chrome. With
+ * no manifest equivalent, the per-section icon/color values stay in the small
+ * static {@link SEARCH_SECTION_META} table keyed by pillar id. A search-capable
+ * pillar with no entry there is still federated,
  * decorated with {@link DEFAULT_SECTION_META} — membership is registry-driven,
  * only the chrome falls back.
  */
@@ -46,7 +42,7 @@ import type { PillarSnapshot, PillarStatus } from '@pops/pillar-sdk/discovery';
 import type { PillarSearchGroup, SearchSource } from './engine.js';
 import type { Query, SearchContext, SearchHit } from './types.js';
 
-/** Per-pillar section decoration, ported from the monolith adapter descriptors. */
+/** Per-pillar section decoration. */
 export interface PillarSearchMeta {
   /** Section domain (drives context-section detection via domain-app-mapping). */
   readonly domain: string;
@@ -57,15 +53,13 @@ export interface PillarSearchMeta {
 }
 
 /**
- * Section presentation metadata, ported from the monolith adapter descriptors.
- * This table does NOT decide membership — that is the live registry's job (a
- * pillar whose manifest declares `search.adapters`). It only supplies the
- * section chrome (icon/color/domain) the manifest's `search` slot does not
- * express:
+ * Section presentation metadata. This table does NOT decide membership — that
+ * is the live registry's job (a pillar whose manifest declares
+ * `search.adapters`). It only supplies the section chrome (icon/color/domain)
+ * the manifest's `search` slot does not express:
  *   - contacts → `contact` adapter (`Users`, blue) — the authoritative entity
- *     store (PRD-163); the section a contact search hit lands in. Core's
- *     residual entities adapter was removed in Stage 4a (N5); contacts is now
- *     the sole entities-search source.
+ *     store (see pillars/contacts/docs/prds/entities) and the sole
+ *     entities-search source; the section a contact search hit lands in.
  *   - finance → transactions/budgets/wishlist adapters, aggregated under one
  *     `/search`; decorated with the transactions descriptor (`ArrowRightLeft`,
  *     green) as the pillar-representative section.
@@ -118,11 +112,10 @@ export type SearchInvoker = (
 ) => Promise<CallResult<PillarSearchResponse>>;
 
 /**
- * Minimal typed view of a search-capable pillar's contract router for the
- * SDK proxy. `search.search` returns the raw `{ hits }` response; the SDK's
- * `PillarHandle` proxy wraps it in `Promise<CallResult<…>>`. Modelled on the
- * `CerebrumEmbeddingsShape` pattern in the monolith embeddings client — an
- * object-literal type (not an interface) so it is assignable to the proxy's
+ * Minimal typed view of a search-capable pillar's `search.search` procedure for
+ * the SDK proxy. It returns the raw `{ hits }` response; the SDK's
+ * `PillarHandle` proxy wraps it in `Promise<CallResult<…>>`. An object-literal
+ * type (not an interface) so it is assignable to the proxy's
  * `Record<string, unknown>` constraint.
  */
 type PillarSearchRouter = {

--- a/pillars/orchestrator/src/search/query-parser.ts
+++ b/pillars/orchestrator/src/search/query-parser.ts
@@ -1,11 +1,6 @@
 /**
  * Structured query parser — extracts typed filter tokens from search input.
  *
- * Relocated verbatim from the monolith engine
- * (`apps/pops-api/src/modules/core/search/query-parser.ts`) so the
- * orchestrator parses the user's raw input the same way the in-process engine
- * did before federation.
- *
  * Supported filters:
  *   type:<value>     — entity/content type
  *   domain:<value>   — search domain


### PR DESCRIPTION
## Wave 5 — agent-first comment hygiene (orchestrator pillar) · 11/12

Federated search + AI-tool registry (stateless, no DB). Same pass as the registry template (#3560).

- **8 files, net -24.** 5 comments deleted, 12 corrected.
- **All PRD-NNN removed** (2 dropped, 5 to fully-qualified resolvable doc anchors). grep PRD-[0-9] orchestrator = 0. ADR-NNN kept.
- **Comments/labels only** — 0 logic / 0 functional-string changes (adversarial verify + non-comment-diff scan = 0).
- Green: typecheck, 68 tests, format, lint.
