### PR TITLE
chore(shell): comment hygiene on config files (Wave 5 cleanup)

### DIFF
--- a/pillars/shell/playwright.config.ts
+++ b/pillars/shell/playwright.config.ts
@@ -13,7 +13,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
  * is dormant — `fe-test-e2e.yml` is gated to `workflow_dispatch` until the
  * specs are rewritten against the REST stack.
  *
- * Install-set switching (see foundation/plugin-contract):
+ * Install-set switching (see docs/themes/foundation/prds/plugin-contract):
  *
  *   The shell consumes `MODULES` from `@pops/module-registry` at build
  *   time. To exercise the install-set boundary across two distinct shell

--- a/pillars/shell/playwright.config.ts
+++ b/pillars/shell/playwright.config.ts
@@ -8,17 +8,12 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 /**
  * Playwright configuration for POPS Shell E2E tests.
  *
- * NOTE (lake-migration): this suite was written against the now-deleted
- * `apps/pops-api` tRPC monolith — specs mock/route `/trpc/**` and the
- * `globalSetup` seeded an `e2e` named environment via `POST :3000/env/...`.
- * The lake is now seven independent REST pillars + a static-built shell;
- * none of that surface exists, so the suite cannot pass without a full
- * rewrite against the REST stack (out of scope). The `fe-test-e2e.yml`
- * workflow is therefore gated to `workflow_dispatch` only. The dead
- * pops-api `webServer` (cwd `../pops-api`) has been removed below so the
- * harness no longer references a deleted directory.
+ * NOTE: these specs target a removed tRPC surface (`/trpc/**`, a seeded `e2e`
+ * named environment) that no longer exists on the REST pillars, so the suite
+ * is dormant — `fe-test-e2e.yml` is gated to `workflow_dispatch` until the
+ * specs are rewritten against the REST stack.
  *
- * Install-set switching (PRD-101 US-11 follow-up, issue #2595):
+ * Install-set switching (see foundation/plugin-contract):
  *
  *   The shell consumes `MODULES` from `@pops/module-registry` at build
  *   time. To exercise the install-set boundary across two distinct shell

--- a/pillars/shell/vite.config.ts
+++ b/pillars/shell/vite.config.ts
@@ -6,10 +6,9 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 /**
- * PRD-101 US-11 follow-up (issue #2595): when `POPS_REGISTRY_SNAPSHOT`
- * is set, alias `@pops/module-registry` to the snapshot file so the
- * shell consumes a build-specific install set. Unset in production and
- * default dev builds.
+ * When `POPS_REGISTRY_SNAPSHOT` is set, alias `@pops/module-registry` to the
+ * snapshot file so the shell consumes a build-specific install set. Unset in
+ * production and default dev builds.
  */
 const registrySnapshot = process.env.POPS_REGISTRY_SNAPSHOT;
 


### PR DESCRIPTION
## Wave 5 cleanup — shell pillar-root config comments

Two shell config files (`playwright.config.ts`, `vite.config.ts`) sat outside the per-module candidate scope in #3571, so their comments were missed. This drops a stale lake-migration narration block (keeping the live gotcha — the E2E suite is dormant and `fe-test-e2e.yml` is gated to `workflow_dispatch` until rewritten for REST) and the `PRD-101 US-11` / issue breadcrumbs.

Comment-only. Completes "0 PRD-NNN in code comments" across all pillars.
