### PR TITLE
fix(ui): repair Tailwind @source globs after pillars/libs rename + add coverage guards

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -190,6 +190,26 @@ jobs:
       - name: Every pillar app is referenced by the shell bundle map
         run: node scripts/check-bundle-map-coverage.mjs
 
+  tailwind-source-coverage:
+    name: Tailwind @source coverage
+    # NON-required gate: asserts every `@source` glob in the single Tailwind
+    # theme entry (libs/ui/src/theme/globals.css) matches real files, and that
+    # no className-bearing UI file falls outside those globs. Tailwind v4 never
+    # errors on an empty `@source` glob, so the pillars/libs rename silently
+    # voided the old `apps/*`/`packages/*` globs and collapsed the UI with no
+    # build error. This guard makes that class of rot loud. It reads the source
+    # tree directly and pulls in no third-party deps, so it skips `pnpm install`.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Gate self-test (proves the guard catches a stale/empty glob)
+        run: node scripts/check-tailwind-source-coverage.mjs --self-test
+      - name: Every @source glob matches files and every UI file is covered
+        run: node scripts/check-tailwind-source-coverage.mjs
+
   vendored-contracts:
     name: Vendored contract drift (ADR-033)
     # A consumer that vendors a producer pillar's OpenAPI snapshot (because the

--- a/libs/ui/.storybook/main.ts
+++ b/libs/ui/.storybook/main.ts
@@ -35,7 +35,7 @@ const config: StorybookConfig = {
           { find: '@pops/ui', replacement: path.resolve(__dirname, '../src') },
           {
             find: '@pops/app-ai',
-            replacement: path.resolve(__dirname, '../../../pillars/registry/app/src'),
+            replacement: path.resolve(__dirname, '../../../pillars/ai/app/src'),
           },
           {
             find: '@pops/app-cerebrum',

--- a/libs/ui/scripts/check-storybook-coverage.mjs
+++ b/libs/ui/scripts/check-storybook-coverage.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Asserts that every frontend `@pops/app-*` workspace package is enumerated as
- * a Vite source alias in `libs/ui/.storybook/main.ts`.
+ * a Vite source alias in `libs/ui/.storybook/main.ts`, AND that each alias's
+ * replacement path resolves to that package's real `app/src` directory.
  *
  * Storybook is `@pops/ui`'s dev surface (P2-T04): it renders pillar-frontend
  * stories and resolves the `@pops/app-*` specifiers those stories reach
@@ -19,20 +20,33 @@
  * Frontend app packages are colocated inside their owning pillar at
  * `pillars/<pillar>/app/` (PRD-253); discovery walks those pillar app dirs.
  *
- * Fails (exit 1) on any missing alias so future drift surfaces in CI instead
- * of waiting for someone to file a story and find it cannot resolve the
- * pillar it renders (issue #2706).
+ * Two failure modes are caught (exit 1):
+ *   1. A frontend package with NO alias — its stories cannot resolve the
+ *      pillar they render (issue #2706).
+ *   2. An alias whose `replacement` points at a missing or WRONG directory —
+ *      e.g. `@pops/app-ai` mapped at `pillars/registry/app/src` (which does
+ *      not exist) instead of `pillars/ai/app/src`. The original key-only check
+ *      passed this silently; the alias only breaks once an AI-pillar story is
+ *      filed. Validating the resolved path makes that drift loud at CI time.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../..');
 const PILLARS_DIR = resolve(REPO_ROOT, 'pillars');
-const STORYBOOK_MAIN = resolve(__dirname, '../.storybook/main.ts');
+const STORYBOOK_DIR = resolve(__dirname, '../.storybook');
+const STORYBOOK_MAIN = resolve(STORYBOOK_DIR, 'main.ts');
 
+/**
+ * Discover frontend app packages: each pillar's `app/` dir that has a
+ * `src/routes.tsx` and a `@pops/app-*` package name. Returns the package name
+ * paired with the absolute `app/src` dir its Storybook alias must resolve to.
+ *
+ * @returns {{ name: string, srcDir: string }[]}
+ */
 function listFrontendAppPackages() {
   return readdirSync(PILLARS_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -45,30 +59,67 @@ function listFrontendAppPackages() {
         return false;
       }
     })
-    .map((appDir) => JSON.parse(readFileSync(resolve(appDir, 'package.json'), 'utf8')).name)
-    .filter((name) => typeof name === 'string' && name.startsWith('@pops/app-'))
-    .toSorted();
+    .map((appDir) => ({
+      name: JSON.parse(readFileSync(resolve(appDir, 'package.json'), 'utf8')).name,
+      srcDir: resolve(appDir, 'src'),
+    }))
+    .filter((pkg) => typeof pkg.name === 'string' && pkg.name.startsWith('@pops/app-'))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Parse `@pops/app-*` aliases from `main.ts`, resolving each
+ * `path.resolve(__dirname, '<rel>')` replacement (relative to the `.storybook`
+ * dir, which is `main.ts`'s own `__dirname`) to an absolute path.
+ *
+ * @returns {{ name: string, replacement: string }[]}
+ */
 function readAliases() {
   const source = readFileSync(STORYBOOK_MAIN, 'utf8');
-  const matches = source.matchAll(/find:\s*'(@pops\/app-[a-z0-9-]+)'/g);
-  return [...matches].map((m) => m[1]);
+  const pattern =
+    /find:\s*'(@pops\/app-[a-z0-9-]+)'\s*,\s*replacement:\s*path\.resolve\(\s*__dirname\s*,\s*'([^']+)'\s*\)/g;
+  return [...source.matchAll(pattern)].map((m) => ({
+    name: m[1],
+    replacement: resolve(STORYBOOK_DIR, m[2]),
+  }));
 }
 
 const expected = listFrontendAppPackages();
-const aliases = new Set(readAliases());
+const aliases = readAliases();
+const aliasByName = new Map(aliases.map((a) => [a.name, a]));
 
-const missingAliases = expected.filter((name) => !aliases.has(name));
+/** @type {string[]} */
+const errors = [];
 
-if (missingAliases.length === 0) {
+for (const pkg of expected) {
+  const alias = aliasByName.get(pkg.name);
+  if (!alias) {
+    errors.push(
+      `${pkg.name}: no Vite alias in .storybook/main.ts — its stories cannot resolve the pillar they render.`
+    );
+    continue;
+  }
+  if (!existsSync(alias.replacement)) {
+    errors.push(
+      `${pkg.name}: alias points at a non-existent path ${alias.replacement} — expected ${pkg.srcDir}.`
+    );
+  } else if (alias.replacement !== pkg.srcDir) {
+    errors.push(
+      `${pkg.name}: alias points at the wrong pillar ${alias.replacement} — expected ${pkg.srcDir}.`
+    );
+  }
+}
+
+if (errors.length === 0) {
   process.stdout.write(
-    `@pops/ui storybook aliases all ${expected.length} frontend @pops/app-* packages.\n`
+    `@pops/ui storybook aliases all ${expected.length} frontend @pops/app-* packages to their app/src.\n`
   );
   process.exit(0);
 }
 
-console.error('Missing Vite aliases in libs/ui/.storybook/main.ts:');
-for (const name of missingAliases) console.error(`  - ${name}`);
-console.error('\nAdd a `resolve.alias` for the package above so its stories load in Storybook.');
+console.error('Storybook alias problems in libs/ui/.storybook/main.ts:');
+for (const message of errors) console.error(`  - ${message}`);
+console.error(
+  '\nEach @pops/app-* frontend needs a `resolve.alias` whose replacement is its own `pillars/<pillar>/app/src`.'
+);
 process.exit(1);

--- a/libs/ui/src/theme/globals.css
+++ b/libs/ui/src/theme/globals.css
@@ -7,9 +7,12 @@
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 
-/* Explicitly source all apps and packages so Tailwind scans for utility classes */
-@source "../../../../apps/*/src/**/*.{ts,tsx}";
-@source "../../../../packages/*/src/**/*.{ts,tsx}";
+/* Explicitly source all pillars and libs so Tailwind scans for utility classes.
+   globals.css lives in libs/ui, so Tailwind's automatic detection only covers
+   libs/ui; these globs add every other package. src dirs sit at mixed depths
+   (pillars/shell/src, pillars/finance/app/src), hence the recursive glob. */
+@source "../../../../pillars/**/src/**/*.{ts,tsx}";
+@source "../../../../libs/**/src/**/*.{ts,tsx}";
 
 /*---break---
  */

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "exports:check": "node scripts/check-exports.mjs",
     "check:bundle-map": "node scripts/check-bundle-map-coverage.mjs",
     "check:bundle-map:self-test": "node scripts/check-bundle-map-coverage.mjs --self-test",
+    "check:tailwind-source": "node scripts/check-tailwind-source-coverage.mjs",
+    "check:tailwind-source:self-test": "node scripts/check-tailwind-source-coverage.mjs --self-test",
     "check:vendored-contracts": "node scripts/ci/check-vendored-contracts.mjs",
     "check:vendored-contracts:self-test": "node scripts/ci/check-vendored-contracts.mjs --self-test",
     "ci:fix": "pnpm lint:fix && pnpm format && pnpm typecheck",

--- a/scripts/check-tailwind-source-coverage.mjs
+++ b/scripts/check-tailwind-source-coverage.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Tailwind `@source` coverage guard.
+ *
+ * The whole in-repo FE is one Vite/Tailwind build. Tailwind v4 only generates
+ * a utility class if it finds that class in a scanned source file. Because the
+ * single theme entry `libs/ui/src/theme/globals.css` lives inside the `libs/ui`
+ * package, Tailwind's automatic detection only covers `libs/ui`; every other
+ * package is pulled in by explicit `@source` globs in that file. Tailwind does
+ * NOT error when an `@source` glob matches zero files — so a stale glob (e.g.
+ * the `apps/*` / `packages/*` globs left behind by the pillars/libs rename)
+ * silently stops generating most utilities and the UI collapses with no build
+ * error. This guard makes that failure loud at CI time.
+ *
+ * What it checks:
+ *   1. EMPTY GLOBS — every `@source` glob in globals.css must match at least
+ *      one real file. A glob that matches nothing is the rename-rot this guard
+ *      exists to catch.
+ *   2. UNCOVERED SOURCE — no `className`-bearing `.tsx`/`.jsx`/`.mdx` file under
+ *      `pillars/` or `libs/` may fall outside every glob's reach. The globs only
+ *      match `{ts,tsx}` under a `src/` dir, so a UI file authored outside `src/`
+ *      or as `.jsx`/`.mdx` would silently lose its styling. (`.storybook/` is
+ *      exempt: its decorator classes are plain CSS selectors from globals.css,
+ *      not scanned utilities.)
+ *
+ * Usage:
+ *   node scripts/check-tailwind-source-coverage.mjs              check the real tree
+ *   node scripts/check-tailwind-source-coverage.mjs --self-test  prove the guard catches rot
+ *
+ * Exit 0 when every glob is non-empty and every UI file is covered; non-zero on
+ * any empty glob, any uncovered file, a failed self-test, or a discovery error.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const GLOBALS_CSS = resolve(repoRoot, 'libs/ui/src/theme/globals.css');
+
+/** Extensions of files that can author Tailwind utility classes via JSX. */
+const UI_EXTENSIONS = new Set(['.tsx', '.jsx', '.mdx']);
+/** Extensions worth indexing at all (UI files plus `.ts` for glob-match counting). */
+const INDEX_EXTENSIONS = new Set(['.ts', '.tsx', '.jsx', '.mdx']);
+/** Directory names never walked. */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'coverage',
+  'storybook-static',
+  '.turbo',
+]);
+
+/**
+ * Extract the raw `@source` glob strings from a globals.css source.
+ *
+ * @param {string} css
+ * @returns {string[]}
+ */
+export function parseSources(css) {
+  return [...css.matchAll(/@source\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
+}
+
+/**
+ * Compile a filesystem glob (supporting `**`, `*`, `?`, and `{a,b}` brace
+ * lists) into an anchored RegExp matched against absolute POSIX-style paths.
+ *
+ * @param {string} glob
+ * @returns {RegExp}
+ */
+export function globToRegExp(glob) {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        i++;
+        if (glob[i + 1] === '/') {
+          i++;
+          re += '(?:.*/)?'; // `**/` — zero or more path segments
+        } else {
+          re += '.*'; // `**` — anything, including `/`
+        }
+      } else {
+        re += '[^/]*'; // `*` — anything within a single segment
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if (c === '{') {
+      const end = glob.indexOf('}', i);
+      const inner = glob
+        .slice(i + 1, end)
+        .split(',')
+        .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('|');
+      re += `(?:${inner})`;
+      i = end;
+    } else if ('.+^$()|[]\\'.includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/**
+ * The directory to start walking for a glob: the static prefix before its
+ * first metacharacter.
+ *
+ * @param {string} absGlob
+ * @returns {string}
+ */
+function globBaseDir(absGlob) {
+  const metaIdx = absGlob.search(/[*?{]/);
+  const prefix = metaIdx === -1 ? absGlob : absGlob.slice(0, metaIdx);
+  return prefix.endsWith('/') ? prefix.slice(0, -1) : dirname(prefix);
+}
+
+/**
+ * Recursively collect indexable files under `dir`. Reads contents only for UI
+ * files (to flag `className` usage); `.ts` files are indexed path-only so glob
+ * emptiness can still count them without reading thousands of files.
+ *
+ * @param {string} dir
+ * @param {Map<string, { path: string, ext: string, hasClassName: boolean }>} out
+ */
+function walk(dir, out) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(join(dir, entry.name), out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const ext = extname(entry.name);
+    if (!INDEX_EXTENSIONS.has(ext)) continue;
+    const path = join(dir, entry.name);
+    if (out.has(path)) continue;
+    const hasClassName = UI_EXTENSIONS.has(ext) && readFileSync(path, 'utf8').includes('className');
+    out.set(path, { path, ext, hasClassName });
+  }
+}
+
+/**
+ * @typedef {object} CoverageResult
+ * @property {string[]} emptyGlobs  Globs that matched zero indexed files.
+ * @property {string[]} uncovered   `className`-bearing UI files matched by no glob.
+ */
+
+/**
+ * Pure core: given absolute `@source` globs and an indexed file list, find
+ * globs that match nothing and UI files matched by no glob. No I/O, so the
+ * self-test can drive it over synthetic fixtures.
+ *
+ * @param {string[]} absGlobs
+ * @param {{ path: string, ext: string, hasClassName: boolean }[]} files
+ * @returns {CoverageResult}
+ */
+export function evaluateCoverage(absGlobs, files) {
+  const compiled = absGlobs.map((glob) => ({ glob, re: globToRegExp(glob) }));
+  const emptyGlobs = compiled
+    .filter(({ re }) => !files.some((f) => re.test(f.path)))
+    .map(({ glob }) => glob);
+  const uncovered = files
+    .filter(
+      (f) =>
+        UI_EXTENSIONS.has(f.ext) &&
+        f.hasClassName &&
+        !f.path.includes('/.storybook/') &&
+        !compiled.some(({ re }) => re.test(f.path))
+    )
+    .map((f) => f.path);
+  return { emptyGlobs, uncovered };
+}
+
+/**
+ * Drive the guard against the real tree.
+ *
+ * @returns {boolean} true when every glob is non-empty and every UI file is covered.
+ */
+function run() {
+  if (!existsSync(GLOBALS_CSS)) {
+    console.error(`globals.css not found at ${GLOBALS_CSS}.`);
+    return false;
+  }
+  const cssDir = dirname(GLOBALS_CSS);
+  const rawGlobs = parseSources(readFileSync(GLOBALS_CSS, 'utf8'));
+  if (rawGlobs.length === 0) {
+    console.error(
+      `No @source globs found in ${GLOBALS_CSS}. Expected explicit pillar/lib sources.`
+    );
+    return false;
+  }
+  const absGlobs = rawGlobs.map((g) => resolve(cssDir, g));
+
+  const baseDirs = new Set([resolve(repoRoot, 'pillars'), resolve(repoRoot, 'libs')]);
+  for (const g of absGlobs) baseDirs.add(globBaseDir(g));
+
+  /** @type {Map<string, { path: string, ext: string, hasClassName: boolean }>} */
+  const index = new Map();
+  for (const dir of baseDirs) walk(dir, index);
+  const files = [...index.values()];
+
+  const { emptyGlobs, uncovered } = evaluateCoverage(absGlobs, files);
+
+  console.log(
+    `Checked ${rawGlobs.length} @source glob(s) against ${files.length} indexed file(s).`
+  );
+  for (const g of rawGlobs) {
+    const abs = resolve(cssDir, g);
+    if (!emptyGlobs.includes(abs)) console.log(`  OK    ${g}`);
+  }
+
+  if (emptyGlobs.length === 0 && uncovered.length === 0) {
+    console.log('OK — every @source glob matches files and every UI file is covered.');
+    return true;
+  }
+
+  if (emptyGlobs.length > 0) {
+    console.error(`FAIL — ${emptyGlobs.length} @source glob(s) match no files (stale path?):`);
+    for (const abs of emptyGlobs) {
+      const raw = rawGlobs[absGlobs.indexOf(abs)] ?? abs;
+      console.error(`  XX  ${raw}`);
+    }
+    console.error(
+      '  Tailwind silently skips an empty @source glob — fix the path so its classes generate.'
+    );
+  }
+  if (uncovered.length > 0) {
+    console.error(
+      `FAIL — ${uncovered.length} className-bearing UI file(s) outside every @source glob:`
+    );
+    for (const path of uncovered) console.error(`  XX  ${path.slice(repoRoot.length + 1)}`);
+    console.error(
+      '  Move it under a covered `src/` dir (as .ts/.tsx) or widen the @source globs, or its Tailwind classes will not generate.'
+    );
+  }
+  return false;
+}
+
+/**
+ * Synthetic fixtures proving the guard catches a stale (empty) glob and an
+ * uncovered UI file, and passes a correct tree. Mirrors the `--self-test`
+ * convention in check-bundle-map-coverage.mjs.
+ *
+ * @returns {boolean}
+ */
+function selfTest() {
+  const root = '/r';
+  const goodGlobs = [`${root}/pillars/**/src/**/*.{ts,tsx}`, `${root}/libs/**/src/**/*.{ts,tsx}`];
+  const staleGlobs = [`${root}/apps/*/src/**/*.{ts,tsx}`, `${root}/packages/*/src/**/*.{ts,tsx}`];
+
+  const files = [
+    { path: `${root}/pillars/finance/app/src/Dashboard.tsx`, ext: '.tsx', hasClassName: true },
+    { path: `${root}/pillars/shell/src/main.tsx`, ext: '.tsx', hasClassName: true },
+    { path: `${root}/libs/ui/src/Button.tsx`, ext: '.tsx', hasClassName: true },
+    { path: `${root}/pillars/x/app/Outside.tsx`, ext: '.tsx', hasClassName: true },
+    { path: `${root}/pillars/x/app/src/Weird.jsx`, ext: '.jsx', hasClassName: true },
+    { path: `${root}/libs/ui/.storybook/preview.tsx`, ext: '.tsx', hasClassName: true },
+  ];
+
+  const pillarsSrc = globToRegExp(goodGlobs[0]);
+  const good = evaluateCoverage(goodGlobs, files);
+  const stale = evaluateCoverage(staleGlobs, files);
+
+  const checks = {
+    'regex matches a nested app/src .tsx': pillarsSrc.test(
+      `${root}/pillars/finance/app/src/Dashboard.tsx`
+    ),
+    'regex matches a shallow src .tsx': pillarsSrc.test(`${root}/pillars/shell/src/main.tsx`),
+    'regex rejects a file outside src/': !pillarsSrc.test(`${root}/pillars/x/app/Outside.tsx`),
+    'regex rejects a .jsx (wrong ext)': !pillarsSrc.test(`${root}/pillars/x/app/src/Weird.jsx`),
+    'good globs are all non-empty': good.emptyGlobs.length === 0,
+    'good globs flag the outside-src + .jsx files': good.uncovered.length === 2,
+    'good globs exempt .storybook': !good.uncovered.some((p) => p.includes('/.storybook/')),
+    'stale apps/packages globs flagged empty': stale.emptyGlobs.length === 2,
+  };
+
+  const ok = Object.values(checks).every(Boolean);
+  if (ok) {
+    console.log(
+      'self-test OK — guard flags empty (stale) globs and uncovered UI files, passes a correct tree.'
+    );
+  } else {
+    console.error('SELF-TEST FAILED — guard did not behave as expected:');
+    for (const [label, passed] of Object.entries(checks)) {
+      console.error(`  ${passed ? 'OK' : 'XX'}  ${label}`);
+    }
+  }
+  return ok;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node scripts/check-tailwind-source-coverage.mjs [--self-test]\n' +
+        'Asserts every @source glob in libs/ui globals.css matches files and covers all UI source.'
+    );
+    process.exit(2);
+  }
+  if (args.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+  process.exit(run() ? 0 : 1);
+}
+
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '')) {
+  main();
+}


### PR DESCRIPTION
## What
The finance dashboard (and every pillar) rendered with a collapsed layout — content shoved to one side, grids stacked to a single column. Root cause: the single Tailwind v4 theme entry (`libs/ui/src/theme/globals.css`) still pointed its `@source` scan globs at the pre-migration `apps/*` and `packages/*` dirs, deleted in the pillars/libs rename. Tailwind v4 **silently** skips an empty `@source` glob, so only classes also present in `libs/ui` were generated; every pillar-only layout class (responsive grids, flex distribution, max-widths) was dropped — with no build error.

## Fix
- `globals.css`: scan `pillars/**/src/**` and `libs/**/src/**` (mixed depths: `pillars/shell/src`, `pillars/finance/app/src`).

## Guards added (so this can't silently recur)
- **`scripts/check-tailwind-source-coverage.mjs`** — fails CI if any `@source` glob matches zero files, or a `className`-bearing UI file falls outside the globs (authored outside `src/` or as `.jsx`/`.mdx`). Pure-core + `--self-test`, wired into `quality.yml` and `pnpm check:tailwind-source`.
- **Storybook coverage guard** strengthened to validate each `@pops/app-*` alias resolves to its real `pillars/<name>/app/src` (previously only checked the alias key existed). This surfaced and fixed a latent bug: `@pops/app-ai` aliased to non-existent `pillars/registry/app/src`.

## Verification
Built the shell with broken vs fixed globs:

| | broken (apps/packages) | fixed (pillars/libs) |
|---|---|---|
| CSS bundle | 46 KB | 175 KB |
| responsive utilities | 13 | 100+ |
| `sm:grid-cols-2` / `lg:grid-cols-4` | missing | present |

Cross-checked finance/food/cerebrum app classes (incl. arbitrary-value grids) all present in the single shell bundle. Both new guards green on the real tree; `pnpm lint` / `format:check` / `typecheck` pass locally.