### PR TITLE
fix(finance): preserve import progress fields so processing step renders

### DIFF
--- a/pillars/finance/app/src/components/imports/ProcessingStep.test.tsx
+++ b/pillars/finance/app/src/components/imports/ProcessingStep.test.tsx
@@ -112,6 +112,36 @@ describe('ProcessingStep', () => {
     });
   });
 
+  it('renders live batch progress without crashing while status is processing', async () => {
+    mockProcessSessionId = 'sess-1';
+    mockGetImportProgress.mockResolvedValue({
+      data: {
+        sessionId: 'sess-1',
+        status: 'processing',
+        errors: [],
+        currentBatch: [
+          { description: 'Coffee shop', status: 'processing' },
+          { description: 'Grocery store', status: 'success' },
+        ],
+        currentStep: 'matching',
+        processedCount: 1,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        totalTransactions: 4,
+      },
+      error: undefined,
+    });
+    render(renderStep());
+    expect(await screen.findByText('Processing 1/4 transactions...')).toBeInTheDocument();
+    expect(screen.getByText('Coffee shop')).toBeInTheDocument();
+    expect(screen.getByText('Grocery store')).toBeInTheDocument();
+    expect(screen.getByText('Matching entities').nextElementSibling).toHaveTextContent(
+      'In progress...'
+    );
+    expect(screen.getByText('Checking for duplicates').nextElementSibling).toHaveTextContent(
+      'Complete'
+    );
+  });
+
   it('shows Retry button when the progress query reports a failed status', async () => {
     mockProcessSessionId = 'sess-1';
     mockGetImportProgress.mockResolvedValue({

--- a/pillars/finance/app/src/components/imports/ProcessingStep.tsx
+++ b/pillars/finance/app/src/components/imports/ProcessingStep.tsx
@@ -76,7 +76,7 @@ export function ProcessingStep() {
     <div className="flex flex-col items-center space-y-6">
       <ProgressDisplay
         isProcessing={Boolean(isProcessing)}
-        progress={progress as never}
+        progress={progress ?? undefined}
         parsedCount={parsedTransactions.length}
       />
       {completedWarnings?.map((warning) => (

--- a/pillars/finance/app/src/components/imports/processing/useProcessing.ts
+++ b/pillars/finance/app/src/components/imports/processing/useProcessing.ts
@@ -19,12 +19,25 @@ interface ImportProgressShape {
   status: ProgressResponse['status'];
   result?: ProcessImportOutput;
   errors?: ProgressResponse['errors'];
+  currentStep?: ProgressResponse['currentStep'];
+  totalTransactions: number;
+  processedCount: number;
+  currentBatch: ProgressResponse['currentBatch'];
 }
 
 function toProgressShape(res: ImportsGetImportProgressResponses[200]): ImportProgressShape | null {
   if (!res) return null;
   const result = res.result && 'matched' in res.result ? res.result : undefined;
-  return { sessionId: res.sessionId, status: res.status, result, errors: res.errors };
+  return {
+    sessionId: res.sessionId,
+    status: res.status,
+    result,
+    errors: res.errors,
+    currentStep: res.currentStep,
+    totalTransactions: res.totalTransactions,
+    processedCount: res.processedCount,
+    currentBatch: res.currentBatch,
+  };
 }
 
 export function useHasAlreadyProcessed(): boolean {


### PR DESCRIPTION
## Problem

Running an import crashed the finance app with:

```
TypeError: undefined is not an object (evaluating 't.currentBatch.length')
```

`toProgressShape` (`useProcessing.ts`) reduced the import-progress REST response down to `{ sessionId, status, result, errors }`, **dropping** `currentBatch`, `currentStep`, `totalTransactions`, and `processedCount`. `ProcessingStep` then passed that gutted object to `ProgressDisplay` through `progress as never`, which silenced the type mismatch. Once the import reached `status === 'processing'`, `buildBatchItems` dereferenced `progress.currentBatch.length` on an `undefined` value → crash. The same missing fields also fed `NaN` to the progress bar and left the step indicators stuck on "pending".

The existing tests never caught it because they only covered the `failed` status, where `!isProcessing` short-circuits before `currentBatch` is read.

## Fix

- Carry the four dropped fields through `ImportProgressShape` and `toProgressShape` — all are already present on the REST 200 payload.
- Drop the `progress as never` cast; the shape is now structurally assignable to `ProgressLike`.
- Add a `processing`-path test that asserts the live batch, the `processed/total` count, and the per-step status render. Verified it fails (crashes) on the old `toProgressShape` and passes with the fix.

## Verification

- `tsc --noEmit` — clean
- `pnpm --filter @pops/app-finance test` — 380/380 pass
- `pnpm lint` / `pnpm format:check` — clean