### PR TITLE
refactor(finance): drop the correction-proposal as-never cluster + manuallyEdited cast

### DIFF
--- a/.escape-hatch-baseline.json
+++ b/.escape-hatch-baseline.json
@@ -23,17 +23,7 @@
   "pillars/cerebrum/scripts/generate-openapi.ts": {
     "as unknown as": 2
   },
-  "pillars/finance/app/src/components/imports/correction-proposal/CorrectionProposalWorkflow.tsx": {
-    "as never": 1
-  },
-  "pillars/finance/app/src/components/imports/correction-proposal/CorrectionRuleManagerDialog.tsx": {
-    "as never": 1
-  },
-  "pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowPanels.tsx": {
-    "as never": 5
-  },
   "pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowSlots.tsx": {
-    "as never": 3,
     "eslint-disable": 1
   },
   "pillars/finance/app/src/components/imports/processing/useProcessing.ts": {

--- a/pillars/finance/app/src/components/imports/correction-proposal/CorrectionProposalWorkflow.tsx
+++ b/pillars/finance/app/src/components/imports/correction-proposal/CorrectionProposalWorkflow.tsx
@@ -22,7 +22,7 @@ export function CorrectionProposalWorkflow(props: CorrectionProposalWorkflowProp
   const view = useViewSelection(localOpsHook, previewHook);
 
   const handleOpenChange = useResetOnClose({
-    setLocalOps: localOpsHook.setLocalOps as never,
+    setLocalOps: localOpsHook.setLocalOps,
     setSelectedClientId: localOpsHook.setSelectedClientId,
     setPreviewView: view.setPreviewView,
     resetPreviewState: previewHook.resetPreviewState,

--- a/pillars/finance/app/src/components/imports/correction-proposal/CorrectionRuleManagerDialog.tsx
+++ b/pillars/finance/app/src/components/imports/correction-proposal/CorrectionRuleManagerDialog.tsx
@@ -11,6 +11,8 @@ import { RuleManagerFooter } from './rule-manager/Footer';
 import { RuleManagerBody } from './rule-manager/RuleManagerBody';
 import { useRuleManagerHooks } from './rule-manager/useRuleManagerHooks';
 
+import type { LocalOp } from './types';
+
 export interface CorrectionRuleManagerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -22,7 +24,7 @@ export interface CorrectionRuleManagerDialogProps {
 interface CleanupArgs {
   setBrowseSearch: (v: string) => void;
   setBrowseSelectedRuleId: (v: string | null) => void;
-  setLocalOps: (v: never[]) => void;
+  setLocalOps: React.Dispatch<React.SetStateAction<LocalOp[]>>;
   setSelectedClientId: (v: string | null) => void;
   setPreviewView: (v: PreviewView) => void;
   resetPreviewState: () => void;
@@ -63,7 +65,7 @@ export function CorrectionRuleManagerDialog(props: CorrectionRuleManagerDialogPr
     buildOpenChangeHandler(onOpenChange, onBrowseClose, dialogState.browseInitialPendingCountRef, {
       setBrowseSearch: dialogState.setBrowseSearch,
       setBrowseSelectedRuleId: selection.setBrowseSelectedRuleId,
-      setLocalOps: setLocalOps as never,
+      setLocalOps,
       setSelectedClientId,
       setPreviewView: dialogState.setPreviewView,
       resetPreviewState: previewHook.resetPreviewState,

--- a/pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowPanels.tsx
+++ b/pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowPanels.tsx
@@ -14,6 +14,9 @@ import type {
   CorrectionSignal,
   TriggeringTransactionContext,
 } from '../../correction-proposal-shared';
+import type { UsePreviewEffectsReturn } from '../../hooks/preview-effects-helpers';
+import type { UseLocalOpsReturn } from '../../hooks/useLocalOps';
+import type { AiMessage, PreviewChangeSetOutput } from '../types';
 
 export function previewLabel(view: PreviewView, hasSelectedOp: boolean): string {
   if (view === 'combined') return 'Combined effect of entire ChangeSet';
@@ -47,35 +50,35 @@ export function renderProposalBodyState({
 }
 
 interface ProposalBodyProps {
-  localOpsHook: {
-    localOps: unknown[];
-    selectedClientId: string | null;
-    setSelectedClientId: (id: string | null) => void;
-    selectedOp: unknown;
-    updateOp: (id: string, m: unknown) => void;
-    handleDeleteOp: (id: string) => void;
-    handleAddNewRuleOp: () => void;
-    handleAddTargetedOp: unknown;
-  };
-  previewHook: {
-    previewMutationPending: boolean;
-    hasDirty: boolean;
-    handleRerunPreview: () => void;
-  };
+  localOpsHook: Pick<
+    UseLocalOpsReturn,
+    | 'localOps'
+    | 'selectedClientId'
+    | 'setSelectedClientId'
+    | 'selectedOp'
+    | 'updateOp'
+    | 'handleDeleteOp'
+    | 'handleAddNewRuleOp'
+    | 'handleAddTargetedOp'
+  >;
+  previewHook: Pick<
+    UsePreviewEffectsReturn,
+    'previewMutationPending' | 'hasDirty' | 'handleRerunPreview'
+  >;
   excludeIds: ReadonlySet<string>;
   isBusy: boolean;
   previewView: PreviewView;
   setPreviewView: (v: PreviewView) => void;
   currentPreviewLabel: string;
-  previewResult: unknown;
+  previewResult: PreviewChangeSetOutput | null;
   previewError: string | null;
   previewTruncated: boolean;
 }
 
 export function ProposalBody(props: ProposalBodyProps) {
   const { localOpsHook, previewHook, excludeIds, isBusy } = props;
-  const ops = localOpsHook.localOps as never[];
-  const selectedOp = localOpsHook.selectedOp as { clientId: string } | null;
+  const ops = localOpsHook.localOps;
+  const selectedOp = localOpsHook.selectedOp;
   return (
     <>
       <OpsListPanel
@@ -84,12 +87,12 @@ export function ProposalBody(props: ProposalBodyProps) {
         onSelect={localOpsHook.setSelectedClientId}
         onDelete={localOpsHook.handleDeleteOp}
         onAddNewRule={localOpsHook.handleAddNewRuleOp}
-        onAddTargeted={localOpsHook.handleAddTargetedOp as never}
+        onAddTargeted={localOpsHook.handleAddTargetedOp}
         excludeIds={excludeIds}
         disabled={isBusy}
       />
       <DetailPanel
-        op={selectedOp as never}
+        op={selectedOp}
         onChange={(mutator) => {
           if (!selectedOp) return;
           localOpsHook.updateOp(selectedOp.clientId, mutator);
@@ -100,7 +103,7 @@ export function ProposalBody(props: ProposalBodyProps) {
         view={props.previewView}
         onViewChange={props.setPreviewView}
         label={props.currentPreviewLabel}
-        previewResult={props.previewResult as never}
+        previewResult={props.previewResult}
         previewError={props.previewError}
         isPending={previewHook.previewMutationPending}
         stale={previewHook.hasDirty}
@@ -123,7 +126,7 @@ export function ContextHeader({
   triggeringTransaction: TriggeringTransactionContext | null;
   rationale: string | null;
   opCount: number;
-  combinedSummary: never;
+  combinedSummary: PreviewChangeSetOutput['summary'] | null;
 }) {
   return (
     <ContextPanel
@@ -143,7 +146,7 @@ interface SubpanelArgs {
   setRejectMode: (v: boolean) => void;
   handleConfirmReject: () => void;
   rejectMutationPending: boolean;
-  aiMessages: unknown[];
+  aiMessages: AiMessage[];
   aiInstruction: string;
   setAiInstruction: (v: string) => void;
   handleAiSubmit: () => void;
@@ -167,7 +170,7 @@ export function ProposalSubpanel(args: SubpanelArgs) {
   }
   return (
     <AiHelperPanel
-      messages={args.aiMessages as never}
+      messages={args.aiMessages}
       instruction={args.aiInstruction}
       onInstructionChange={args.setAiInstruction}
       onSubmit={args.handleAiSubmit}

--- a/pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowSlots.tsx
+++ b/pillars/finance/app/src/components/imports/correction-proposal/workflow/WorkflowSlots.tsx
@@ -11,6 +11,7 @@ import {
   renderProposalBodyState,
 } from './WorkflowPanels';
 
+import type { LocalOp, PreviewChangeSetOutput } from '../types';
 import type { CorrectionProposalWorkflowProps, useWorkflowHooks } from './useWorkflowHooks';
 
 interface FooterProps {
@@ -51,7 +52,7 @@ export function ProposalFooter(props: FooterProps) {
 }
 
 interface ResetArgs {
-  setLocalOps: (v: never[]) => void;
+  setLocalOps: React.Dispatch<React.SetStateAction<LocalOp[]>>;
   setSelectedClientId: (v: string | null) => void;
   setPreviewView: (v: PreviewView) => void;
   resetPreviewState: () => void;
@@ -91,7 +92,7 @@ export function useResetOnClose(args: ResetArgs) {
 export interface ViewSelection {
   previewView: PreviewView;
   setPreviewView: React.Dispatch<React.SetStateAction<PreviewView>>;
-  previewResult: unknown;
+  previewResult: PreviewChangeSetOutput | null;
   previewError: string | null;
   previewTruncated: boolean;
   currentPreviewLabel: string;
@@ -137,8 +138,8 @@ export function renderBody(
   if (state) return state;
   return (
     <ProposalBody
-      localOpsHook={hooks.localOpsHook as never}
-      previewHook={hooks.previewHook as never}
+      localOpsHook={hooks.localOpsHook}
+      previewHook={hooks.previewHook}
       excludeIds={view.excludeIds}
       isBusy={hooks.mutationsHook.isBusy}
       previewView={view.previewView}
@@ -164,7 +165,7 @@ export function renderHeader(
       triggeringTransaction={triggeringTransaction}
       rationale={hooks.localOpsHook.rationale}
       opCount={hooks.localOpsHook.localOps.length}
-      combinedSummary={(hooks.previewHook.combinedPreview?.summary ?? null) as never}
+      combinedSummary={hooks.previewHook.combinedPreview?.summary ?? null}
     />
   );
 }

--- a/pillars/finance/app/src/components/imports/transaction-card/badges.test.tsx
+++ b/pillars/finance/app/src/components/imports/transaction-card/badges.test.tsx
@@ -3,14 +3,14 @@ import { describe, expect, it } from 'vitest';
 
 import { HeaderBadges } from './badges';
 
-import type { ProcessedTransaction } from '@pops/finance';
+import type { ProcessedTransaction } from '../../../store/import-store-types';
 
 type MatchType = NonNullable<ProcessedTransaction['entity']>['matchType'];
 
 function makeTx(
   matchType: MatchType,
-  overrides: Partial<ProcessedTransaction & { manuallyEdited?: boolean }> = {}
-): ProcessedTransaction & { manuallyEdited?: boolean } {
+  overrides: Partial<ProcessedTransaction> = {}
+): ProcessedTransaction {
   return {
     date: '2026-04-01',
     description: 'WOOLWORTHS 1234',

--- a/pillars/finance/app/src/components/imports/transaction-card/badges.test.tsx
+++ b/pillars/finance/app/src/components/imports/transaction-card/badges.test.tsx
@@ -9,8 +9,8 @@ type MatchType = NonNullable<ProcessedTransaction['entity']>['matchType'];
 
 function makeTx(
   matchType: MatchType,
-  overrides: Partial<ProcessedTransaction> = {}
-): ProcessedTransaction {
+  overrides: Partial<ProcessedTransaction & { manuallyEdited?: boolean }> = {}
+): ProcessedTransaction & { manuallyEdited?: boolean } {
   return {
     date: '2026-04-01',
     description: 'WOOLWORTHS 1234',
@@ -53,5 +53,17 @@ describe('HeaderBadges — Auto-matched badge', () => {
     render(<HeaderBadges transaction={makeTx('learned')} />);
     expect(screen.getByText('Rule matched')).toBeInTheDocument();
     expect(screen.queryByText('Auto-matched')).not.toBeInTheDocument();
+  });
+});
+
+describe('HeaderBadges — Edited badge (store-side manuallyEdited)', () => {
+  it('shows "Edited" when manuallyEdited is true', () => {
+    render(<HeaderBadges transaction={makeTx('ai', { manuallyEdited: true })} />);
+    expect(screen.getByText('Edited')).toBeInTheDocument();
+  });
+
+  it('does not show "Edited" when manuallyEdited is absent', () => {
+    render(<HeaderBadges transaction={makeTx('ai')} />);
+    expect(screen.queryByText('Edited')).not.toBeInTheDocument();
   });
 });

--- a/pillars/finance/app/src/components/imports/transaction-card/badges.tsx
+++ b/pillars/finance/app/src/components/imports/transaction-card/badges.tsx
@@ -9,11 +9,16 @@ type EntityMatchType = NonNullable<ProcessedTransaction['entity']>['matchType'];
 /** Match types the system produced on its own — as opposed to `manual`, an explicit/`learned` rule, or `none`. */
 const AUTO_MATCH_TYPES: readonly EntityMatchType[] = ['alias', 'exact', 'prefix', 'contains', 'ai'];
 
-export function HeaderBadges({ transaction }: { transaction: ProcessedTransaction }) {
+export function HeaderBadges({
+  transaction,
+}: {
+  // `manuallyEdited` is a store-side augmentation (import-store-types.ts) absent from the
+  // contract type; widen the prop instead of casting at the read site.
+  transaction: ProcessedTransaction & { manuallyEdited?: boolean };
+}) {
   const matchType = transaction.entity?.matchType;
   const isAutoMatched = matchType !== undefined && AUTO_MATCH_TYPES.includes(matchType);
-  const isEdited = (transaction as ProcessedTransaction & { manuallyEdited?: boolean })
-    .manuallyEdited;
+  const isEdited = transaction.manuallyEdited;
   const ruleProvenance = transaction.ruleProvenance;
   const isRuleMatched = Boolean(ruleProvenance) || transaction.entity?.matchType === 'learned';
   const overriddenRules = transaction.matchedRules?.slice(1) ?? [];

--- a/pillars/finance/app/src/components/imports/transaction-card/badges.tsx
+++ b/pillars/finance/app/src/components/imports/transaction-card/badges.tsx
@@ -2,20 +2,16 @@ import { Zap } from 'lucide-react';
 
 import { Badge, Popover, PopoverContent, PopoverTrigger } from '@pops/ui';
 
-import type { MatchedRule, ProcessedTransaction } from '@pops/finance';
+import type { MatchedRule } from '@pops/finance';
+
+import type { ProcessedTransaction } from '../../../store/import-store-types';
 
 type EntityMatchType = NonNullable<ProcessedTransaction['entity']>['matchType'];
 
 /** Match types the system produced on its own — as opposed to `manual`, an explicit/`learned` rule, or `none`. */
 const AUTO_MATCH_TYPES: readonly EntityMatchType[] = ['alias', 'exact', 'prefix', 'contains', 'ai'];
 
-export function HeaderBadges({
-  transaction,
-}: {
-  // `manuallyEdited` is a store-side augmentation (import-store-types.ts) absent from the
-  // contract type; widen the prop instead of casting at the read site.
-  transaction: ProcessedTransaction & { manuallyEdited?: boolean };
-}) {
+export function HeaderBadges({ transaction }: { transaction: ProcessedTransaction }) {
   const matchType = transaction.entity?.matchType;
   const isAutoMatched = matchType !== undefined && AUTO_MATCH_TYPES.includes(matchType);
   const isEdited = transaction.manuallyEdited;


### PR DESCRIPTION
## Why

Pays down the densest escape-hatch cluster grandfathered by #3581 — the REST-migration `correction-proposal/workflow/` code, where **10 `as never` casts** laundered hook types across the panel boundary (exactly the class the ratchet exists to retire).

Every cast was pure decoupling, **not** hiding a real mismatch: `tsc` passes and **392 finance tests are unchanged** after removal. Type-level only, zero runtime change.

## Changes

- **WorkflowPanels** — `ProposalBodyProps.localOpsHook`/`previewHook` now `Pick<>` of the real `UseLocalOpsReturn`/`UsePreviewEffectsReturn`; `previewResult`/`aiMessages`/`combinedSummary` typed as `PreviewChangeSetOutput | null` / `AiMessage[]` / `PreviewChangeSetOutput['summary'] | null`. Drops 5 `as never` + a stray `as { clientId }`.
- **WorkflowSlots** — `ViewSelection.previewResult` + `ResetArgs.setLocalOps` typed to the real shapes; drops 3 `as never`.
- **CorrectionProposalWorkflow / CorrectionRuleManagerDialog** — `setLocalOps` typed `Dispatch<SetStateAction<LocalOp[]>>`; drops 2 `as never`.
- **badges.tsx** — replaces the `transaction as … & { manuallyEdited?: boolean }` read-site cast with a widened prop type (the field is a store-side augmentation of the contract type). Adds Edited-badge tests.

## Ratchet

Baseline **44 → 34**. Only the one NECESSARY hook-dep `eslint-disable` remains in the cluster.

## Verification

- `tsc --noEmit` — clean
- `pnpm --filter @pops/app-finance test` — 392/392
- `pnpm lint` / `pnpm format:check` — clean
- escape-hatch gate (self-test + check) — pass at 34