### PR TITLE
fix(finance): dedupe entity re-selection on matched import cards

### DIFF
--- a/pillars/finance/app/src/components/imports/TransactionGroup.test.tsx
+++ b/pillars/finance/app/src/components/imports/TransactionGroup.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TransactionGroup } from './TransactionGroup';
+
+import type { ProcessedTransaction } from '@pops/finance';
+
+import type { TransactionGroup as TransactionGroupType } from '../../lib/transaction-utils';
+
+function makeTxn(checksum: string): ProcessedTransaction {
+  return {
+    date: '2026-02-06',
+    description: `TXN ${checksum}`,
+    amount: -12.5,
+    account: 'Amex',
+    rawRow: `{"checksum":"${checksum}"}`,
+    checksum,
+    entity: { matchType: 'none' },
+    status: 'uncertain',
+  };
+}
+
+function makeGroup(): TransactionGroupType {
+  return {
+    entityName: 'Bunnings Warehouse',
+    transactions: [makeTxn('a'), makeTxn('b')],
+    aiSuggestion: false,
+  };
+}
+
+function renderGroup(overrides: Partial<Parameters<typeof TransactionGroup>[0]> = {}) {
+  return render(
+    <TransactionGroup
+      group={makeGroup()}
+      onAcceptAll={vi.fn()}
+      onCreateAndAssignAll={vi.fn()}
+      onEntitySelect={vi.fn()}
+      onBulkEntitySelect={vi.fn()}
+      onCreateEntity={vi.fn()}
+      onAcceptAiSuggestion={vi.fn()}
+      onEdit={vi.fn()}
+      entities={[
+        { id: 'ent-1', name: 'Bunnings Warehouse' },
+        { id: 'ent-2', name: 'Coles' },
+      ]}
+      {...overrides}
+    />
+  );
+}
+
+describe('TransactionGroup — standardized bulk entity picker', () => {
+  it('renders the searchable EntitySelect combobox (not a native <select>) for bulk assignment', async () => {
+    const user = userEvent.setup();
+    const { container } = renderGroup();
+
+    await user.click(screen.getByRole('button', { name: /choose existing/i }));
+
+    expect(screen.getByText(/select entity to assign to all 2 transactions/i)).toBeInTheDocument();
+
+    // The standardized picker is the @pops/ui EntitySelect: a combobox-role
+    // *button* trigger (with aria-expanded), showing the placeholder — not the
+    // legacy native <select> element.
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-expanded');
+    expect(trigger).toHaveTextContent(/choose entity/i);
+    expect(container.querySelector('select')).toBeNull();
+  });
+
+  it('does not show the picker until "Choose existing" is toggled', () => {
+    renderGroup();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText(/select entity to assign to all/i)).not.toBeInTheDocument();
+  });
+
+  it('hides the picker when no entities are available', async () => {
+    const user = userEvent.setup();
+    renderGroup({ entities: [] });
+
+    await user.click(screen.getByRole('button', { name: /choose existing/i }));
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+});

--- a/pillars/finance/app/src/components/imports/TransactionGroup.tsx
+++ b/pillars/finance/app/src/components/imports/TransactionGroup.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
-import { Collapsible, CollapsibleContent, Label, Select as UiSelect } from '@pops/ui';
+import { Collapsible, CollapsibleContent, Label } from '@pops/ui';
 
 import { EditableTransactionCard } from './EditableTransactionCard';
+import { EntitySelect } from './EntitySelect';
 import { GroupHeader } from './transaction-group/GroupHeader';
 import { TransactionCard } from './TransactionCard';
 
@@ -53,22 +54,19 @@ function BulkEntitySelector({
       <Label className="block mb-2">
         Select entity to assign to all {group.transactions.length} transactions:
       </Label>
-      <UiSelect
+      <EntitySelect
+        entities={entities}
         placeholder="Choose entity..."
-        options={entities.map((entity) => ({ label: entity.name, value: entity.id }))}
-        onChange={(e) => {
-          const selectedEntity = entities.find((ent) => ent.id === e.target.value);
-          if (!selectedEntity) return;
+        onChange={(entityId, entityName) => {
           if (onBulkEntitySelect) {
-            onBulkEntitySelect(group.transactions, selectedEntity.id, selectedEntity.name);
+            onBulkEntitySelect(group.transactions, entityId, entityName);
           } else {
             for (const t of group.transactions) {
-              onEntitySelect(t, selectedEntity.id, selectedEntity.name);
+              onEntitySelect(t, entityId, entityName);
             }
           }
           onClose();
         }}
-        defaultValue=""
       />
     </div>
   );

--- a/pillars/finance/app/src/components/imports/review/useReviewActions.test.ts
+++ b/pillars/finance/app/src/components/imports/review/useReviewActions.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { moveOneToMatched, type LocalTxState } from './useReviewActions';
+
+import type { ProcessedTransaction } from '../../../store/importStore';
+
+function makeProcessed(
+  checksum: string,
+  overrides: Partial<ProcessedTransaction> = {}
+): ProcessedTransaction {
+  return {
+    date: '2026-02-06',
+    description: `TXN ${checksum}`,
+    amount: -44.63,
+    account: 'Amex',
+    rawRow: `{"checksum":"${checksum}"}`,
+    checksum,
+    entity: { matchType: 'none' },
+    status: 'uncertain',
+    ...overrides,
+  };
+}
+
+function emptyState(overrides: Partial<LocalTxState> = {}): LocalTxState {
+  return { matched: [], uncertain: [], failed: [], skipped: [], ...overrides };
+}
+
+describe('moveOneToMatched', () => {
+  it('replaces an already-matched transaction in place instead of appending a duplicate', () => {
+    const target = makeProcessed('bunnings', {
+      description: 'BUNNINGS WAREHOUSE KING KINGSGROVE',
+      status: 'matched',
+      entity: { matchType: 'learned' },
+    });
+    const other = makeProcessed('maccas', { status: 'matched', entity: { matchType: 'ai' } });
+    const prev = emptyState({ matched: [other, target] });
+
+    const next = moveOneToMatched(prev, {
+      transaction: target,
+      entityId: 'ent-bunnings',
+      entityName: 'Bunnings Warehouse',
+      matchType: 'manual',
+    });
+
+    // No duplicate: the matched bucket keeps the same length.
+    expect(next.matched).toHaveLength(2);
+    // Only one card carries the target checksum after the update.
+    expect(next.matched.filter((t) => t.checksum === 'bunnings')).toHaveLength(1);
+    // Position is preserved (target stays at index 1, behind `other`).
+    expect(next.matched[1]?.checksum).toBe('bunnings');
+    // The picked entity actually lands on the transaction.
+    expect(next.matched[1]?.entity).toEqual({
+      entityId: 'ent-bunnings',
+      entityName: 'Bunnings Warehouse',
+      matchType: 'manual',
+      confidence: 1,
+    });
+    // Untouched sibling is left exactly as-is.
+    expect(next.matched[0]).toBe(other);
+  });
+
+  it('appends when the transaction is not already matched, removing it from uncertain', () => {
+    const target = makeProcessed('unknown-1', { status: 'uncertain' });
+    const prev = emptyState({ uncertain: [target] });
+
+    const next = moveOneToMatched(prev, {
+      transaction: target,
+      entityId: 'ent-x',
+      entityName: 'X Corp',
+      matchType: 'manual',
+    });
+
+    expect(next.uncertain).toHaveLength(0);
+    expect(next.matched).toHaveLength(1);
+    expect(next.matched[0]?.checksum).toBe('unknown-1');
+    expect(next.matched[0]?.status).toBe('matched');
+  });
+
+  it('removes the transaction from the failed bucket when promoting it', () => {
+    const target = makeProcessed('failed-1', { status: 'failed' });
+    const prev = emptyState({ failed: [target] });
+
+    const next = moveOneToMatched(prev, {
+      transaction: target,
+      entityId: 'ent-y',
+      entityName: 'Y Ltd',
+      matchType: 'manual',
+    });
+
+    expect(next.failed).toHaveLength(0);
+    expect(next.matched.map((t) => t.checksum)).toEqual(['failed-1']);
+  });
+
+  it('never mutates the skipped bucket and leaves unrelated buckets referentially intact', () => {
+    const skipped = makeProcessed('skip-1', { status: 'skipped' });
+    const target = makeProcessed('unknown-2', { status: 'uncertain' });
+    const prev = emptyState({ uncertain: [target], skipped: [skipped] });
+
+    const next = moveOneToMatched(prev, {
+      transaction: target,
+      entityId: 'ent-z',
+      entityName: 'Z GmbH',
+      matchType: 'manual',
+    });
+
+    expect(next.skipped).toBe(prev.skipped);
+    expect(next.skipped).toEqual([skipped]);
+  });
+
+  it('re-selecting the same entity twice is idempotent — no growth on repeated picks', () => {
+    const target = makeProcessed('dedupe', { status: 'matched', entity: { matchType: 'manual' } });
+    const prev = emptyState({ matched: [target] });
+
+    const args = {
+      transaction: target,
+      entityId: 'ent-a',
+      entityName: 'A',
+      matchType: 'manual' as const,
+    };
+    const once = moveOneToMatched(prev, args);
+    const twice = moveOneToMatched(once, { ...args, transaction: once.matched[0] ?? target });
+
+    expect(twice.matched).toHaveLength(1);
+    expect(twice.matched[0]?.entity.entityId).toBe('ent-a');
+  });
+});

--- a/pillars/finance/app/src/components/imports/review/useReviewActions.test.ts
+++ b/pillars/finance/app/src/components/imports/review/useReviewActions.test.ts
@@ -107,6 +107,36 @@ describe('moveOneToMatched', () => {
     expect(next.skipped).toEqual([skipped]);
   });
 
+  it('collapses pre-existing duplicate matched entries down to a single copy at the first position', () => {
+    const dupeA = makeProcessed('dupe', {
+      status: 'matched',
+      description: 'FIRST COPY',
+      entity: { matchType: 'learned' },
+    });
+    const dupeB = makeProcessed('dupe', {
+      status: 'matched',
+      description: 'SECOND COPY',
+      entity: { matchType: 'ai' },
+    });
+    const other = makeProcessed('other', { status: 'matched' });
+    // Corrupted prior state: two entries share the same checksum.
+    const prev = emptyState({ matched: [dupeA, other, dupeB] });
+
+    const next = moveOneToMatched(prev, {
+      transaction: dupeA,
+      entityId: 'ent-dupe',
+      entityName: 'Deduped Co',
+      matchType: 'manual',
+    });
+
+    expect(next.matched.filter((t) => t.checksum === 'dupe')).toHaveLength(1);
+    // Single survivor sits at the first duplicate's original index (0).
+    expect(next.matched[0]?.checksum).toBe('dupe');
+    expect(next.matched[0]?.entity.entityName).toBe('Deduped Co');
+    // The unrelated matched row is preserved once, after the collapsed entry.
+    expect(next.matched.map((t) => t.checksum)).toEqual(['dupe', 'other']);
+  });
+
   it('re-selecting the same entity twice is idempotent — no growth on repeated picks', () => {
     const target = makeProcessed('dedupe', { status: 'matched', entity: { matchType: 'manual' } });
     const prev = emptyState({ matched: [target] });

--- a/pillars/finance/app/src/components/imports/review/useReviewActions.ts
+++ b/pillars/finance/app/src/components/imports/review/useReviewActions.ts
@@ -30,11 +30,14 @@ export interface MoveArgs {
  * Move a transaction into the `matched` bucket with the chosen entity, removing
  * any prior copy of it from every bucket first.
  *
- * The transaction is identified by `checksum`. When it already lives in
- * `matched` (e.g. re-assigning the entity on a rule-matched card) it is replaced
- * in place so the card keeps its position; otherwise it is appended. Failing to
- * drop the existing `matched` entry previously appended a duplicate and left the
- * original card untouched, so picking an entity looked like a no-op.
+ * The transaction is identified by `checksum`. Any prior copy is dropped from
+ * every bucket — including collapsing duplicate `matched` entries down to a
+ * single one — so the result holds exactly one copy per checksum. When it
+ * already lives in `matched` (e.g. re-assigning the entity on a rule-matched
+ * card) the replacement keeps the original card's position; otherwise it is
+ * appended. Failing to drop the existing `matched` entry previously appended a
+ * duplicate and left the original card untouched, so picking an entity looked
+ * like a no-op.
  *
  * Exported for unit testing the dedupe/replace invariant.
  */
@@ -47,14 +50,17 @@ export function moveOneToMatched(prev: LocalTxState, args: MoveArgs): LocalTxSta
   } as ProcessedTransaction;
   const withoutTx = (list: ProcessedTransaction[]): ProcessedTransaction[] =>
     list.filter((t) => t.checksum !== transaction.checksum);
-  const alreadyMatched = prev.matched.some((t) => t.checksum === transaction.checksum);
+  const firstMatchedIdx = prev.matched.findIndex((t) => t.checksum === transaction.checksum);
   return {
     ...prev,
     uncertain: withoutTx(prev.uncertain),
     failed: withoutTx(prev.failed),
-    matched: alreadyMatched
-      ? prev.matched.map((t) => (t.checksum === transaction.checksum ? matchedTx : t))
-      : [...prev.matched, matchedTx],
+    // Insert at the first prior position (collapsing any duplicates) when the
+    // transaction was already matched, else append.
+    matched:
+      firstMatchedIdx === -1
+        ? [...prev.matched, matchedTx]
+        : withoutTx(prev.matched).toSpliced(firstMatchedIdx, 0, matchedTx),
   };
 }
 

--- a/pillars/finance/app/src/components/imports/review/useReviewActions.ts
+++ b/pillars/finance/app/src/components/imports/review/useReviewActions.ts
@@ -4,7 +4,7 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import type { ProcessedTransaction } from '../../../store/importStore';
 
-interface LocalTxState {
+export interface LocalTxState {
   matched: ProcessedTransaction[];
   uncertain: ProcessedTransaction[];
   failed: ProcessedTransaction[];
@@ -19,27 +19,42 @@ type GenerateProposal = (args: {
   transactionType?: 'purchase' | 'transfer' | 'income' | null;
 }) => Promise<void>;
 
-interface MoveArgs {
+export interface MoveArgs {
   transaction: ProcessedTransaction;
   entityId: string;
   entityName: string;
   matchType: 'manual' | 'ai';
 }
 
-function moveOneToMatched(prev: LocalTxState, args: MoveArgs): LocalTxState {
+/**
+ * Move a transaction into the `matched` bucket with the chosen entity, removing
+ * any prior copy of it from every bucket first.
+ *
+ * The transaction is identified by `checksum`. When it already lives in
+ * `matched` (e.g. re-assigning the entity on a rule-matched card) it is replaced
+ * in place so the card keeps its position; otherwise it is appended. Failing to
+ * drop the existing `matched` entry previously appended a duplicate and left the
+ * original card untouched, so picking an entity looked like a no-op.
+ *
+ * Exported for unit testing the dedupe/replace invariant.
+ */
+export function moveOneToMatched(prev: LocalTxState, args: MoveArgs): LocalTxState {
   const { transaction, entityId, entityName, matchType } = args;
+  const matchedTx = {
+    ...transaction,
+    entity: { entityId, entityName, matchType, confidence: 1 },
+    status: 'matched' as const,
+  } as ProcessedTransaction;
+  const withoutTx = (list: ProcessedTransaction[]): ProcessedTransaction[] =>
+    list.filter((t) => t.checksum !== transaction.checksum);
+  const alreadyMatched = prev.matched.some((t) => t.checksum === transaction.checksum);
   return {
     ...prev,
-    uncertain: prev.uncertain.filter((t) => t.checksum !== transaction.checksum),
-    failed: prev.failed.filter((t) => t.checksum !== transaction.checksum),
-    matched: [
-      ...prev.matched,
-      {
-        ...transaction,
-        entity: { entityId, entityName, matchType, confidence: 1 },
-        status: 'matched' as const,
-      } as ProcessedTransaction,
-    ],
+    uncertain: withoutTx(prev.uncertain),
+    failed: withoutTx(prev.failed),
+    matched: alreadyMatched
+      ? prev.matched.map((t) => (t.checksum === transaction.checksum ? matchedTx : t))
+      : [...prev.matched, matchedTx],
   };
 }
 

--- a/pillars/shell/e2e/import-matched-entity-reassign.spec.ts
+++ b/pillars/shell/e2e/import-matched-entity-reassign.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression test — finance import: re-assigning the entity on an
+ * already-*matched* transaction must update that card in place, not silently
+ * duplicate it.
+ *
+ * Reproduces the reported bug: on the Review step's Matched tab, opening a
+ * card's "Choose entity…" combobox and picking an entity appeared to do
+ * nothing. Root cause: the reducer that moved a transaction into the `matched`
+ * bucket removed prior copies only from `uncertain`/`failed`, never from
+ * `matched` itself — so re-selecting on an already-matched card appended a
+ * duplicate at the end of the list while leaving the clicked card (keyed by
+ * index) visually unchanged.
+ *
+ * Flow covered:
+ *   Upload a one-row CSV whose merchant the seeded matcher classifies as
+ *   Matched (WOOLWORTHS METRO → alias match on the Woolworths seed entity),
+ *   then on the Matched tab re-assign that card from Woolworths to Coles and
+ *   assert:
+ *     - the Matched tab count stays at 1 (no duplicate row appended),
+ *     - exactly one card still carries the merchant description,
+ *     - that single card's combobox now reads "Coles".
+ *
+ *   Before the fix this failed on every assertion: the tab showed (2), two
+ *   cards carried the description, and the original card still read
+ *   "Woolworths".
+ *
+ * Isolation:
+ *   A dedicated env (`e2e-matched-reassign`) seeded via POST /env/<name> keeps
+ *   this spec independent of the shared `e2e` env. `findSimilar` only scans
+ *   uncertain/failed, so the single-row import never triggers the
+ *   correction-proposal dialog.
+ */
+import { expect, test, type Page, type APIRequestContext } from '@playwright/test';
+
+const API_URL = process.env['FINANCE_API_URL'] ?? 'http://localhost:3000';
+const ENV_NAME = 'e2e-matched-reassign';
+
+const MERCHANT = 'WOOLWORTHS METRO 1234';
+const matchedCsv = `Date,Description,Amount
+10/02/2026,${MERCHANT},87.45`;
+
+async function resetEnvironment(request: APIRequestContext): Promise<void> {
+  await request.delete(`${API_URL}/env/${ENV_NAME}`);
+  const res = await request.post(`${API_URL}/env/${ENV_NAME}`, {
+    data: { seed: 'test', ttl: 3600 },
+  });
+  if (res.status() !== 201) {
+    const body = await res.text();
+    throw new Error(`Failed to create '${ENV_NAME}' env: ${res.status()} ${body}`);
+  }
+}
+
+async function deleteEnvironment(request: APIRequestContext): Promise<void> {
+  await request.delete(`${API_URL}/env/${ENV_NAME}`);
+}
+
+async function routeAllTrpcToEnv(page: Page, envName: string): Promise<void> {
+  await page.route('/trpc/**', async (route) => {
+    const url = new URL(route.request().url());
+    url.searchParams.set('env', envName);
+    const response = await route.fetch({ url: url.toString() });
+    await route.fulfill({ response });
+  });
+}
+
+async function walkToReview(page: Page, content: string, fileName: string): Promise<void> {
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles({
+    name: fileName,
+    mimeType: 'text/csv',
+    buffer: Buffer.from(content),
+  });
+  await expect(page.getByText(fileName)).toBeVisible();
+
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await expect(page.getByRole('heading', { name: 'Map Columns' })).toBeVisible();
+  await page.getByRole('button', { name: /^next$/i }).click();
+
+  await expect(page.getByRole('heading', { name: 'Review', exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test.describe('Finance import — re-assign entity on a matched card', () => {
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    await resetEnvironment(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteEnvironment(request);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    await routeAllTrpcToEnv(page, ENV_NAME);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  test('picking a different entity replaces the matched card in place without duplicating it', async ({
+    page,
+  }) => {
+    await page.goto('/finance/import');
+    await walkToReview(page, matchedCsv, 'matched-reassign.csv');
+
+    const matchedTab = page.getByRole('tab', { name: /matched/i });
+    await expect(matchedTab).toHaveText(/matched.*\(1\)/i, { timeout: 10_000 });
+    await matchedTab.click();
+
+    const matchedPanel = page.getByRole('tabpanel', { name: /matched/i });
+    const merchantCard = matchedPanel
+      .locator('[data-testid="transaction-card"]')
+      .filter({ hasText: MERCHANT })
+      .filter({ visible: true });
+
+    await expect(merchantCard).toHaveCount(1);
+    await expect(merchantCard.getByRole('combobox')).toContainText('Woolworths');
+
+    // Open the combobox and pick a *different* seeded entity.
+    await merchantCard.getByRole('combobox').click();
+    const listbox = page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+    await listbox.getByRole('option', { name: /coles/i }).click();
+    await expect(listbox).toBeHidden();
+
+    // The reported bug: a duplicate row is appended and the clicked card is
+    // left unchanged. Post-fix, the single card is updated in place.
+    await expect(matchedTab).toHaveText(/matched.*\(1\)/i);
+
+    const cardsForMerchant = matchedPanel
+      .locator('[data-testid="transaction-card"]')
+      .filter({ hasText: MERCHANT })
+      .filter({ visible: true });
+    await expect(cardsForMerchant).toHaveCount(1);
+    await expect(cardsForMerchant.getByRole('combobox')).toContainText('Coles');
+    await expect(cardsForMerchant.getByRole('combobox')).not.toContainText('Woolworths');
+  });
+});


### PR DESCRIPTION
## Problem

On the finance import **Review** step's **Matched** tab, opening a card's
"Choose entity…" combobox and picking an entity appeared to do nothing.

### Root cause

`moveOneToMatched` (`useReviewActions.ts`) — the reducer behind every entity
selection — removed prior copies of the transaction only from `uncertain` and
`failed`, then unconditionally **appended** a fresh copy to `matched`. For a
transaction already living in `matched` (e.g. a rule-matched card whose
rule-provided entity id doesn't resolve to a listed option, so it shows the
placeholder), this appended a **duplicate** at the end of the list. Because
`MatchedTab` keys cards by array index, the clicked card kept rendering its
stale "Choose entity…" state while the duplicate landed off-screen at the
bottom — indistinguishable from "nothing happened".

## Fix

Drop the transaction from every bucket first, and when it is already in
`matched`, **replace it in place** (preserving the card's position) instead of
appending.

## Bonus — picker standardization

The Uncertain tab's bulk picker (`BulkEntitySelector`) used a legacy
non-searchable native `<select>`. It now uses the same searchable
`EntitySelect` combobox as the Matched tab and the transaction/rule dialogs,
which also simplifies the handler (no `e.target.value` / `find`).

## Tests

- **`useReviewActions.test.ts`** — reducer unit tests for the
  dedupe/replace-in-place invariant. The key case fails against the old
  append-only logic (it produced a duplicate + length growth).
- **`TransactionGroup.test.tsx`** — asserts the standardized searchable
  combobox renders for bulk assignment instead of a native `<select>`.
- **`import-matched-entity-reassign.spec.ts`** — e2e reproduction of the
  reported bug (re-assigning a matched card must not duplicate the row).
  Filed in the shell e2e suite, which is currently **dormant** against the REST
  stack (`fe-test-e2e.yml` is `workflow_dispatch`-only until the
  `e2e-rest-rewrite`); it revives with its siblings. The vitest tests are the
  active CI-gating guard.

Verification: finance app `tsc --noEmit` clean, 400/400 tests pass, oxlint +
oxfmt clean, escape-hatch ratchet unchanged (34/34).
